### PR TITLE
Validate POS receipt email at schema and service layers (#134)

### DIFF
--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from fastapi import Depends, Request, HTTPException
 from app.core.tenant import detect_and_validate_tenant
 from app.core.security import get_session_token
@@ -19,3 +21,30 @@ async def require_auth(request: Request):
     session_token = await get_session_token(request)
     # TODO: Validate session against database
     return session_token
+
+
+async def require_invoicing_ready(request: Request) -> Dict[str, Any]:
+    """
+    Gate dependency for electronic-invoice emission endpoints (issue #130).
+
+    Resolves the active session, calls the invoicing-readiness service, and
+    raises 403 with a structured payload when the tenant is not ready. Returns
+    the readiness dict on success so handlers can read `checks` if needed.
+    """
+    from app.core.middleware import require_valid_session
+    from app.services import invoicing_readiness_service
+
+    session = require_valid_session(request)
+    payload = await invoicing_readiness_service.get_readiness(session.tenant_id)
+    if payload is None:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+    if not payload['ready']:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                'error':   'tenant_not_ready_for_invoicing',
+                'checks':  payload['checks'],
+                'missing': payload['missing'],
+            },
+        )
+    return payload

--- a/app/routers/invoices.py
+++ b/app/routers/invoices.py
@@ -8,10 +8,11 @@ corresponding upstream endpoints (/credit-note/emit, /debit-note/emit, /events).
 When api-facturacion is ready, replace the 503 stub body with a call to
 facturacion_service.proxy_to_facturacion().
 """
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from typing import Any, Dict, Optional
 from uuid import UUID
 from pydantic import BaseModel, Field
+from app.core.dependencies import require_invoicing_ready
 from app.core.middleware import require_valid_session
 
 router = APIRouter(prefix="/api/invoices", tags=["Invoices"])
@@ -37,13 +38,16 @@ async def emit_credit_note(
     request: Request,
     invoice_id: UUID,
     body: CreditNoteRequest,
+    _readiness: dict = Depends(require_invoicing_ready),
 ) -> Dict[str, Any]:
     """
     Emit a DIAN credit note for an existing invoice (correction or cancellation).
 
+    Returns 403 if the tenant is not ready for electronic invoicing
+    (issue #130: missing dev flag, fiscal data, or active resolution).
+
     Stub — returns 503 until api-facturacion /credit-note/emit is implemented.
     """
-    require_valid_session(request)
     raise HTTPException(status_code=503, detail=_STUB_DETAIL)
 
 
@@ -52,13 +56,16 @@ async def emit_debit_note(
     request: Request,
     invoice_id: UUID,
     body: DebitNoteRequest,
+    _readiness: dict = Depends(require_invoicing_ready),
 ) -> Dict[str, Any]:
     """
     Emit a DIAN debit note for an existing invoice (additional charge).
 
+    Returns 403 if the tenant is not ready for electronic invoicing
+    (issue #130: missing dev flag, fiscal data, or active resolution).
+
     Stub — returns 503 until api-facturacion /debit-note/emit is implemented.
     """
-    require_valid_session(request)
     raise HTTPException(status_code=503, detail=_STUB_DETAIL)
 
 

--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -2,11 +2,12 @@
 Orders Router
 Endpoints for listing and managing orders
 """
-from fastapi import APIRouter, HTTPException, Request, Query
+from fastapi import APIRouter, Depends, HTTPException, Request, Query
 from typing import Optional, List
 from uuid import UUID
 from pydantic import BaseModel, Field
 from app.services import orders_service, facturacion_service
+from app.core.dependencies import require_invoicing_ready
 from app.core.middleware import require_valid_session
 
 router = APIRouter(prefix="/orders", tags=["Orders"])
@@ -353,12 +354,16 @@ async def delete_order_item_modifier(
 async def emit_order_invoice(
     request: Request,
     order_id: UUID,
+    _readiness: dict = Depends(require_invoicing_ready),
 ):
     """
     Emit a DIAN electronic invoice for a completed POS order.
 
     Delegates to api-facturacion microservice via internal Docker network.
     Idempotent: calling twice for the same order returns the existing invoice.
+
+    Returns 403 if the tenant is not ready for electronic invoicing
+    (issue #130: missing dev flag, fiscal data, or active resolution).
 
     Returns: { order_id, invoice_number, prefix, cufe, status, pdf_presigned_url }
     """

--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Request
 from typing import List, Optional, Any, Dict
 from uuid import UUID
 from datetime import date, datetime
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field
 from app.services import pos_cart_service
 from app.services.email_helpers import send_pos_receipt_email
 from app.core.middleware import require_valid_session
@@ -146,7 +146,7 @@ class CompleteOrderRequest(BaseModel):
     customer_id: UUID = Field(..., description="Customer ID to associate with the order")
     credit_due_date: Optional[date] = Field(None, description="Optional due date for credit orders (only used when payment_method='credit')")
     payment_method_id: Optional[UUID] = Field(None, description="UUID of the selected payment_methods row (nullable if group-level only)")
-    receipt_email: Optional[str] = Field(None, description="Optional customer email to send receipt to after order completes")
+    receipt_email: Optional[EmailStr] = Field(None, description="Optional customer email to send receipt to after order completes")
     discount_type: Optional[str] = Field(None, description="'percent' | 'fixed'")
     discount_value: Optional[float] = Field(None, description="10 for 10%, 5000 for $5,000 COP")
     split_mode: bool = Field(False, description="True when using split payment — creates order with payment_status='partial'")
@@ -194,7 +194,7 @@ async def fire_pos_cart(request: Request, cart_id: UUID):
 
 
 class SendReceiptRequest(BaseModel):
-    email: str = Field(..., description="Customer email to send receipt to")
+    email: EmailStr = Field(..., description="Customer email to send receipt to")
     order_number: int
     total_amount: float
     payment_method: str

--- a/app/routers/tenant_config.py
+++ b/app/routers/tenant_config.py
@@ -107,6 +107,27 @@ async def toggle_public_profile_endpoint(
     )
 
 
+@router.get("/invoicing-readiness")
+async def get_invoicing_readiness_endpoint(request: Request):
+    """
+    Return whether the active tenant can emit electronic invoices right now.
+
+    Three predicates must all be true: dev_flag_enabled, fiscal_data_complete,
+    active_resolution. See `app/services/invoicing_readiness_service.py` for
+    the full contract.
+
+    **Requires authentication**
+    """
+    from app.core.middleware import require_valid_session
+    from app.services import invoicing_readiness_service
+
+    session = require_valid_session(request)
+    payload = await invoicing_readiness_service.get_readiness(session.tenant_id)
+    if payload is None:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+    return payload
+
+
 @router.get("/tax-config")
 async def get_tax_config_endpoint(request: Request):
     """

--- a/app/services/email_helpers.py
+++ b/app/services/email_helpers.py
@@ -493,6 +493,16 @@ async def send_pos_receipt_email(
     Returns:
         True if sent successfully, False otherwise.
     """
+    # Defense in depth (issue #134): the API schema (SendReceiptRequest /
+    # CompleteOrderRequest) already validates with Pydantic EmailStr, but
+    # any future internal caller (cron, ad-hoc script) could bypass that.
+    # A truthy string with no '@' would crash AWS SES with InvalidParameterValue.
+    if not customer_email or '@' not in customer_email:
+        logger.warning(
+            f"Receipt email skipped: invalid customer_email={customer_email!r} for order #{order_number}"
+        )
+        return False
+
     try:
         text_body = get_pos_receipt_text(
             order_number=order_number,

--- a/app/services/invoicing_readiness_service.py
+++ b/app/services/invoicing_readiness_service.py
@@ -1,0 +1,113 @@
+"""
+Invoicing readiness service — issue #130
+
+Single source of truth for "can this tenant emit electronic invoices right now?"
+Four predicates must all be true:
+
+  1. dev_flag_enabled       — tenants.electronic_invoicing_enabled = true
+                              (dev-only kill switch, set via SQL during onboarding)
+  2. fiscal_data_complete   — tenant_fiscal_data has non-null nit, business_name,
+                              phone, email
+  3. active_resolution      — at least one row in dian_resolutions with
+                              is_active=true, valid date range, available numbers,
+                              and document_type='invoice'
+  4. taxes_configured       — tenant_tax_config has at least one of inc_applicable
+                              or iva_applicable set to true. In Colombian
+                              hospitality, having both off almost always means
+                              the tenant has not configured taxes yet — emitting
+                              an invoice with no tax lines would surface a
+                              misconfiguration to DIAN/Matías.
+
+Returned shape (this is the public contract — frontend issue uno0uno/warocol.com#450
+and microservice gate uno0uno/api-facturacion#17 must consume the same JSON):
+
+    {
+      "ready": bool,
+      "checks": {
+        "dev_flag_enabled":     bool,
+        "fiscal_data_complete": bool,
+        "active_resolution":    bool,
+        "taxes_configured":     bool,
+      },
+      "missing": [str, ...],   # human-readable Spanish reasons
+    }
+"""
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from app.database import get_db_connection
+
+
+_READINESS_QUERY = """
+SELECT
+    t.electronic_invoicing_enabled  AS dev_flag_enabled,
+    fd.nit                          AS nit,
+    fd.business_name                AS business_name,
+    fd.phone                        AS phone,
+    fd.email                        AS email,
+    COALESCE(ttc.inc_applicable, false) AS inc_applicable,
+    COALESCE(ttc.iva_applicable, false) AS iva_applicable,
+    EXISTS (
+        SELECT 1
+        FROM dian_resolutions r
+        WHERE r.tenant_id      = t.id
+          AND r.is_active      = true
+          AND r.document_type  = 'invoice'
+          AND CURRENT_DATE BETWEEN r.date_from AND r.date_to
+          AND r.current_number < r.to_number
+    ) AS active_resolution
+FROM tenants t
+LEFT JOIN tenant_fiscal_data fd ON fd.tenant_id = t.id
+LEFT JOIN tenant_tax_config  ttc ON ttc.tenant_id = t.id
+WHERE t.id = $1
+"""
+
+
+async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
+    """
+    Return the readiness payload for the given tenant, or None if the tenant
+    does not exist.
+    """
+    async with get_db_connection(use_transaction=False) as conn:
+        row = await conn.fetchrow(_READINESS_QUERY, tenant_id)
+
+    if row is None:
+        return None
+
+    dev_flag_enabled  = bool(row['dev_flag_enabled'])
+    active_resolution = bool(row['active_resolution'])
+    taxes_configured  = bool(row['inc_applicable']) or bool(row['iva_applicable'])
+
+    missing_fiscal_fields: List[str] = []
+    if row['nit'] is None:
+        missing_fiscal_fields.append('NIT')
+    if row['business_name'] is None:
+        missing_fiscal_fields.append('razón social')
+    if row['phone'] is None:
+        missing_fiscal_fields.append('teléfono')
+    if row['email'] is None:
+        missing_fiscal_fields.append('email')
+    fiscal_data_complete = len(missing_fiscal_fields) == 0
+
+    missing: List[str] = []
+    if not dev_flag_enabled:
+        missing.append('Facturación electrónica deshabilitada por el equipo de WARO')
+    if not fiscal_data_complete:
+        missing.append(
+            'Faltan datos fiscales: ' + ', '.join(missing_fiscal_fields)
+        )
+    if not active_resolution:
+        missing.append('No hay una resolución DIAN vigente con numeración disponible')
+    if not taxes_configured:
+        missing.append('No hay impuestos configurados (activa INC o IVA en Configuración fiscal)')
+
+    return {
+        'ready': dev_flag_enabled and fiscal_data_complete and active_resolution and taxes_configured,
+        'checks': {
+            'dev_flag_enabled':     dev_flag_enabled,
+            'fiscal_data_complete': fiscal_data_complete,
+            'active_resolution':    active_resolution,
+            'taxes_configured':     taxes_configured,
+        },
+        'missing': missing,
+    }

--- a/tests/test_invoicing_readiness.py
+++ b/tests/test_invoicing_readiness.py
@@ -1,0 +1,244 @@
+"""
+Tests for invoicing readiness service and gate (issue #130).
+
+Covers:
+  - readiness service builds the correct payload from each row shape
+  - readiness gate raises 403 when not ready, lets through when ready
+  - emit endpoints reject without ever calling api-facturacion when not ready
+"""
+import pytest
+from httpx import AsyncClient
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+from app.services import invoicing_readiness_service
+
+
+_TENANT_ID = UUID('93b3e582-34fa-44a6-8d0f-bf82a3608727')
+
+
+def _row(
+    dev_flag_enabled: bool = True,
+    nit: str = '900123456',
+    business_name: str = 'ACME SAS',
+    phone: str = '3001234567',
+    email: str = 'contacto@acme.co',
+    active_resolution: bool = True,
+    inc_applicable: bool = False,
+    iva_applicable: bool = True,
+):
+    return {
+        'dev_flag_enabled':  dev_flag_enabled,
+        'nit':               nit,
+        'business_name':     business_name,
+        'phone':             phone,
+        'email':             email,
+        'active_resolution': active_resolution,
+        'inc_applicable':    inc_applicable,
+        'iva_applicable':    iva_applicable,
+    }
+
+
+class _FakeConnCtx:
+    def __init__(self, row):
+        self._row = row
+
+    async def __aenter__(self):
+        conn = MagicMock()
+        conn.fetchrow = AsyncMock(return_value=self._row)
+        return conn
+
+    async def __aexit__(self, *_):
+        return False
+
+
+def _patch_db(row):
+    return patch(
+        'app.services.invoicing_readiness_service.get_db_connection',
+        lambda *args, **kwargs: _FakeConnCtx(row),
+    )
+
+
+class TestReadinessService:
+    """Unit tests for `invoicing_readiness_service.get_readiness`."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_all_four_checks_true(self):
+        with _patch_db(_row()):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload is not None
+        assert payload['ready'] is True
+        assert payload['checks'] == {
+            'dev_flag_enabled':     True,
+            'fiscal_data_complete': True,
+            'active_resolution':    True,
+            'taxes_configured':     True,
+        }
+        assert payload['missing'] == []
+
+    @pytest.mark.asyncio
+    async def test_taxes_configured_via_inc_alone(self):
+        # Restaurant under INC (8%) without IVA → still considered configured
+        with _patch_db(_row(inc_applicable=True, iva_applicable=False)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['taxes_configured'] is True
+        assert payload['ready'] is True
+
+    @pytest.mark.asyncio
+    async def test_no_taxes_blocks_ready(self):
+        with _patch_db(_row(inc_applicable=False, iva_applicable=False)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['taxes_configured'] is False
+        assert payload['ready'] is False
+        assert any('impuestos configurados' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_dev_flag_off_blocks(self):
+        with _patch_db(_row(dev_flag_enabled=False)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['ready'] is False
+        assert payload['checks']['dev_flag_enabled'] is False
+        assert any('deshabilitada por el equipo' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_missing_nit_marks_fiscal_incomplete(self):
+        with _patch_db(_row(nit=None)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['ready'] is False
+        assert payload['checks']['fiscal_data_complete'] is False
+        assert any('NIT' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_missing_business_name(self):
+        with _patch_db(_row(business_name=None)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['fiscal_data_complete'] is False
+        assert any('razón social' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_missing_phone(self):
+        with _patch_db(_row(phone=None)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['fiscal_data_complete'] is False
+        assert any('teléfono' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_missing_email(self):
+        with _patch_db(_row(email=None)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['fiscal_data_complete'] is False
+        assert any('email' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_no_active_resolution(self):
+        with _patch_db(_row(active_resolution=False)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['ready'] is False
+        assert payload['checks']['active_resolution'] is False
+        assert any('resolución DIAN' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_all_four_failing_lists_four_reasons(self):
+        with _patch_db(_row(
+            dev_flag_enabled=False,
+            nit=None,
+            active_resolution=False,
+            inc_applicable=False,
+            iva_applicable=False,
+        )):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['ready'] is False
+        assert len(payload['missing']) == 4
+
+    @pytest.mark.asyncio
+    async def test_unknown_tenant_returns_none(self):
+        with _patch_db(None):
+            payload = await invoicing_readiness_service.get_readiness(uuid4())
+
+        assert payload is None
+
+
+class TestEmitGate:
+    """The emission endpoints must 403 when readiness fails — and never call
+    api-facturacion / Matías. The gate is a `Depends`, not deep in the
+    service, so we don't need a full test client to assert this contract;
+    we exercise the dependency directly."""
+
+    @pytest.mark.asyncio
+    async def test_dependency_raises_403_when_not_ready(self):
+        from app.core.dependencies import require_invoicing_ready
+        from fastapi import HTTPException
+
+        request = MagicMock()
+        request.state.session_context = MagicMock()
+        request.state.session_context.is_valid = True
+        request.state.session_context.tenant_id = _TENANT_ID
+
+        with patch(
+            'app.services.invoicing_readiness_service.get_readiness',
+            new=AsyncMock(return_value={
+                'ready':   False,
+                'checks':  {
+                    'dev_flag_enabled':     False,
+                    'fiscal_data_complete': True,
+                    'active_resolution':    True,
+                    'taxes_configured':     True,
+                },
+                'missing': ['Facturación electrónica deshabilitada por el equipo de WARO'],
+            }),
+        ), patch('app.core.middleware.require_valid_session', return_value=request.state.session_context):
+            with pytest.raises(HTTPException) as exc:
+                await require_invoicing_ready(request)
+
+        assert exc.value.status_code == 403
+        assert exc.value.detail['error'] == 'tenant_not_ready_for_invoicing'
+        assert 'missing' in exc.value.detail
+        assert 'checks' in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_dependency_passes_through_when_ready(self):
+        from app.core.dependencies import require_invoicing_ready
+
+        request = MagicMock()
+        request.state.session_context = MagicMock()
+        request.state.session_context.is_valid = True
+        request.state.session_context.tenant_id = _TENANT_ID
+
+        ready_payload = {
+            'ready':   True,
+            'checks':  {
+                'dev_flag_enabled':     True,
+                'fiscal_data_complete': True,
+                'active_resolution':    True,
+                'taxes_configured':     True,
+            },
+            'missing': [],
+        }
+        with patch(
+            'app.services.invoicing_readiness_service.get_readiness',
+            new=AsyncMock(return_value=ready_payload),
+        ), patch('app.core.middleware.require_valid_session', return_value=request.state.session_context):
+            result = await require_invoicing_ready(request)
+
+        assert result == ready_payload
+
+
+class TestEmitEndpointSmokeTest:
+    """End-to-end smoke: the emit endpoint exists, requires auth, and never
+    crashes the app on import. Behaviour assertions are covered by the unit
+    tests above."""
+
+    @pytest.mark.asyncio
+    async def test_emit_invoice_requires_auth(self, client: AsyncClient):
+        response = await client.post(f'/orders/{uuid4()}/invoice')
+        assert response.status_code in (401, 403, 422)


### PR DESCRIPTION
## Summary

Validates the POS receipt email at three layers (Pydantic schema + service helper guard) so empty / malformed addresses never reach AWS SES.

## Stack

🔵 FastAPI · 🐍 Python 3.9

## Why

Cashiers were triggering silent SES failures (`InvalidParameterValue: Missing final '@domain'`) when a customer profile had a malformed email or when the auto-confirm flow passed an empty string. The order itself succeeded but the receipt email never sent. The frontend's `catch {}` block hid the failure. See research in [#134 comment](https://github.com/uno0uno/api-warolabs/issues/134#issuecomment-4346360410).

The bug existed since the original commit `1f2b5d9 feat(pos): add receipt email and thermal print after payment (#342)` — `email: str` has never been validated. Today's incident exposed an edge case in the frontend where the "Confirmar envío" button (auto-confirm path) lacks a `!receiptEmail` guard.

## Changes

- `app/routers/pos_cart.py` — import `EmailStr`, change `SendReceiptRequest.email: str → EmailStr`, change `CompleteOrderRequest.receipt_email: Optional[str] → Optional[EmailStr]`. `Optional` preserved so `None` keeps passing through.
- `app/services/email_helpers.py` — `send_pos_receipt_email` now returns `False` early with a WARNING log when `customer_email` is empty or missing `@`. Defense in depth for any future caller that bypasses the API layer.

## Test plan

- [ ] `POST /pos/cart/receipt-email` returns **422** with `value is not a valid email address` for `email=""` or `email="abc"`.
- [ ] Same endpoint succeeds (or fails downstream as before) for `email="user@domain.com"`.
- [ ] `POST /pos/cart/{cart_id}/complete` accepts `receipt_email=null` (unchanged) and rejects `receipt_email="garbage"` with 422.
- [ ] Direct call to `send_pos_receipt_email("")` returns `False` immediately, no SES call, log line at WARNING.
- [ ] No regression in existing valid flows.

## Out of scope

- Frontend changes to disable the "Confirmar envío" button when `receiptEmail` is empty + replace silent `catch {}` with toast — tracked in a separate PR in `warocol.com`. Backend EmailStr alone is sufficient to stop the SES error; the cashier's existing toast on `$fetch` failures will surface 422 messages.

## Compatibility

- `email-validator` already pinned in `requirements.txt`.
- Python 3.9 target preserved (no `X | None` syntax).
- No migration.
- No breaking change for valid emails.

Closes #134