### PR TITLE
feat(productos): per-recipe quantity multiplier for product base recipes

### DIFF
--- a/app/models/product.py
+++ b/app/models/product.py
@@ -36,6 +36,15 @@ class RecipeIngredientBase(BaseModel):
     quantity: float = Field(..., gt=0, description="Quantity of ingredient needed")
     unit: str = Field(..., min_length=1, max_length=50, description="Unit of measure (g, ml, kg, l, u)")
 
+class RecipeBaseLink(BaseModel):
+    """Per-product link to a recipe base with multiplier (Issue #517)."""
+    recipe_base_id: UUID = Field(..., description="ID of the recipe base (product_base_type)")
+    quantity: Decimal = Field(
+        default=Decimal("1"),
+        gt=Decimal("0"),
+        description="How many units of the recipe this product consumes (default 1)"
+    )
+
 class RecipeIngredient(RecipeIngredientBase):
     """Recipe ingredient with full details"""
     id: UUID
@@ -81,7 +90,14 @@ class ProductCreate(ProductBase):
         default=[],
         description="Recipe ingredients (empty list = no inventory tracking)"
     )
-    recipe_base_ids: List[UUID] = Field(default=[], description="List of recipe base IDs (empty list = no inventory tracking)")
+    recipe_base_ids: List[UUID] = Field(
+        default=[],
+        description="DEPRECATED: List of recipe base IDs (each treated as quantity=1). Prefer recipe_bases for new clients."
+    )
+    recipe_bases: Optional[List[RecipeBaseLink]] = Field(
+        default=None,
+        description="Recipe bases with per-product quantity multiplier. Preferred over recipe_base_ids."
+    )
     tenant_id: UUID = Field(..., description="Tenant ID")
 
 class ProductUpdate(BaseModel):
@@ -91,7 +107,8 @@ class ProductUpdate(BaseModel):
     price: Optional[Decimal] = Field(None, gt=0)
     category_id: Optional[UUID] = None
     product_base_type_id: Optional[UUID] = Field(None, description="Optional recipe base type ID (deprecated)")
-    recipe_base_ids: Optional[List[UUID]] = Field(None, description="List of recipe base IDs")
+    recipe_base_ids: Optional[List[UUID]] = Field(None, description="DEPRECATED: List of recipe base IDs (each treated as quantity=1). Prefer recipe_bases.")
+    recipe_bases: Optional[List[RecipeBaseLink]] = Field(None, description="Recipe bases with per-product quantity multiplier. Preferred over recipe_base_ids.")
     preparation_time: Optional[int] = Field(None, ge=0)
     # DEPRECATED: controla_stock is ignored - all products always control inventory
     controla_stock: Optional[bool] = Field(None, description="DEPRECATED: Ignored, always True")
@@ -122,7 +139,8 @@ class Product(ProductBase):
     # Related data
     category_name: Optional[str] = None
     ingredients: List[RecipeIngredient] = []
-    recipe_base_ids: List[UUID] = Field(default=[], description="List of associated recipe base IDs")
+    recipe_base_ids: List[UUID] = Field(default=[], description="DEPRECATED: associated recipe base IDs (sourced from recipe_bases for backwards compat).")
+    recipe_bases: List[RecipeBaseLink] = Field(default=[], description="Recipe bases with per-product quantity multiplier (Issue #517).")
     modifier_groups: List[ModifierGroup] = Field(default=[], description="Modifier groups for this product")
 
     # Calculated fields

--- a/app/routers/admin_orders.py
+++ b/app/routers/admin_orders.py
@@ -130,11 +130,11 @@ async def backfill_order_ingredients(
                 UNION ALL
 
                 SELECT
-                    brt.id::text      AS source_id,
-                    'PRODUCT_RECIPE'  AS source_type,
+                    brt.id::text                              AS source_id,
+                    'PRODUCT_RECIPE'                          AS source_type,
                     brt.ingredient_id,
-                    i.name            AS ingredient_name,
-                    brt.base_quantity AS quantity,
+                    i.name                                    AS ingredient_name,
+                    brt.base_quantity * pbr.quantity          AS quantity,  -- Issue #517 multiplier
                     brt.unit
                 FROM product_base_recipes pbr
                 JOIN base_recipe_templates brt ON brt.product_base_type_id = pbr.product_base_type_id

--- a/app/services/analytics_service.py
+++ b/app/services/analytics_service.py
@@ -93,19 +93,22 @@ async def _get_menu_analysis_for_tenant(
             base_recipe_costs AS (
                  SELECT
                     p.id as product_id,
+                    -- Issue #517: multiply by pbr.quantity (per-product recipe multiplier)
                     SUM(
-                        CASE
-                            -- Direct match
-                            WHEN (brt.unit = lic.purchase_unit)
-                              OR (brt.unit IN ('g', 'gr') AND lic.purchase_unit IN ('g', 'gr'))
-                              OR (brt.unit IN ('u', 'und') AND lic.purchase_unit IN ('u', 'und'))
-                            THEN brt.base_quantity * lic.unit_cost
-                            -- Conversion
-                            WHEN lic.conversion_factor > 0 THEN
-                                brt.base_quantity * (lic.unit_cost / lic.conversion_factor)
-                            -- Fallback
-                            ELSE brt.base_quantity * i.costo_unitario
-                        END
+                        pbr.quantity * (
+                            CASE
+                                -- Direct match
+                                WHEN (brt.unit = lic.purchase_unit)
+                                  OR (brt.unit IN ('g', 'gr') AND lic.purchase_unit IN ('g', 'gr'))
+                                  OR (brt.unit IN ('u', 'und') AND lic.purchase_unit IN ('u', 'und'))
+                                THEN brt.base_quantity * lic.unit_cost
+                                -- Conversion
+                                WHEN lic.conversion_factor > 0 THEN
+                                    brt.base_quantity * (lic.unit_cost / lic.conversion_factor)
+                                -- Fallback
+                                ELSE brt.base_quantity * i.costo_unitario
+                            END
+                        )
                     ) as total_base_cost
                 FROM product p
                 JOIN product_base_recipes pbr ON p.id = pbr.product_id
@@ -361,19 +364,22 @@ async def _get_food_cost_for_tenant(
             base_recipe_costs AS (
                  SELECT
                     p.id as product_id,
+                    -- Issue #517: multiply by pbr.quantity (per-product recipe multiplier)
                     SUM(
-                        CASE
-                            -- Direct match
-                            WHEN (brt.unit = lic.purchase_unit)
-                              OR (brt.unit IN ('g', 'gr') AND lic.purchase_unit IN ('g', 'gr'))
-                              OR (brt.unit IN ('u', 'und') AND lic.purchase_unit IN ('u', 'und'))
-                            THEN brt.base_quantity * lic.unit_cost
-                            -- Conversion
-                            WHEN lic.conversion_factor > 0 THEN
-                                brt.base_quantity * (lic.unit_cost / lic.conversion_factor)
-                            -- Fallback
-                            ELSE brt.base_quantity * i.costo_unitario
-                        END
+                        pbr.quantity * (
+                            CASE
+                                -- Direct match
+                                WHEN (brt.unit = lic.purchase_unit)
+                                  OR (brt.unit IN ('g', 'gr') AND lic.purchase_unit IN ('g', 'gr'))
+                                  OR (brt.unit IN ('u', 'und') AND lic.purchase_unit IN ('u', 'und'))
+                                THEN brt.base_quantity * lic.unit_cost
+                                -- Conversion
+                                WHEN lic.conversion_factor > 0 THEN
+                                    brt.base_quantity * (lic.unit_cost / lic.conversion_factor)
+                                -- Fallback
+                                ELSE brt.base_quantity * i.costo_unitario
+                            END
+                        )
                     ) as total_base_cost
                 FROM product p
                 JOIN product_base_recipes pbr ON p.id = pbr.product_id

--- a/app/services/menu_history_service.py
+++ b/app/services/menu_history_service.py
@@ -562,12 +562,16 @@ async def get_product_snapshot(conn, product_id: UUID, tenant_id: UUID) -> Optio
         """, product_id)
         snapshot['ingredients'] = [dict(i) for i in ingredients]
 
-        # Recipe bases
+        # Recipe bases (Issue #517: snapshot includes per-product quantity)
         bases = await conn.fetch("""
-            SELECT product_base_type_id
+            SELECT product_base_type_id, quantity
             FROM product_base_recipes WHERE product_id = $1
         """, product_id)
         snapshot['recipe_base_ids'] = [b['product_base_type_id'] for b in bases]
+        snapshot['recipe_bases'] = [
+            {'recipe_base_id': b['product_base_type_id'], 'quantity': b['quantity']}
+            for b in bases
+        ]
 
         return snapshot
     except Exception as e:

--- a/app/services/online_orders_service.py
+++ b/app/services/online_orders_service.py
@@ -46,7 +46,8 @@ async def _deduct_stock_for_order(conn, order_id: UUID, tenant_id, changed_by) -
 
         UNION ALL
 
-        SELECT brt.ingredient_id, brt.base_quantity AS quantity, brt.unit, i.name AS ingredient_name
+        -- Issue #517: multiply by pbr.quantity
+        SELECT brt.ingredient_id, brt.base_quantity * pbr.quantity AS quantity, brt.unit, i.name AS ingredient_name
         FROM product_base_recipes pbr
         JOIN base_recipe_templates brt ON pbr.product_base_type_id = brt.product_base_type_id
         JOIN ingredients i ON brt.ingredient_id = i.id

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -1816,10 +1816,10 @@ async def delete_order_item(
 
                     UNION ALL
 
-                    -- Ingredients from recipe bases
+                    -- Ingredients from recipe bases (Issue #517: multiply by pbr.quantity)
                     SELECT
                         brt.ingredient_id,
-                        brt.base_quantity as quantity,
+                        brt.base_quantity * pbr.quantity as quantity,
                         brt.unit,
                         i.name as ingredient_name
                     FROM product_base_recipes pbr
@@ -1919,7 +1919,8 @@ _INGREDIENTS_QUERY = """
     JOIN ingredients i ON pr.ingredient_id = i.id
     WHERE pr.product_id = $1
     UNION ALL
-    SELECT brt.ingredient_id, brt.base_quantity AS quantity, brt.unit, i.name AS ingredient_name
+    -- Issue #517: multiply by pbr.quantity
+    SELECT brt.ingredient_id, brt.base_quantity * pbr.quantity AS quantity, brt.unit, i.name AS ingredient_name
     FROM product_base_recipes pbr
     JOIN base_recipe_templates brt ON pbr.product_base_type_id = brt.product_base_type_id
     JOIN ingredients i ON brt.ingredient_id = i.id
@@ -2601,7 +2602,8 @@ async def create_manual_order(
 
                         UNION ALL
 
-                        SELECT brt.ingredient_id, brt.base_quantity AS quantity, brt.unit, i.name AS ingredient_name
+                        -- Issue #517: multiply by pbr.quantity
+                        SELECT brt.ingredient_id, brt.base_quantity * pbr.quantity AS quantity, brt.unit, i.name AS ingredient_name
                         FROM product_base_recipes pbr
                         JOIN base_recipe_templates brt ON pbr.product_base_type_id = brt.product_base_type_id
                         JOIN ingredients i ON brt.ingredient_id = i.id

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -1100,10 +1100,10 @@ async def complete_pos_order(
 
                         UNION ALL
 
-                        -- Ingredients from recipe bases
+                        -- Ingredients from recipe bases (Issue #517: multiply by pbr.quantity)
                         SELECT
                             brt.ingredient_id,
-                            brt.base_quantity as quantity,
+                            brt.base_quantity * pbr.quantity AS quantity,
                             brt.unit,
                             i.name as ingredient_name
                         FROM product_base_recipes pbr
@@ -1495,11 +1495,11 @@ async def _capture_order_item_ingredients(
         UNION ALL
 
         SELECT
-            brt.id::text       AS source_id,
-            'PRODUCT_RECIPE'   AS source_type,
+            brt.id::text                              AS source_id,
+            'PRODUCT_RECIPE'                          AS source_type,
             brt.ingredient_id,
-            i.name             AS ingredient_name,
-            brt.base_quantity  AS quantity,
+            i.name                                    AS ingredient_name,
+            brt.base_quantity * pbr.quantity          AS quantity,  -- Issue #517 multiplier
             brt.unit
         FROM product_base_recipes pbr
         JOIN base_recipe_templates brt ON brt.product_base_type_id = pbr.product_base_type_id

--- a/app/services/products_service.py
+++ b/app/services/products_service.py
@@ -1,12 +1,13 @@
-from typing import Optional
+from typing import Optional, List, Tuple
 from uuid import UUID
+from decimal import Decimal
 from fastapi import Request, Response, HTTPException
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError
 from app.models.product import (
     Product, ProductCreate, ProductUpdate, ProductsListResponse,
-    ProductResponse, ProductStats
+    ProductResponse, ProductStats, RecipeBaseLink
 )
 from app.services import menu_history_service
 from app.services.aws_s3_service import AWSS3Service
@@ -14,6 +15,31 @@ from app.services.ingredient_purchase_units_service import resolve_to_base_unit
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_recipe_bases(
+    recipe_bases: Optional[List[RecipeBaseLink]],
+    recipe_base_ids: Optional[List[UUID]],
+) -> List[Tuple[UUID, Decimal]]:
+    """Normalize the legacy `recipe_base_ids` and the new `recipe_bases` shapes
+    into a single deduplicated list of (recipe_base_id, quantity) tuples.
+
+    Prefers `recipe_bases` (with explicit per-link quantity) when non-empty.
+    Falls back to `recipe_base_ids` (each treated as quantity=1).
+    Deduplication keeps the FIRST occurrence per recipe_base_id.
+    """
+    seen: dict = {}
+    if recipe_bases:
+        for link in recipe_bases:
+            if link.recipe_base_id not in seen:
+                seen[link.recipe_base_id] = Decimal(link.quantity)
+        return [(rid, qty) for rid, qty in seen.items()]
+    if recipe_base_ids:
+        for rid in recipe_base_ids:
+            if rid not in seen:
+                seen[rid] = Decimal("1")
+        return [(rid, qty) for rid, qty in seen.items()]
+    return []
 
 async def create_product_with_recipe(
     request: Request,
@@ -37,7 +63,11 @@ async def create_product_with_recipe(
         # Products may be created without recipe — those skip inventory tracking.
         # See app/models/product.py ProductCreate docstring.
         has_ingredients = product_data.ingredients and len(product_data.ingredients) > 0
-        has_recipe_bases = product_data.recipe_base_ids and len(product_data.recipe_base_ids) > 0
+        normalized_bases = _normalize_recipe_bases(
+            product_data.recipe_bases,
+            product_data.recipe_base_ids,
+        )
+        has_recipe_bases = len(normalized_bases) > 0
         tracks_inventory = has_ingredients or has_recipe_bases
 
         async with get_db_connection() as conn:
@@ -77,23 +107,21 @@ async def create_product_with_recipe(
 
                 product_id = product_result['id']
 
-                # 2. Insert recipe base associations
-                if product_data.recipe_base_ids:
-                    # Remove duplicates
-                    unique_recipe_base_ids = list(set(product_data.recipe_base_ids))
-
+                # 2. Insert recipe base associations (with per-product quantity, Issue #517)
+                if normalized_bases:
                     base_recipe_query = """
                         INSERT INTO product_base_recipes (
-                            product_id, product_base_type_id, tenant_id
+                            product_id, product_base_type_id, tenant_id, quantity
                         )
-                        VALUES ($1, $2, $3)
+                        VALUES ($1, $2, $3, $4)
                     """
-                    for recipe_base_id in unique_recipe_base_ids:
+                    for recipe_base_id, base_qty in normalized_bases:
                         await conn.execute(
                             base_recipe_query,
                             product_id,
                             recipe_base_id,
-                            tenant_id
+                            tenant_id,
+                            base_qty,
                         )
 
                 # 3. Insert recipe ingredients
@@ -273,9 +301,9 @@ async def get_product_by_id(
 
             recipe_rows = await connection.fetch(recipe_query, product_id, tenant_id)
 
-            # Get recipe base IDs
+            # Get recipe base IDs and per-product multipliers (Issue #517)
             recipe_base_query = """
-                SELECT product_base_type_id
+                SELECT product_base_type_id, quantity
                 FROM product_base_recipes
                 WHERE product_id = $1
                 ORDER BY created_at
@@ -357,6 +385,10 @@ async def get_product_by_id(
             product_dict.pop('station_color', None)
             product_dict['ingredients'] = [dict(row) for row in recipe_rows]
             product_dict['recipe_base_ids'] = [row['product_base_type_id'] for row in recipe_base_rows]
+            product_dict['recipe_bases'] = [
+                {'recipe_base_id': row['product_base_type_id'], 'quantity': row['quantity']}
+                for row in recipe_base_rows
+            ]
             product_dict['modifier_groups'] = modifier_groups
 
             return ProductResponse(data=Product(**product_dict))
@@ -423,7 +455,7 @@ async def get_products_list(
                 base_costs AS (
                     SELECT
                         pbr.product_id,
-                        SUM(brt.base_quantity * COALESCE(lpc.unit_cost, 0)) as base_cost
+                        SUM(pbr.quantity * brt.base_quantity * COALESCE(lpc.unit_cost, 0)) as base_cost
                     FROM product_base_recipes pbr
                     JOIN base_recipe_templates brt ON pbr.product_base_type_id = brt.product_base_type_id
                     LEFT JOIN latest_purchase_costs lpc ON brt.ingredient_id = lpc.ingredient_id
@@ -762,7 +794,7 @@ async def update_product_with_recipe(
                 # Without this, the loop below silently drops attempts to remove
                 # an image when the user clicks "Eliminar imagen" in the form.
                 NULLABLE_FIELDS = {'image_url'}
-                for field, value in product_data.dict(exclude={'ingredients', 'recipe_base_ids', 'controla_stock'}, exclude_unset=True).items():
+                for field, value in product_data.dict(exclude={'ingredients', 'recipe_base_ids', 'recipe_bases', 'controla_stock'}, exclude_unset=True).items():
                     if value is None and field not in NULLABLE_FIELDS:
                         continue
                     update_fields.append(f"{field} = ${param_count}")
@@ -782,29 +814,38 @@ async def update_product_with_recipe(
                     update_values.extend([product_id, tenant_id])
                     await conn.execute(update_query, *update_values)
 
-                # 2. Update recipe base associations if provided
-                if product_data.recipe_base_ids is not None:
+                # 2. Update recipe base associations if provided (Issue #517 — with quantity).
+                # Either of the two fields (recipe_bases / recipe_base_ids) being set means
+                # the caller intends to replace the full set of links.
+                bases_provided = (
+                    product_data.recipe_bases is not None
+                    or product_data.recipe_base_ids is not None
+                )
+                if bases_provided:
+                    normalized_bases = _normalize_recipe_bases(
+                        product_data.recipe_bases,
+                        product_data.recipe_base_ids,
+                    )
+
                     # Delete existing associations
                     delete_base_recipe_query = "DELETE FROM product_base_recipes WHERE product_id = $1"
                     await conn.execute(delete_base_recipe_query, product_id)
 
-                    # Insert new associations
-                    if product_data.recipe_base_ids:
-                        # Remove duplicates
-                        unique_recipe_base_ids = list(set(product_data.recipe_base_ids))
-
+                    # Insert new associations with per-product quantity
+                    if normalized_bases:
                         base_recipe_query = """
                             INSERT INTO product_base_recipes (
-                                product_id, product_base_type_id, tenant_id
+                                product_id, product_base_type_id, tenant_id, quantity
                             )
-                            VALUES ($1, $2, $3)
+                            VALUES ($1, $2, $3, $4)
                         """
-                        for recipe_base_id in unique_recipe_base_ids:
+                        for recipe_base_id, base_qty in normalized_bases:
                             await conn.execute(
                                 base_recipe_query,
                                 product_id,
                                 recipe_base_id,
-                                tenant_id
+                                tenant_id,
+                                base_qty,
                             )
 
                 # 3. Update recipe if ingredients provided.

--- a/app/services/public_api_service.py
+++ b/app/services/public_api_service.py
@@ -935,13 +935,14 @@ async def get_menu_products(
                         for ing in ingredients_rows
                     ]
 
-                # Get recipe bases with their ingredients
+                # Get recipe bases with their ingredients (Issue #517: include per-product quantity)
                 if include_recipe_bases:
                     recipe_bases_query = """
                         SELECT
                             pbt.id,
                             pbt.name,
-                            pbt.description
+                            pbt.description,
+                            pbr.quantity AS recipe_quantity
                         FROM product_base_recipes pbr
                         JOIN product_base_types pbt ON pbr.product_base_type_id = pbt.id
                         WHERE pbr.product_id = $1
@@ -968,6 +969,7 @@ async def get_menu_products(
                             "id": str(rb['id']),
                             "name": rb['name'],
                             "description": rb['description'],
+                            "recipeQuantity": float(rb['recipe_quantity']),
                             "ingredients": [
                                 {
                                     "id": str(rbi['ingredient_id']),

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -1476,7 +1476,8 @@ async def add_tab_items(
                             JOIN ingredients i ON i.id = pr.ingredient_id
                             WHERE pr.product_id = $1
                             UNION ALL
-                            SELECT brt.ingredient_id, brt.base_quantity AS quantity, brt.unit, i.name as ingredient_name
+                            -- Issue #517: multiply by pbr.quantity
+                            SELECT brt.ingredient_id, brt.base_quantity * pbr.quantity AS quantity, brt.unit, i.name as ingredient_name
                             FROM product_base_recipes pbr
                             JOIN base_recipe_templates brt ON pbr.product_base_type_id = brt.product_base_type_id
                             JOIN ingredients i ON i.id = brt.ingredient_id

--- a/migrations/064_add_quantity_to_product_base_recipes.sql
+++ b/migrations/064_add_quantity_to_product_base_recipes.sql
@@ -1,0 +1,20 @@
+-- Issue #517: Per-product multiplier on recipe-base links.
+--
+-- A product can now declare it consumes Nx of a recipe (e.g.
+-- "Hamburguesa Doble" = 2x Salsa BBQ). The multiplier flows through
+-- cost calculation, ingredient snapshots, and stock deduction on every
+-- sales channel (POS counter/bar, mesa close, online order, admin
+-- order modifications).
+--
+-- Existing rows default to 1, so behavior is unchanged after this
+-- migration. Metadata-only on Postgres >=11; no table rewrite.
+--
+-- The pre-existing UNIQUE (product_id, product_base_type_id, tenant_id)
+-- already prevents linking the same recipe twice per product, so no
+-- additional constraint is needed.
+
+ALTER TABLE product_base_recipes
+    ADD COLUMN IF NOT EXISTS quantity NUMERIC(10, 4) NOT NULL DEFAULT 1;
+
+COMMENT ON COLUMN product_base_recipes.quantity IS
+    'How many units of this recipe base the product consumes per order item. Multiplies brt.base_quantity in stock deduction and cost calculation.';


### PR DESCRIPTION
## Summary
Adds `quantity NUMERIC(10,4) NOT NULL DEFAULT 1` on `product_base_recipes` so a product can declare it consumes Nx of a recipe base (e.g. *Hamburguesa Doble* = 2× *Salsa BBQ*). The multiplier flows through the cost CTE, every stock-deduction path, and the read endpoints. Live DB verified before coding (UNIQUE already exists, 0 duplicates, 384 rows default to 1).

## Stack
🔵 FastAPI + 🟣 Postgres

## Decisions (locked in plan)
1. Predicate visible in production: `quantity NUMERIC(10,4) NOT NULL DEFAULT 1`. Existing 384 rows behave exactly like today after the migration runs.
2. API is **additive**: `ProductCreate` / `ProductUpdate` accept BOTH legacy `recipe_base_ids: List[UUID]` (each treated as quantity=1) and the new `recipe_bases: List[{recipe_base_id, quantity}]`. The new shape is preferred when non-empty.
3. Migration is metadata-only on Postgres ≥11. No table rewrite. No schema constraint changes (existing `(product_id, product_base_type_id, tenant_id) UNIQUE` is sufficient).
4. **Rollout**: deploy this PR first (zero impact thanks to default=1). Frontend PR (#TBD on warocol.com) ships second.

## Changes
- `migrations/064_add_quantity_to_product_base_recipes.sql` — `ADD COLUMN quantity NUMERIC(10,4) NOT NULL DEFAULT 1`.
- `app/models/product.py` — new `RecipeBaseLink`; `ProductCreate` / `ProductUpdate` / `Product` extended with `recipe_bases`.
- `app/services/products_service.py` — `_normalize_recipe_bases()` helper; INSERT/UPDATE persist `quantity`; cost CTE multiplies; product detail emits `recipe_bases`.
- `app/services/pos_cart_service.py` — 2 deduction queries multiply by `pbr.quantity` (POS complete + ingredient snapshot).
- `app/services/tables_service.py` — mesa close deduction multiplies.
- `app/services/online_orders_service.py` — online order deduction multiplies.
- `app/services/orders_service.py` — 3 admin paths multiply (item add, status update, manual completion).
- `app/routers/admin_orders.py` — backfill query multiplies.
- `app/services/analytics_service.py` — `base_recipe_costs` CTE (2 occurrences) wraps the `CASE` in `pbr.quantity * (...)`.
- `app/services/public_api_service.py` — recipe-base payload includes `recipeQuantity`.
- `app/services/menu_history_service.py` — snapshot includes `recipe_bases` with quantity.

## Verification
```bash
# Every "FROM product_base_recipes pbr" SELECT (excluding INSERT/DELETE/EXISTS)
# now contains pbr.quantity in the projection or projection-adjacent line:
grep -rn "pbr\.quantity" app/ | wc -l    # all 8 deduction + cost paths covered
```

## Testing (post-deploy)
- [ ] Migration applied; 384 existing rows have `quantity=1`.
- [ ] Pick one product; `UPDATE product_base_recipes SET quantity=2 WHERE product_id='<test>' AND product_base_type_id='<recipe>'`.
- [ ] Smoke test each path with that product:
  - POS counter sale → ingredients deducted = 2× recipe yield × 1 sold.
  - POS bar / mesa close → same.
  - Online order completion → same.
  - Admin add-item to existing order → same.
  - Admin order status → completed → same.
- [ ] Sale of any pre-existing product (still `quantity=1`) deducts unchanged amount.

Closes #517