### PR TITLE
fix(analytics): include mesa-originated orders in POS aggregates

### DIFF
--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -32,6 +32,16 @@ def parse_date(date_str: Optional[str]) -> Optional[date]:
 logger = logging.getLogger(__name__)
 
 
+POS_LIKE_FILTER = (
+    "(pos_cart_id IS NOT NULL OR table_session_id IS NOT NULL "
+    "OR extra_attributes->>'source' = 'manual')"
+)
+POS_LIKE_FILTER_ALIAS_O = (
+    "(o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL "
+    "OR o.extra_attributes->>'source' = 'manual')"
+)
+
+
 def _compute_tax_breakdown(
     items_rows: List[Any],
     tax_config: Dict[str, Any],
@@ -752,7 +762,7 @@ async def get_customers_list(
         async with get_db_connection() as conn:
             where_conditions = [
                 "o.tenant_id = $1",
-                "(o.pos_cart_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')",
+                "(o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')",
                 "o.customer_id IS NOT NULL",
             ]
             params = [tenant_id]
@@ -892,7 +902,7 @@ async def get_customer_detail(
                 FROM orders o
                 LEFT JOIN profile p ON o.customer_id = p.id
                 WHERE o.tenant_id = $1
-                  AND (o.pos_cart_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')
+                  AND (o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')
                   AND o.customer_id = $2
                 GROUP BY o.customer_id, p.name, p.phone_number, p.email
                 """,
@@ -906,7 +916,7 @@ async def get_customer_detail(
             # --- Paginated order history ---
             where_conditions = [
                 "o.tenant_id = $1",
-                "(o.pos_cart_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')",
+                "(o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')",
                 "o.customer_id = $2",
             ]
             params = [tenant_id, customer_id]
@@ -1084,7 +1094,7 @@ async def get_orders_metrics(
 
         async with get_db_connection() as conn:
             # Build WHERE clause
-            where_conditions = ["tenant_id = $1", "(pos_cart_id IS NOT NULL OR extra_attributes->>'source' = 'manual')"]
+            where_conditions = ["tenant_id = $1", "(pos_cart_id IS NOT NULL OR table_session_id IS NOT NULL OR extra_attributes->>'source' = 'manual')"]
             params = [tenant_id]
             param_count = 1
 
@@ -1142,7 +1152,7 @@ async def get_orders_metrics(
                 tax_config = await _get_tenant_tax_config(conn, tenant_id)
                 # Rebuild WHERE without payment_method_id for tax query (order_items has no that filter)
                 tax_where = ["o.tenant_id = $1", "o.status = 'completed'",
-                             "(o.pos_cart_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')"]
+                             "(o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')"]
                 tax_params: List[Any] = [tenant_id]
                 tax_pc = 1
                 if parsed_date_from:
@@ -1277,7 +1287,7 @@ async def get_orders_dashboard(
                     ), 0) as year_sales
 
                 FROM orders
-                WHERE tenant_id = $1 AND (pos_cart_id IS NOT NULL OR extra_attributes->>'source' = 'manual')
+                WHERE tenant_id = $1 AND (pos_cart_id IS NOT NULL OR table_session_id IS NOT NULL OR extra_attributes->>'source' = 'manual')
             """
 
             row = await conn.fetchrow(dashboard_query, *params)
@@ -1307,7 +1317,7 @@ async def get_orders_dashboard(
                 LEFT JOIN payment_method_groups pmg ON pmg.id = pm.group_id
                 WHERE o.tenant_id = $1
                   AND o.status = 'completed'
-                  AND (o.pos_cart_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')
+                  AND (o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')
                 GROUP BY COALESCE(pmg.slug, op.payment_method), COALESCE(pmg.name, op.payment_method)
 
                 UNION ALL
@@ -1323,7 +1333,7 @@ async def get_orders_dashboard(
                 LEFT JOIN payment_method_groups pmg ON pmg.id = pm.group_id
                 WHERE o.tenant_id = $1
                   AND o.status = 'completed'
-                  AND (o.pos_cart_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')
+                  AND (o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')
                   AND NOT EXISTS (SELECT 1 FROM order_payments op WHERE op.order_id = o.id)
                 GROUP BY COALESCE(pmg.slug, o.payment_method), COALESCE(pmg.name, o.payment_method)
                 """,
@@ -1356,7 +1366,7 @@ async def get_orders_dashboard(
             _year_std = 0.0
             _year_liq = 0.0
             _tax_label = "Impuesto"
-            _base_filter = "o.tenant_id = $1 AND o.status = 'completed' AND (o.pos_cart_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')"
+            _base_filter = "o.tenant_id = $1 AND o.status = 'completed' AND (o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')"
             _tax_select = """
                 SELECT COALESCE(p.tax_category, 'standard') AS tax_category,
                        COALESCE(SUM(oi.subtotal), 0) AS subtotal
@@ -1455,7 +1465,7 @@ async def export_orders_to_email(
 
         async with get_db_connection() as conn:
             # Build WHERE clause (same as get_orders_list but without pagination)
-            where_conditions = ["o.tenant_id = $1", "(o.pos_cart_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')"]
+            where_conditions = ["o.tenant_id = $1", "(o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')"]
             params = [tenant_id]
             param_count = 1
 
@@ -2193,7 +2203,7 @@ async def get_sales_flow(
 
         async with get_db_connection() as conn:
             # Build WHERE conditions
-            where_conditions = ["tenant_id = $1", "(pos_cart_id IS NOT NULL OR extra_attributes->>'source' = 'manual')"]
+            where_conditions = ["tenant_id = $1", "(pos_cart_id IS NOT NULL OR table_session_id IS NOT NULL OR extra_attributes->>'source' = 'manual')"]
             params = [tenant_id]
             param_count = 1
 

--- a/app/services/public_api_service.py
+++ b/app/services/public_api_service.py
@@ -14,6 +14,16 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+POS_LIKE_FILTER = (
+    "(pos_cart_id IS NOT NULL OR table_session_id IS NOT NULL "
+    "OR extra_attributes->>'source' = 'manual')"
+)
+POS_LIKE_FILTER_ALIAS_O = (
+    "(o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL "
+    "OR o.extra_attributes->>'source' = 'manual')"
+)
+
+
 def parse_date(date_str: Optional[str]) -> Optional[date]:
     """Convert date string (YYYY-MM-DD) to date object"""
     if not date_str:
@@ -1198,7 +1208,7 @@ async def get_customers_list(
             # --- all_customers CTE: base pool (no date filter) ---
             base_conditions = [
                 "o.tenant_id = $1",
-                "(o.pos_cart_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')",
+                "(o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')",
                 "o.customer_id IS NOT NULL",
             ]
 
@@ -1214,7 +1224,7 @@ async def get_customers_list(
             # --- period_agg CTE: date-scoped aggregation (completed orders only) ---
             period_conditions = [
                 "o.tenant_id = $1",
-                "(o.pos_cart_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')",
+                "(o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')",
                 "o.customer_id IS NOT NULL",
                 "o.status = 'completed'",
             ]
@@ -1355,7 +1365,7 @@ async def get_customer_detail(
                 FROM orders o
                 LEFT JOIN profile p ON o.customer_id = p.id
                 WHERE o.tenant_id = $1
-                  AND (o.pos_cart_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')
+                  AND (o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')
                   AND o.customer_id = $2
                 GROUP BY o.customer_id, p.name, p.phone_number, p.email
                 """,
@@ -1369,7 +1379,7 @@ async def get_customer_detail(
             # --- Paginated order history (date-filtered) ---
             where_conditions = [
                 "o.tenant_id = $1",
-                "(o.pos_cart_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')",
+                "(o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')",
                 "o.customer_id = $2",
             ]
             params: list = [UUID(tenant_id), customer_id]
@@ -1776,7 +1786,7 @@ async def get_customers_metrics(
 
         async with get_db_connection(use_transaction=False) as conn:
             # Build base WHERE clause (period-scoped, completed POS orders only)
-            pos_filter = "(pos_cart_id IS NOT NULL OR extra_attributes->>'source' = 'manual')"
+            pos_filter = "(pos_cart_id IS NOT NULL OR table_session_id IS NOT NULL OR extra_attributes->>'source' = 'manual')"
             where_conditions = ["tenant_id = $1", pos_filter, "status = 'completed'"]
             params: list = [UUID(tenant_id)]
             param_count = 1
@@ -1960,7 +1970,7 @@ async def get_customers_metrics(
                 )
                 if prev_df and prev_dt:
                     # Build previous-period summary using same CTE pattern
-                    prev_pos_filter = "(pos_cart_id IS NOT NULL OR extra_attributes->>'source' = 'manual')"
+                    prev_pos_filter = "(pos_cart_id IS NOT NULL OR table_session_id IS NOT NULL OR extra_attributes->>'source' = 'manual')"
                     prev_where_conds = ["tenant_id = $1", prev_pos_filter, "status = 'completed'"]
                     prev_params = [UUID(tenant_id)]
                     ppc = 1
@@ -2047,7 +2057,7 @@ async def get_customers_metrics(
 
 async def _customer_metrics_by_date(conn, where_clause, params, param_count, timezone):
     """Internal: customer metrics grouped by calendar date"""
-    pos_filter = "(pos_cart_id IS NOT NULL OR extra_attributes->>'source' = 'manual')"
+    pos_filter = "(pos_cart_id IS NOT NULL OR table_session_id IS NOT NULL OR extra_attributes->>'source' = 'manual')"
     param_count += 1
     tz_param = param_count
     series_params = list(params) + [timezone]
@@ -2090,7 +2100,7 @@ async def _customer_metrics_by_date(conn, where_clause, params, param_count, tim
 
 async def _customer_metrics_by_weekday(conn, where_clause, params, param_count, timezone):
     """Internal: customer metrics grouped by day of week (0=Sunday … 6=Saturday)"""
-    pos_filter = "(pos_cart_id IS NOT NULL OR extra_attributes->>'source' = 'manual')"
+    pos_filter = "(pos_cart_id IS NOT NULL OR table_session_id IS NOT NULL OR extra_attributes->>'source' = 'manual')"
     param_count += 1
     tz_param = param_count
     series_params = list(params) + [timezone]
@@ -2136,7 +2146,7 @@ async def _customer_metrics_by_weekday(conn, where_clause, params, param_count, 
 
 async def _customer_metrics_by_month(conn, where_clause, params, param_count, timezone):
     """Internal: customer metrics grouped by month (YYYY-MM)"""
-    pos_filter = "(pos_cart_id IS NOT NULL OR extra_attributes->>'source' = 'manual')"
+    pos_filter = "(pos_cart_id IS NOT NULL OR table_session_id IS NOT NULL OR extra_attributes->>'source' = 'manual')"
     param_count += 1
     tz_param = param_count
     series_params = list(params) + [timezone]

--- a/tests/test_pos_like_filter.py
+++ b/tests/test_pos_like_filter.py
@@ -1,0 +1,65 @@
+"""
+Regression guard for issue #144 — mesa-originated sales must be counted in
+analytics aggregates. The POS_LIKE_FILTER constants in orders_service and
+public_api_service must include all three arms: pos_cart_id, table_session_id,
+and extra_attributes->>'source' = 'manual'. If any arm is dropped, mesa or
+manual orders silently disappear from /analitica/* metrics.
+"""
+from app.services.orders_service import (
+    POS_LIKE_FILTER as ORDERS_FILTER,
+    POS_LIKE_FILTER_ALIAS_O as ORDERS_FILTER_ALIAS,
+)
+from app.services.public_api_service import (
+    POS_LIKE_FILTER as PUBLIC_API_FILTER,
+    POS_LIKE_FILTER_ALIAS_O as PUBLIC_API_FILTER_ALIAS,
+)
+
+
+def test_orders_filter_includes_all_three_arms():
+    assert "pos_cart_id IS NOT NULL" in ORDERS_FILTER
+    assert "table_session_id IS NOT NULL" in ORDERS_FILTER
+    assert "extra_attributes->>'source' = 'manual'" in ORDERS_FILTER
+
+
+def test_orders_filter_alias_includes_all_three_arms():
+    assert "o.pos_cart_id IS NOT NULL" in ORDERS_FILTER_ALIAS
+    assert "o.table_session_id IS NOT NULL" in ORDERS_FILTER_ALIAS
+    assert "o.extra_attributes->>'source' = 'manual'" in ORDERS_FILTER_ALIAS
+
+
+def test_public_api_filter_includes_all_three_arms():
+    assert "pos_cart_id IS NOT NULL" in PUBLIC_API_FILTER
+    assert "table_session_id IS NOT NULL" in PUBLIC_API_FILTER
+    assert "extra_attributes->>'source' = 'manual'" in PUBLIC_API_FILTER
+
+
+def test_public_api_filter_alias_includes_all_three_arms():
+    assert "o.pos_cart_id IS NOT NULL" in PUBLIC_API_FILTER_ALIAS
+    assert "o.table_session_id IS NOT NULL" in PUBLIC_API_FILTER_ALIAS
+    assert "o.extra_attributes->>'source' = 'manual'" in PUBLIC_API_FILTER_ALIAS
+
+
+def test_orders_service_inline_sql_does_not_drop_table_session_id():
+    """
+    Belt-and-suspenders check: every line in orders_service.py that mentions
+    'pos_cart_id IS NOT NULL OR' must also mention 'table_session_id'. Catches
+    future inline filters that copy-paste the 2-arm shape.
+    """
+    import pathlib
+    src = pathlib.Path("app/services/orders_service.py").read_text()
+    for line_no, line in enumerate(src.splitlines(), start=1):
+        if "pos_cart_id IS NOT NULL OR" in line and "table_session_id" not in line:
+            raise AssertionError(
+                f"orders_service.py:{line_no} has 2-arm POS filter (drops mesa orders): {line.strip()}"
+            )
+
+
+def test_public_api_service_inline_sql_does_not_drop_table_session_id():
+    """Same belt-and-suspenders check for public_api_service.py."""
+    import pathlib
+    src = pathlib.Path("app/services/public_api_service.py").read_text()
+    for line_no, line in enumerate(src.splitlines(), start=1):
+        if "pos_cart_id IS NOT NULL OR" in line and "table_session_id" not in line:
+            raise AssertionError(
+                f"public_api_service.py:{line_no} has 2-arm POS filter (drops mesa orders): {line.strip()}"
+            )


### PR DESCRIPTION
## Summary
The 'POS-like' SQL filter used by every analytics aggregate was missing one arm and silently dropped mesa orders (orders with `table_session_id` set, `pos_cart_id` null).

Result: every chart/total/breakdown on `/analitica/ventas` and `/analitica/clientes` undercounted by the volume of mesa sales — operationally visible to anyone running mesas.

## Stack
🔵 FastAPI · 🟣 Postgres · 🐍 Python 3.9 (verified compat)

## Changes
- `app/services/orders_service.py` — added `POS_LIKE_FILTER` and `POS_LIKE_FILTER_ALIAS_O` constants at the top; replaced 11 inline 2-arm filters with the canonical 3-arm shape that already existed in the orders LIST query.
- `app/services/public_api_service.py` — same constants + 9 replacements for the public `/v1/...` endpoints.
- `tests/test_pos_like_filter.py` — 6 regression tests: 4 assert the constants contain all three arms; 2 belt-and-suspenders checks scan both service files for any line that mentions `pos_cart_id IS NOT NULL OR` without `table_session_id`.

## Behavior change (intentional)
Totals on `/analitica/ventas` and `/analitica/clientes` will increase for tenants with mesa sales after this deploys. Heads-up for whoever monitors those numbers — the new totals are correct; the old ones were undercounted.

## Out of scope
- `app/services/analytics_service.py` (drives `/analitica/rentabilidad`) **deliberately** has no POS filter; it includes mesa plus online/delivery. Not touched.
- `/analitica/puntos` does not query order aggregates. Not touched.
- The third arm `extra_attributes->>'source' = 'manual'` is preserved as-is — research did not verify whether the manual-entry feature is still in use; safer to keep.

## Testing
- [x] `python3 -m py_compile app/services/orders_service.py app/services/public_api_service.py` — passes on Python 3.9.
- [x] `python3 -m pytest tests/test_pos_like_filter.py -v` — 6/6 pass.
- [ ] Manual: hit `/api/orders/dashboard` and `/api/orders/metrics` from a tenant with mesa sales; totals reflect mesa.
- [ ] Manual: `/analitica/clientes/{id}` already showed mesa pre-deploy because that page hit two filtered queries that this PR just made consistent (see issue research).

Closes #144