### PR TITLE
feat(billing): outgoing webhook fired on subscription payment approval

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -85,6 +85,11 @@ class Settings(BaseSettings):
     # Cron secret — grace period reminders (issue #62)
     cron_secret: Optional[str] = Field(default=None, alias='CRON_SECRET')
 
+    # Outgoing webhook fired on subscription payment approval (issue #156).
+    # Empty / None → no-op. Set to any URL (Discord, n8n, Slack, custom) to
+    # receive a JSON payload describing each successful renewal.
+    billing_webhook_url: Optional[str] = Field(default=None, alias='BILLING_WEBHOOK_URL')
+
     # api-facturacion microservice — DIAN electronic invoicing (issue #128)
     facturacion_api_url: str = Field(default='http://api-facturacion:8001', alias='FACTURACION_API_URL')
 

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 from app.config import settings
 from app.core.middleware import require_valid_session
 from app.database import get_db_connection
-from app.services import billing_service, billing_email_service, wompi_service
+from app.services import billing_service, billing_email_service, billing_webhook_service, wompi_service
 
 logger = logging.getLogger(__name__)
 
@@ -397,6 +397,21 @@ async def wompi_webhook(
                 tenant_name=tenant_info["tenant_name"],
                 tenant_email=tenant_info["tenant_email"],
                 next_period_end=tenant_info["next_period_end"],
+            )
+            # Outgoing webhook (issue #156). No-op when BILLING_WEBHOOK_URL
+            # is empty. Failures are logged but never block activation.
+            background_tasks.add_task(
+                billing_webhook_service.send_payment_approved_webhook,
+                tenant_id=tenant_info["tenant_id"],
+                subscription_id=tenant_info["subscription_id"],
+                tenant_name=tenant_info["tenant_name"],
+                tenant_email=tenant_info["tenant_email"],
+                plan_name=tenant_info["plan_name"],
+                amount=amount_cents / 100,
+                currency="COP",
+                next_period_end=tenant_info["next_period_end"],
+                gateway_reference=payment_link_id,
+                transaction_id=transaction_id,
             )
 
     elif wompi_status in ("DECLINED", "VOIDED", "ERROR"):

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -770,9 +770,11 @@ async def activate_tenant_subscription(
     """
     row = await conn.fetchrow("""
         SELECT ts.id, ts.tenant_id, ts.billing_cycle,
-               t.name AS tenant_name, t.email AS tenant_email
+               t.name AS tenant_name, t.email AS tenant_email,
+               sp.name AS plan_name
         FROM tenant_subscriptions ts
         JOIN tenants t ON t.id = ts.tenant_id
+        JOIN subscription_plans sp ON sp.id = ts.plan_id
         WHERE ts.gateway_reference = $1
           AND ts.status = 'pending'
     """, gateway_reference)
@@ -812,8 +814,11 @@ async def activate_tenant_subscription(
     )
 
     return {
+        "tenant_id": str(row["tenant_id"]),
+        "subscription_id": str(row["id"]),
         "tenant_name": row["tenant_name"],
         "tenant_email": row["tenant_email"],
+        "plan_name": row["plan_name"],
         "next_period_end": next_period_end,
     }
 

--- a/app/services/billing_webhook_service.py
+++ b/app/services/billing_webhook_service.py
@@ -1,0 +1,78 @@
+"""Outgoing webhook for billing events (issue #156).
+
+Fires once per successful subscription payment. Triggered as a FastAPI
+``BackgroundTask`` from the Wompi webhook handler — runs after the HTTP
+response is sent so it never blocks Wompi's retry policy.
+
+Failures are logged at WARNING and swallowed: webhook delivery problems
+must NEVER roll back the subscription activation that has already
+committed to the DB.
+"""
+import logging
+from typing import Optional
+from urllib.parse import urlparse
+
+import httpx
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+async def send_payment_approved_webhook(
+    *,
+    tenant_id: str,
+    subscription_id: str,
+    tenant_name: str,
+    tenant_email: Optional[str],
+    plan_name: str,
+    amount: float,
+    currency: str,
+    next_period_end: str,
+    gateway_reference: str,
+    transaction_id: str,
+) -> None:
+    """POST a ``subscription.payment_approved`` JSON payload to
+    ``BILLING_WEBHOOK_URL``.
+
+    No-op when the env var is unset/empty (zero overhead, no error log).
+    """
+    url = settings.billing_webhook_url
+    if not url:
+        return
+
+    payload = {
+        "event": "subscription.payment_approved",
+        "tenant_id": tenant_id,
+        "subscription_id": subscription_id,
+        "tenant_name": tenant_name,
+        "tenant_email": tenant_email,
+        "plan_name": plan_name,
+        "amount": amount,
+        "currency": currency,
+        "next_period_end": next_period_end,
+        "gateway_reference": gateway_reference,
+        "transaction_id": transaction_id,
+    }
+
+    # Log only the hostname — the URL may contain a token (Discord, etc.).
+    host = urlparse(url).hostname or "<unknown>"
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(url, json=payload)
+            response.raise_for_status()
+        logger.info(
+            "billing_webhook: delivered host=%s tenant=%s amount=%s",
+            host, tenant_id, amount,
+        )
+    except httpx.HTTPError as exc:
+        logger.warning(
+            "billing_webhook: delivery failed (non-fatal) host=%s tenant=%s err=%s",
+            host, tenant_id, type(exc).__name__,
+        )
+    except Exception as exc:
+        logger.warning(
+            "billing_webhook: unexpected error (non-fatal) host=%s tenant=%s err=%s",
+            host, tenant_id, type(exc).__name__,
+        )

--- a/app/services/billing_webhook_service.py
+++ b/app/services/billing_webhook_service.py
@@ -41,22 +41,42 @@ async def send_payment_approved_webhook(
     if not url:
         return
 
-    payload = {
-        "event": "subscription.payment_approved",
-        "tenant_id": tenant_id,
-        "subscription_id": subscription_id,
-        "tenant_name": tenant_name,
-        "tenant_email": tenant_email,
-        "plan_name": plan_name,
-        "amount": amount,
-        "currency": currency,
-        "next_period_end": next_period_end,
-        "gateway_reference": gateway_reference,
-        "transaction_id": transaction_id,
-    }
-
     # Log only the hostname — the URL may contain a token (Discord, etc.).
     host = urlparse(url).hostname or "<unknown>"
+
+    # Discord webhooks reject arbitrary JSON — they need `content` or `embeds`.
+    # Detect Discord URLs and format accordingly; everything else gets the raw
+    # generic payload.
+    if host and host.endswith("discord.com"):
+        payload = {
+            "embeds": [{
+                "title": "💳 Subscription payment approved",
+                "color": 3066993,
+                "fields": [
+                    {"name": "Tenant", "value": f"{tenant_name} (`{tenant_id}`)", "inline": False},
+                    {"name": "Email", "value": tenant_email or "—", "inline": True},
+                    {"name": "Plan", "value": plan_name, "inline": True},
+                    {"name": "Amount", "value": f"{amount:,.0f} {currency}", "inline": True},
+                    {"name": "Next period end", "value": next_period_end, "inline": True},
+                    {"name": "Gateway ref", "value": f"`{gateway_reference}`", "inline": False},
+                    {"name": "Transaction", "value": f"`{transaction_id}`", "inline": False},
+                ],
+            }],
+        }
+    else:
+        payload = {
+            "event": "subscription.payment_approved",
+            "tenant_id": tenant_id,
+            "subscription_id": subscription_id,
+            "tenant_name": tenant_name,
+            "tenant_email": tenant_email,
+            "plan_name": plan_name,
+            "amount": amount,
+            "currency": currency,
+            "next_period_end": next_period_end,
+            "gateway_reference": gateway_reference,
+            "transaction_id": transaction_id,
+        }
 
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:


### PR DESCRIPTION
## Summary
Adds an outgoing HTTP webhook that fires once per successful subscription payment. Configurable via `BILLING_WEBHOOK_URL` env var; empty = no-op. See [#156](https://github.com/uno0uno/api-warolabs/issues/156) for full design and rationale.

## Stack
🔵 FastAPI · 🐍 Python 3.9

## Changes
- `app/config.py` — new `billing_webhook_url` Optional[str] field.
- `app/services/billing_service.py` — extend `activate_tenant_subscription` SELECT (JOIN `subscription_plans`) and add `tenant_id`, `subscription_id`, `plan_name` to return dict. Existing keys unchanged, backwards-compatible with `send_payment_renewed_email`.
- `app/services/billing_webhook_service.py` (new) — single async function `send_payment_approved_webhook` using httpx with 10s timeout. Logs only hostname on error. Swallows all exceptions — never blocks activation.
- `app/routers/billing.py` — enqueue the new background task in the Wompi webhook handler, right after the existing email task on the APPROVED branch.

## Payload (canonical)
```json
{
  "event": "subscription.payment_approved",
  "tenant_id": "...",
  "subscription_id": "...",
  "tenant_name": "...",
  "tenant_email": "...",
  "plan_name": "Pro",
  "amount": 9000.00,
  "currency": "COP",
  "next_period_end": "2026-06-01T00:00:00+00:00",
  "gateway_reference": "...",
  "transaction_id": "..."
}
```

## Validation
- [x] `python3 -m py_compile` clean on Python 3.9 for all 4 modified/new files.
- [x] No PEP 604 unions, no lowercase generics in signatures, no `match`/`case`, no `tomllib`.
- [x] No new dependencies — `httpx>=0.27.1` already in requirements.
- [ ] Manual smoke test post-merge: point `BILLING_WEBHOOK_URL` at webhook.site, complete a Wompi sandbox payment, verify JSON arrives.

## Acceptance criteria (from #156)
- [x] `BILLING_WEBHOOK_URL` env var present in local + prod (✅ already set as empty placeholder).
- [x] `app/config.py` exposes `settings.billing_webhook_url`.
- [x] `app/services/billing_webhook_service.py` created.
- [x] `activate_tenant_subscription` returns the 6-key dict including `tenant_id`, `subscription_id`, `plan_name`.
- [x] Empty `BILLING_WEBHOOK_URL` → zero httpx calls, no errors, no log spam.
- [x] Webhook delivery failure logs hostname only (never the full URL).

## Deploy notes (per stakeholder instruction)

**No deploy** is performed by this PR. Code lands when explicitly authorized. With the env var still empty, merging is safe — every webhook task will short-circuit before any HTTP call.

Closes #156