### PR TITLE
Tenant readiness gate for electronic invoicing (#130)

### DIFF
--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from fastapi import Depends, Request, HTTPException
 from app.core.tenant import detect_and_validate_tenant
 from app.core.security import get_session_token
@@ -19,3 +21,30 @@ async def require_auth(request: Request):
     session_token = await get_session_token(request)
     # TODO: Validate session against database
     return session_token
+
+
+async def require_invoicing_ready(request: Request) -> Dict[str, Any]:
+    """
+    Gate dependency for electronic-invoice emission endpoints (issue #130).
+
+    Resolves the active session, calls the invoicing-readiness service, and
+    raises 403 with a structured payload when the tenant is not ready. Returns
+    the readiness dict on success so handlers can read `checks` if needed.
+    """
+    from app.core.middleware import require_valid_session
+    from app.services import invoicing_readiness_service
+
+    session = require_valid_session(request)
+    payload = await invoicing_readiness_service.get_readiness(session.tenant_id)
+    if payload is None:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+    if not payload['ready']:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                'error':   'tenant_not_ready_for_invoicing',
+                'checks':  payload['checks'],
+                'missing': payload['missing'],
+            },
+        )
+    return payload

--- a/app/routers/invoices.py
+++ b/app/routers/invoices.py
@@ -8,10 +8,11 @@ corresponding upstream endpoints (/credit-note/emit, /debit-note/emit, /events).
 When api-facturacion is ready, replace the 503 stub body with a call to
 facturacion_service.proxy_to_facturacion().
 """
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from typing import Any, Dict, Optional
 from uuid import UUID
 from pydantic import BaseModel, Field
+from app.core.dependencies import require_invoicing_ready
 from app.core.middleware import require_valid_session
 
 router = APIRouter(prefix="/api/invoices", tags=["Invoices"])
@@ -37,13 +38,16 @@ async def emit_credit_note(
     request: Request,
     invoice_id: UUID,
     body: CreditNoteRequest,
+    _readiness: dict = Depends(require_invoicing_ready),
 ) -> Dict[str, Any]:
     """
     Emit a DIAN credit note for an existing invoice (correction or cancellation).
 
+    Returns 403 if the tenant is not ready for electronic invoicing
+    (issue #130: missing dev flag, fiscal data, or active resolution).
+
     Stub — returns 503 until api-facturacion /credit-note/emit is implemented.
     """
-    require_valid_session(request)
     raise HTTPException(status_code=503, detail=_STUB_DETAIL)
 
 
@@ -52,13 +56,16 @@ async def emit_debit_note(
     request: Request,
     invoice_id: UUID,
     body: DebitNoteRequest,
+    _readiness: dict = Depends(require_invoicing_ready),
 ) -> Dict[str, Any]:
     """
     Emit a DIAN debit note for an existing invoice (additional charge).
 
+    Returns 403 if the tenant is not ready for electronic invoicing
+    (issue #130: missing dev flag, fiscal data, or active resolution).
+
     Stub — returns 503 until api-facturacion /debit-note/emit is implemented.
     """
-    require_valid_session(request)
     raise HTTPException(status_code=503, detail=_STUB_DETAIL)
 
 

--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -2,11 +2,12 @@
 Orders Router
 Endpoints for listing and managing orders
 """
-from fastapi import APIRouter, HTTPException, Request, Query
+from fastapi import APIRouter, Depends, HTTPException, Request, Query
 from typing import Optional, List
 from uuid import UUID
 from pydantic import BaseModel, Field
 from app.services import orders_service, facturacion_service
+from app.core.dependencies import require_invoicing_ready
 from app.core.middleware import require_valid_session
 
 router = APIRouter(prefix="/orders", tags=["Orders"])
@@ -353,12 +354,16 @@ async def delete_order_item_modifier(
 async def emit_order_invoice(
     request: Request,
     order_id: UUID,
+    _readiness: dict = Depends(require_invoicing_ready),
 ):
     """
     Emit a DIAN electronic invoice for a completed POS order.
 
     Delegates to api-facturacion microservice via internal Docker network.
     Idempotent: calling twice for the same order returns the existing invoice.
+
+    Returns 403 if the tenant is not ready for electronic invoicing
+    (issue #130: missing dev flag, fiscal data, or active resolution).
 
     Returns: { order_id, invoice_number, prefix, cufe, status, pdf_presigned_url }
     """

--- a/app/routers/tenant_config.py
+++ b/app/routers/tenant_config.py
@@ -107,6 +107,27 @@ async def toggle_public_profile_endpoint(
     )
 
 
+@router.get("/invoicing-readiness")
+async def get_invoicing_readiness_endpoint(request: Request):
+    """
+    Return whether the active tenant can emit electronic invoices right now.
+
+    Three predicates must all be true: dev_flag_enabled, fiscal_data_complete,
+    active_resolution. See `app/services/invoicing_readiness_service.py` for
+    the full contract.
+
+    **Requires authentication**
+    """
+    from app.core.middleware import require_valid_session
+    from app.services import invoicing_readiness_service
+
+    session = require_valid_session(request)
+    payload = await invoicing_readiness_service.get_readiness(session.tenant_id)
+    if payload is None:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+    return payload
+
+
 @router.get("/tax-config")
 async def get_tax_config_endpoint(request: Request):
     """

--- a/app/services/invoicing_readiness_service.py
+++ b/app/services/invoicing_readiness_service.py
@@ -1,0 +1,113 @@
+"""
+Invoicing readiness service — issue #130
+
+Single source of truth for "can this tenant emit electronic invoices right now?"
+Four predicates must all be true:
+
+  1. dev_flag_enabled       — tenants.electronic_invoicing_enabled = true
+                              (dev-only kill switch, set via SQL during onboarding)
+  2. fiscal_data_complete   — tenant_fiscal_data has non-null nit, business_name,
+                              phone, email
+  3. active_resolution      — at least one row in dian_resolutions with
+                              is_active=true, valid date range, available numbers,
+                              and document_type='invoice'
+  4. taxes_configured       — tenant_tax_config has at least one of inc_applicable
+                              or iva_applicable set to true. In Colombian
+                              hospitality, having both off almost always means
+                              the tenant has not configured taxes yet — emitting
+                              an invoice with no tax lines would surface a
+                              misconfiguration to DIAN/Matías.
+
+Returned shape (this is the public contract — frontend issue uno0uno/warocol.com#450
+and microservice gate uno0uno/api-facturacion#17 must consume the same JSON):
+
+    {
+      "ready": bool,
+      "checks": {
+        "dev_flag_enabled":     bool,
+        "fiscal_data_complete": bool,
+        "active_resolution":    bool,
+        "taxes_configured":     bool,
+      },
+      "missing": [str, ...],   # human-readable Spanish reasons
+    }
+"""
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from app.database import get_db_connection
+
+
+_READINESS_QUERY = """
+SELECT
+    t.electronic_invoicing_enabled  AS dev_flag_enabled,
+    fd.nit                          AS nit,
+    fd.business_name                AS business_name,
+    fd.phone                        AS phone,
+    fd.email                        AS email,
+    COALESCE(ttc.inc_applicable, false) AS inc_applicable,
+    COALESCE(ttc.iva_applicable, false) AS iva_applicable,
+    EXISTS (
+        SELECT 1
+        FROM dian_resolutions r
+        WHERE r.tenant_id      = t.id
+          AND r.is_active      = true
+          AND r.document_type  = 'invoice'
+          AND CURRENT_DATE BETWEEN r.date_from AND r.date_to
+          AND r.current_number < r.to_number
+    ) AS active_resolution
+FROM tenants t
+LEFT JOIN tenant_fiscal_data fd ON fd.tenant_id = t.id
+LEFT JOIN tenant_tax_config  ttc ON ttc.tenant_id = t.id
+WHERE t.id = $1
+"""
+
+
+async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
+    """
+    Return the readiness payload for the given tenant, or None if the tenant
+    does not exist.
+    """
+    async with get_db_connection(use_transaction=False) as conn:
+        row = await conn.fetchrow(_READINESS_QUERY, tenant_id)
+
+    if row is None:
+        return None
+
+    dev_flag_enabled  = bool(row['dev_flag_enabled'])
+    active_resolution = bool(row['active_resolution'])
+    taxes_configured  = bool(row['inc_applicable']) or bool(row['iva_applicable'])
+
+    missing_fiscal_fields: List[str] = []
+    if row['nit'] is None:
+        missing_fiscal_fields.append('NIT')
+    if row['business_name'] is None:
+        missing_fiscal_fields.append('razón social')
+    if row['phone'] is None:
+        missing_fiscal_fields.append('teléfono')
+    if row['email'] is None:
+        missing_fiscal_fields.append('email')
+    fiscal_data_complete = len(missing_fiscal_fields) == 0
+
+    missing: List[str] = []
+    if not dev_flag_enabled:
+        missing.append('Facturación electrónica deshabilitada por el equipo de WARO')
+    if not fiscal_data_complete:
+        missing.append(
+            'Faltan datos fiscales: ' + ', '.join(missing_fiscal_fields)
+        )
+    if not active_resolution:
+        missing.append('No hay una resolución DIAN vigente con numeración disponible')
+    if not taxes_configured:
+        missing.append('No hay impuestos configurados (activa INC o IVA en Configuración fiscal)')
+
+    return {
+        'ready': dev_flag_enabled and fiscal_data_complete and active_resolution and taxes_configured,
+        'checks': {
+            'dev_flag_enabled':     dev_flag_enabled,
+            'fiscal_data_complete': fiscal_data_complete,
+            'active_resolution':    active_resolution,
+            'taxes_configured':     taxes_configured,
+        },
+        'missing': missing,
+    }

--- a/app/services/invoicing_readiness_service.py
+++ b/app/services/invoicing_readiness_service.py
@@ -12,11 +12,28 @@ Four predicates must all be true:
                               is_active=true, valid date range, available numbers,
                               and document_type='invoice'
   4. taxes_configured       — tenant_tax_config has at least one of inc_applicable
-                              or iva_applicable set to true. In Colombian
-                              hospitality, having both off almost always means
-                              the tenant has not configured taxes yet — emitting
-                              an invoice with no tax lines would surface a
-                              misconfiguration to DIAN/Matías.
+                              or iva_applicable set to true,
+                              OR tenant is "no responsable de IVA"
+                              (tenant_fiscal_data.tax_regime_id = 2,
+                              Art. 437 parágrafo 3 ET).
+
+About taxes_configured (relaxed in this iteration of #130):
+
+  DIAN Resolución 000165 de 2023 + Art. 437 parágrafo 3 ET allow tenants
+  classified as "no responsable de IVA" to emit electronic invoices WITHOUT
+  any IVA line. The factura must instead carry the legal note
+  "No responsable de IVA — Art. 437 parágrafo 3 ET". For those tenants,
+  emitting without INC or IVA configured is the correct behaviour, not a
+  misconfiguration.
+
+  For tenants who ARE responsible for IVA (tax_regime_id = 1) we keep the
+  stricter check: at least one of INC or IVA must be applicable. Restaurants
+  in the hospitality sector almost always cobrar at least one of the two,
+  so emitting with both off remains a misconfiguration we want to block.
+
+  Two follow-up scenarios are tracked separately and NOT covered here:
+    - Responsable de IVA que vende solo bienes excluidos (Art. 424 ET)
+    - Bienes exentos con tarifa 0% (Art. 477 / 481 ET)
 
 Returned shape (this is the public contract — frontend issue uno0uno/warocol.com#450
 and microservice gate uno0uno/api-facturacion#17 must consume the same JSON):
@@ -38,6 +55,12 @@ from uuid import UUID
 from app.database import get_db_connection
 
 
+# tax_regime_id values in tenant_fiscal_data (catalog mirrored in pages/facturacion.vue):
+#   1 = Responsable de IVA
+#   2 = No responsable del impuesto (Art. 437 parágrafo 3 ET)
+TAX_REGIME_NO_RESPONSABLE = 2
+
+
 _READINESS_QUERY = """
 SELECT
     t.electronic_invoicing_enabled  AS dev_flag_enabled,
@@ -45,6 +68,7 @@ SELECT
     fd.business_name                AS business_name,
     fd.phone                        AS phone,
     fd.email                        AS email,
+    fd.tax_regime_id                AS tax_regime_id,
     COALESCE(ttc.inc_applicable, false) AS inc_applicable,
     COALESCE(ttc.iva_applicable, false) AS iva_applicable,
     EXISTS (
@@ -76,7 +100,10 @@ async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
 
     dev_flag_enabled  = bool(row['dev_flag_enabled'])
     active_resolution = bool(row['active_resolution'])
-    taxes_configured  = bool(row['inc_applicable']) or bool(row['iva_applicable'])
+
+    is_no_responsable = row['tax_regime_id'] == TAX_REGIME_NO_RESPONSABLE
+    has_any_tax = bool(row['inc_applicable']) or bool(row['iva_applicable'])
+    taxes_configured = has_any_tax or is_no_responsable
 
     missing_fiscal_fields: List[str] = []
     if row['nit'] is None:
@@ -99,7 +126,13 @@ async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
     if not active_resolution:
         missing.append('No hay una resolución DIAN vigente con numeración disponible')
     if not taxes_configured:
-        missing.append('No hay impuestos configurados (activa INC o IVA en Configuración fiscal)')
+        # Only reachable when the tenant IS responsable de IVA (regime != 2)
+        # and has neither INC nor IVA applicable — that is the misconfiguration
+        # we want to block for the hospitality use case.
+        missing.append(
+            'No hay impuestos configurados (activa INC o IVA en Configuración fiscal,'
+            ' o cambia el régimen tributario a "No responsable" si aplica)'
+        )
 
     return {
         'ready': dev_flag_enabled and fiscal_data_complete and active_resolution and taxes_configured,

--- a/tests/test_invoicing_readiness.py
+++ b/tests/test_invoicing_readiness.py
@@ -26,6 +26,7 @@ def _row(
     active_resolution: bool = True,
     inc_applicable: bool = False,
     iva_applicable: bool = True,
+    tax_regime_id: int = 1,   # 1 = Responsable de IVA, 2 = No responsable
 ):
     return {
         'dev_flag_enabled':  dev_flag_enabled,
@@ -33,6 +34,7 @@ def _row(
         'business_name':     business_name,
         'phone':             phone,
         'email':             email,
+        'tax_regime_id':     tax_regime_id,
         'active_resolution': active_resolution,
         'inc_applicable':    inc_applicable,
         'iva_applicable':    iva_applicable,
@@ -87,13 +89,24 @@ class TestReadinessService:
         assert payload['ready'] is True
 
     @pytest.mark.asyncio
-    async def test_no_taxes_blocks_ready(self):
-        with _patch_db(_row(inc_applicable=False, iva_applicable=False)):
+    async def test_responsable_without_taxes_blocks_ready(self):
+        # Responsable de IVA (regime=1) without INC and without IVA → still blocks
+        with _patch_db(_row(inc_applicable=False, iva_applicable=False, tax_regime_id=1)):
             payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
 
         assert payload['checks']['taxes_configured'] is False
         assert payload['ready'] is False
         assert any('impuestos configurados' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_no_responsable_passes_without_taxes(self):
+        # No responsable de IVA (regime=2) emits without INC/IVA — Art. 437 ET parágrafo 3
+        with _patch_db(_row(inc_applicable=False, iva_applicable=False, tax_regime_id=2)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['taxes_configured'] is True
+        assert payload['ready'] is True
+        assert payload['missing'] == []
 
     @pytest.mark.asyncio
     async def test_dev_flag_off_blocks(self):
@@ -154,6 +167,7 @@ class TestReadinessService:
             active_resolution=False,
             inc_applicable=False,
             iva_applicable=False,
+            tax_regime_id=1,   # Responsable — needs taxes; if regime were 2, taxes pass
         )):
             payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
 

--- a/tests/test_invoicing_readiness.py
+++ b/tests/test_invoicing_readiness.py
@@ -1,0 +1,244 @@
+"""
+Tests for invoicing readiness service and gate (issue #130).
+
+Covers:
+  - readiness service builds the correct payload from each row shape
+  - readiness gate raises 403 when not ready, lets through when ready
+  - emit endpoints reject without ever calling api-facturacion when not ready
+"""
+import pytest
+from httpx import AsyncClient
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+from app.services import invoicing_readiness_service
+
+
+_TENANT_ID = UUID('93b3e582-34fa-44a6-8d0f-bf82a3608727')
+
+
+def _row(
+    dev_flag_enabled: bool = True,
+    nit: str = '900123456',
+    business_name: str = 'ACME SAS',
+    phone: str = '3001234567',
+    email: str = 'contacto@acme.co',
+    active_resolution: bool = True,
+    inc_applicable: bool = False,
+    iva_applicable: bool = True,
+):
+    return {
+        'dev_flag_enabled':  dev_flag_enabled,
+        'nit':               nit,
+        'business_name':     business_name,
+        'phone':             phone,
+        'email':             email,
+        'active_resolution': active_resolution,
+        'inc_applicable':    inc_applicable,
+        'iva_applicable':    iva_applicable,
+    }
+
+
+class _FakeConnCtx:
+    def __init__(self, row):
+        self._row = row
+
+    async def __aenter__(self):
+        conn = MagicMock()
+        conn.fetchrow = AsyncMock(return_value=self._row)
+        return conn
+
+    async def __aexit__(self, *_):
+        return False
+
+
+def _patch_db(row):
+    return patch(
+        'app.services.invoicing_readiness_service.get_db_connection',
+        lambda *args, **kwargs: _FakeConnCtx(row),
+    )
+
+
+class TestReadinessService:
+    """Unit tests for `invoicing_readiness_service.get_readiness`."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_all_four_checks_true(self):
+        with _patch_db(_row()):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload is not None
+        assert payload['ready'] is True
+        assert payload['checks'] == {
+            'dev_flag_enabled':     True,
+            'fiscal_data_complete': True,
+            'active_resolution':    True,
+            'taxes_configured':     True,
+        }
+        assert payload['missing'] == []
+
+    @pytest.mark.asyncio
+    async def test_taxes_configured_via_inc_alone(self):
+        # Restaurant under INC (8%) without IVA → still considered configured
+        with _patch_db(_row(inc_applicable=True, iva_applicable=False)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['taxes_configured'] is True
+        assert payload['ready'] is True
+
+    @pytest.mark.asyncio
+    async def test_no_taxes_blocks_ready(self):
+        with _patch_db(_row(inc_applicable=False, iva_applicable=False)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['taxes_configured'] is False
+        assert payload['ready'] is False
+        assert any('impuestos configurados' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_dev_flag_off_blocks(self):
+        with _patch_db(_row(dev_flag_enabled=False)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['ready'] is False
+        assert payload['checks']['dev_flag_enabled'] is False
+        assert any('deshabilitada por el equipo' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_missing_nit_marks_fiscal_incomplete(self):
+        with _patch_db(_row(nit=None)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['ready'] is False
+        assert payload['checks']['fiscal_data_complete'] is False
+        assert any('NIT' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_missing_business_name(self):
+        with _patch_db(_row(business_name=None)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['fiscal_data_complete'] is False
+        assert any('razón social' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_missing_phone(self):
+        with _patch_db(_row(phone=None)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['fiscal_data_complete'] is False
+        assert any('teléfono' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_missing_email(self):
+        with _patch_db(_row(email=None)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['fiscal_data_complete'] is False
+        assert any('email' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_no_active_resolution(self):
+        with _patch_db(_row(active_resolution=False)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['ready'] is False
+        assert payload['checks']['active_resolution'] is False
+        assert any('resolución DIAN' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_all_four_failing_lists_four_reasons(self):
+        with _patch_db(_row(
+            dev_flag_enabled=False,
+            nit=None,
+            active_resolution=False,
+            inc_applicable=False,
+            iva_applicable=False,
+        )):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['ready'] is False
+        assert len(payload['missing']) == 4
+
+    @pytest.mark.asyncio
+    async def test_unknown_tenant_returns_none(self):
+        with _patch_db(None):
+            payload = await invoicing_readiness_service.get_readiness(uuid4())
+
+        assert payload is None
+
+
+class TestEmitGate:
+    """The emission endpoints must 403 when readiness fails — and never call
+    api-facturacion / Matías. The gate is a `Depends`, not deep in the
+    service, so we don't need a full test client to assert this contract;
+    we exercise the dependency directly."""
+
+    @pytest.mark.asyncio
+    async def test_dependency_raises_403_when_not_ready(self):
+        from app.core.dependencies import require_invoicing_ready
+        from fastapi import HTTPException
+
+        request = MagicMock()
+        request.state.session_context = MagicMock()
+        request.state.session_context.is_valid = True
+        request.state.session_context.tenant_id = _TENANT_ID
+
+        with patch(
+            'app.services.invoicing_readiness_service.get_readiness',
+            new=AsyncMock(return_value={
+                'ready':   False,
+                'checks':  {
+                    'dev_flag_enabled':     False,
+                    'fiscal_data_complete': True,
+                    'active_resolution':    True,
+                    'taxes_configured':     True,
+                },
+                'missing': ['Facturación electrónica deshabilitada por el equipo de WARO'],
+            }),
+        ), patch('app.core.middleware.require_valid_session', return_value=request.state.session_context):
+            with pytest.raises(HTTPException) as exc:
+                await require_invoicing_ready(request)
+
+        assert exc.value.status_code == 403
+        assert exc.value.detail['error'] == 'tenant_not_ready_for_invoicing'
+        assert 'missing' in exc.value.detail
+        assert 'checks' in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_dependency_passes_through_when_ready(self):
+        from app.core.dependencies import require_invoicing_ready
+
+        request = MagicMock()
+        request.state.session_context = MagicMock()
+        request.state.session_context.is_valid = True
+        request.state.session_context.tenant_id = _TENANT_ID
+
+        ready_payload = {
+            'ready':   True,
+            'checks':  {
+                'dev_flag_enabled':     True,
+                'fiscal_data_complete': True,
+                'active_resolution':    True,
+                'taxes_configured':     True,
+            },
+            'missing': [],
+        }
+        with patch(
+            'app.services.invoicing_readiness_service.get_readiness',
+            new=AsyncMock(return_value=ready_payload),
+        ), patch('app.core.middleware.require_valid_session', return_value=request.state.session_context):
+            result = await require_invoicing_ready(request)
+
+        assert result == ready_payload
+
+
+class TestEmitEndpointSmokeTest:
+    """End-to-end smoke: the emit endpoint exists, requires auth, and never
+    crashes the app on import. Behaviour assertions are covered by the unit
+    tests above."""
+
+    @pytest.mark.asyncio
+    async def test_emit_invoice_requires_auth(self, client: AsyncClient):
+        response = await client.post(f'/orders/{uuid4()}/invoice')
+        assert response.status_code in (401, 403, 422)


### PR DESCRIPTION
## Summary

Adds the backend readiness gate that prevents emitting electronic invoices until a tenant is fully configured with Matías/DIAN.

## Stack

🔵 FastAPI · 🟣 PostgreSQL · 🐍 Python 3.9

## Changes

- **Migration 054** (gitignored, applied via psql) — `tenants.electronic_invoicing_enabled BOOLEAN NOT NULL DEFAULT false`. Dev-only kill switch, set via SQL.
- `app/services/invoicing_readiness_service.py` *(new)* — single SQL JOIN that returns `{ ready, checks: { dev_flag_enabled, fiscal_data_complete, active_resolution, taxes_configured }, missing[] }`.
- `app/routers/tenant_config.py` — `GET /api/tenant/invoicing-readiness` endpoint.
- `app/core/dependencies.py` — `require_invoicing_ready` dependency that raises `403 Forbidden` with the structured payload when not ready.
- `app/routers/orders.py` — gates `POST /{order_id}/invoice`.
- `app/routers/invoices.py` — gates `POST /{invoice_id}/credit-note` and `/debit-note`.
- `tests/test_invoicing_readiness.py` *(new)* — covers each failure mode + happy path + dependency contract.

## Why four checks

1. `dev_flag_enabled` — Matías portal onboarding is manual; gate prevents premature emission.
2. `fiscal_data_complete` — required by Matías for the invoice payload.
3. `active_resolution` — required by DIAN; emission needs an authorized number range.
4. `taxes_configured` — INC or IVA must be on; emitting without tax lines surfaces a misconfiguration to DIAN/Matías.

## Test plan

- [ ] `GET /api/tenant/invoicing-readiness` returns the four-check shape.
- [ ] `POST /orders/{id}/invoice` returns `403` with `tenant_not_ready_for_invoicing` when any check fails.
- [ ] `pytest tests/test_invoicing_readiness.py -v` passes.
- [ ] Existing read endpoints (GET /orders/{id}/invoice, dian-status) continue to work — they don't go through the gate.

Closes #130