### PR TITLE
fix(otp): use EMAIL_FROM env var instead of hardcoded sender

### DIFF
--- a/app/services/otp_service.py
+++ b/app/services/otp_service.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException
 from app.database import get_db_connection
 from app.services.aws_ses_service import AWSSESService
 from app.core.exceptions import APIError
+from app.config import settings
 import logging
 
 logger = logging.getLogger(__name__)
@@ -105,7 +106,7 @@ WARO Colombia
             """.strip()
 
             email_sent = await ses_service.send_email(
-                from_email="hola@warocol.com",
+                from_email=settings.email_from or "hola@warocol.com",
                 from_name="WARO Colombia",
                 to_emails=[email],
                 subject=subject,


### PR DESCRIPTION
## Summary
- `otp_service.py` tenía `from_email` hardcodeado como `"hola@warocol.com"`
- Ahora usa `settings.email_from` (leído de `NUXT_PRIVATE_EMAIL_FROM` en `.env`)
- Fallback al valor hardcodeado si la var no está definida

## Changes
- `app/services/otp_service.py`: import `settings` + usar `settings.email_from or "hola@warocol.com"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)