### PR TITLE
feat(online-orders): write ingredient snapshot on completion (CMV parity with POS)

### DIFF
--- a/app/services/online_orders_service.py
+++ b/app/services/online_orders_service.py
@@ -17,6 +17,11 @@ from app.services.waros_service import evaluate_and_award
 from app.services.cierre_service import _get_tenant_tax_config, _post_order_gl_entry, _post_order_cogs_gl_entry
 from app.services.ingredient_purchase_units_service import resolve_recipe_quantity_to_base_unit
 from app.services.comandas_service import fire_comandas
+# Issue #521 — reuse the POS snapshot writer so online orders also write
+# order_item_ingredients (per-line ingredient cost). Without this the COGS
+# GL entry posted right after deduction sums an empty table and skips,
+# leaving online sales out of CMV. Same function, same idempotency guarantees.
+from app.services.pos_cart_service import _capture_order_item_ingredients
 import logging
 
 logger = logging.getLogger(__name__)
@@ -29,7 +34,8 @@ async def _deduct_stock_for_order(conn, order_id: UUID, tenant_id, changed_by) -
     """
     items = await conn.fetch(
         """
-        SELECT oi.product_id, oi.quantity, p.name AS product_name, o.order_number
+        SELECT oi.id AS order_item_id, oi.product_id, oi.quantity,
+               p.name AS product_name, o.order_number
         FROM order_items oi
         JOIN product p ON p.id = oi.product_id
         JOIN orders o ON o.id = oi.order_id
@@ -54,6 +60,18 @@ async def _deduct_stock_for_order(conn, order_id: UUID, tenant_id, changed_by) -
     """
 
     for item in items:
+        # Issue #521: write the per-line ingredient snapshot first so the
+        # subsequent _post_order_cogs_gl_entry (called by the caller after
+        # this function returns) finds rows to sum. Idempotent via
+        # UNIQUE (order_item_id, ingredient_id) — re-running is safe.
+        await _capture_order_item_ingredients(
+            conn,
+            order_item_id=item["order_item_id"],
+            product_id=item["product_id"],
+            item_quantity=float(item["quantity"]),
+            tenant_id=str(tenant_id),
+        )
+
         ingredients = await conn.fetch(ingredients_query, item["product_id"])
         order_number = item["order_number"]
 


### PR DESCRIPTION
## Summary
Online (storefront) delivery / pickup orders had stock movements written correctly but never wrote `order_item_ingredients`. The COGS GL call (`_post_order_cogs_gl_entry`) that follows `_deduct_stock_for_order` (already at lines 502 and 619) was therefore summing an empty table and silently skipping. Every completed online order ended with no GL entry — CMV silently understated for the entire online channel.

## Stack
🔵 FastAPI + 🟣 Postgres

## Decisions (per plan)
1. **Reuse, don't extract** — import `pos_cart_service._capture_order_item_ingredients` directly. ~10 LOC change. Refactor to a shared `order_ingredients_snapshot.py` module is a follow-up if a third caller appears.
2. **Snapshot before stock movement** per item, mirroring POS. Same transaction means atomic.
3. **No backfill** of the 5 historical online orders without snapshots (out of scope per the issue).
4. **No modifier-ingredient deduction** changes (separate gap, separate issue).

## Changes
- `app/services/online_orders_service.py` (+19 / -1):
  - Add `oi.id AS order_item_id` to the items SELECT in `_deduct_stock_for_order`.
  - Import `_capture_order_item_ingredients` from `pos_cart_service`.
  - Call it per item, BEFORE the existing stock-deduction loop.

No DB migration, no model change, no router change, no frontend.

## Verification

After deploy, place a delivery order from the storefront, mark completed, then run:

```sql
-- A. Snapshot rows exist
SELECT i.name, oii.quantity, oii.unit_cost, oii.total_cost
  FROM order_item_ingredients oii
  JOIN order_items oi ON oi.id = oii.order_item_id
  JOIN ingredients i ON i.id = oii.ingredient_id
 WHERE oi.order_id = '<order-id>';

-- B. CMV GL entry posted
SELECT description, total_debit, total_credit
  FROM tenant_journal_entries
 WHERE source_module = 'orden_cogs' AND source_id = '<order-id>';
```

Both must return rows. Compare with POS reference (#13456) — same shape.

## Testing
- [ ] After deploy + new delivery order → `order_item_ingredients` populated for direct + recipe-base ingredients.
- [ ] After deploy + new delivery order → `tenant_journal_entries` has the CMV entry posted, `total_debit = total_credit = SUM(oii.total_cost)`.
- [ ] Re-running completion (any retry path) does NOT duplicate snapshot or GL rows.
- [ ] `pbr.quantity` multiplier from #517 honored in the snapshot quantity (works automatically because `_capture_order_item_ingredients` already uses the multiplied UNION).
- [ ] No regression on POS / mesa / admin paths.

Closes #521