### PR TITLE
feat(orders): auto_complete flag — pending→confirmed→completed in one action

### DIFF
--- a/app/routers/online_orders.py
+++ b/app/routers/online_orders.py
@@ -14,6 +14,7 @@ router = APIRouter(prefix="/online/orders", tags=["Online Orders (Authenticated)
 class UpdateOrderStatusRequest(BaseModel):
     new_status: Literal["confirmed", "preparing", "delivered", "completed", "cancelled"]
     reason: Optional[str] = None
+    auto_complete: bool = False
 
 
 @router.get("")
@@ -85,5 +86,5 @@ async def update_online_order_status(
     **Requires valid session cookie.**
     """
     return await online_orders_service.update_order_status(
-        request, order_id, body.new_status, body.reason
+        request, order_id, body.new_status, body.reason, body.auto_complete
     )

--- a/app/services/online_orders_service.py
+++ b/app/services/online_orders_service.py
@@ -258,6 +258,7 @@ async def update_order_status(
     order_id: UUID,
     new_status: str,
     reason: Optional[str] = None,
+    auto_complete: bool = False,
 ) -> dict:
     """
     Validate the status transition, then atomically:
@@ -320,6 +321,55 @@ async def update_order_status(
                 """,
                 order_id, old_status, new_status, changed_by, reason,
             )
+
+            # 5. Auto-complete: if requested and this was a pending → confirmed transition,
+            #    immediately execute a second confirmed → completed transition in the same conn.
+            if auto_complete and old_status == "pending" and new_status == "confirmed":
+                # 5a. UPDATE orders to completed
+                await conn.execute(
+                    """
+                    UPDATE orders
+                    SET status = $1, updated_at = NOW()
+                    WHERE id = $2 AND tenant_id = $3
+                    """,
+                    "completed", order_id, tenant_id,
+                )
+
+                # 5b. INSERT second history row
+                auto_history_row = await conn.fetchrow(
+                    """
+                    INSERT INTO order_status_history
+                        (order_id, old_status, new_status, changed_by, reason)
+                    VALUES ($1, $2, $3, $4::uuid, $5)
+                    RETURNING change_date
+                    """,
+                    order_id, "confirmed", "completed", changed_by, None,
+                )
+
+                # Override the return payload to reflect the final completed state
+                return {
+                    "success": True,
+                    "data": {
+                        "order_id": str(order_id),
+                        "old_status": old_status,           # "pending"
+                        "new_status": "completed",           # final state
+                        "changed_at": auto_history_row["change_date"].isoformat(),
+                        "reason": reason,
+                        "auto_completed": True,
+                        "transitions": [
+                            {
+                                "from": old_status,
+                                "to": "confirmed",
+                                "changed_at": history_row["change_date"].isoformat(),
+                            },
+                            {
+                                "from": "confirmed",
+                                "to": "completed",
+                                "changed_at": auto_history_row["change_date"].isoformat(),
+                            },
+                        ],
+                    },
+                }
 
             return {
                 "success": True,

--- a/tests/test_online_order_status.py
+++ b/tests/test_online_order_status.py
@@ -364,3 +364,130 @@ class TestUpdateOrderStatusStateMachine:
                 f"/online/orders/{order_id}/status",
                 json={"new_status": "cancelled", "reason": "test rollback"},
             )
+
+
+class TestAutoComplete:
+    """Tests for auto_complete flag on pending → confirmed transition."""
+
+    @pytest.mark.asyncio
+    async def test_auto_complete_pending_to_completed(self, auth_client: AsyncClient):
+        """
+        auto_complete=True on pending → confirmed should leave the order as
+        completed and produce two history rows.
+        """
+        from app.database import get_db_connection
+
+        async with get_db_connection(use_transaction=False) as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT id FROM orders
+                WHERE tenant_id = $1
+                  AND status = 'pending'
+                  AND online_cart_id IS NOT NULL
+                LIMIT 1
+                """,
+                TENANT_ID,
+            )
+
+        if not row:
+            pytest.skip("No pending online orders found in test DB")
+
+        order_id = str(row["id"])
+
+        with patch(
+            "app.services.online_orders_service.require_valid_session",
+            return_value=_mock_session_context(),
+        ):
+            response = await auth_client.patch(
+                f"/online/orders/{order_id}/status",
+                json={"new_status": "confirmed", "auto_complete": True},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["data"]["new_status"] == "completed"
+        assert data["data"]["old_status"] == "pending"
+        assert data["data"]["auto_completed"] is True
+        assert len(data["data"]["transitions"]) == 2
+        assert data["data"]["transitions"][0]["from"] == "pending"
+        assert data["data"]["transitions"][0]["to"] == "confirmed"
+        assert data["data"]["transitions"][1]["from"] == "confirmed"
+        assert data["data"]["transitions"][1]["to"] == "completed"
+
+        # Verify DB state
+        from app.database import get_db_connection
+        async with get_db_connection(use_transaction=False) as conn:
+            db_row = await conn.fetchrow(
+                "SELECT status FROM orders WHERE id = $1", row["id"]
+            )
+            history_rows = await conn.fetch(
+                """
+                SELECT old_status, new_status FROM order_status_history
+                WHERE order_id = $1
+                ORDER BY change_date ASC
+                """,
+                row["id"],
+            )
+
+        assert db_row["status"] == "completed"
+        transitions = [(r["old_status"], r["new_status"]) for r in history_rows]
+        assert ("pending", "confirmed") in transitions
+        assert ("confirmed", "completed") in transitions
+
+        # Rollback: force back to pending for other tests
+        async with get_db_connection() as conn:
+            await conn.execute(
+                "UPDATE orders SET status = 'pending', updated_at = NOW() WHERE id = $1",
+                row["id"],
+            )
+
+    @pytest.mark.asyncio
+    async def test_auto_complete_false_leaves_confirmed(self, auth_client: AsyncClient):
+        """
+        auto_complete=False (default) on pending → confirmed should leave the
+        order as confirmed — unchanged from existing behavior.
+        """
+        from app.database import get_db_connection
+
+        async with get_db_connection(use_transaction=False) as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT id FROM orders
+                WHERE tenant_id = $1
+                  AND status = 'pending'
+                  AND online_cart_id IS NOT NULL
+                LIMIT 1
+                """,
+                TENANT_ID,
+            )
+
+        if not row:
+            pytest.skip("No pending online orders found in test DB")
+
+        order_id = str(row["id"])
+
+        with patch(
+            "app.services.online_orders_service.require_valid_session",
+            return_value=_mock_session_context(),
+        ):
+            response = await auth_client.patch(
+                f"/online/orders/{order_id}/status",
+                json={"new_status": "confirmed", "auto_complete": False},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["data"]["new_status"] == "confirmed"
+        assert data["data"].get("auto_completed") is not True
+
+        # Rollback: confirmed → cancelled to leave DB in a clean state
+        with patch(
+            "app.services.online_orders_service.require_valid_session",
+            return_value=_mock_session_context(),
+        ):
+            await auth_client.patch(
+                f"/online/orders/{order_id}/status",
+                json={"new_status": "cancelled", "reason": "test rollback"},
+            )


### PR DESCRIPTION
## Summary
- Add `auto_complete: bool = False` to `PATCH /online/orders/:id/status`
- When `true` + `new_status: confirmed`: atomically transitions `pending→confirmed→completed`
- Two rows inserted in `order_status_history` (full audit trail preserved)
- Second row has `reason: null` (identified via `auto_completed: true` in response)
- Existing state machine unchanged

## Stack
FastAPI + PostgreSQL

## Changes
- `app/routers/online_orders.py`: Added `auto_complete` field to request model
- `app/services/online_orders_service.py`: Added atomic double-transition logic
- `tests/test_online_order_status.py`: Added `TestAutoComplete` class

Closes #104