### PR TITLE
fix(email): use EMAIL_FROM env var in email_helpers (#129)

### DIFF
--- a/app/services/email_helpers.py
+++ b/app/services/email_helpers.py
@@ -138,7 +138,7 @@ Tecnología colombiana para el mundo.
 
         ses_service = AWSSESService()
         success = await ses_service.send_email(
-            from_email="hola@warocol.com",
+            from_email=settings.email_from or "hola@warocol.com",
             from_name="Saifer 101 de Waro Colombia",
             to_emails=[supplier_email],
             subject=f"Nueva Solicitud de Cotización - {purchase_number}",
@@ -284,7 +284,7 @@ Tecnología colombiana para el mundo.
 
         ses_service = AWSSESService()
         success = await ses_service.send_email(
-            from_email="hola@warocol.com",
+            from_email=settings.email_from or "hola@warocol.com",
             from_name="Saifer 101 de Waro Colombia",
             to_emails=[supplier_email],
             subject=f"{purchase_number} - {info['title']}",
@@ -343,7 +343,7 @@ async def send_order_confirmation_email(
 
         ses_service = AWSSESService()
         success = await ses_service.send_email(
-            from_email="hola@warocol.com",
+            from_email=settings.email_from or "hola@warocol.com",
             from_name="WARO Colombia",
             to_emails=[customer_email],
             subject=subject,


### PR DESCRIPTION
## Summary
- Order confirmation emails were sending from hardcoded `hola@warocol.com`
- Same fix already applied to `otp_service.py` — now consistent across all email services
- Uses `settings.email_from or "hola@warocol.com"` fallback for safety

## Stack
🔵 FastAPI

## Changes
- `app/services/email_helpers.py`: replaced all hardcoded `hola@warocol.com` with `settings.email_from or "hola@warocol.com"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)