### PR TITLE
feat(pos): cash tender input + change calculation per cash payment

### DIFF
--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -151,6 +151,8 @@ class CompleteOrderRequest(BaseModel):
     discount_value: Optional[float] = Field(None, description="10 for 10%, 5000 for $5,000 COP")
     split_mode: bool = Field(False, description="True when using split payment — creates order with payment_status='partial'")
     split_first_amount: float = Field(0.0, description="Amount for the first split payment (used only when split_mode=True)")
+    split_first_cash_received: Optional[float] = Field(None, description="Issue #524 — cash handed over by the customer for the first split payment. NULL for non-cash methods. Must be >= split_first_amount when set.")
+    cash_received: Optional[float] = Field(None, description="Issue #524 — cash handed over for a single (non-split) cash payment. NULL for non-cash methods. Must be >= total_amount.")
     table_session_id: Optional[UUID] = Field(None, description="Bar/table session ID — links the order to a session for source tracking")
     delivery_address_id: Optional[UUID] = Field(None, description="UUID of an addresses_profile row owned by customer_id. When set, this order is treated as a delivery and the comanda fires with source_type='delivery'.")
     scheduled_time: Optional[datetime] = Field(None, description="ISO datetime for scheduled delivery. NULL = ASAP. Forward-compatible: v1 UI sends NULL only.")
@@ -187,6 +189,8 @@ async def complete_order(
         order_data.delivery_address_id,
         order_data.scheduled_time,
         order_data.delivery_instructions,
+        split_first_cash_received=order_data.split_first_cash_received,
+        cash_received=order_data.cash_received,
     )
 
 
@@ -223,6 +227,7 @@ class AddPaymentRequest(BaseModel):
     amount: float = Field(..., gt=0, description="Amount for this payment")
     payment_method: str = Field(..., description="cash | card | digital | credit or custom slug")
     payment_method_id: Optional[str] = Field(None, description="UUID of payment_methods row")
+    cash_received: Optional[float] = Field(None, description="Issue #524 — cash handed over by the customer. NULL for non-cash. Must be >= amount when set.")
 
 
 class AddPaymentResponse(BaseModel):
@@ -279,4 +284,5 @@ async def add_cart_payment(
         amount=payment_data.amount,
         payment_method=payment_data.payment_method,
         payment_method_id=payment_data.payment_method_id,
+        cash_received=payment_data.cash_received,
     )

--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -123,12 +123,15 @@ class CloseSessionRequest(BaseModel):
     discount_value: Optional[float] = Field(None, description="10 for 10%, 5000 for $5,000 COP")
     split_mode: bool = Field(False, description="True when using split payment — keeps session open, marks orders as partial")
     split_first_amount: float = Field(0.0, description="Amount for the first split payment (used only when split_mode=True)")
+    split_first_cash_received: Optional[float] = Field(None, description="Issue #524 — cash handed over for the first split payment when payment_method='cash'. Must be >= split_first_amount.")
+    cash_received: Optional[float] = Field(None, description="Issue #524 — cash handed over for a single (non-split) cash close. Must be >= total session amount.")
 
 
 class AddSessionPaymentRequest(BaseModel):
     amount: float = Field(..., description="Amount for this partial payment")
     payment_method: str = Field(..., description="cash | card | digital")
     payment_method_id: Optional[UUID] = Field(None, description="UUID of the selected payment_methods row")
+    cash_received: Optional[float] = Field(None, description="Issue #524 — cash handed over for this payment when payment_method='cash'. Must be >= amount.")
 
 
 @router.post("/{table_id}/close")
@@ -152,6 +155,8 @@ async def close_session(request: Request, table_id: UUID, body: CloseSessionRequ
         body.credit_due_date, body.payment_method_id,
         body.discount_type, body.discount_value,
         body.split_mode, body.split_first_amount,
+        split_first_cash_received=body.split_first_cash_received,
+        cash_received=body.cash_received,
     )
 
 
@@ -165,6 +170,7 @@ async def add_session_payment(request: Request, table_id: UUID, body: AddSession
     return await tables_service.add_session_payment(
         request, table_id,
         body.amount, body.payment_method, body.payment_method_id,
+        cash_received=body.cash_received,
     )
 
 

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -600,12 +600,27 @@ async def add_order_payment(
     amount: float,
     payment_method: str,
     payment_method_id: Optional[str] = None,
+    cash_received: Optional[float] = None,
 ) -> Dict[str, Any]:
     """
     Add a partial payment to a POS cart's underlying order.
     Supports split payments (Mode 1: by amount, Mode 2: equal split).
     When paid_total >= total_amount, completes the order automatically.
+
+    Issue #524: cash_received captures the bill amount handed by the customer
+    (only valid for payment_method='cash'). Change due is derived as
+    cash_received - amount and is not stored.
     """
+    # Issue #524 — defense in depth: validate cash tender at service layer
+    # so we throw a clean error before the DB CHECK constraint catches it.
+    if cash_received is not None:
+        if payment_method != 'cash':
+            raise APIError("cash_received solo aplica a pagos en efectivo", status_code=400)
+        if cash_received < amount:
+            raise APIError(
+                f"Efectivo recibido ({cash_received}) debe ser mayor o igual al monto a cobrar ({amount})",
+                status_code=400,
+            )
     try:
         session_context = require_valid_session(request)
         tenant_id = session_context.tenant_id
@@ -669,14 +684,15 @@ async def add_order_payment(
                 payment_row = await conn.fetchrow(
                     """
                     INSERT INTO order_payments
-                        (order_id, tenant_id, amount, payment_method, payment_method_id, created_by_user_id)
+                        (order_id, tenant_id, amount, payment_method, payment_method_id, created_by_user_id, cash_received)
                     VALUES
-                        ($1, $2, $3, $4, $5::uuid, $6::uuid)
+                        ($1, $2, $3, $4, $5::uuid, $6::uuid, $7)
                     RETURNING id
                     """,
                     order_id, tenant_id, amount, payment_method,
                     payment_method_id,
                     user_id,
+                    cash_received,
                 )
                 payment_id = str(payment_row["id"])
 
@@ -756,6 +772,9 @@ async def complete_pos_order(
     delivery_address_id: Optional[UUID] = None,
     scheduled_time: Optional[datetime] = None,
     delivery_instructions: Optional[str] = None,
+    *,
+    split_first_cash_received: Optional[float] = None,
+    cash_received: Optional[float] = None,
 ) -> dict:
     """
     Complete a POS order:
@@ -864,15 +883,29 @@ async def complete_pos_order(
                 if _discount_amount:
                     _item_subtotals = _distribute_discount(_item_subtotals, _discount_amount)
 
+                # Issue #524 — single-payment cash flow stores cash_received on the orders row.
+                # Split mode keeps it NULL here and stores per-line on order_payments below (step 7a).
+                _orders_cash_received: Optional[float] = None
+                if not split_mode and cash_received is not None:
+                    if payment_method != 'cash':
+                        raise APIError("cash_received solo aplica a pagos en efectivo", status_code=400)
+                    if cash_received < float(_discounted_total):
+                        raise APIError(
+                            f"Efectivo recibido ({cash_received}) debe ser mayor o igual al total ({_discounted_total})",
+                            status_code=400,
+                        )
+                    _orders_cash_received = cash_received
+
                 order_query = """
                     INSERT INTO orders (
                         user_id, tenant_id, customer_id, payment_method, pos_cart_id,
                         order_date, total_amount, status, payment_status, credit_due_date,
                         payment_method_id, discount_type, discount_value, discount_amount,
                         table_session_id,
-                        delivery_address_id, scheduled_time, delivery_instructions
+                        delivery_address_id, scheduled_time, delivery_instructions,
+                        cash_received
                     )
-                    VALUES ($1, $2, $3, $4, $5, NOW(), $6, 'completed', $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+                    VALUES ($1, $2, $3, $4, $5, NOW(), $6, 'completed', $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
                     RETURNING id, order_number, created_at
                 """
                 order_row = await conn.fetchrow(
@@ -893,6 +926,7 @@ async def complete_pos_order(
                     delivery_address_id,
                     scheduled_time,
                     delivery_instructions,
+                    _orders_cash_received,
                 )
                 order_id = order_row['id']
                 order_number = order_row['order_number']
@@ -1229,20 +1263,30 @@ async def complete_pos_order(
                 except Exception as _fe:
                     logger.error(f"Auto-fire failed for POS order {order_id}: {_fe}")
 
-                # 7a. In split mode: record first payment; cart stays active
+                # 7a. In split mode: record first payment; cart stays active.
+                # Issue #524: split_first_cash_received is captured when the first split is cash.
                 _split_paid_total = 0.0
                 _split_remaining = float(_discounted_total)
                 _split_is_complete = False
                 if split_mode and split_first_amount > 0:
+                    if split_first_cash_received is not None:
+                        if payment_method != 'cash':
+                            raise APIError("split_first_cash_received solo aplica a pagos en efectivo", status_code=400)
+                        if split_first_cash_received < split_first_amount:
+                            raise APIError(
+                                f"Efectivo recibido ({split_first_cash_received}) debe ser mayor o igual al monto ({split_first_amount})",
+                                status_code=400,
+                            )
                     await conn.execute(
                         """
                         INSERT INTO order_payments
-                            (order_id, tenant_id, amount, payment_method, payment_method_id, created_by_user_id)
-                        VALUES ($1, $2, $3, $4, $5::uuid, $6::uuid)
+                            (order_id, tenant_id, amount, payment_method, payment_method_id, created_by_user_id, cash_received)
+                        VALUES ($1, $2, $3, $4, $5::uuid, $6::uuid, $7)
                         """,
                         order_id, tenant_id, split_first_amount, payment_method,
                         str(payment_method_id) if payment_method_id else None,
                         str(user_id) if user_id else None,
+                        split_first_cash_received,
                     )
                     _split_paid_total = split_first_amount
                     _split_remaining = max(0.0, float(_discounted_total) - split_first_amount)

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -539,7 +539,7 @@ async def open_session(request: Request, table_id: UUID) -> dict:
         raise APIError(f"Error opening session: {e}", status_code=500)
 
 
-async def close_session(request: Request, table_id: UUID, payment_method: Optional[str] = None, customer_id: Optional[str] = None, credit_due_date: Optional[date] = None, payment_method_id: Optional[UUID] = None, discount_type: Optional[str] = None, discount_value: Optional[float] = None, split_mode: bool = False, split_first_amount: float = 0.0) -> dict:
+async def close_session(request: Request, table_id: UUID, payment_method: Optional[str] = None, customer_id: Optional[str] = None, credit_due_date: Optional[date] = None, payment_method_id: Optional[UUID] = None, discount_type: Optional[str] = None, discount_value: Optional[float] = None, split_mode: bool = False, split_first_amount: float = 0.0, *, split_first_cash_received: Optional[float] = None, cash_received: Optional[float] = None) -> dict:
     """
     Close the active session for a table.
     If payment_method is provided, marks all pending orders as completed with that payment method.
@@ -681,6 +681,34 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                         f"discount_amount={_discount_amount}) for session {session_row['id']}"
                     )
 
+                    # Issue #524 — single-payment (non-split) cash close: attach cash_received
+                    # to the FIRST completed order in the session (others stay NULL). Cierre
+                    # SUM(cash_received) over a period reconstructs total cash received correctly.
+                    if not split_mode and cash_received is not None:
+                        if payment_method != 'cash':
+                            raise APIError("cash_received solo aplica a pagos en efectivo", status_code=400)
+                        session_total_for_check = await conn.fetchval(
+                            "SELECT COALESCE(SUM(total_amount), 0) FROM orders WHERE table_session_id = $1 AND status = 'completed'",
+                            session_row["id"],
+                        )
+                        if cash_received < float(session_total_for_check or 0):
+                            raise APIError(
+                                f"Efectivo recibido ({cash_received}) debe ser mayor o igual al total de la sesión ({session_total_for_check})",
+                                status_code=400,
+                            )
+                        await conn.execute(
+                            """
+                            UPDATE orders SET cash_received = $1
+                             WHERE id = (
+                               SELECT id FROM orders
+                                WHERE table_session_id = $2 AND status = 'completed'
+                                ORDER BY created_at LIMIT 1
+                             )
+                            """,
+                            cash_received,
+                            session_row["id"],
+                        )
+
                     # GL journal entries — one per order, atomic with session close
                     # Failure is swallowed: GL must never block the close
                     try:
@@ -713,8 +741,20 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                         logger.error(f"GL entries failed for session {session_row['id']}: {_gl_exc}")
 
                     # In split_mode: record first payment proportionally across session orders
-                    # and keep session open
+                    # and keep session open.
+                    # Issue #524: validate split_first_cash_received once, then attach the full
+                    # cash_received to the FIRST order's row only (others stay NULL). Cierre sums
+                    # cash_received over the period — putting it once is correct and avoids the
+                    # CHECK (cash_received >= amount) constraint violating on proportionally-split rows.
                     if split_mode and split_first_amount > 0:
+                        if split_first_cash_received is not None:
+                            if payment_method != 'cash':
+                                raise APIError("split_first_cash_received solo aplica a pagos en efectivo", status_code=400)
+                            if split_first_cash_received < split_first_amount:
+                                raise APIError(
+                                    f"Efectivo recibido ({split_first_cash_received}) debe ser mayor o igual al monto ({split_first_amount})",
+                                    status_code=400,
+                                )
                         user_id = session_context.user_id if hasattr(session_context, 'user_id') else None
                         order_rows = await conn.fetch(
                             "SELECT id, total_amount FROM orders WHERE table_session_id = $1 AND status = 'completed' ORDER BY created_at",
@@ -729,15 +769,18 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                                 else:
                                     portion = round(split_first_amount * float(ord_row["total_amount"]) / session_total)
                                     remaining_payment -= portion
+                                # Issue #524: cash_received only on the first row (sum still correct over period)
+                                row_cash_received = split_first_cash_received if i == 0 else None
                                 await conn.execute(
                                     """
                                     INSERT INTO order_payments
-                                        (order_id, tenant_id, amount, payment_method, payment_method_id, created_by_user_id)
-                                    VALUES ($1, $2, $3, $4, $5::uuid, $6::uuid)
+                                        (order_id, tenant_id, amount, payment_method, payment_method_id, created_by_user_id, cash_received)
+                                    VALUES ($1, $2, $3, $4, $5::uuid, $6::uuid, $7)
                                     """,
                                     ord_row["id"], tenant_id, portion, payment_method,
                                     str(payment_method_id) if payment_method_id else None,
                                     str(user_id) if user_id else None,
+                                    row_cash_received,
                                 )
 
                 else:
@@ -912,12 +955,26 @@ async def add_session_payment(
     amount: float,
     payment_method: str,
     payment_method_id: Optional[UUID] = None,
+    cash_received: Optional[float] = None,
 ) -> dict:
     """
     Add a partial payment to an open mesa session that is in split payment mode.
     Distributes the payment proportionally across session orders.
     When total paid >= session total, closes the session and marks all orders as paid.
+
+    Issue #524: cash_received captures the bill amount handed by the customer for
+    cash payment lines. Stored on the FIRST proportional row only (NULL on the
+    rest); cierre SUM(cash_received) over a period yields the correct total.
     """
+    # Issue #524 — defense-in-depth validation
+    if cash_received is not None:
+        if payment_method != 'cash':
+            raise APIError("cash_received solo aplica a pagos en efectivo", status_code=400)
+        if cash_received < amount:
+            raise APIError(
+                f"Efectivo recibido ({cash_received}) debe ser mayor o igual al monto ({amount})",
+                status_code=400,
+            )
     try:
         session_context = require_valid_session(request)
         tenant_id = session_context.tenant_id
@@ -955,15 +1012,18 @@ async def add_session_payment(
                     else:
                         portion = round(amount * float(ord_row["total_amount"]) / session_total)
                         remaining_payment -= portion
+                    # Issue #524 — cash_received only on the first row (sum still correct over period)
+                    row_cash_received = cash_received if i == 0 else None
                     await conn.execute(
                         """
                         INSERT INTO order_payments
-                            (order_id, tenant_id, amount, payment_method, payment_method_id, created_by_user_id)
-                        VALUES ($1, $2, $3, $4, $5::uuid, $6::uuid)
+                            (order_id, tenant_id, amount, payment_method, payment_method_id, created_by_user_id, cash_received)
+                        VALUES ($1, $2, $3, $4, $5::uuid, $6::uuid, $7)
                         """,
                         ord_row["id"], tenant_id, portion, payment_method,
                         str(payment_method_id) if payment_method_id else None,
                         str(user_id) if user_id else None,
+                        row_cash_received,
                     )
 
                 # Recompute paid total

--- a/migrations/065_add_cash_received_to_order_payments.sql
+++ b/migrations/065_add_cash_received_to_order_payments.sql
@@ -1,0 +1,35 @@
+-- Issue #524: cash tender + change calculation per cash payment line.
+--
+-- The cashier records how much cash the customer handed over and the
+-- system derives the change (vuelto) live. Persisted on:
+--   * order_payments.cash_received — for split-tender cash lines.
+--   * orders.cash_received — for single-payment (non-split) cash sales,
+--     because the existing flow does NOT insert order_payments rows for
+--     single payments (cierre relies on that absence as a "legacy" fallback
+--     to avoid double-counting).
+--
+-- Both columns are nullable; non-cash methods leave NULL. Existing rows
+-- stay NULL — backwards compatible. Metadata-only on PG >=11 (no table
+-- rewrite).
+
+-- Per-line cash tender (split mode)
+ALTER TABLE order_payments
+    ADD COLUMN IF NOT EXISTS cash_received NUMERIC(12, 2) NULL;
+
+ALTER TABLE order_payments
+    ADD CONSTRAINT chk_order_payment_cash_received_gte_amount
+    CHECK (cash_received IS NULL OR cash_received >= amount);
+
+COMMENT ON COLUMN order_payments.cash_received IS
+    'Cash handed over by the customer for this split payment line. Always NULL for non-cash methods. Change due is derived: cash_received - amount.';
+
+-- Order-level cash tender (single-payment cash sales — flow does not insert order_payments rows)
+ALTER TABLE orders
+    ADD COLUMN IF NOT EXISTS cash_received NUMERIC(12, 2) NULL;
+
+ALTER TABLE orders
+    ADD CONSTRAINT chk_orders_cash_received_gte_total
+    CHECK (cash_received IS NULL OR cash_received >= total_amount);
+
+COMMENT ON COLUMN orders.cash_received IS
+    'Cash handed over by the customer for the entire order, used only when the order has a single cash payment (no order_payments rows). Always NULL for split-mode orders or non-cash sales. Change due is derived: cash_received - total_amount.';


### PR DESCRIPTION
## Summary
Cashier captures \`cash_received\` for cash payment lines; system derives \`vuelto = received - amount\` and persists per the existing single vs split flow.

## Stack
🔵 FastAPI + 🟣 Postgres

## Storage strategy (driven by existing flows)
- **Split-tender cash lines** → \`order_payments.cash_received\` (per row).
- **Single-payment cash sale** → \`orders.cash_received\` (the single-payment flow does NOT insert into \`order_payments\`; cierre legacy fallback reads \`orders.total_amount\` — adding rows would double-count).
- Both columns nullable, with \`CHECK (cash_received IS NULL OR cash_received >= amount/total_amount)\`.

## API additive — 4 endpoints accept new optional fields
- \`POST /api/pos/cart/{id}/complete\`: \`cash_received\`, \`split_first_cash_received\`
- \`POST /api/pos/cart/{id}/payments\`: \`cash_received\`
- \`POST /api/tables/{id}/close\`: \`cash_received\`, \`split_first_cash_received\`
- \`POST /api/tables/{id}/payments\`: \`cash_received\`

Non-cash methods that send the field get a clean 400.

## Changes
- Migration 065 — adds \`cash_received\` + CHECK to both \`order_payments\` and \`orders\`.
- \`pos_cart_service.py\` — 2 INSERTs + service-layer validation.
- \`tables_service.py\` — 2 INSERTs + a separate UPDATE for non-split mesa close.
- Routers — body models extended.

Frontend PR: warocol.com #525 (will be created next).

Closes #524 (backend half)