### PR TITLE
feat(tenant-config): auto_select_generic_enabled flag (#529)

### DIFF
--- a/app/models/tenant_public_profile.py
+++ b/app/models/tenant_public_profile.py
@@ -69,6 +69,12 @@ class TenantPublicProfileBase(BaseModel):
     comandas_enabled: bool = Field(False, description="Whether the comandas/KDS module is enabled. When false, system behaves exactly as today.")
     kds_enabled: bool = Field(False, description="Whether KDS station screens (/cocina/[id]) are enabled. Requires comandas_enabled=true.")
 
+    # POS personalization (issue #529)
+    auto_select_generic_enabled: bool = Field(
+        False,
+        description="POS: when true, /pos/checkout pre-selects the Genérico customer (phone_number='0000000000') in counter/bar mode."
+    )
+
 class TenantPublicProfileCreate(TenantPublicProfileBase):
     """Create tenant public profile"""
     tenant_id: UUID = Field(..., description="Tenant ID")
@@ -105,6 +111,7 @@ class TenantPublicProfileUpdate(BaseModel):
     tables_enabled: Optional[bool] = None
     comandas_enabled: Optional[bool] = None
     kds_enabled: Optional[bool] = None
+    auto_select_generic_enabled: Optional[bool] = None
 
 class TenantPublicProfile(TenantPublicProfileBase):
     """Complete tenant public profile with all fields"""

--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -70,9 +70,10 @@ async def upsert_public_profile(
                         accepts_online_orders, min_order_amount, estimated_preparation_time,
                         tables_enabled,
                         comandas_enabled, kds_enabled,
+                        auto_select_generic_enabled,
                         updated_at
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, CURRENT_TIMESTAMP)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, CURRENT_TIMESTAMP)
                     ON CONFLICT (tenant_id)
                     DO UPDATE SET
                         slug = EXCLUDED.slug,
@@ -98,6 +99,7 @@ async def upsert_public_profile(
                         tables_enabled = EXCLUDED.tables_enabled,
                         comandas_enabled = EXCLUDED.comandas_enabled,
                         kds_enabled = EXCLUDED.kds_enabled,
+                        auto_select_generic_enabled = EXCLUDED.auto_select_generic_enabled,
                         updated_at = CURRENT_TIMESTAMP
                     RETURNING *
                 """
@@ -127,7 +129,8 @@ async def upsert_public_profile(
                     profile_data.estimated_preparation_time,
                     profile_data.tables_enabled,
                     profile_data.comandas_enabled,
-                    profile_data.kds_enabled
+                    profile_data.kds_enabled,
+                    profile_data.auto_select_generic_enabled
                 )
 
                 profile = TenantPublicProfile(**dict(result))
@@ -193,8 +196,9 @@ async def update_public_profile(
                         business_hours, social_media,
                         accepts_online_orders, min_order_amount, estimated_preparation_time,
                         is_manually_open,
-                        comandas_enabled, kds_enabled
-                    ) VALUES ($1, $2, $3, FALSE, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+                        comandas_enabled, kds_enabled,
+                        auto_select_generic_enabled
+                    ) VALUES ($1, $2, $3, FALSE, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
                     RETURNING *
                 """
                 result = await conn.fetchrow(
@@ -218,6 +222,7 @@ async def update_public_profile(
                     data_dict.get('is_manually_open', True),
                     data_dict.get('comandas_enabled', False),
                     data_dict.get('kds_enabled', False),
+                    data_dict.get('auto_select_generic_enabled', False),
                 )
 
                 profile_data_dict = dict(result)

--- a/migrations/066_add_auto_select_generic_customer_to_tenant_public_profiles.sql
+++ b/migrations/066_add_auto_select_generic_customer_to_tenant_public_profiles.sql
@@ -1,0 +1,11 @@
+-- 066_add_auto_select_generic_customer_to_tenant_public_profiles.sql
+-- Issue #529 — feat(pos-checkout): auto-select Genérico customer at checkout open
+--
+-- Adds a per-tenant boolean flag that, when true, makes /pos/checkout
+-- pre-select the Genérico customer (phone_number='0000000000') in counter
+-- and bar modes, eliminating the modal step on every fast counter sale.
+--
+-- Default false to preserve current behavior for existing tenants.
+
+ALTER TABLE tenant_public_profiles
+    ADD COLUMN IF NOT EXISTS auto_select_generic_enabled BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary

Backend support for issue #529: adds `auto_select_generic_enabled BOOLEAN NOT NULL DEFAULT false` on `tenant_public_profiles`, exposes it on `TenantPublicProfileBase` and `TenantPublicProfileUpdate`, and wires it into the upsert and first-time-create paths in `tenant_config_service.update_public_profile`. The PATCH dynamic update path picks up the new field automatically via `model_dump(exclude_unset=True)`.

## Stack

🟣 Postgres + 🔵 FastAPI

## Changes

- `migrations/066_add_auto_select_generic_customer_to_tenant_public_profiles.sql`: idempotent ALTER TABLE
- `app/models/tenant_public_profile.py`: new field on Base + Update (Python 3.9 compatible — `Optional[bool]`)
- `app/services/tenant_config_service.py`: extend the two explicit INSERT column lists

## Testing

- Migration applied locally and verified: `\d tenant_public_profiles` shows the new column with the right default.
- `python3 -m py_compile` passes for the two changed files.
- The corresponding frontend PR ships the toggle UI and the checkout hook.

Refs #529