### PR TITLE
fix(email): use FRONTEND_URL env var for tracking link and email footer

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     aws_secret_access_key: Optional[str] = Field(default=None, alias='NUXT_PRIVATE_AWS_SECRET_ACCESS_KEY')
     aws_region: Optional[str] = Field(default=None, alias='NUXT_PRIVATE_AWS_REGION')
     email_from: Optional[str] = Field(default=None, alias='NUXT_PRIVATE_EMAIL_FROM')
+    frontend_url: str = Field(default="https://warocol.com", alias='FRONTEND_URL')
 
     # Cloudflare R2 - S3-compatible storage
     r2_access_key_id: Optional[str] = Field(default=None, alias='NUXT_PRIVATE_R2_ACCESS_KEY_ID')

--- a/app/templates/order_confirmation_template.py
+++ b/app/templates/order_confirmation_template.py
@@ -6,6 +6,7 @@ Plain text format — matches the style of other transactional emails in the sys
 from datetime import datetime
 from zoneinfo import ZoneInfo
 from typing import Optional
+from app.config import settings
 
 BOGOTA_TZ = ZoneInfo("America/Bogota")
 
@@ -126,7 +127,7 @@ def get_order_confirmation_text(
 
     tracking_block = ""
     if order_id:
-        tracking_block = f"\nVER TU PEDIDO\n-------------\nPuedes seguir el estado de tu pedido en:\nhttps://warocol.com/mis-pedidos/{order_id}\n"
+        tracking_block = f"\nVER TU PEDIDO\n-------------\nPuedes seguir el estado de tu pedido en:\n{settings.frontend_url}/mis-pedidos/{order_id}\n"
 
     return f"""¡Hola!
 
@@ -152,7 +153,7 @@ El restaurante está revisando tu pedido. Te notificaremos cuando esté confirma
 {tracking_block}
 Gracias,
 WARO Colombia
-hola@warocol.com
+{settings.email_from or "hola@warocol.com"}
 """.strip()
 
 


### PR DESCRIPTION
## Summary
- Order confirmation email tenía `https://warocol.com/mis-pedidos/...` hardcodeado
- El footer tenía `hola@warocol.com` hardcodeado
- Ahora ambos se leen de variables de entorno

## Changes
- `app/config.py`: agrega `frontend_url` (`FRONTEND_URL`, default `https://warocol.com`)
- `app/templates/order_confirmation_template.py`: usa `settings.frontend_url` y `settings.email_from`
- `.env`: agrega `FRONTEND_URL=http://localhost:8080/waro-colombia` en dev, comentado en prod

## En local ahora enviará
```
https://warocol.com → http://localhost:8080/waro-colombia/mis-pedidos/{id}
hola@warocol.com → hola@warolabs.com (NUXT_PRIVATE_EMAIL_FROM)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)