### PR TITLE
feat(online-orders): wire accepts_online_orders as storefront gate

### DIFF
--- a/app/models/tenant_public_profile.py
+++ b/app/models/tenant_public_profile.py
@@ -54,8 +54,8 @@ class TenantPublicProfileBase(BaseModel):
     seo_title: Optional[str] = Field(None, max_length=255, description="Meta title for SEO")
     seo_description: Optional[str] = Field(None, description="Meta description for SEO")
 
-    # Future configuration
-    accepts_online_orders: bool = Field(False, description="Whether online orders are enabled (future)")
+    # Online ordering gate — controls storefront catalog ordering AND POS delivery toggle
+    accepts_online_orders: bool = Field(False, description="Whether the tenant accepts online orders. Gates storefront catalog ordering AND the POS delivery toggle.")
     min_order_amount: Decimal = Field(Decimal('0'), description="Minimum order amount (future)")
     estimated_preparation_time: int = Field(30, description="Estimated preparation time in minutes")
 

--- a/app/services/online_cart_service.py
+++ b/app/services/online_cart_service.py
@@ -629,9 +629,10 @@ async def checkout_cart(cart_id: UUID) -> dict:
                 if not items:
                     raise HTTPException(status_code=400, detail="El carrito está vacío")
 
-                # 4. Validate open status and minimum order amount from tenant profile
+                # 4. Validate online ordering gate, open status and minimum order amount from tenant profile
                 tenant_profile_query = """
-                    SELECT min_order_amount, estimated_preparation_time, is_manually_open, business_hours
+                    SELECT min_order_amount, estimated_preparation_time, is_manually_open, business_hours,
+                           accepts_online_orders
                     FROM tenant_public_profiles
                     WHERE tenant_id = $1
                 """
@@ -641,6 +642,11 @@ async def checkout_cart(cart_id: UUID) -> dict:
                 if profile:
                     from app.services.public_restaurant_service import is_currently_open
                     import json as _json
+                    if not profile['accepts_online_orders']:
+                        raise HTTPException(
+                            status_code=403,
+                            detail="Este restaurante no recibe pedidos en línea actualmente."
+                        )
                     bh = profile['business_hours']
                     if isinstance(bh, str):
                         bh = _json.loads(bh)


### PR DESCRIPTION
Closes uno0uno/warocol.com#496

## Summary

Make `accepts_online_orders` actually work as a gate. Until now the field was a placeholder — stored, exposed via API, and editable in `/negocio`, but never enforced. This wires it as a real guard at storefront checkout. The same field will gate the new POS delivery toggle in #497.

## Stack

🔵 FastAPI + 🟣 Postgres (no migration — column already exists).

## Changes

- **`app/models/tenant_public_profile.py:58`** — field description updated. No more `"(future)"`. Documents that the toggle now gates both storefront ordering and the POS delivery toggle.
- **`app/services/online_cart_service.py:633-654`** — extended the existing tenant-profile SELECT to include `accepts_online_orders`, then added a 403 guard ahead of the existing `is_currently_open` check (the not-accepting state is more permanent than "closed right now", so we surface it first).

## Pre-deploy data fix

Before this PR: only Waro Colombia (the single tenant with active online traffic) had `accepts_online_orders=false`. Flipping the gate would have killed its ordering. We ran a one-row UPDATE earlier (transcript captured) to set Waro Colombia → `true`. The other 8 tenants remain in their current state.

After deploy:
- 3 tenants with toggle ON: Waro Colombia, ARMELO PERRØ, Natural Food.
- 6 tenants with toggle OFF (no real activity).

## Testing

### DB-level (live tunnel)
- ✅ Verified column types and final adoption (3 enabled / 6 disabled).
- ✅ Confirmed Waro Colombia has the toggle ON before deploying the gate.

### Backend static
- ✅ AST parse clean for both modified files.
- ✅ `ruff check --target-version py39 --select F,E7,E9` clean for the changed files (one pre-existing E402 in unrelated file, not introduced here).

### Behavioral acceptance
- [ ] `POST /api/online/cart/{id}/checkout` returns 403 with Spanish message when tenant has `accepts_online_orders=false`.
- [ ] Returns 200 happy path when toggle is `true`.
- [ ] Compose: when both `accepts_online_orders=false` AND `is_manually_open=false`, the 403 not-accepting error wins (priority).
- [ ] Existing tenants with toggle ON keep working — no regression.
- [ ] `/api/tenant/public-profile` GET continues to return the field unchanged.

## Companion PR

Frontend changes (storefront — hide cart UI / disable checkout / banner copy) ship in a separate front_nuxt PR. Suggested deploy order: this PR first (backend gate enforced silently — frontend without it would still get a graceful 403 with a Spanish error), frontend second.

## Out of scope

- POS delivery toggle visibility (#497) — that issue's frontend will read the same `accepts_online_orders` field once this lands.
- Admin UI for the toggle — already exists at `/negocio`, no work needed.