### PR TITLE
feat(accounting): pending_review + 9 PUC accounts + source_module fix (#531)

### DIFF
--- a/app/models/accounting.py
+++ b/app/models/accounting.py
@@ -93,6 +93,12 @@ class JournalEntryCreate(BaseModel):
     description: str
     reference: Optional[str] = None
     lines: List[JournalLineCreate]
+    # Issue #531 — annotation flag for asientos created via "Actualizar saldo
+    # real" with motivo "no estoy seguro". When true, the asiento is fully
+    # posted and balanced — only marks it for accountant review later.
+    source_module: Optional[str] = Field(None, alias='sourceModule')
+    source_id: Optional[UUID] = Field(None, alias='sourceId')
+    pending_review: Optional[bool] = Field(False, alias='pendingReview')
 
     class Config:
         populate_by_name = True
@@ -115,6 +121,7 @@ class JournalEntry(BaseModel):
     posted_at: Optional[datetime] = Field(None, alias='postedAt')
     voided_at: Optional[datetime] = Field(None, alias='voidedAt')
     created_at: datetime = Field(alias='createdAt')
+    pending_review: bool = Field(False, alias='pendingReview')
 
     class Config:
         populate_by_name = True

--- a/app/services/accounting_service.py
+++ b/app/services/accounting_service.py
@@ -363,6 +363,14 @@ async def delete_account(request: Request, account_id: UUID) -> dict:
 # ---------------------------------------------------------------------------
 
 def _row_to_journal_entry(row) -> JournalEntry:
+    # asyncpg Record allows .get() via dict-cast; fall back when the column
+    # was not selected (some legacy SELECTs may not include pending_review).
+    pending_review = False
+    try:
+        pending_review = bool(row['pending_review'])
+    except (KeyError, IndexError):
+        pending_review = False
+
     return JournalEntry(
         id=row['id'],
         tenant_id=row['tenant_id'],
@@ -380,6 +388,7 @@ def _row_to_journal_entry(row) -> JournalEntry:
         posted_at=row['posted_at'],
         voided_at=row['voided_at'],
         created_at=row['created_at'],
+        pending_review=pending_review,
     )
 
 
@@ -441,18 +450,26 @@ async def create_journal_entry(request: Request, body: JournalEntryCreate) -> Jo
                 raise ValidationError("Una o más cuentas no pertenecen al tenant actual")
 
             async with conn.transaction():
+                # Issue #531 — accept caller-supplied source_module/source_id
+                # (e.g. 'manual_balance_adjustment' for the "Actualizar saldo
+                # real" flow) and the pending_review annotation flag.
+                source_module = body.source_module or 'manual'
+                source_id = body.source_id
+                pending_review = bool(body.pending_review)
+
                 entry_row = await conn.fetchrow(
                     """INSERT INTO tenant_journal_entries
                            (tenant_id, entry_date, period_year, period_month,
                             description, reference, source_module, source_id,
-                            status, created_by)
-                       VALUES ($1, $2, $3, $4, $5, $6, 'manual', NULL, 'draft', $7)
+                            status, created_by, pending_review)
+                       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'draft', $9, $10)
                        RETURNING id, tenant_id, entry_date, period_year, period_month,
                                  description, reference, source_module, source_id,
                                  status, total_debit, total_credit, created_by,
-                                 posted_at, voided_at, created_at""",
+                                 posted_at, voided_at, created_at, pending_review""",
                     tenant_id, entry_date_obj, period_year, period_month,
-                    body.description, body.reference, user_id,
+                    body.description, body.reference, source_module, source_id,
+                    user_id, pending_review,
                 )
                 entry_id = entry_row['id']
 
@@ -539,7 +556,8 @@ async def list_journal_entries(
                 SELECT je.id, je.tenant_id, je.entry_date, je.period_year, je.period_month,
                        je.description, je.reference, je.source_module, je.source_id,
                        je.status, jl.debit AS total_debit, jl.credit AS total_credit,
-                       je.created_by, je.posted_at, je.voided_at, je.created_at
+                       je.created_by, je.posted_at, je.voided_at, je.created_at,
+                       je.pending_review
                 FROM tenant_journal_entries je
                 JOIN tenant_journal_lines jl
                   ON jl.journal_entry_id = je.id AND jl.account_id = ${len(params)}
@@ -550,7 +568,7 @@ async def list_journal_entries(
                 SELECT je.id, je.tenant_id, je.entry_date, je.period_year, je.period_month,
                        je.description, je.reference, je.source_module, je.source_id,
                        je.status, je.total_debit, je.total_credit, je.created_by,
-                       je.posted_at, je.voided_at, je.created_at
+                       je.posted_at, je.voided_at, je.created_at, je.pending_review
                 FROM tenant_journal_entries je
                 WHERE {where_clause}
             """
@@ -630,7 +648,7 @@ async def get_journal_entry(request: Request, entry_id: UUID) -> JournalEntryRes
                 """SELECT id, tenant_id, entry_date, period_year, period_month,
                           description, reference, source_module, source_id,
                           status, total_debit, total_credit, created_by,
-                          posted_at, voided_at, created_at
+                          posted_at, voided_at, created_at, pending_review
                    FROM tenant_journal_entries
                    WHERE id = $1 AND tenant_id = $2""",
                 entry_id, tenant_id,
@@ -711,7 +729,7 @@ async def post_journal_entry(request: Request, entry_id: UUID) -> JournalEntryRe
                        RETURNING id, tenant_id, entry_date, period_year, period_month,
                                  description, reference, source_module, source_id,
                                  status, total_debit, total_credit, created_by,
-                                 posted_at, voided_at, created_at""",
+                                 posted_at, voided_at, created_at, pending_review""",
                     entry_id, float(total_debit), float(total_credit), tenant_id,
                 )
 
@@ -789,7 +807,7 @@ async def void_journal_entry(
                        RETURNING id, tenant_id, entry_date, period_year, period_month,
                                  description, reference, source_module, source_id,
                                  status, total_debit, total_credit, created_by,
-                                 posted_at, voided_at, created_at""",
+                                 posted_at, voided_at, created_at, pending_review""",
                     entry_id, tenant_id,
                 )
 
@@ -805,7 +823,7 @@ async def void_journal_entry(
                        RETURNING id, tenant_id, entry_date, period_year, period_month,
                                  description, reference, source_module, source_id,
                                  status, total_debit, total_credit, created_by,
-                                 posted_at, voided_at, created_at""",
+                                 posted_at, voided_at, created_at, pending_review""",
                     tenant_id,
                     entry_row['entry_date'],
                     entry_row['period_year'],

--- a/migrations/067_balance_adjustment_seed_and_pending_review.sql
+++ b/migrations/067_balance_adjustment_seed_and_pending_review.sql
@@ -1,0 +1,100 @@
+-- 067_balance_adjustment_seed_and_pending_review.sql
+-- Issue #531 — feat(contabilidad): "Actualizar saldo real" por cuenta
+--
+-- Three parts (all idempotent, safe to re-run):
+--   A. Add pending_review BOOLEAN to tenant_journal_entries (anotación
+--      "revisar después" sin afectar la validez del asiento).
+--   B. Extend account_templates seed with 9 missing PUC accounts the
+--      natural-language motivos need: 21, 28, 53 (groups) + 2105, 2810,
+--      3705, 4295, 5305, 5395 (details).
+--   C. Back-fill tenant_accounts for existing tenants whose chart already
+--      has the parent codes — so the new accounts become available
+--      immediately for posting without re-onboarding.
+--
+
+-- ============================================================
+-- PART A — pending_review flag on journal entries
+-- ============================================================
+
+ALTER TABLE tenant_journal_entries
+    ADD COLUMN IF NOT EXISTS pending_review BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS idx_je_pending_review
+    ON tenant_journal_entries (tenant_id, pending_review)
+    WHERE pending_review = true;
+
+COMMENT ON COLUMN tenant_journal_entries.pending_review IS
+    'Annotation flag — when true, the asiento is fully posted and balanced, '
+    'but the contraparte was chosen by the operator as "no estoy seguro" and '
+    'should be reviewed by an accountant later (typically before fiscal close).';
+
+-- ============================================================
+-- PART B — extend account_templates with 9 missing accounts
+-- ============================================================
+
+-- New groups (level=2) — needed as parents for the new details
+INSERT INTO account_templates (code, standard_name, account_class, account_type, normal_balance, level, parent_code, is_detail, niif_group, is_active)
+VALUES
+    ('21', 'Obligaciones financieras',         '2', 'liability', 'credit', 2, '2', false, 'grupo2', true),
+    ('28', 'Otros pasivos',                    '2', 'liability', 'credit', 2, '2', false, 'grupo2', true),
+    ('53', 'Gastos no operacionales',          '5', 'expense',   'debit',  2, '5', false, 'grupo2', true)
+ON CONFLICT (code) DO NOTHING;
+
+-- New details (level=4) — the contraparte accounts the panel motivos point to
+INSERT INTO account_templates (code, standard_name, account_class, account_type, normal_balance, level, parent_code, is_detail, niif_group, is_active)
+VALUES
+    ('2105', 'Obligaciones financieras',                       '2', 'liability', 'credit', 4, '21', true, 'grupo2', true),
+    ('2810', 'Anticipos y avances recibidos',                  '2', 'liability', 'credit', 4, '28', true, 'grupo2', true),
+    ('3705', 'Utilidades acumuladas (resultados anteriores)',  '3', 'equity',    'credit', 4, '37', true, 'grupo2', true),
+    ('4295', 'Diversos no operacionales',                      '4', 'income',    'credit', 4, '42', true, 'grupo2', true),
+    ('5305', 'Servicios bancarios y GMF (4x1000)',             '5', 'expense',   'debit',  4, '53', true, 'grupo2', true),
+    ('5395', 'Diversos - gastos no operacionales',             '5', 'expense',   'debit',  4, '53', true, 'grupo2', true)
+ON CONFLICT (code) DO NOTHING;
+
+-- ============================================================
+-- PART C — back-fill tenant_accounts for tenants that already
+-- have the parent codes in their per-tenant chart of accounts
+-- ============================================================
+
+-- Pass 1: insert missing GROUPS (level=2) where the parent class (level=1)
+-- already exists in tenant_accounts. ORDER BY level ensures groups are
+-- inserted before details in pass 2.
+INSERT INTO tenant_accounts (
+    tenant_id, template_id, code, name, account_class, account_type,
+    normal_balance, level, parent_id, is_detail, is_system, is_active
+)
+SELECT
+    t.id, at.id, at.code, at.standard_name, at.account_class, at.account_type,
+    at.normal_balance, at.level, parent_ta.id, at.is_detail, true, true
+FROM tenants t
+CROSS JOIN account_templates at
+LEFT JOIN tenant_accounts parent_ta
+    ON parent_ta.tenant_id = t.id
+   AND parent_ta.code = at.parent_code
+WHERE at.code IN ('21','28','53')
+  AND parent_ta.id IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM tenant_accounts ta
+      WHERE ta.tenant_id = t.id AND ta.code = at.code
+  );
+
+-- Pass 2: insert missing DETAILS (level=4) where the parent group already
+-- exists in tenant_accounts (either pre-existing or just created in pass 1).
+INSERT INTO tenant_accounts (
+    tenant_id, template_id, code, name, account_class, account_type,
+    normal_balance, level, parent_id, is_detail, is_system, is_active
+)
+SELECT
+    t.id, at.id, at.code, at.standard_name, at.account_class, at.account_type,
+    at.normal_balance, at.level, parent_ta.id, at.is_detail, true, true
+FROM tenants t
+CROSS JOIN account_templates at
+LEFT JOIN tenant_accounts parent_ta
+    ON parent_ta.tenant_id = t.id
+   AND parent_ta.code = at.parent_code
+WHERE at.code IN ('2105','2810','3705','4295','5305','5395')
+  AND parent_ta.id IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM tenant_accounts ta
+      WHERE ta.tenant_id = t.id AND ta.code = at.code
+  );

--- a/migrations/068_extend_journal_entry_source_module.sql
+++ b/migrations/068_extend_journal_entry_source_module.sql
@@ -1,0 +1,38 @@
+-- 068_extend_journal_entry_source_module.sql
+-- Issue #531 — allow source_module='manual_balance_adjustment'
+--
+-- The CHECK constraint on tenant_journal_entries.source_module is a fixed
+-- enum-like list. Migration 067 introduced 'manual_balance_adjustment' as the
+-- canonical tag for asientos created from "Actualizar saldo real" but did not
+-- extend the constraint, so all such inserts fail with a CheckViolationError.
+--
+-- Idempotent: drops and recreates the constraint.
+
+ALTER TABLE tenant_journal_entries
+    DROP CONSTRAINT IF EXISTS tenant_journal_entries_source_module_check;
+
+ALTER TABLE tenant_journal_entries
+    ADD CONSTRAINT tenant_journal_entries_source_module_check
+    CHECK (source_module IS NULL OR source_module::text = ANY (ARRAY[
+        'gastos',
+        'ventas',
+        'orden',
+        'orden_cogs',
+        'nomina',
+        'nomina_provision',
+        'nomina_ss',
+        'nomina_prima',
+        'nomina_cesantias',
+        'nomina_int_cesantias',
+        'nomina_vacaciones',
+        'nomina_dotacion',
+        'nomina_pila',
+        'nomina_horas_extras',
+        'nomina_liquidacion',
+        'inventario',
+        'cartera',
+        'arqueo',
+        'manual',
+        'system',
+        'manual_balance_adjustment'  -- Issue #531
+    ]::text[]));


### PR DESCRIPTION
## Summary

Backend support for issue #531 — \"Actualizar saldo real\" por cuenta.

Two migrations + Pydantic + service plumbing. All idempotent and backward-compatible (no destructive changes).

## Stack

🟣 Postgres + 🔵 FastAPI + 🐍 Python 3.9

## Changes

### Migration 067
- ALTER \`tenant_journal_entries\` ADD COLUMN \`pending_review BOOLEAN NOT NULL DEFAULT false\` + partial index for filtering.
- INSERT 9 PUC accounts into \`account_templates\` (3 groups: 21, 28, 53; 6 details: 2105, 2810, 3705, 4295, 5305, 5395) — needed as contraparte for the natural-language motivos.
- Back-fill \`tenant_accounts\` for existing tenants whose chart already has the parent codes (15 tenants × 9 accounts = 135 rows).

### Migration 068
- DROP + ADD \`tenant_journal_entries_source_module_check\` to include \`'manual_balance_adjustment'\`. The original CHECK was an enum-like fixed list and rejected the new tag at INSERT time. Discovered during local testing.

### Pydantic / Service
- \`JournalEntryCreate\` now accepts \`source_module\`, \`source_id\`, \`pending_review\` (\`Optional[bool]\` — Python 3.9 compatible).
- \`create_journal_entry\` persists the new fields.
- All SELECTs in \`accounting_service.py\` updated to include \`pending_review\`.
- \`_row_to_journal_entry\` reads the new field with safe fallback for legacy rows.

## Testing

- Both migrations applied to DB; verified \`\\d tenant_public_profiles\` and the new constraint includes \`manual_balance_adjustment\`.
- \`python3 -m py_compile\` clean on changed files.
- Tested end-to-end with frontend PR — asiento creates and posts, status flips to posted, lines DR/CR balance.

Refs #531