### PR TITLE
feat(pos-tax-preview): add GET /api/pos/cart/{id}/tax-preview endpoint

### DIFF
--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -2,7 +2,7 @@
 POS Cart Router
 Endpoints for managing POS cart persistence
 """
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, Query
 from typing import List, Optional, Any, Dict
 from uuid import UUID
 from datetime import date, datetime
@@ -279,4 +279,26 @@ async def add_cart_payment(
         amount=payment_data.amount,
         payment_method=payment_data.payment_method,
         payment_method_id=payment_data.payment_method_id,
+    )
+
+
+@router.get("/{cart_id}/tax-preview")
+async def get_cart_tax_preview(
+    request: Request,
+    cart_id: UUID,
+    discount_amount: Optional[float] = Query(
+        None,
+        ge=0,
+        description="Issue #526 — in-flight discount applied client-side, used to compute taxes on the post-discount base.",
+    ),
+):
+    """
+    Return the running tax breakdown for an in-flight POS cart.
+
+    Mirrors the shape of the mesa preview returned by GET /api/tables/{id}/current.
+    Used by the cart sidebar in counter / bar mode so it shows live IVA / IPC
+    instead of a hardcoded "Impuestos (0%)".
+    """
+    return await pos_cart_service.get_cart_tax_preview(
+        request, cart_id, discount_amount,
     )

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -594,6 +594,86 @@ async def update_cart_total(conn, cart_id: UUID):
     await conn.execute(total_query, cart_id)
 
 
+async def get_cart_tax_preview(
+    request: Request,
+    cart_id: UUID,
+    discount_amount: Optional[float] = None,
+) -> Dict[str, Any]:
+    """
+    Issue #526 — preview the tax breakdown for an in-flight POS cart.
+
+    Mirrors the mesa preview at tables_service.get_current_session (which
+    aggregates order_items by tax_category) but sources rows from
+    pos_cart_items because POS counter/bar carts have no orders yet.
+    Reuses the shared `_compute_tax_breakdown` helper so the sidebar
+    always agrees with the cobrar response.
+
+    pos_cart_items.subtotal already includes modifier prices (computed in
+    create_cart_with_batch_items: `subtotal = (unit_price + modifiers_total) * quantity`),
+    so no extra JOIN to pos_cart_item_modifiers is needed.
+
+    Args:
+        cart_id: the active POS cart UUID.
+        discount_amount: optional in-flight discount applied client-side
+            but used here to compute taxes on the post-discount base.
+
+    Returns:
+        {"standard_tax": float, "liquor_tax": float, "standard_tax_label": str}
+    """
+    # Local imports keep cierre / orders helpers cycle-free at module import
+    from app.services.orders_service import _compute_tax_breakdown
+
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    async with get_db_connection() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT
+                COALESCE(p.tax_category, 'standard') AS tax_category,
+                COALESCE(SUM(pci.subtotal), 0) AS subtotal
+              FROM pos_cart_items pci
+              JOIN product p ON p.id = pci.product_id
+             WHERE pci.cart_id = $1
+             GROUP BY COALESCE(p.tax_category, 'standard')
+            """,
+            cart_id,
+        )
+
+        # Empty cart short-circuit: helper expects rows; return zero shape directly.
+        if not rows:
+            return {
+                "standard_tax": 0.0,
+                "liquor_tax": 0.0,
+                "standard_tax_label": "Impuesto",
+            }
+
+        # Apply discount proportionally before tax breakdown — mirrors
+        # close_session/complete_pos_order behaviour. Guard against discount
+        # >= total (frontend should clamp, but defense in depth).
+        tax_rows: List[dict] = [{"tax_category": r["tax_category"], "subtotal": float(r["subtotal"])} for r in rows]
+        if discount_amount is not None and discount_amount > 0:
+            total_subtotal = sum(r["subtotal"] for r in tax_rows)
+            if total_subtotal > 0:
+                effective_discount = min(float(discount_amount), total_subtotal)
+                factor = 1.0 - (effective_discount / total_subtotal)
+                tax_rows = [
+                    {"tax_category": r["tax_category"], "subtotal": max(0.0, r["subtotal"] * factor)}
+                    for r in tax_rows
+                ]
+
+        tax_config = await _get_tenant_tax_config(conn, tenant_id)
+        std_tax, liq_tax, tax_label = _compute_tax_breakdown(tax_rows, tax_config)
+
+    return {
+        "standard_tax": float(std_tax),
+        "liquor_tax": float(liq_tax),
+        "standard_tax_label": tax_label,
+    }
+
+
 async def add_order_payment(
     request: Request,
     cart_id: str,


### PR DESCRIPTION
## Summary
Backend endpoint that mirrors the mesa tax preview for in-flight POS carts. Reuses the shared \`_compute_tax_breakdown\` helper (same as mesa, same as cobrar response), so the sidebar preview always agrees with the post-cobro modal.

## Stack
🔵 FastAPI + 🟣 Postgres

## Changes
- \`app/services/pos_cart_service.py\` — new \`get_cart_tax_preview(request, cart_id, discount_amount)\` (~80 LOC).
- \`app/routers/pos_cart.py\` — new \`GET /{cart_id}/tax-preview?discount_amount=N\` (~24 LOC).

No DB schema change. No model change. \`pos_cart_items.subtotal\` already includes modifier prices (verified at \`create_cart_with_batch_items:184\`).

## Behavior
- Empty cart → \`{standard_tax: 0, liquor_tax: 0, standard_tax_label: "Impuesto"}\` (no exception).
- Tenant with no taxes → returns 0/0 with default label.
- Discount applied proportionally across tax categories before breakout (mirrors close_session / complete_pos_order).
- Discount > total → clamped to total (defense in depth).

## Manual smoke test
\`\`\`bash
# Auth required (returns 401 unauthenticated)
curl -s "http://localhost:8080/api/pos/cart/<cart_id>/tax-preview"
# {"error":true,"message":"Valid session required"}

# Authenticated (via UI session) — for $40k cart on Waro Colombia (IVA 19% included):
# expects {"standard_tax": 6386, "liquor_tax": 0, "standard_tax_label": "IVA (19%)"}
\`\`\`

## Companion frontend PR
warocol.com #527 — sidebar consumes this endpoint when in counter / bar mode.

## Note re: #506
This endpoint uses the helper directly. The complete_pos_order path still has its own inline copy (subject of #506). Until #506 is fixed, the sidebar (helper-based) and modal (inline-based) may show ≤rounding differences. Sidebar is the correct value. Coordinate merges.

Closes #526