### PR TITLE
fix(kds): resolve ?token= to tenant_id session context

### DIFF
--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -429,8 +429,36 @@ async def session_validation_middleware(request: Request, call_next):
 
         # Handle exact root path separately
         if path == '/' or any(path.startswith(endpoint) for endpoint in public_endpoints) or any(path.startswith(prefix) for prefix in public_prefixes) or kds_public:
-            request.state.session_context = SessionContext()
             request.state.api_key_context = ApiKeyContext()
+
+            # KDS endpoints with ?token=... → resolve token to tenant_id and
+            # inject a synthetic SessionContext so downstream services that
+            # call require_valid_session() succeed without an operator login.
+            if kds_public and kds_token_param:
+                try:
+                    from app.database import get_db_connection as _kds_get_conn
+                    async with _kds_get_conn() as _kds_conn:
+                        _kds_row = await _kds_conn.fetchrow(
+                            "SELECT tenant_id FROM kds_tokens WHERE token = $1 AND revoked_at IS NULL",
+                            kds_token_param,
+                        )
+                    if _kds_row:
+                        request.state.session_context = SessionContext({
+                            'user_id': None,
+                            'tenant_id': _kds_row['tenant_id'],
+                            'email': None,
+                            'name': 'KDS Token',
+                            'expires_at': None,
+                            'is_active': True,
+                        })
+                    else:
+                        request.state.session_context = SessionContext()
+                except Exception as _kds_err:
+                    logger.warning(f"KDS token validation failed: {_kds_err}")
+                    request.state.session_context = SessionContext()
+            else:
+                request.state.session_context = SessionContext()
+
             return await call_next(request)
 
         # First, check for API key authentication


### PR DESCRIPTION
## Summary
KDS screens accessed via `/cocina/[id]?token=...` were getting 401 from `/api/comandas?...&token=...` because the middleware bypassed session validation but left an empty `SessionContext`. The downstream `require_valid_session()` call then rejected the request.

This change validates the token against `kds_tokens` and, when valid, injects a synthetic `SessionContext` with the resolved `tenant_id` so services can scope their queries normally.

## Behavior changes
- KDS GET/PATCH on `/api/comandas` or `/api/stations/...` with a valid `?token=` → now succeeds (services see `is_valid=True`, `tenant_id=<tenant>`).
- Tokenless GETs to those endpoints → still fall through to empty SessionContext (services still 401, unchanged).
- Revoked tokens → empty SessionContext (services 401).

## Test plan
- [ ] Open `/cocina/<station>?token=<valid>` → comandas list loads
- [ ] Same URL with revoked or wrong token → 401, page shows error state
- [ ] No regression on `/pos` (operator session still works as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)