### PR TITLE
fix(sessions): throttle last_activity_at writes + drop dead indexes

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -7,6 +7,16 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+
+# Issue #146: throttle the per-request `sessions.last_activity_at` write so
+# bursty POS traffic (mesa mode, many concurrent cashiers) doesn't pile up
+# UPDATEs on a single hot row. The conditional UPDATE only writes when the
+# stored timestamp is older than this interval — see app/core/security.py
+# get_session_from_request and app/services/auth_service.py get_session_data.
+# Postgres-INTERVAL string; consumed inside an SQL literal.
+SESSION_ACTIVITY_THROTTLE = "30 seconds"
+
+
 async def get_session_token(request: Request) -> str:
     """Extract valid session-token from cookies - validates and cleans up invalid tokens"""
     from app.database import get_db_connection
@@ -314,11 +324,16 @@ async def get_session_from_request(request: Request) -> Optional[dict]:
             if not session_result:
                 return None
 
-            # Update last activity timestamp
-            await conn.execute("""
+            # Update last activity timestamp — throttled to once per
+            # SESSION_ACTIVITY_THROTTLE window. The WHERE filter makes a no-op
+            # round-trip (PK lookup + skip) when the session was already
+            # touched recently, so we don't generate heap/index churn on
+            # every authenticated request.
+            await conn.execute(f"""
                 UPDATE sessions
                 SET last_activity_at = NOW()
                 WHERE id = $1
+                  AND last_activity_at < NOW() - INTERVAL '{SESSION_ACTIVITY_THROTTLE}'
             """, session_token)
 
             return {

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -5,7 +5,7 @@ from typing import Optional, Dict, Any
 from uuid import UUID
 from fastapi import Request, Response
 from app.database import get_db_connection
-from app.core.security import get_session_token, clear_session_cookie, set_session_cookie, get_client_ip
+from app.core.security import get_session_token, clear_session_cookie, set_session_cookie, get_client_ip, SESSION_ACTIVITY_THROTTLE
 from app.core.exceptions import AuthenticationError
 from app.core.middleware import require_valid_session
 from app.models.auth import User, Session, Tenant, SessionResponse, SwitchTenantResponse, UpdateProfileResponse
@@ -40,9 +40,13 @@ async def get_session_data(request: Request, response: Response) -> SessionRespo
                 raise AuthenticationError("Session expired")
             
             
-            # Update last activity for analytics tracking (exact logic from warolabs.com)
+            # Update last activity for analytics tracking — throttled to once
+            # per SESSION_ACTIVITY_THROTTLE window so bursty POS traffic doesn't
+            # pile up UPDATEs on the same row (issue #146).
             await conn.execute(
-                'UPDATE sessions SET last_activity_at = NOW() WHERE id = $1',
+                f"UPDATE sessions SET last_activity_at = NOW() "
+                f"WHERE id = $1 "
+                f"  AND last_activity_at < NOW() - INTERVAL '{SESSION_ACTIVITY_THROTTLE}'",
                 session_token
             )
             

--- a/migrations/057_sessions_drop_dead_indexes_and_tune_autovacuum.sql
+++ b/migrations/057_sessions_drop_dead_indexes_and_tune_autovacuum.sql
@@ -1,0 +1,31 @@
+-- Issue #146: kill write amplification on the sessions table.
+--
+-- These three indexes had 0 reads in pg_stat_user_indexes (verified 2026-05-02);
+-- they only existed to be updated, costing 6× write amplification per UPDATE.
+-- Dropping idx_sessions_last_activity additionally enables HOT updates because
+-- it was the only indexed column actually changing in the per-request UPDATE.
+--
+-- Run order: this file is safe to apply at any time of day. CONCURRENTLY makes
+-- the DROPs non-blocking; existing reads/writes are unaffected during the drop.
+--
+-- Rollback (if any future feature needs these indexes):
+--   CREATE INDEX CONCURRENTLY idx_sessions_last_activity ON public.sessions (last_activity_at);
+--   CREATE INDEX CONCURRENTLY idx_sessions_created_at    ON public.sessions (created_at);
+--   CREATE INDEX CONCURRENTLY idx_sessions_ip_address    ON public.sessions (ip_address);
+--   ALTER TABLE public.sessions RESET (
+--     autovacuum_vacuum_scale_factor,
+--     autovacuum_analyze_scale_factor,
+--     autovacuum_vacuum_cost_limit
+--   );
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_sessions_last_activity;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_sessions_created_at;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_sessions_ip_address;
+
+-- Sessions is high-churn write-heavy. Tighten autovacuum locally so dead tuples
+-- are reclaimed at 5% bloat instead of the 20% global default.
+ALTER TABLE public.sessions SET (
+  autovacuum_vacuum_scale_factor = 0.05,
+  autovacuum_analyze_scale_factor = 0.05,
+  autovacuum_vacuum_cost_limit = 2000
+);

--- a/tests/test_session_activity_throttle.py
+++ b/tests/test_session_activity_throttle.py
@@ -1,0 +1,79 @@
+"""
+Regression guard for issue #146 — the per-request UPDATE on
+`sessions.last_activity_at` must be conditional, writing only when the stored
+timestamp is older than SESSION_ACTIVITY_THROTTLE. If the conditional WHERE
+ever regresses to the unconditional 2-arm shape, mesa-time bursty POS traffic
+will reproduce the original 65 ms / 78%-of-DB-time slowdown.
+
+These tests are static — they parse the source files and assert the SQL shape.
+A live DB-roundtrip test would require auth seeding the smoke harness doesn't
+provide; static checks catch the regression that matters (someone reverting the
+WHERE clause) without needing the full integration stack.
+"""
+import pathlib
+import re
+
+from app.core.security import SESSION_ACTIVITY_THROTTLE
+
+
+SECURITY_PY = pathlib.Path("app/core/security.py")
+AUTH_SERVICE_PY = pathlib.Path("app/services/auth_service.py")
+
+
+def test_throttle_constant_exists_and_is_a_postgres_interval_literal():
+    # Constant must be a string Postgres can parse inside INTERVAL '...'.
+    # Allowed shapes: "<n> seconds", "<n> minutes", "<n> hours". Reject anything
+    # that doesn't fit so a typo can't silently disable the throttle.
+    assert isinstance(SESSION_ACTIVITY_THROTTLE, str)
+    assert re.fullmatch(
+        r"\d+\s+(seconds?|minutes?|hours?)",
+        SESSION_ACTIVITY_THROTTLE,
+    ), (
+        f"SESSION_ACTIVITY_THROTTLE={SESSION_ACTIVITY_THROTTLE!r} is not a valid "
+        "Postgres INTERVAL literal — must look like '30 seconds'."
+    )
+
+
+def test_security_py_uses_conditional_update():
+    src = SECURITY_PY.read_text()
+    # Pattern must include both the SET and the time-bounded WHERE.
+    assert "UPDATE sessions" in src
+    assert "SET last_activity_at = NOW()" in src
+    assert "last_activity_at < NOW() - INTERVAL" in src, (
+        "app/core/security.py lost the conditional throttle on the "
+        "`UPDATE sessions SET last_activity_at` write. This re-introduces "
+        "the per-request write storm — see issue #146."
+    )
+
+
+def test_auth_service_py_uses_conditional_update():
+    src = AUTH_SERVICE_PY.read_text()
+    assert "UPDATE sessions" in src
+    assert "SET last_activity_at = NOW()" in src
+    assert "last_activity_at < NOW() - INTERVAL" in src, (
+        "app/services/auth_service.py lost the conditional throttle on the "
+        "`UPDATE sessions SET last_activity_at` write. This re-introduces "
+        "the per-request write storm — see issue #146."
+    )
+
+
+def test_no_unconditional_session_activity_update_remains_in_codebase():
+    """
+    Belt-and-suspenders: scan both files for the legacy 2-arm shape.
+    The legacy shape is:
+        UPDATE sessions SET last_activity_at = NOW() WHERE id = $X
+    with no `AND last_activity_at < ...` follow-up. We catch that by checking
+    every line that mentions the SET clause and ensuring the surrounding
+    statement (within 5 lines forward) also includes the conditional WHERE.
+    """
+    for path in (SECURITY_PY, AUTH_SERVICE_PY):
+        lines = path.read_text().splitlines()
+        for i, line in enumerate(lines):
+            if "SET last_activity_at = NOW()" not in line:
+                continue
+            window = "\n".join(lines[i : i + 5])
+            assert "last_activity_at < NOW() - INTERVAL" in window, (
+                f"{path}:{i + 1} contains an unconditional "
+                f"UPDATE sessions SET last_activity_at = NOW() — must be "
+                f"throttled (see issue #146): {line.strip()}"
+            )


### PR DESCRIPTION
## Summary

POS users reported slowness on **2026-05-01 18:00 Bogotá** when mesas got enabled. `pg_stat_statements` pinpointed a single statement consuming **78.1% of all DB time** with 65 ms mean exec time — a primary-key UPDATE that should take <1 ms.

```sql
UPDATE sessions SET last_activity_at = NOW() WHERE id = $1
```

## Root cause (three compounding)

Verified via `pg_stat_user_indexes`:
1. **`idx_sessions_last_activity`, `idx_sessions_created_at`, `idx_sessions_ip_address`** each had **0 read scans**. Pure write amplification — each UPDATE refreshed all three for nothing.
2. **`idx_sessions_last_activity` was blocking HOT updates** because `last_activity_at` is the only column being changed. Drop it → every UPDATE becomes a same-page heap rewrite (sub-ms).
3. **Default autovacuum** (`scale_factor=0.2`) couldn't keep up with the write rate; `sessions` sat at **135.9% dead-tuple ratio**.

## Stack
🔵 FastAPI · 🟣 Postgres 16 · 🐍 Python 3.9 (verified compat)

## Changes (3 layers, one PR)

### B — Migration `057_sessions_drop_dead_indexes_and_tune_autovacuum.sql`
- `DROP INDEX CONCURRENTLY` × 3 (the dead indexes).
- `ALTER TABLE sessions SET autovacuum_vacuum_scale_factor=0.05, autovacuum_analyze_scale_factor=0.05, autovacuum_vacuum_cost_limit=2000`.
- Rollback documented inline.

### C — Conditional UPDATE in two sites
- `app/core/security.py:317-336` — middleware path (every authenticated request).
- `app/services/auth_service.py:43-50` — `/auth/session.get` path.
- New constant `SESSION_ACTIVITY_THROTTLE = "30 seconds"` in `app/core/security.py:17`.
- Pattern: `UPDATE ... WHERE id = $1 AND last_activity_at < NOW() - INTERVAL '30 seconds'` — Postgres skips the row entirely if the threshold isn't met (PK seek + no-op).

### Regression tests — `tests/test_session_activity_throttle.py`
- 4 static guards: constant shape valid, both files use the conditional WHERE, no unconditional 2-arm shape remains in scope.

## Out-of-band ops (run by hand on prod, post-merge)

```sql
-- Layer A — bloat cleanup (already authorized; run as a separate ops command,
-- not a migration, because it's a one-shot maintenance op).
VACUUM (VERBOSE, ANALYZE) public.sessions;
REINDEX INDEX CONCURRENTLY public.sessions_pkey;
REINDEX INDEX CONCURRENTLY public.idx_sessions_user_id;

-- Layer D — observability (so we have query-level evidence of next slowdown).
ALTER SYSTEM SET log_min_duration_statement = '500ms';
SELECT pg_reload_conf();

-- Reset stats so post-deploy measurement is clean.
SELECT pg_stat_statements_reset();
```

Rollback for D: `ALTER SYSTEM RESET log_min_duration_statement; SELECT pg_reload_conf();`

## Acceptance criteria
- [x] Constant + conditional UPDATE in both sites.
- [x] Migration 057 with CONCURRENTLY drops + per-table autovacuum.
- [x] Static regression tests pass.
- [ ] Post-deploy: `UPDATE sessions ... last_activity_at` mean < 2 ms.
- [ ] Post-deploy: that statement < 5% of total DB time.
- [ ] Post-deploy: `sessions` dead_pct < 20% sustained.

## Verified during research
- `last_activity_at` has **0 read queries** anywhere in `app/` (only writes + a single PK read in the SELECT before the UPDATE, then returned to client).
- Front-end never reads `lastActivity` (grep returned no matches in `front_nuxt/`).
- `cleanup_zombie_sessions` filters by `expires_at`, not `last_activity_at` — unaffected.
- Python 3.9 compat: no PEP 604 unions / lowercase generics / `match` / `tomllib` introduced.

Closes #146