### PR TITLE
feat(customers-search): expose fiscal_id in search results

### DIFF
--- a/app/models/customer.py
+++ b/app/models/customer.py
@@ -70,11 +70,17 @@ class CustomerSearchResponse(BaseModel):
 
 
 class CustomerSummary(BaseModel):
-    """Minimal customer data for search results"""
+    """Minimal customer data for search results.
+    Includes fiscal_id so the POS search results can show the cédula/NIT
+    that matched, helping the cashier confirm the right customer when
+    several share a similar name (Issue #526 follow-up).
+    """
     id: UUID
     name: Optional[str] = None
     phone_number: Optional[str] = None
     email: Optional[str] = None
+    fiscal_id: Optional[str] = None
+    fiscal_id_type: Optional[str] = None
 
 
 class CustomerUpdate(FiscalDataMixin):

--- a/app/services/customers_service.py
+++ b/app/services/customers_service.py
@@ -404,12 +404,16 @@ async def search_customers_by_query(
         async with get_db_connection() as conn:
             # Match against name, phone, OR fiscal_id (NIT/cédula) so users
             # can find a customer by typing the document number.
+            # Also return fiscal_id + fiscal_id_type so the UI can display
+            # the document that matched.
             query = """
                 SELECT DISTINCT
                     p.id,
                     p.name,
                     p.phone_number,
-                    p.email
+                    p.email,
+                    p.fiscal_id,
+                    p.fiscal_id_type
                 FROM profile p
                 JOIN tenant_members tm ON tm.user_id = p.id
                 WHERE tm.tenant_id = $1
@@ -430,7 +434,9 @@ async def search_customers_by_query(
                     id=row['id'],
                     name=row['name'],
                     phone_number=row['phone_number'],
-                    email=row['email']
+                    email=row['email'],
+                    fiscal_id=row['fiscal_id'],
+                    fiscal_id_type=row['fiscal_id_type'],
                 )
                 for row in rows
             ]


### PR DESCRIPTION
## Summary
The customers search-by-query endpoint already matched against \`profile.fiscal_id\` (cédula / NIT) — cashiers could find a customer by document number. But the response only returned \`id, name, phone, email\`. When the search hit a customer by NIT, the cashier couldn't see WHICH customer's NIT had matched.

## Stack
🔵 FastAPI + 🟣 Postgres

## Changes
- \`app/models/customer.py\` — add \`fiscal_id\` + \`fiscal_id_type\` to \`CustomerSummary\`.
- \`app/services/customers_service.py\` — extend the SELECT in \`search_customers_by_query\` to return those two columns.

No new query, no new endpoint, no DB change.

## Companion frontend PR
warocol.com #528 — adds the placeholder hint and renders the document in result cards.