### PR TITLE
fix(tables): cancel comanda_items before deleting order_items in discard_table_session

### DIFF
--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -1657,6 +1657,24 @@ async def discard_table_session(request: Request, table_id: UUID) -> dict:
                     """,
                     session_id,
                 )
+                # Cancel comanda_items pointing at the order_items we are about
+                # to delete. comanda_items.order_item_id has FK NO ACTION, so a
+                # raw DELETE on order_items would raise ForeignKeyViolationError
+                # whenever KDS comandas exist. Same pattern as #158 in clear_tab.
+                await conn.execute(
+                    """
+                    UPDATE comanda_items
+                    SET status = 'cancelled',
+                        cancelled_at = NOW(),
+                        order_item_id = NULL
+                    WHERE order_item_id IN (
+                        SELECT oi.id FROM order_items oi
+                        JOIN orders o ON o.id = oi.order_id
+                        WHERE o.table_session_id = $1 AND o.status = 'pending'
+                    )
+                    """,
+                    session_id,
+                )
                 await conn.execute(
                     """
                     DELETE FROM order_items


### PR DESCRIPTION
## Summary

Pre-emptive fix for the same FK violation pattern that #158 patched in `clear_tab`. `discard_table_session` (backing `DELETE /api/tables/:id/session`, used by the active-mesa banner "Descartar" button) deletes `order_items` directly without first nulling `comanda_items.order_item_id` — would raise `ForeignKeyViolationError` whenever KDS comandas exist.

## Stack
🔵 FastAPI + 🟣 Postgres

## Why this matters

The bug is **latent**. The "Descartar" path is rarely used (most operators close-with-payment instead), so production logs haven't surfaced it yet. But it would explode the moment a user discards a session that has already fired items to the kitchen.

## Changes
- `app/services/tables_service.py:1659+` — insert `UPDATE comanda_items SET status='cancelled', cancelled_at=NOW(), order_item_id=NULL` between the existing `DELETE FROM order_item_modifiers` and `DELETE FROM order_items`. Identical pattern to the #158 fix in `clear_tab`.

## Test plan

The fix mirrors #158 byte-for-byte. The same smoke test approach validates it:

```sql
BEGIN;
-- seed: order + order_item + comanda + comanda_item linked to a real open session
-- run discard_table_session SQL block
-- verify comanda_item.status = 'cancelled', cancelled_at NOT NULL, order_item_id NULL
-- verify order_items + orders + session.is_discarded = TRUE
ROLLBACK;
```

Production smoke test for #158 already validated the SQL pattern works correctly against Waro Colombia data. This PR applies the same pattern to a second code path — no new SQL semantics introduced.

## Risk

- **Low** — additive change (one extra `UPDATE` statement before existing `DELETE`).
- No schema changes, no migration.
- Same proven pattern from a recently-shipped, already-deployed fix.
- Existing 409 guards (bar table, completed orders) are not touched.

Closes #160
Related: #158 (the reference fix)