### PR TITLE
feat(tenant-config): add expediter_enabled flag for POS expediter mode

### DIFF
--- a/app/models/tenant_public_profile.py
+++ b/app/models/tenant_public_profile.py
@@ -75,6 +75,14 @@ class TenantPublicProfileBase(BaseModel):
         description="POS: when true, /pos/checkout pre-selects the Genérico customer (phone_number='0000000000') in counter/bar mode."
     )
 
+    # POS expediter mode (issue #537)
+    expediter_enabled: bool = Field(
+        False,
+        description="POS expediter: when true, waiters can advance comanda state "
+                    "(preparing → ready → delivered) from /pos via a slide-over panel, "
+                    "without touching the KDS. Requires comandas_enabled=true."
+    )
+
 class TenantPublicProfileCreate(TenantPublicProfileBase):
     """Create tenant public profile"""
     tenant_id: UUID = Field(..., description="Tenant ID")
@@ -112,6 +120,7 @@ class TenantPublicProfileUpdate(BaseModel):
     comandas_enabled: Optional[bool] = None
     kds_enabled: Optional[bool] = None
     auto_select_generic_enabled: Optional[bool] = None
+    expediter_enabled: Optional[bool] = None
 
 class TenantPublicProfile(TenantPublicProfileBase):
     """Complete tenant public profile with all fields"""

--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -71,9 +71,10 @@ async def upsert_public_profile(
                         tables_enabled,
                         comandas_enabled, kds_enabled,
                         auto_select_generic_enabled,
+                        expediter_enabled,
                         updated_at
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, CURRENT_TIMESTAMP)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, CURRENT_TIMESTAMP)
                     ON CONFLICT (tenant_id)
                     DO UPDATE SET
                         slug = EXCLUDED.slug,
@@ -100,6 +101,7 @@ async def upsert_public_profile(
                         comandas_enabled = EXCLUDED.comandas_enabled,
                         kds_enabled = EXCLUDED.kds_enabled,
                         auto_select_generic_enabled = EXCLUDED.auto_select_generic_enabled,
+                        expediter_enabled = EXCLUDED.expediter_enabled,
                         updated_at = CURRENT_TIMESTAMP
                     RETURNING *
                 """
@@ -130,7 +132,8 @@ async def upsert_public_profile(
                     profile_data.tables_enabled,
                     profile_data.comandas_enabled,
                     profile_data.kds_enabled,
-                    profile_data.auto_select_generic_enabled
+                    profile_data.auto_select_generic_enabled,
+                    profile_data.expediter_enabled
                 )
 
                 profile = TenantPublicProfile(**dict(result))
@@ -197,8 +200,9 @@ async def update_public_profile(
                         accepts_online_orders, min_order_amount, estimated_preparation_time,
                         is_manually_open,
                         comandas_enabled, kds_enabled,
-                        auto_select_generic_enabled
-                    ) VALUES ($1, $2, $3, FALSE, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
+                        auto_select_generic_enabled,
+                        expediter_enabled
+                    ) VALUES ($1, $2, $3, FALSE, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
                     RETURNING *
                 """
                 result = await conn.fetchrow(
@@ -223,6 +227,7 @@ async def update_public_profile(
                     data_dict.get('comandas_enabled', False),
                     data_dict.get('kds_enabled', False),
                     data_dict.get('auto_select_generic_enabled', False),
+                    data_dict.get('expediter_enabled', False),
                 )
 
                 profile_data_dict = dict(result)
@@ -257,6 +262,16 @@ async def update_public_profile(
                     raise HTTPException(
                         status_code=400,
                         detail="kds_enabled requiere que comandas_enabled sea true"
+                    )
+
+            # Issue #537 — expediter_enabled also requires comandas_enabled.
+            if data_dict.get('expediter_enabled') is True:
+                current_comandas = exists['comandas_enabled'] if exists else False
+                new_comandas = data_dict.get('comandas_enabled', current_comandas)
+                if not new_comandas:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="expediter_enabled requiere que comandas_enabled sea true"
                     )
 
             # Validate slug if it's being changed


### PR DESCRIPTION
## Summary
- New `expediter_enabled` boolean on `tenant_public_profiles` (migration 069 already applied in prod).
- Upsert + update SQL paths include the new column.
- Cross-validation in `update_public_profile`: setting `expediter_enabled=true` requires `comandas_enabled=true` (raises 400 otherwise).

## Test plan
- [x] DB column exists in prod (verified via tunnel)
- [ ] PATCH `/api/api/tenant/public-profile` with `expediter_enabled=true` works when comandas is on
- [ ] Same call returns 400 when comandas is off

🤖 Generated with [Claude Code](https://claude.com/claude-code)