### PR TITLE
feat(metodos-pago, orders, dian): glAccountCode on create + payment_method_id on manual orders + DIAN date parsing (#533)

### DIFF
--- a/app/models/payment_method.py
+++ b/app/models/payment_method.py
@@ -78,6 +78,10 @@ class CreateMethodRequest(BaseModel):
     groupId: str
     name: str
     sortOrder: int = 0
+    # Issue #533 — optional. Set when the auto-create-PUC-sub-account flow
+    # in /finanzas/metodos-pago/{groupId} creates the sub-account first and
+    # passes its code in here so the method is linked in one round-trip.
+    glAccountCode: Optional[str] = None
 
 
 class PatchMethodRequest(BaseModel):

--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -220,6 +220,11 @@ class ManualOrderItem(BaseModel):
 class CreateManualOrderRequest(BaseModel):
     order_date: str
     payment_method: str
+    # Issue #533 follow-up — when the operator picks a specific method from the
+    # dropdown (Nequi, Daviplata, etc.), persist the method UUID so the order
+    # is linked to the right gl_account_code-bearing method (and not just the
+    # group slug). Optional for backward compatibility.
+    payment_method_id: Optional[str] = None
     customer_id: Optional[str] = None
     items: List[ManualOrderItem] = Field(min_length=1)
 
@@ -237,6 +242,7 @@ async def create_manual_order(
         request,
         order_date=data.order_date,
         payment_method=data.payment_method,
+        payment_method_id=data.payment_method_id,
         items=[item.model_dump() for item in data.items],
         customer_id=data.customer_id
     )

--- a/app/routers/tenant_config.py
+++ b/app/routers/tenant_config.py
@@ -2,6 +2,8 @@
 Tenant configuration router - admin endpoints for managing public profiles
 Authentication required
 """
+from datetime import date as _date
+from asyncpg.exceptions import UniqueViolationError
 from fastapi import APIRouter, Request, Body, HTTPException
 from fastapi.responses import JSONResponse
 from app.services import tenant_config_service
@@ -309,28 +311,49 @@ async def create_dian_resolution(request: Request, data: dict = Body(...)):
     resolution_number = data.get('resolution_number', '').strip()
     from_number = int(data.get('from_number', 0))
     to_number = int(data.get('to_number', 0))
-    date_from = data.get('date_from')
-    date_to = data.get('date_to')
+    # asyncpg requires real date objects for `date` columns — the SQL ::date
+    # cast happens AFTER parameter binding, so passing a 'YYYY-MM-DD' string
+    # raises AttributeError ('str' has no 'toordinal'). Parse here.
+    raw_from = data.get('date_from')
+    raw_to = data.get('date_to')
+    if not raw_from or not raw_to:
+        raise HTTPException(status_code=422, detail="date_from y date_to son requeridos")
+    try:
+        date_from = _date.fromisoformat(raw_from)
+        date_to = _date.fromisoformat(raw_to)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=422, detail="Formato de fecha inválido. Usa YYYY-MM-DD")
     document_type = data.get('document_type', 'invoice')
     current_number = int(data.get('current_number', from_number - 1))
 
     if not prefix or not resolution_number or from_number <= 0 or to_number <= 0:
-        from fastapi import HTTPException
         raise HTTPException(status_code=422, detail="Prefijo, número de resolución y rango son requeridos")
     if from_number >= to_number:
-        from fastapi import HTTPException
         raise HTTPException(status_code=422, detail="El rango 'desde' debe ser menor que 'hasta'")
 
     async with get_db_connection() as conn:
         row_id = _uuid.uuid4()
-        await conn.execute(
-            """INSERT INTO dian_resolutions
-                   (id, tenant_id, resolution_number, prefix, date_from, date_to,
-                    from_number, to_number, current_number, is_active, document_type)
-               VALUES ($1, $2, $3, $4, $5::date, $6::date, $7, $8, $9, true, $10)""",
-            row_id, tenant_id, resolution_number, prefix,
-            date_from, date_to, from_number, to_number, current_number, document_type,
-        )
+        try:
+            await conn.execute(
+                """INSERT INTO dian_resolutions
+                       (id, tenant_id, resolution_number, prefix, date_from, date_to,
+                        from_number, to_number, current_number, is_active, document_type)
+                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, true, $10)""",
+                row_id, tenant_id, resolution_number, prefix,
+                date_from, date_to, from_number, to_number, current_number, document_type,
+            )
+        except UniqueViolationError as e:
+            # Partial unique index idx_dian_resolutions_active_prefix:
+            # only one ACTIVE resolution per (tenant, prefix) is allowed.
+            if 'idx_dian_resolutions_active_prefix' in str(e):
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"Ya existe una resolución activa con prefijo '{prefix}'. "
+                        "Desactívala primero o usa un prefijo diferente."
+                    ),
+                )
+            raise
 
     return {'success': True, 'data': {'id': str(row_id)}, 'message': 'Resolución creada'}
 
@@ -344,14 +367,26 @@ async def update_dian_resolution(request: Request, resolution_id: str, data: dic
     session = require_valid_session(request)
     tenant_id = session.tenant_id
 
+    # Parse dates (asyncpg requires date objects, not strings — same reason
+     # as the POST endpoint above).
+    raw_from = data.get('date_from')
+    raw_to = data.get('date_to')
+    if not raw_from or not raw_to:
+        raise HTTPException(status_code=422, detail="date_from y date_to son requeridos")
+    try:
+        date_from = _date.fromisoformat(raw_from)
+        date_to = _date.fromisoformat(raw_to)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=422, detail="Formato de fecha inválido. Usa YYYY-MM-DD")
+
     async with get_db_connection() as conn:
         result = await conn.execute(
             """UPDATE dian_resolutions
-               SET resolution_number = $1, prefix = $2, date_from = $3::date, date_to = $4::date,
+               SET resolution_number = $1, prefix = $2, date_from = $3, date_to = $4,
                    from_number = $5, to_number = $6, current_number = $7, document_type = $8
                WHERE id = $9::uuid AND tenant_id = $10""",
             data.get('resolution_number'), data.get('prefix', '').strip().upper(),
-            data.get('date_from'), data.get('date_to'),
+            date_from, date_to,
             int(data.get('from_number', 0)), int(data.get('to_number', 0)),
             int(data.get('current_number', 0)), data.get('document_type', 'invoice'),
             resolution_id, tenant_id,

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -2444,7 +2444,8 @@ async def create_manual_order(
     order_date: str,
     payment_method: str,
     items: List[dict],
-    customer_id: Optional[str] = None
+    customer_id: Optional[str] = None,
+    payment_method_id: Optional[str] = None,
 ) -> dict:
     """
     Create an order manually with a custom date, bypassing the POS cart.
@@ -2484,15 +2485,16 @@ async def create_manual_order(
                 order_row = await conn.fetchrow(
                     """
                     INSERT INTO orders (
-                        tenant_id, customer_id, payment_method,
+                        tenant_id, customer_id, payment_method, payment_method_id,
                         order_date, total_amount, status, extra_attributes
                     )
-                    VALUES ($1, $2, $3, $4, $5, 'completed', $6)
+                    VALUES ($1, $2, $3, $4, $5, $6, 'completed', $7)
                     RETURNING id, order_number, order_date, created_at
                     """,
                     tenant_id,
                     UUID(customer_id) if customer_id else None,
                     payment_method,
+                    UUID(payment_method_id) if payment_method_id else None,
                     order_datetime,
                     total_amount,
                     json.dumps({"source": "manual"})

--- a/app/services/payment_method_service.py
+++ b/app/services/payment_method_service.py
@@ -252,16 +252,20 @@ async def create_method(request: Request, body: CreateMethodRequest) -> dict:
             )
 
         try:
+            # Issue #533 — accept gl_account_code on creation so the auto-create
+            # flow in /finanzas/metodos-pago/{groupId} can link the new method
+            # to its sub-account in a single round-trip (instead of POST + PATCH).
             row = await conn.fetchrow(
                 """
-                INSERT INTO payment_methods (tenant_id, group_id, name, sort_order)
-                VALUES ($1, $2, $3, $4)
-                RETURNING id, tenant_id, group_id, name, is_active, sort_order
+                INSERT INTO payment_methods (tenant_id, group_id, name, sort_order, gl_account_code)
+                VALUES ($1, $2, $3, $4, $5)
+                RETURNING id, tenant_id, group_id, name, is_active, sort_order, gl_account_code
                 """,
                 tenant_id,
                 group_id,
                 body.name,
                 body.sortOrder,
+                body.glAccountCode if body.glAccountCode else None,
             )
         except UniqueViolationError:
             raise ValidationError(
@@ -277,6 +281,7 @@ async def create_method(request: Request, body: CreateMethodRequest) -> dict:
             "name": row["name"],
             "isActive": row["is_active"],
             "sortOrder": row["sort_order"],
+            "glAccountCode": row["gl_account_code"],
         },
     }
 


### PR DESCRIPTION
## Summary

Backend bundle for #533 (auto-create PUC sub-account when creating a payment method) plus adjacent fixes surfaced during testing. All changes are non-destructive and backward-compatible.

## Stack

🔵 FastAPI + 🐍 Python 3.9

## Changes

### Payment methods (#533 core)
- `app/models/payment_method.py` — \`CreateMethodRequest\` now exposes \`glAccountCode: Optional[str] = None\` (previously only PatchMethodRequest had it; the field was being silently dropped on POST).
- `app/services/payment_method_service.py` — \`create_method\` INSERT persists \`gl_account_code\` and returns it. Auto-create flow links the new method to the new sub-account in a single round-trip.

### Manual orders (/ventas/crear)
- `app/routers/orders.py` — \`CreateManualOrderRequest\` accepts \`payment_method_id: Optional[str]\`.
- `app/services/orders_service.py` — \`create_manual_order\` persists it on \`orders.payment_method_id\` (was always NULL before). Lets GL posting resolve to the right method-level sub-account.

### DIAN resolutions (/facturacion)
- `app/routers/tenant_config.py` — Two fixes on POST + PUT \`/dian-resolutions\`:
  1. Parse \`date_from\` / \`date_to\` to \`datetime.date\` BEFORE binding (asyncpg requires real \`date\` objects; SQL ::date cast happens after binding so passing \`'YYYY-MM-DD'\` string raised \`AttributeError: 'str' object has no attribute 'toordinal'\`).
  2. Catch \`UniqueViolationError\` on \`idx_dian_resolutions_active_prefix\` and return 409 with user-friendly message instead of 500.

## Testing

- \`python3 -m py_compile\` clean on all modified files.
- Tested end-to-end with the frontend PR locally — auto-create flow creates account + method + linkage in single submit; manual order registers \`payment_method_id\`; DIAN resolution creation works with date strings; duplicate-prefix conflict returns clear 409.

Refs #533