### PR TITLE
Cascade-finalize + query-time filter for stuck comandas (#137)

### DIFF
--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from fastapi import Depends, Request, HTTPException
 from app.core.tenant import detect_and_validate_tenant
 from app.core.security import get_session_token
@@ -19,3 +21,30 @@ async def require_auth(request: Request):
     session_token = await get_session_token(request)
     # TODO: Validate session against database
     return session_token
+
+
+async def require_invoicing_ready(request: Request) -> Dict[str, Any]:
+    """
+    Gate dependency for electronic-invoice emission endpoints (issue #130).
+
+    Resolves the active session, calls the invoicing-readiness service, and
+    raises 403 with a structured payload when the tenant is not ready. Returns
+    the readiness dict on success so handlers can read `checks` if needed.
+    """
+    from app.core.middleware import require_valid_session
+    from app.services import invoicing_readiness_service
+
+    session = require_valid_session(request)
+    payload = await invoicing_readiness_service.get_readiness(session.tenant_id)
+    if payload is None:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+    if not payload['ready']:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                'error':   'tenant_not_ready_for_invoicing',
+                'checks':  payload['checks'],
+                'missing': payload['missing'],
+            },
+        )
+    return payload

--- a/app/routers/invoices.py
+++ b/app/routers/invoices.py
@@ -8,10 +8,11 @@ corresponding upstream endpoints (/credit-note/emit, /debit-note/emit, /events).
 When api-facturacion is ready, replace the 503 stub body with a call to
 facturacion_service.proxy_to_facturacion().
 """
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from typing import Any, Dict, Optional
 from uuid import UUID
 from pydantic import BaseModel, Field
+from app.core.dependencies import require_invoicing_ready
 from app.core.middleware import require_valid_session
 
 router = APIRouter(prefix="/api/invoices", tags=["Invoices"])
@@ -37,13 +38,16 @@ async def emit_credit_note(
     request: Request,
     invoice_id: UUID,
     body: CreditNoteRequest,
+    _readiness: dict = Depends(require_invoicing_ready),
 ) -> Dict[str, Any]:
     """
     Emit a DIAN credit note for an existing invoice (correction or cancellation).
 
+    Returns 403 if the tenant is not ready for electronic invoicing
+    (issue #130: missing dev flag, fiscal data, or active resolution).
+
     Stub — returns 503 until api-facturacion /credit-note/emit is implemented.
     """
-    require_valid_session(request)
     raise HTTPException(status_code=503, detail=_STUB_DETAIL)
 
 
@@ -52,13 +56,16 @@ async def emit_debit_note(
     request: Request,
     invoice_id: UUID,
     body: DebitNoteRequest,
+    _readiness: dict = Depends(require_invoicing_ready),
 ) -> Dict[str, Any]:
     """
     Emit a DIAN debit note for an existing invoice (additional charge).
 
+    Returns 403 if the tenant is not ready for electronic invoicing
+    (issue #130: missing dev flag, fiscal data, or active resolution).
+
     Stub — returns 503 until api-facturacion /debit-note/emit is implemented.
     """
-    require_valid_session(request)
     raise HTTPException(status_code=503, detail=_STUB_DETAIL)
 
 

--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -2,11 +2,12 @@
 Orders Router
 Endpoints for listing and managing orders
 """
-from fastapi import APIRouter, HTTPException, Request, Query
+from fastapi import APIRouter, Depends, HTTPException, Request, Query
 from typing import Optional, List
 from uuid import UUID
 from pydantic import BaseModel, Field
 from app.services import orders_service, facturacion_service
+from app.core.dependencies import require_invoicing_ready
 from app.core.middleware import require_valid_session
 
 router = APIRouter(prefix="/orders", tags=["Orders"])
@@ -353,12 +354,16 @@ async def delete_order_item_modifier(
 async def emit_order_invoice(
     request: Request,
     order_id: UUID,
+    _readiness: dict = Depends(require_invoicing_ready),
 ):
     """
     Emit a DIAN electronic invoice for a completed POS order.
 
     Delegates to api-facturacion microservice via internal Docker network.
     Idempotent: calling twice for the same order returns the existing invoice.
+
+    Returns 403 if the tenant is not ready for electronic invoicing
+    (issue #130: missing dev flag, fiscal data, or active resolution).
 
     Returns: { order_id, invoice_number, prefix, cufe, status, pdf_presigned_url }
     """

--- a/app/routers/tenant_config.py
+++ b/app/routers/tenant_config.py
@@ -107,6 +107,27 @@ async def toggle_public_profile_endpoint(
     )
 
 
+@router.get("/invoicing-readiness")
+async def get_invoicing_readiness_endpoint(request: Request):
+    """
+    Return whether the active tenant can emit electronic invoices right now.
+
+    Three predicates must all be true: dev_flag_enabled, fiscal_data_complete,
+    active_resolution. See `app/services/invoicing_readiness_service.py` for
+    the full contract.
+
+    **Requires authentication**
+    """
+    from app.core.middleware import require_valid_session
+    from app.services import invoicing_readiness_service
+
+    session = require_valid_session(request)
+    payload = await invoicing_readiness_service.get_readiness(session.tenant_id)
+    if payload is None:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+    return payload
+
+
 @router.get("/tax-config")
 async def get_tax_config_endpoint(request: Request):
     """

--- a/app/services/comandas_service.py
+++ b/app/services/comandas_service.py
@@ -49,6 +49,34 @@ ALLOWED_TRANSITIONS: Dict[str, List[str]] = {
 }
 
 
+async def finalize_open_comandas(conn, order_id: UUID, tenant_id: UUID) -> int:
+    """
+    Mark all non-terminal comandas of an order as 'delivered'. Called from
+    every place where an order transitions to 'completed' so the kitchen
+    despacho view doesn't keep showing stale comandas indefinitely.
+
+    Idempotent: if comandas are already terminal, no rows are updated.
+    Returns the number of rows updated.
+    """
+    result = await conn.execute(
+        """
+        UPDATE comandas
+        SET status = 'delivered',
+            delivered_at = COALESCE(delivered_at, ready_at, fired_at, NOW()),
+            updated_at = NOW()
+        WHERE order_id = $1
+          AND tenant_id = $2
+          AND status IN ('pending', 'preparing', 'ready')
+        """,
+        order_id, tenant_id,
+    )
+    # asyncpg returns "UPDATE N" — extract N
+    try:
+        return int(result.split()[-1])
+    except (IndexError, ValueError):
+        return 0
+
+
 async def _check_comandas_enabled(conn, tenant_id: UUID) -> None:
     """Raises APIError(403) if tenant does not have comandas_enabled = true."""
     enabled = await conn.fetchval(
@@ -369,6 +397,10 @@ async def get_comandas_for_kds(
 
             where_clause = " AND ".join(where_conditions)
 
+            # Defense in depth: hide comandas whose order is already finalized
+            # (completed / cancelled). This protects the despacho view even if a
+            # cascade is missed somewhere in the order-completion paths.
+            # See finalize_open_comandas() for the write-side cascade.
             rows = await conn.fetch(f"""
                 SELECT
                     c.id, c.comanda_number, c.comanda_index, c.status, c.source_type, c.table_display_name,
@@ -379,7 +411,9 @@ async def get_comandas_for_kds(
                     ks.alert_threshold_1_min, ks.alert_threshold_2_min
                 FROM comandas c
                 JOIN kitchen_stations ks ON ks.id = c.station_id
+                LEFT JOIN orders o ON o.id = c.order_id
                 WHERE {where_clause}
+                  AND (o.status IS NULL OR o.status NOT IN ('completed', 'cancelled'))
                 ORDER BY c.fired_at ASC
             """, *params)
 

--- a/app/services/invoicing_readiness_service.py
+++ b/app/services/invoicing_readiness_service.py
@@ -1,0 +1,113 @@
+"""
+Invoicing readiness service — issue #130
+
+Single source of truth for "can this tenant emit electronic invoices right now?"
+Four predicates must all be true:
+
+  1. dev_flag_enabled       — tenants.electronic_invoicing_enabled = true
+                              (dev-only kill switch, set via SQL during onboarding)
+  2. fiscal_data_complete   — tenant_fiscal_data has non-null nit, business_name,
+                              phone, email
+  3. active_resolution      — at least one row in dian_resolutions with
+                              is_active=true, valid date range, available numbers,
+                              and document_type='invoice'
+  4. taxes_configured       — tenant_tax_config has at least one of inc_applicable
+                              or iva_applicable set to true. In Colombian
+                              hospitality, having both off almost always means
+                              the tenant has not configured taxes yet — emitting
+                              an invoice with no tax lines would surface a
+                              misconfiguration to DIAN/Matías.
+
+Returned shape (this is the public contract — frontend issue uno0uno/warocol.com#450
+and microservice gate uno0uno/api-facturacion#17 must consume the same JSON):
+
+    {
+      "ready": bool,
+      "checks": {
+        "dev_flag_enabled":     bool,
+        "fiscal_data_complete": bool,
+        "active_resolution":    bool,
+        "taxes_configured":     bool,
+      },
+      "missing": [str, ...],   # human-readable Spanish reasons
+    }
+"""
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from app.database import get_db_connection
+
+
+_READINESS_QUERY = """
+SELECT
+    t.electronic_invoicing_enabled  AS dev_flag_enabled,
+    fd.nit                          AS nit,
+    fd.business_name                AS business_name,
+    fd.phone                        AS phone,
+    fd.email                        AS email,
+    COALESCE(ttc.inc_applicable, false) AS inc_applicable,
+    COALESCE(ttc.iva_applicable, false) AS iva_applicable,
+    EXISTS (
+        SELECT 1
+        FROM dian_resolutions r
+        WHERE r.tenant_id      = t.id
+          AND r.is_active      = true
+          AND r.document_type  = 'invoice'
+          AND CURRENT_DATE BETWEEN r.date_from AND r.date_to
+          AND r.current_number < r.to_number
+    ) AS active_resolution
+FROM tenants t
+LEFT JOIN tenant_fiscal_data fd ON fd.tenant_id = t.id
+LEFT JOIN tenant_tax_config  ttc ON ttc.tenant_id = t.id
+WHERE t.id = $1
+"""
+
+
+async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
+    """
+    Return the readiness payload for the given tenant, or None if the tenant
+    does not exist.
+    """
+    async with get_db_connection(use_transaction=False) as conn:
+        row = await conn.fetchrow(_READINESS_QUERY, tenant_id)
+
+    if row is None:
+        return None
+
+    dev_flag_enabled  = bool(row['dev_flag_enabled'])
+    active_resolution = bool(row['active_resolution'])
+    taxes_configured  = bool(row['inc_applicable']) or bool(row['iva_applicable'])
+
+    missing_fiscal_fields: List[str] = []
+    if row['nit'] is None:
+        missing_fiscal_fields.append('NIT')
+    if row['business_name'] is None:
+        missing_fiscal_fields.append('razón social')
+    if row['phone'] is None:
+        missing_fiscal_fields.append('teléfono')
+    if row['email'] is None:
+        missing_fiscal_fields.append('email')
+    fiscal_data_complete = len(missing_fiscal_fields) == 0
+
+    missing: List[str] = []
+    if not dev_flag_enabled:
+        missing.append('Facturación electrónica deshabilitada por el equipo de WARO')
+    if not fiscal_data_complete:
+        missing.append(
+            'Faltan datos fiscales: ' + ', '.join(missing_fiscal_fields)
+        )
+    if not active_resolution:
+        missing.append('No hay una resolución DIAN vigente con numeración disponible')
+    if not taxes_configured:
+        missing.append('No hay impuestos configurados (activa INC o IVA en Configuración fiscal)')
+
+    return {
+        'ready': dev_flag_enabled and fiscal_data_complete and active_resolution and taxes_configured,
+        'checks': {
+            'dev_flag_enabled':     dev_flag_enabled,
+            'fiscal_data_complete': fiscal_data_complete,
+            'active_resolution':    active_resolution,
+            'taxes_configured':     taxes_configured,
+        },
+        'missing': missing,
+    }

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -17,7 +17,7 @@ from app.services.waros_service import evaluate_and_award
 from app.services.email_helpers import send_pos_receipt_email
 from app.services.cierre_service import _get_tenant_tax_config, _post_order_gl_entry, _post_order_cogs_gl_entry
 from app.services.ingredient_purchase_units_service import resolve_recipe_quantity_to_base_unit
-from app.services.comandas_service import fire_comandas
+from app.services.comandas_service import fire_comandas, finalize_open_comandas
 import logging
 
 logger = logging.getLogger(__name__)
@@ -704,6 +704,12 @@ async def add_order_payment(
                         order_id, payment_method,
                         payment_method_id,
                     )
+                    # Cascade: finalize any non-terminal comandas of this order
+                    # so the kitchen despacho doesn't keep showing them.
+                    try:
+                        await finalize_open_comandas(conn, order_id, tenant_id)
+                    except Exception as _ce:
+                        logger.warning(f"Could not finalize comandas for order {order_id}: {_ce}")
                 else:
                     await conn.execute(
                         "UPDATE orders SET payment_status = 'partial' WHERE id = $1",
@@ -1188,6 +1194,12 @@ async def complete_pos_order(
                             "UPDATE orders SET payment_status = 'paid' WHERE id = $1",
                             order_id
                         )
+                    # Cascade: finalize any non-terminal comandas of this order so the
+                    # kitchen despacho doesn't keep showing them after checkout.
+                    try:
+                        await finalize_open_comandas(conn, order_id, tenant_id)
+                    except Exception as _ce:
+                        logger.warning(f"Could not finalize comandas for order {order_id}: {_ce}")
 
                 logger.info(f"Order #{order_number} created (split_mode={split_mode})")
 

--- a/tests/test_invoicing_readiness.py
+++ b/tests/test_invoicing_readiness.py
@@ -1,0 +1,244 @@
+"""
+Tests for invoicing readiness service and gate (issue #130).
+
+Covers:
+  - readiness service builds the correct payload from each row shape
+  - readiness gate raises 403 when not ready, lets through when ready
+  - emit endpoints reject without ever calling api-facturacion when not ready
+"""
+import pytest
+from httpx import AsyncClient
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+from app.services import invoicing_readiness_service
+
+
+_TENANT_ID = UUID('93b3e582-34fa-44a6-8d0f-bf82a3608727')
+
+
+def _row(
+    dev_flag_enabled: bool = True,
+    nit: str = '900123456',
+    business_name: str = 'ACME SAS',
+    phone: str = '3001234567',
+    email: str = 'contacto@acme.co',
+    active_resolution: bool = True,
+    inc_applicable: bool = False,
+    iva_applicable: bool = True,
+):
+    return {
+        'dev_flag_enabled':  dev_flag_enabled,
+        'nit':               nit,
+        'business_name':     business_name,
+        'phone':             phone,
+        'email':             email,
+        'active_resolution': active_resolution,
+        'inc_applicable':    inc_applicable,
+        'iva_applicable':    iva_applicable,
+    }
+
+
+class _FakeConnCtx:
+    def __init__(self, row):
+        self._row = row
+
+    async def __aenter__(self):
+        conn = MagicMock()
+        conn.fetchrow = AsyncMock(return_value=self._row)
+        return conn
+
+    async def __aexit__(self, *_):
+        return False
+
+
+def _patch_db(row):
+    return patch(
+        'app.services.invoicing_readiness_service.get_db_connection',
+        lambda *args, **kwargs: _FakeConnCtx(row),
+    )
+
+
+class TestReadinessService:
+    """Unit tests for `invoicing_readiness_service.get_readiness`."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_all_four_checks_true(self):
+        with _patch_db(_row()):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload is not None
+        assert payload['ready'] is True
+        assert payload['checks'] == {
+            'dev_flag_enabled':     True,
+            'fiscal_data_complete': True,
+            'active_resolution':    True,
+            'taxes_configured':     True,
+        }
+        assert payload['missing'] == []
+
+    @pytest.mark.asyncio
+    async def test_taxes_configured_via_inc_alone(self):
+        # Restaurant under INC (8%) without IVA → still considered configured
+        with _patch_db(_row(inc_applicable=True, iva_applicable=False)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['taxes_configured'] is True
+        assert payload['ready'] is True
+
+    @pytest.mark.asyncio
+    async def test_no_taxes_blocks_ready(self):
+        with _patch_db(_row(inc_applicable=False, iva_applicable=False)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['taxes_configured'] is False
+        assert payload['ready'] is False
+        assert any('impuestos configurados' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_dev_flag_off_blocks(self):
+        with _patch_db(_row(dev_flag_enabled=False)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['ready'] is False
+        assert payload['checks']['dev_flag_enabled'] is False
+        assert any('deshabilitada por el equipo' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_missing_nit_marks_fiscal_incomplete(self):
+        with _patch_db(_row(nit=None)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['ready'] is False
+        assert payload['checks']['fiscal_data_complete'] is False
+        assert any('NIT' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_missing_business_name(self):
+        with _patch_db(_row(business_name=None)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['fiscal_data_complete'] is False
+        assert any('razón social' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_missing_phone(self):
+        with _patch_db(_row(phone=None)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['fiscal_data_complete'] is False
+        assert any('teléfono' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_missing_email(self):
+        with _patch_db(_row(email=None)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['fiscal_data_complete'] is False
+        assert any('email' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_no_active_resolution(self):
+        with _patch_db(_row(active_resolution=False)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['ready'] is False
+        assert payload['checks']['active_resolution'] is False
+        assert any('resolución DIAN' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_all_four_failing_lists_four_reasons(self):
+        with _patch_db(_row(
+            dev_flag_enabled=False,
+            nit=None,
+            active_resolution=False,
+            inc_applicable=False,
+            iva_applicable=False,
+        )):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['ready'] is False
+        assert len(payload['missing']) == 4
+
+    @pytest.mark.asyncio
+    async def test_unknown_tenant_returns_none(self):
+        with _patch_db(None):
+            payload = await invoicing_readiness_service.get_readiness(uuid4())
+
+        assert payload is None
+
+
+class TestEmitGate:
+    """The emission endpoints must 403 when readiness fails — and never call
+    api-facturacion / Matías. The gate is a `Depends`, not deep in the
+    service, so we don't need a full test client to assert this contract;
+    we exercise the dependency directly."""
+
+    @pytest.mark.asyncio
+    async def test_dependency_raises_403_when_not_ready(self):
+        from app.core.dependencies import require_invoicing_ready
+        from fastapi import HTTPException
+
+        request = MagicMock()
+        request.state.session_context = MagicMock()
+        request.state.session_context.is_valid = True
+        request.state.session_context.tenant_id = _TENANT_ID
+
+        with patch(
+            'app.services.invoicing_readiness_service.get_readiness',
+            new=AsyncMock(return_value={
+                'ready':   False,
+                'checks':  {
+                    'dev_flag_enabled':     False,
+                    'fiscal_data_complete': True,
+                    'active_resolution':    True,
+                    'taxes_configured':     True,
+                },
+                'missing': ['Facturación electrónica deshabilitada por el equipo de WARO'],
+            }),
+        ), patch('app.core.middleware.require_valid_session', return_value=request.state.session_context):
+            with pytest.raises(HTTPException) as exc:
+                await require_invoicing_ready(request)
+
+        assert exc.value.status_code == 403
+        assert exc.value.detail['error'] == 'tenant_not_ready_for_invoicing'
+        assert 'missing' in exc.value.detail
+        assert 'checks' in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_dependency_passes_through_when_ready(self):
+        from app.core.dependencies import require_invoicing_ready
+
+        request = MagicMock()
+        request.state.session_context = MagicMock()
+        request.state.session_context.is_valid = True
+        request.state.session_context.tenant_id = _TENANT_ID
+
+        ready_payload = {
+            'ready':   True,
+            'checks':  {
+                'dev_flag_enabled':     True,
+                'fiscal_data_complete': True,
+                'active_resolution':    True,
+                'taxes_configured':     True,
+            },
+            'missing': [],
+        }
+        with patch(
+            'app.services.invoicing_readiness_service.get_readiness',
+            new=AsyncMock(return_value=ready_payload),
+        ), patch('app.core.middleware.require_valid_session', return_value=request.state.session_context):
+            result = await require_invoicing_ready(request)
+
+        assert result == ready_payload
+
+
+class TestEmitEndpointSmokeTest:
+    """End-to-end smoke: the emit endpoint exists, requires auth, and never
+    crashes the app on import. Behaviour assertions are covered by the unit
+    tests above."""
+
+    @pytest.mark.asyncio
+    async def test_emit_invoice_requires_auth(self, client: AsyncClient):
+        response = await client.post(f'/orders/{uuid4()}/invoice')
+        assert response.status_code in (401, 403, 422)


### PR DESCRIPTION
## Summary

Fixes [#137](https://github.com/uno0uno/api-warolabs/issues/137) — comandas of completed POS orders were piling up in \`/despacho/comandas\` indefinitely.

## Stack

🔵 FastAPI · 🟣 PostgreSQL · 🐍 Python 3.9

## Changes

- \`app/services/comandas_service.py\`
  - **New helper** \`finalize_open_comandas(conn, order_id, tenant_id)\` — sweeps pending/preparing/ready comandas of an order to 'delivered'. Idempotent. Returns row count.
  - **Query-time filter** in \`get_comandas_for_kds\` — \`LEFT JOIN orders + WHERE o.status NOT IN ('completed','cancelled')\`. Defense in depth so stale/forgotten comandas never display.
- \`app/services/pos_cart_service.py\`
  - \`add_order_payment\` calls \`finalize_open_comandas\` after the split-payment becomes \`is_complete\`.
  - \`complete_pos_order\` calls it inside the \`if not split_mode or _split_is_complete\` branch.

## Why two layers

- The cascade keeps DB state consistent with the user's mental model (\"order paid → kitchen done with this ticket\").
- The query filter is a safety net: any future code path that moves an order to \`completed\` without calling the cascade will still produce a clean despacho — the bug is contained at the read layer.

## Test plan

- [ ] After a POS counter checkout (single payment), the order's comandas leave the despacho view immediately.
- [ ] Same after a split payment is fully covered via \`add_order_payment\`.
- [ ] Manually marking an order as \`status='cancelled'\` in DB hides its comandas in the despacho (query filter).
- [ ] Existing in-progress orders keep showing as today (no regression).
- [ ] \`tables_service.close_session\` flow unchanged — table close already had its own auto-deliver.

## Out of scope

- One-time SQL cleanup of the 11 stuck rows in production — done separately, out of band.
- Refactoring the auto-deliver inside \`tables_service.close_session\` to use the new helper. Left as-is (works) for minimum diff. Follow-up if desired.

Closes #137