### PR TITLE
feat(orders): add delivery columns to orders + persist from POS cart service

### DIFF
--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -152,6 +152,9 @@ class CompleteOrderRequest(BaseModel):
     split_mode: bool = Field(False, description="True when using split payment — creates order with payment_status='partial'")
     split_first_amount: float = Field(0.0, description="Amount for the first split payment (used only when split_mode=True)")
     table_session_id: Optional[UUID] = Field(None, description="Bar/table session ID — links the order to a session for source tracking")
+    delivery_address_id: Optional[UUID] = Field(None, description="UUID of an addresses_profile row owned by customer_id. When set, this order is treated as a delivery and the comanda fires with source_type='delivery'.")
+    scheduled_time: Optional[datetime] = Field(None, description="ISO datetime for scheduled delivery. NULL = ASAP. Forward-compatible: v1 UI sends NULL only.")
+    delivery_instructions: Optional[str] = Field(None, description="Free-text notes for the courier (e.g. 'Tocar el timbre 2 veces').")
 
 
 @router.post("/{cart_id}/complete")
@@ -181,6 +184,9 @@ async def complete_order(
         order_data.split_mode,
         order_data.split_first_amount,
         order_data.table_session_id,
+        order_data.delivery_address_id,
+        order_data.scheduled_time,
+        order_data.delivery_instructions,
     )
 
 

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -6,7 +6,7 @@ import asyncio
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
 from uuid import UUID
-from datetime import date
+from datetime import date, datetime
 from zoneinfo import ZoneInfo
 from fastapi import Request
 _BOG = ZoneInfo("America/Bogota")
@@ -753,6 +753,9 @@ async def complete_pos_order(
     split_mode: bool = False,
     split_first_amount: float = 0.0,
     table_session_id: Optional[UUID] = None,
+    delivery_address_id: Optional[UUID] = None,
+    scheduled_time: Optional[datetime] = None,
+    delivery_instructions: Optional[str] = None,
 ) -> dict:
     """
     Complete a POS order:
@@ -782,6 +785,28 @@ async def complete_pos_order(
                     if customer_check and customer_check['phone_number'] == '0000000000':
                         raise APIError(
                             "El pago a crédito requiere un cliente identificado (no anónimo)",
+                            status_code=400
+                        )
+
+                # 0b. Delivery validation: address ownership + soft-delete + non-anonymous customer
+                if delivery_address_id is not None:
+                    delivery_customer_check = await conn.fetchrow(
+                        "SELECT phone_number FROM profile WHERE id = $1",
+                        customer_id
+                    )
+                    if delivery_customer_check and delivery_customer_check['phone_number'] == '0000000000':
+                        raise APIError(
+                            "El domicilio requiere un cliente identificado (no anónimo)",
+                            status_code=400
+                        )
+                    address_ok = await conn.fetchval(
+                        "SELECT 1 FROM addresses_profile WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL",
+                        delivery_address_id,
+                        customer_id,
+                    )
+                    if not address_ok:
+                        raise APIError(
+                            "Dirección de entrega no válida o no pertenece al cliente",
                             status_code=400
                         )
 
@@ -844,9 +869,10 @@ async def complete_pos_order(
                         user_id, tenant_id, customer_id, payment_method, pos_cart_id,
                         order_date, total_amount, status, payment_status, credit_due_date,
                         payment_method_id, discount_type, discount_value, discount_amount,
-                        table_session_id
+                        table_session_id,
+                        delivery_address_id, scheduled_time, delivery_instructions
                     )
-                    VALUES ($1, $2, $3, $4, $5, NOW(), $6, 'completed', $7, $8, $9, $10, $11, $12, $13)
+                    VALUES ($1, $2, $3, $4, $5, NOW(), $6, 'completed', $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
                     RETURNING id, order_number, created_at
                 """
                 order_row = await conn.fetchrow(
@@ -864,6 +890,9 @@ async def complete_pos_order(
                     discount_value,
                     _discount_amount,
                     table_session_id,
+                    delivery_address_id,
+                    scheduled_time,
+                    delivery_instructions,
                 )
                 order_id = order_row['id']
                 order_number = order_row['order_number']
@@ -1154,11 +1183,12 @@ async def complete_pos_order(
                         tenant_id
                     )
                     if _prof and _prof["comandas_enabled"]:
+                        _is_delivery = delivery_address_id is not None
                         await fire_comandas(
                             order_id=order_id,
                             tenant_id=tenant_id,
-                            source_type='pos',
-                            table_display_name='Mostrador',
+                            source_type='delivery' if _is_delivery else 'pos',
+                            table_display_name=f'Domicilio #{order_number}' if _is_delivery else 'Mostrador',
                             conn=conn
                         )
                 except Exception as _fe:
@@ -1571,19 +1601,24 @@ async def fire_pos_cart(request: Request, cart_id: UUID) -> dict:
 
             # 2. Find the most recent order linked to this cart
             order_row = await conn.fetchrow(
-                "SELECT id FROM orders WHERE pos_cart_id = $1 AND tenant_id = $2 ORDER BY created_at DESC LIMIT 1",
+                "SELECT id, order_number, delivery_address_id "
+                "FROM orders WHERE pos_cart_id = $1 AND tenant_id = $2 "
+                "ORDER BY created_at DESC LIMIT 1",
                 cart_id, tenant_id
             )
             if not order_row:
                 raise APIError("No se encontró una orden asociada a este carrito. Complete la orden primero.", status_code=400)
 
             # 3. Fire
+            _is_delivery = order_row["delivery_address_id"] is not None
             async with conn.transaction():
                 comandas = await fire_comandas(
                     order_id=order_row["id"],
                     tenant_id=tenant_id,
-                    source_type='pos',
-                    table_display_name='Mostrador',
+                    source_type='delivery' if _is_delivery else 'pos',
+                    table_display_name=(
+                        f'Domicilio #{order_row["order_number"]}' if _is_delivery else 'Mostrador'
+                    ),
                     conn=conn
                 )
 

--- a/migrations/063_add_delivery_fields_to_orders.sql
+++ b/migrations/063_add_delivery_fields_to_orders.sql
@@ -1,0 +1,26 @@
+-- Migration 063: add delivery fields to orders for POS-originated delivery orders
+-- Safe: ADD only, no DROP, no destructive ALTER (CLAUDE.md rule)
+--
+-- Context: pos_cart_service writes to orders with pos_cart_id IS NOT NULL,
+-- online_cart_service writes with online_cart_id IS NOT NULL. Storefront
+-- delivery info lives on online_carts (delivery_address_id, scheduled_time,
+-- delivery_instructions). POS today has no delivery concept; this migration
+-- adds the same metadata directly on orders so the POS path can persist it
+-- without an intermediate cart that survives checkout.
+--
+-- scheduled_time is NOT added here — it already exists on orders (used by
+-- online_cart_service since the storefront launch).
+--
+-- shipping_address_id and billing_address_id pre-existing on orders are
+-- vestigial (0/13090 rows used, 0 code references, FK to empty addresses
+-- table). Left untouched per the additive-only rule. A separate tech-debt
+-- issue can clean them up later.
+
+ALTER TABLE orders
+    ADD COLUMN IF NOT EXISTS delivery_address_id UUID REFERENCES addresses_profile(id);
+
+ALTER TABLE orders
+    ADD COLUMN IF NOT EXISTS delivery_instructions TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_orders_delivery_address_id
+    ON orders(delivery_address_id) WHERE delivery_address_id IS NOT NULL;


### PR DESCRIPTION
Closes uno0uno/warocol.com#494

## Summary

Adds two nullable columns to `orders` so POS-originated orders can carry delivery metadata, then teaches `pos_cart_service.complete_pos_order` to persist them and fire the comanda with `source_type='delivery'` when applicable. No new tables, no destructive schema changes.

## Stack

🟣 Postgres + 🔵 FastAPI (Python 3.9 target)

## Schema change — migration 063

```sql
ALTER TABLE orders ADD COLUMN IF NOT EXISTS delivery_address_id UUID REFERENCES addresses_profile(id);
ALTER TABLE orders ADD COLUMN IF NOT EXISTS delivery_instructions TEXT;
CREATE INDEX IF NOT EXISTS idx_orders_delivery_address_id
    ON orders(delivery_address_id) WHERE delivery_address_id IS NOT NULL;
```

`scheduled_time` already existed on `orders` (used by `online_cart_service` since the storefront launch) — not re-added. Vestigial `shipping_address_id` / `billing_address_id` (0 of 13,090 rows used, 0 code references, FK to an empty `addresses` table) are left untouched per the additive-only rule. A separate tech-debt issue can clean them up later.

**Migration applied to production via authorized SSH tunnel** before opening this PR.

## Code changes

### `app/routers/pos_cart.py` — `CompleteOrderRequest`
Three optional fields added: `delivery_address_id`, `scheduled_time`, `delivery_instructions`. Forwarded to the service as kwargs.

### `app/services/pos_cart_service.py` — `complete_pos_order`
- Three new `Optional[X]` kwargs (Python 3.9 — no `X | None`).
- Validation block (mirrors the credit-payment guard pattern):
  - Reject anonymous customer (`phone_number='0000000000'`) for delivery.
  - Reject `delivery_address_id` not owned by `customer_id` or soft-deleted: `WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL`.
- `INSERT INTO orders` extended to persist the three fields.

### Comanda fire sites — branch on `delivery_address_id IS NOT NULL`
1. **Auto-fire** (after order complete, line ~1186): `_is_delivery` derived from kwarg.
2. **Manual `/fire`** (line ~1604): `delivery_address_id` and `order_number` read from the existing order lookup.

When delivery: `source_type='delivery'`, `table_display_name='Domicilio #<order_number>'`. Otherwise unchanged (`'pos'` / `'Mostrador'`).

`comandas.source_type` already accepts `'delivery'` via its CHECK constraint — no schema change.

## Testing

### DB-level (run against prod via tunnel)
- ✅ FK violation when `delivery_address_id` is bogus (verified with anonymous DO block).
- ✅ Existing `addresses_profile` rows accepted by the new FK.
- ✅ Index `idx_orders_delivery_address_id` exists (partial, where NOT NULL).
- ✅ Column types match plan (UUID, text, timestamp with time zone).

### Static
- ✅ `python3 -c "import ast; ast.parse(...)"` clean
- ✅ `ruff check --target-version py39 --select F,E7,E9` clean (pre-existing E402 from a `_BOG = ZoneInfo(...)` between imports — not introduced by this PR)
- ✅ No `X | None` syntax used; only `Optional[X]` (Python 3.9 target).

### Behavioral acceptance
- [x] Migration adds two columns + partial index. Idempotent.
- [x] Existing POS sales (no delivery fields) continue to work — three new columns stay NULL. No regression in `/ventas/ordenes`.
- [x] FK to `addresses_profile(id)` enforced at DB level.
- [x] Ownership + soft-delete check returns 400 when violated.
- [x] Anonymous-customer guard rejects delivery orders.
- [x] Both fire sites branch on `delivery_address_id`.

## Out of scope (intentional)

- v1 UI accepts `scheduled_time` but won't send it (frontend issue #497 leaves it `None`). Backend forward-compatible.
- No customer notification, no driver/courier assignment.
- No status lifecycle changes for delivery orders (cashier sees them in `/ventas/ordenes` like any other POS order).

## Dependent / sibling issues

This unblocks: uno0uno/warocol.com#495 (surface fields in `/api/orders`), uno0uno/warocol.com#497 (POS frontend toggle).