### PR TITLE
feat(products): allow products without ingredients (skip inventory tracking)

### DIFF
--- a/app/models/product.py
+++ b/app/models/product.py
@@ -1,5 +1,5 @@
 # Product models for menu management
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field
 from typing import Optional, List, Literal, Dict, Any
 from uuid import UUID
 from datetime import datetime
@@ -68,22 +68,20 @@ class ProductBase(BaseModel):
     kitchen_name: Optional[str] = Field(None, max_length=100)
 
 class ProductCreate(ProductBase):
-    """Create product with recipe"""
-    # Products must have at least one ingredient OR at least one recipe base
-    # Both can be present, but at least one is required for inventory control
+    """Create product with recipe.
+
+    Products MAY have zero ingredients and zero recipe bases — those products
+    do not control inventory (no rows are written to product_recipes /
+    product_base_recipes, and stock deduction is a no-op at order completion).
+    Used for service-like items (delivery surcharge, tip), pre-packed goods
+    that don't warrant inventory tracking, and resale products without recipe.
+    """
     ingredients: List[RecipeIngredientBase] = Field(
         default=[],
-        description="Recipe ingredients (optional if recipe_base_ids provided)"
+        description="Recipe ingredients (empty list = no inventory tracking)"
     )
-    recipe_base_ids: List[UUID] = Field(default=[], description="List of recipe base IDs")
+    recipe_base_ids: List[UUID] = Field(default=[], description="List of recipe base IDs (empty list = no inventory tracking)")
     tenant_id: UUID = Field(..., description="Tenant ID")
-
-    @model_validator(mode='after')
-    def validate_has_ingredients_or_recipe_bases(self):
-        """Ensure product has at least one ingredient or one recipe base"""
-        if not self.ingredients and not self.recipe_base_ids:
-            raise ValueError("El producto debe tener al menos un ingrediente o una receta base")
-        return self
 
 class ProductUpdate(BaseModel):
     """Update product fields"""

--- a/app/services/products_service.py
+++ b/app/services/products_service.py
@@ -33,15 +33,11 @@ async def create_product_with_recipe(
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
 
-        # VALIDATION: Products must have at least one ingredient OR at least one recipe base
+        # Products may be created without recipe — those skip inventory tracking.
+        # See app/models/product.py ProductCreate docstring.
         has_ingredients = product_data.ingredients and len(product_data.ingredients) > 0
         has_recipe_bases = product_data.recipe_base_ids and len(product_data.recipe_base_ids) > 0
-
-        if not has_ingredients and not has_recipe_bases:
-            raise HTTPException(
-                status_code=400,
-                detail="El producto debe tener al menos un ingrediente o una receta base."
-            )
+        tracks_inventory = has_ingredients or has_recipe_bases
 
         async with get_db_connection() as conn:
             # Start transaction
@@ -123,29 +119,38 @@ async def create_product_with_recipe(
                             tenant_id
                         )
 
-                # 4. Calculate and update product cost (last purchase price)
-                cost_query = """
-                    UPDATE product
-                    SET costo_calculado = (
-                        SELECT COALESCE(SUM(
-                            pr.quantity * COALESCE(
-                                (SELECT pi.unit_cost
-                                 FROM tenant_purchase_items pi
-                                 JOIN tenant_purchases tp ON pi.purchase_id = tp.id
-                                 WHERE pi.ingredient_id = pr.ingredient_id
-                                   AND tp.tenant_id = $2
-                                   AND pi.unit_cost IS NOT NULL AND pi.unit_cost > 0
-                                 ORDER BY tp.purchase_date DESC LIMIT 1),
-                                i.costo_unitario, 0
-                            )
-                        ), 0)
-                        FROM product_recipes pr
-                        JOIN ingredients i ON pr.ingredient_id = i.id
-                        WHERE pr.product_id = $1
+                # 4. Calculate and update product cost (last purchase price).
+                # Products without recipe persist costo_calculado=NULL — semantically
+                # "not applicable" rather than "$0", which avoids polluting margin
+                # reports and lets the frontend render "—".
+                if tracks_inventory:
+                    cost_query = """
+                        UPDATE product
+                        SET costo_calculado = (
+                            SELECT COALESCE(SUM(
+                                pr.quantity * COALESCE(
+                                    (SELECT pi.unit_cost
+                                     FROM tenant_purchase_items pi
+                                     JOIN tenant_purchases tp ON pi.purchase_id = tp.id
+                                     WHERE pi.ingredient_id = pr.ingredient_id
+                                       AND tp.tenant_id = $2
+                                       AND pi.unit_cost IS NOT NULL AND pi.unit_cost > 0
+                                     ORDER BY tp.purchase_date DESC LIMIT 1),
+                                    i.costo_unitario, 0
+                                )
+                            ), 0)
+                            FROM product_recipes pr
+                            JOIN ingredients i ON pr.ingredient_id = i.id
+                            WHERE pr.product_id = $1
+                        )
+                        WHERE id = $1
+                    """
+                    await conn.execute(cost_query, product_id, tenant_id)
+                else:
+                    await conn.execute(
+                        "UPDATE product SET costo_calculado = NULL WHERE id = $1",
+                        product_id,
                     )
-                    WHERE id = $1
-                """
-                await conn.execute(cost_query, product_id, tenant_id)
 
                 # 5. Registrar en historial
                 user_id = session_context.user_id if hasattr(session_context, 'user_id') else None
@@ -793,28 +798,9 @@ async def update_product_with_recipe(
                                 tenant_id
                             )
 
-                # 3. Update recipe if ingredients provided
+                # 3. Update recipe if ingredients provided.
+                # Empty list is now valid — product becomes "no inventory tracking".
                 if product_data.ingredients is not None:
-                    # VALIDATION: Cannot remove all ingredients unless there are recipe bases
-                    if len(product_data.ingredients) == 0:
-                        # Check if product will have recipe bases
-                        has_recipe_bases = False
-                        if product_data.recipe_base_ids is not None:
-                            has_recipe_bases = len(product_data.recipe_base_ids) > 0
-                        else:
-                            # Check existing recipe bases in database
-                            existing_bases = await conn.fetchval(
-                                "SELECT COUNT(*) FROM product_base_recipes WHERE product_id = $1",
-                                product_id
-                            )
-                            has_recipe_bases = existing_bases > 0
-
-                        if not has_recipe_bases:
-                            raise HTTPException(
-                                status_code=400,
-                                detail="El producto debe tener al menos un ingrediente o una receta base."
-                            )
-
                     # Delete existing recipe
                     delete_recipe_query = "DELETE FROM product_recipes WHERE product_id = $1"
                     await conn.execute(delete_recipe_query, product_id)
@@ -844,29 +830,47 @@ async def update_product_with_recipe(
                                 tenant_id
                             )
 
-                    # 4. Recalculate product cost (last purchase price)
-                    cost_query = """
-                        UPDATE product
-                        SET costo_calculado = (
-                            SELECT COALESCE(SUM(
-                                pr.quantity * COALESCE(
-                                    (SELECT pi.unit_cost
-                                     FROM tenant_purchase_items pi
-                                     JOIN tenant_purchases tp ON pi.purchase_id = tp.id
-                                     WHERE pi.ingredient_id = pr.ingredient_id
-                                       AND tp.tenant_id = $2
-                                       AND pi.unit_cost IS NOT NULL AND pi.unit_cost > 0
-                                     ORDER BY tp.purchase_date DESC LIMIT 1),
-                                    i.costo_unitario, 0
-                                )
-                            ), 0)
-                            FROM product_recipes pr
-                            JOIN ingredients i ON pr.ingredient_id = i.id
-                            WHERE pr.product_id = $1
+                    # 4. Recalculate product cost (last purchase price).
+                    # Without recipe → NULL (semantically "no aplica") so the
+                    # margin/cost UI renders "—" instead of $0.
+                    has_any_recipe = await conn.fetchval(
+                        """
+                        SELECT EXISTS (
+                            SELECT 1 FROM product_recipes WHERE product_id = $1
+                            UNION ALL
+                            SELECT 1 FROM product_base_recipes WHERE product_id = $1
                         )
-                        WHERE id = $1
-                    """
-                    await conn.execute(cost_query, product_id, tenant_id)
+                        """,
+                        product_id,
+                    )
+                    if has_any_recipe:
+                        cost_query = """
+                            UPDATE product
+                            SET costo_calculado = (
+                                SELECT COALESCE(SUM(
+                                    pr.quantity * COALESCE(
+                                        (SELECT pi.unit_cost
+                                         FROM tenant_purchase_items pi
+                                         JOIN tenant_purchases tp ON pi.purchase_id = tp.id
+                                         WHERE pi.ingredient_id = pr.ingredient_id
+                                           AND tp.tenant_id = $2
+                                           AND pi.unit_cost IS NOT NULL AND pi.unit_cost > 0
+                                         ORDER BY tp.purchase_date DESC LIMIT 1),
+                                        i.costo_unitario, 0
+                                    )
+                                ), 0)
+                                FROM product_recipes pr
+                                JOIN ingredients i ON pr.ingredient_id = i.id
+                                WHERE pr.product_id = $1
+                            )
+                            WHERE id = $1
+                        """
+                        await conn.execute(cost_query, product_id, tenant_id)
+                    else:
+                        await conn.execute(
+                            "UPDATE product SET costo_calculado = NULL WHERE id = $1",
+                            product_id,
+                        )
 
                 # 5. Registrar cambios en historial
                 if old_snapshot:

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -165,3 +165,61 @@ class TestProductByIdEndpoint:
                     product = response.json()
                     assert "data" in product
                     assert product["data"]["id"] == product_id
+
+
+class TestProductCreateModel:
+    """Tests for the ProductCreate Pydantic model — issue #456 (allow products without ingredients)"""
+
+    def test_create_with_empty_recipe_succeeds(self):
+        """Issue #456: ProductCreate must accept empty ingredients AND empty recipe_base_ids."""
+        from app.models.product import ProductCreate
+        product = ProductCreate(
+            name="Cargo de domicilio",
+            price=5000,
+            category_id=uuid4(),
+            ingredients=[],
+            recipe_base_ids=[],
+            tenant_id=uuid4(),
+        )
+        assert product.ingredients == []
+        assert product.recipe_base_ids == []
+
+    def test_create_with_only_ingredients_succeeds(self):
+        """ProductCreate accepts only ingredients (no recipe bases) — pre-existing behavior preserved."""
+        from app.models.product import ProductCreate, RecipeIngredientBase
+        product = ProductCreate(
+            name="Hamburguesa",
+            price=15000,
+            category_id=uuid4(),
+            ingredients=[RecipeIngredientBase(ingredient_id=uuid4(), quantity=100, unit="g")],
+            recipe_base_ids=[],
+            tenant_id=uuid4(),
+        )
+        assert len(product.ingredients) == 1
+
+    def test_create_with_only_recipe_bases_succeeds(self):
+        """ProductCreate accepts only recipe bases (no direct ingredients) — pre-existing behavior preserved."""
+        from app.models.product import ProductCreate
+        product = ProductCreate(
+            name="Combo",
+            price=20000,
+            category_id=uuid4(),
+            ingredients=[],
+            recipe_base_ids=[uuid4()],
+            tenant_id=uuid4(),
+        )
+        assert len(product.recipe_base_ids) == 1
+
+    def test_create_validates_price_still_required(self):
+        """Removing the recipe validator must NOT loosen other validators (price > 0)."""
+        from app.models.product import ProductCreate
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            ProductCreate(
+                name="Bad",
+                price=0,  # invalid: gt=0
+                category_id=uuid4(),
+                ingredients=[],
+                recipe_base_ids=[],
+                tenant_id=uuid4(),
+            )


### PR DESCRIPTION
## Summary

Allows creating products with no ingredients and no recipe bases. Those products do not control inventory — stock deduction is a no-op at order completion in POS, mesa/barra, and delivery surfaces.

## Stack
🔵 FastAPI · 🐍 Python 3.9

## Background

The runtime already supported this case: stock deduction queries use `UNION ALL` which gracefully handles empty recipe rows. Two products without recipe (`Carantanta`, `tomate chonto`) already exist in prod and were sold 15 times without errors — this PR formalizes the path by removing the create/update validators and persisting `costo_calculado=NULL` (instead of 0) for products without recipe.

## Changes

- `app/models/product.py` — drop the `@model_validator` `validate_has_ingredients_or_recipe_bases` from `ProductCreate`. Update docstring.
- `app/services/products_service.py` —
  - `create_product_with_recipe`: drop the duplicate guard. Persist `costo_calculado=NULL` when the product has no recipe.
  - `update_product_with_recipe`: drop the guard that blocked removing all ingredients. Persist `costo_calculado=NULL` when the product ends up without recipe.
- `tests/test_products.py` — 4 new Pydantic-level tests covering: empty recipe accepted, only-ingredients accepted, only-recipe-bases accepted, price>0 still enforced.

## Testing

- [x] `pytest tests/test_products.py::TestProductCreateModel` — 4/4 passing in 3.5s
- [x] App imports clean (`from app import main` exit 0)
- [ ] Manual end-to-end against local: create product without recipe → verify DB row has `costo_calculado IS NULL` → sell in POS → verify no `tenant_ingredient_movements` row inserted
- [ ] Manual: edit existing product, remove all ingredients → save → verify `costo_calculado` becomes NULL

## Pairs with

`uno0uno/warocol.com` PR — frontend toggle and visual badges.

Closes warocol.com#456