### PR TITLE
feat(kds): return full token on GET so operator UI can persist KDS URLs

### DIFF
--- a/app/routers/stations.py
+++ b/app/routers/stations.py
@@ -188,10 +188,15 @@ async def generate_kds_token(request: Request, station_id: UUID):
 
 @router.get("/{station_id}/kds-token")
 async def get_kds_token(request: Request, station_id: UUID):
-    """Get the current active KDS token for a station (masked)."""
+    """Get the current active KDS token for a station.
+
+    Returns the full token so the operator UI can rebuild the KDS URL on
+    every page load without forcing a regenerate. The endpoint is
+    session-protected, so only authenticated tenant operators can read it.
+    """
     from app.core.middleware import require_valid_session
 
-    session = require_valid_session(request)
+    require_valid_session(request)
 
     async with get_db_connection() as conn:
         row = await conn.fetchrow(
@@ -202,13 +207,10 @@ async def get_kds_token(request: Request, station_id: UUID):
     if not row:
         return {'success': True, 'data': None}
 
-    token = row['token']
-    masked = token[:6] + '...' + token[-4:] if len(token) > 10 else '****'
-
     return {
         'success': True,
         'data': {
-            'token_masked': masked,
+            'token': row['token'],
             'created_at': row['created_at'].isoformat() if row['created_at'] else None,
         },
     }


### PR DESCRIPTION
## Summary
The GET \`/api/api/stations/{station_id}/kds-token\` endpoint used to return a masked token. That meant the operator UI on \`Operaciones > Comandas\` had no way to rebuild the public KDS URL on page load and forced a regenerate every time.

This change makes the endpoint return the full token. The endpoint is already session-protected (\`require_valid_session\`), so only authenticated tenant operators — i.e. the same people who issued the token and can revoke it — can read it. Behaviour matches the rest of the operator-facing config endpoints.

Field renamed: \`token_masked\` → \`token\`. No other callers consume the old field (verified via repo grep).

## Test plan
- [ ] GET on a station with an active token → returns \`{ data: { token: '...', created_at: '...' } }\`
- [ ] GET on a station with no token → returns \`{ data: null }\`
- [ ] Endpoint still rejects unauthenticated requests with 401
- [ ] Frontend follow-up PR consumes the new shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)