### PR TITLE
feat(permissions): require_module dependency + role on SessionContext (E2.1)

### DIFF
--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -10,7 +10,15 @@ from app.config import settings
 logger = logging.getLogger(__name__)
 
 class SessionContext:
-    """Session context object"""
+    """Session context object.
+
+    `role` carries the user's role on the active tenant (from
+    `tenant_members.role`). It is None when the user has no active
+    membership row — e.g. KDS-token sessions, or owners of a freshly
+    created tenant before the membership row is written. Required by
+    Epic 2 (#164) so `require_module()` can gate without an extra DB
+    lookup per request.
+    """
     def __init__(self, session_data: Optional[Dict[str, Any]] = None):
         if session_data:
             self.user_id = session_data['user_id']
@@ -19,6 +27,7 @@ class SessionContext:
             self.name = session_data['name']
             self.expires_at = session_data['expires_at']
             self.is_active = session_data['is_active']
+            self.role: Optional[str] = session_data.get('role')
             self.is_valid = True
         else:
             self.user_id = None
@@ -27,8 +36,9 @@ class SessionContext:
             self.name = None
             self.expires_at = None
             self.is_active = False
+            self.role: Optional[str] = None
             self.is_valid = False
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             'user_id': self.user_id,
@@ -37,6 +47,7 @@ class SessionContext:
             'name': self.name,
             'expires_at': self.expires_at,
             'is_active': self.is_active,
+            'role': self.role,
             'is_valid': self.is_valid
         }
 

--- a/app/core/permissions.py
+++ b/app/core/permissions.py
@@ -27,11 +27,13 @@ share the membership table but should never receive any staff module. Keeping
 it in the enum lets the future safeguard trigger and `normalize_role` round-
 trip every legacy row without raising.
 """
+import logging
 from enum import Enum
-from typing import Dict, FrozenSet, Optional, Union
+from typing import Awaitable, Callable, Dict, FrozenSet, Optional, Union
 from uuid import UUID
 
 from cachetools import TTLCache
+from fastapi import HTTPException, Request, status
 
 from app.database import get_db_connection
 
@@ -231,3 +233,164 @@ def invalidate_role_modules(
 
     normalized = role if isinstance(role, Role) else normalize_role(role)
     _role_modules_cache.pop((tenant_id, normalized), None)
+
+
+# ─── Epic 2 (#164): require_module dependency + enforcement-mode cache ─────
+
+# Tenant enforcement mode cache. Shorter TTL than the role-modules cache
+# because flipping a tenant from `shadow` to `enforce` should propagate
+# fast — operators expect a manual rollout step to take effect within a
+# minute, not five.
+_enforcement_mode_cache: TTLCache = TTLCache(maxsize=1000, ttl=60)
+
+# Dedicated logger so ops can route shadow events to a specific sink
+# (Discord channel, Loki stream, etc.) without polluting the request log.
+_shadow_logger = logging.getLogger("permissions.shadow")
+
+
+VALID_MODES = frozenset({"disabled", "shadow", "enforce"})
+
+
+async def _get_enforcement_mode(tenant_id: UUID) -> str:
+    """Resolve `tenants.permissions_enforcement_mode` for a tenant.
+
+    Cached for 60s. Defaults to `'disabled'` if the row is missing or the
+    value is unknown — fail-open is safe here because `disabled` mirrors
+    today's behavior (no gating).
+    """
+    cached = _enforcement_mode_cache.get(tenant_id)
+    if cached is not None:
+        return cached
+
+    async with get_db_connection() as conn:
+        mode = await conn.fetchval(
+            "SELECT permissions_enforcement_mode FROM tenants WHERE id = $1",
+            tenant_id,
+        )
+
+    if mode not in VALID_MODES:
+        mode = "disabled"
+
+    _enforcement_mode_cache[tenant_id] = mode
+    return mode
+
+
+def invalidate_enforcement_mode(tenant_id: UUID) -> None:
+    """Drop the cached enforcement mode for `tenant_id`.
+
+    Call this after every successful UPDATE on
+    `tenants.permissions_enforcement_mode` so a flip from `shadow` to
+    `enforce` (or back) takes effect on the next request instead of after
+    the 60s TTL.
+    """
+    _enforcement_mode_cache.pop(tenant_id, None)
+
+
+def _shadow_or_deny(
+    mode: str,
+    tenant_id: UUID,
+    user_id: Optional[UUID],
+    role: Optional[str],
+    module: Module,
+    reason: str,
+    path: str,
+) -> None:
+    """Branch on enforcement mode: log+allow under shadow, raise 403 under enforce.
+
+    `disabled` never reaches this function (the dependency returns earlier),
+    so we only handle `shadow` and `enforce` here.
+    """
+    if mode == "shadow":
+        # Wrap fields under a single key to avoid colliding with reserved
+        # LogRecord attributes (`module`, `pathname`, etc.). Handlers can
+        # pull `record.permission_event` to ship the structured payload.
+        _shadow_logger.warning(
+            "would_deny",
+            extra={
+                "permission_event": {
+                    "tenant_id": str(tenant_id) if tenant_id else None,
+                    "user_id": str(user_id) if user_id else None,
+                    "role": role,
+                    "module": module.value,
+                    "reason": reason,
+                    "path": path,
+                }
+            },
+        )
+        return
+    # enforce
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=f"Sin permiso para el módulo {module.value}",
+    )
+
+
+def require_module(module: Module) -> Callable[[Request], Awaitable[None]]:
+    """Build a FastAPI dependency that gates `module` per tenant mode.
+
+    Reads `tenants.permissions_enforcement_mode`:
+      * `disabled` → bypass entirely (current behavior, no DB hit beyond
+        the cached lookup).
+      * `shadow`   → if the user lacks the module, log a `permissions.shadow`
+        event and allow the request through. Used to surface false positives
+        before flipping to enforce.
+      * `enforce`  → if the user lacks the module, raise 403.
+
+    Owner short-circuit happens inside `get_role_modules`. Sessions without
+    a valid role (no membership row, KDS tokens, API keys without role
+    plumbing) are treated as "no staff modules" — denied or shadow-logged.
+    Sessions that aren't valid at all return early so `require_valid_session`
+    (still called inside handlers) can raise 401 with its own message —
+    keeps responsibilities split.
+
+    Usage:
+        from fastapi import Depends
+        from app.core.permissions import Module, require_module
+
+        @router.get("/billing", dependencies=[Depends(require_module(Module.MI_PLAN))])
+        async def list_billing(...):
+            ...
+    """
+    async def dependency(request: Request) -> None:
+        from app.core.middleware import get_session_context  # local import to avoid cycle
+
+        session = get_session_context(request)
+        if not session.is_valid:
+            return  # require_valid_session in the handler will surface 401
+
+        tenant_id = session.tenant_id
+        if not tenant_id:
+            return  # no tenant resolved → cannot gate; let handler decide
+
+        mode = await _get_enforcement_mode(tenant_id)
+        if mode == "disabled":
+            return
+
+        path = request.url.path
+        raw_role = session.role
+        if not raw_role:
+            _shadow_or_deny(
+                mode, tenant_id, session.user_id, None, module,
+                reason="no-membership", path=path,
+            )
+            return
+
+        try:
+            normalized = normalize_role(raw_role)
+        except ValueError:
+            _shadow_or_deny(
+                mode, tenant_id, session.user_id, raw_role, module,
+                reason="unknown-role", path=path,
+            )
+            return
+
+        allowed = await get_role_modules(tenant_id, normalized)
+        if module in allowed:
+            return
+
+        _shadow_or_deny(
+            mode, tenant_id, session.user_id, normalized.value, module,
+            reason="not-in-matrix", path=path,
+        )
+
+    return dependency

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -299,12 +299,20 @@ async def get_session_from_request(request: Request) -> Optional[dict]:
 
                     return None
 
-            # Get valid session data
+            # Get valid session data + the user's role on this tenant.
+            # LEFT JOIN tenant_members so a session whose user has no
+            # active membership row still resolves (role becomes None).
+            # Epic 2 (#164) — required by the require_module() dependency
+            # so it can decide log/allow/deny without an extra DB hit.
             session_query = """
                 SELECT s.user_id, s.tenant_id, s.expires_at, s.is_active,
-                       p.email, p.name
+                       p.email, p.name,
+                       tm.role AS role
                 FROM sessions s
                 JOIN profile p ON s.user_id = p.id
+                LEFT JOIN tenant_members tm
+                  ON tm.user_id = s.user_id
+                 AND tm.tenant_id = s.tenant_id
                 WHERE s.id = $1
                   AND s.expires_at > NOW()
                   AND s.is_active = true
@@ -321,7 +329,8 @@ async def get_session_from_request(request: Request) -> Optional[dict]:
                 'email': session_result['email'],
                 'name': session_result['name'],
                 'expires_at': session_result['expires_at'],
-                'is_active': session_result['is_active']
+                'is_active': session_result['is_active'],
+                'role': session_result['role'],
             }
 
     except Exception as e:

--- a/tests/test_permissions_dependency.py
+++ b/tests/test_permissions_dependency.py
@@ -1,0 +1,245 @@
+"""Unit tests for require_module() dependency (Epic 2 / #E2.1).
+
+The dependency reads `tenants.permissions_enforcement_mode` and either
+returns silently (allow), logs a `permissions.shadow` event (shadow), or
+raises 403 (enforce). Tests use mocked session contexts and a stubbed
+DB so they don't need a live tenants table.
+"""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.core import permissions
+from app.core.permissions import (
+    Module,
+    Role,
+    invalidate_enforcement_mode,
+    require_module,
+)
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    """Each test starts with empty caches so cross-talk is impossible."""
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _fake_request(session_context):
+    """Build a fake FastAPI Request whose state.session_context is set."""
+    request = MagicMock()
+    request.state.session_context = session_context
+    request.url.path = "/api/test"
+    return request
+
+
+class _FakeSession:
+    """Minimal SessionContext stand-in. Mirrors the attributes
+    `require_module()` reads — keeps tests free of the real middleware."""
+    def __init__(self, *, is_valid=True, tenant_id=None, user_id=None, role=None):
+        self.is_valid = is_valid
+        self.tenant_id = tenant_id or uuid4()
+        self.user_id = user_id or uuid4()
+        self.role = role
+
+
+def _patch_get_session(session):
+    """Patch `app.core.middleware.get_session_context` to return `session`.
+
+    The dependency imports `get_session_context` lazily inside its body to
+    avoid a circular import, so the patch target is the middleware module.
+    """
+    return patch(
+        "app.core.middleware.get_session_context",
+        return_value=session,
+    )
+
+
+def _patch_enforcement_mode(mode):
+    """Stub the DB call inside `_get_enforcement_mode` to return `mode`."""
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value=mode)
+        yield conn
+    return patch(
+        "app.core.permissions.get_db_connection",
+        side_effect=_ctx,
+    )
+
+
+def _patch_role_modules(modules):
+    """Stub `get_role_modules` to return `modules` (the resolver's output)."""
+    return patch(
+        "app.core.permissions.get_role_modules",
+        new=AsyncMock(return_value=frozenset(modules)),
+    )
+
+
+# ─── Tests ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_disabled_mode_bypasses_for_denied_role():
+    """Mode 'disabled' must allow even when the role lacks the module."""
+    dep = require_module(Module.MI_PLAN)
+    session = _FakeSession(role="cashier")
+    request = _fake_request(session)
+
+    with _patch_get_session(session), _patch_enforcement_mode("disabled"):
+        result = await dep(request)
+
+    assert result is None  # silent allow
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_logs_and_allows_for_denied_role(caplog):
+    """Mode 'shadow' logs at WARN and allows the request through."""
+    dep = require_module(Module.FINANZAS)
+    session = _FakeSession(role="cashier")
+    request = _fake_request(session)
+
+    with _patch_get_session(session), \
+         _patch_enforcement_mode("shadow"), \
+         _patch_role_modules({Module.POS, Module.VENTAS}), \
+         caplog.at_level("WARNING", logger="permissions.shadow"):
+        result = await dep(request)
+
+    assert result is None
+    assert any("would_deny" in rec.message for rec in caplog.records)
+    record = next(rec for rec in caplog.records if "would_deny" in rec.message)
+    event = record.permission_event
+    assert event["role"] == "cashier"
+    assert event["module"] == "finanzas"
+    assert event["reason"] == "not-in-matrix"
+
+
+@pytest.mark.asyncio
+async def test_enforce_mode_raises_403_for_denied_role():
+    """Mode 'enforce' must raise HTTPException(403) when access is denied."""
+    dep = require_module(Module.FINANZAS)
+    session = _FakeSession(role="cashier")
+    request = _fake_request(session)
+
+    with _patch_get_session(session), \
+         _patch_enforcement_mode("enforce"), \
+         _patch_role_modules({Module.POS, Module.VENTAS}):
+        with pytest.raises(HTTPException) as exc_info:
+            await dep(request)
+
+    assert exc_info.value.status_code == 403
+    assert "finanzas" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_allowed_role_passes_in_every_mode():
+    """A role that has the module must pass under all three modes."""
+    dep = require_module(Module.POS)
+    session = _FakeSession(role="cashier")
+    request = _fake_request(session)
+
+    for mode in ("disabled", "shadow", "enforce"):
+        permissions._enforcement_mode_cache.clear()
+        with _patch_get_session(session), \
+             _patch_enforcement_mode(mode), \
+             _patch_role_modules({Module.POS, Module.VENTAS}):
+            result = await dep(request)
+        assert result is None, f"mode={mode} should allow"
+
+
+@pytest.mark.asyncio
+async def test_owner_role_short_circuits_via_resolver():
+    """Owner is granted everything by `get_role_modules` — dependency allows."""
+    dep = require_module(Module.EQUIPO)
+    session = _FakeSession(role="owner")
+    request = _fake_request(session)
+
+    # Real resolver — owner returns all modules without DB.
+    with _patch_get_session(session), _patch_enforcement_mode("enforce"):
+        result = await dep(request)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_invalid_session_returns_silently():
+    """Invalid session → defer to require_valid_session inside the handler."""
+    dep = require_module(Module.POS)
+    session = _FakeSession(is_valid=False)
+    request = _fake_request(session)
+
+    with _patch_get_session(session):
+        result = await dep(request)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_no_membership_role_is_denied_in_enforce(caplog):
+    """User with no role (KDS, API key without membership) → denied/shadow."""
+    dep = require_module(Module.POS)
+    session = _FakeSession(role=None)
+    request = _fake_request(session)
+
+    with _patch_get_session(session), _patch_enforcement_mode("enforce"):
+        with pytest.raises(HTTPException) as exc_info:
+            await dep(request)
+    assert exc_info.value.status_code == 403
+
+    permissions._enforcement_mode_cache.clear()
+    with _patch_get_session(session), \
+         _patch_enforcement_mode("shadow"), \
+         caplog.at_level("WARNING", logger="permissions.shadow"):
+        result = await dep(request)
+    assert result is None
+    assert any(
+        getattr(rec, "permission_event", {}).get("reason") == "no-membership"
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_unknown_role_is_denied():
+    """A role string outside Role + legacy map → denied (defensive)."""
+    dep = require_module(Module.POS)
+    session = _FakeSession(role="nonexistent_role_xyz")
+    request = _fake_request(session)
+
+    with _patch_get_session(session), _patch_enforcement_mode("enforce"):
+        with pytest.raises(HTTPException) as exc_info:
+            await dep(request)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_enforcement_mode_cache_avoids_second_db_call():
+    """Second call for the same tenant must not hit `get_db_connection`."""
+    dep = require_module(Module.POS)
+    session = _FakeSession(role="owner")
+    request = _fake_request(session)
+
+    with _patch_get_session(session), _patch_enforcement_mode("disabled") as mock_db:
+        await dep(request)
+        await dep(request)
+        # `_patch_enforcement_mode` returns a context manager; each entry calls
+        # `get_db_connection` once. We expect exactly ONE call thanks to the cache.
+        assert mock_db.call_count == 1
+
+
+def test_invalidate_enforcement_mode_drops_cached_value():
+    """`invalidate_enforcement_mode` must remove the cached entry."""
+    tenant_id = uuid4()
+    permissions._enforcement_mode_cache[tenant_id] = "enforce"
+    assert permissions._enforcement_mode_cache.get(tenant_id) == "enforce"
+
+    invalidate_enforcement_mode(tenant_id)
+    assert permissions._enforcement_mode_cache.get(tenant_id) is None


### PR DESCRIPTION
Sub-task E2.1 of Epic 2 (#164) — the unblocker for the rest of the RBAC rollout.

## Stack
🔵 FastAPI · 🐍 Python 3.9 · 🟣 PostgreSQL (read-only schema dependency on Epic 1 tables)

## Summary

Three coordinated changes so subsequent batches (E2.3 → E2.16) can wire `require_module()` to routers without re-architecting auth:

| File | Change |
|---|---|
| `app/core/security.py` | `get_session_from_request()` now LEFT JOINs `tenant_members` and returns `role` in the session dict |
| `app/core/middleware.py` | `SessionContext` gains `Optional[str] role`, populated from the new dict key |
| `app/core/permissions.py` | New `require_module(Module)` factory, enforcement-mode TTL cache (60s), `invalidate_enforcement_mode()` for the future admin endpoint |

## Behaviour matrix

| Mode | Allowed role | Denied role | No role / unknown role |
|---|---|---|---|
| `disabled` | pass | pass | pass |
| `shadow` | pass | log + pass | log + pass |
| `enforce` | pass | 403 | 403 |

Owner short-circuits via `get_role_modules` (Epic 1). Invalid sessions return early so `require_valid_session()` (still inside handlers) can raise 401 with its own message.

## Tests

- 10 new cases in `tests/test_permissions_dependency.py` covering the 3 modes × allowed/denied/owner/no-membership/unknown-role/cache.
- 39 Epic 1 tests still pass (resolver + catalog regression).
- Full suite: **516 passed**, 1 unrelated flaky test (`test_emit_invoice_requires_auth` — pre-existing event-loop teardown issue under full runs, passes in isolation).

## Operational notes

- **No router wires `require_module` yet.** Wiring is deferred to E2.3+ per the epic plan. This PR is safe to merge and deploy because nothing reads the new dependency.
- **Default mode is `disabled` for every tenant** (Epic 1 already provisioned the column with that default). Code is on prod the moment this merges, but no enforcement happens.
- **EXPLAIN verified** on dev DB: the new LEFT JOIN runs at ~25 cost units against current row counts (405 tenant_members, 52 sessions). An index on `tenant_members(user_id, tenant_id)` is **not** included here — at current scale a seq scan is sub-millisecond. Add as a separate migration if perf monitoring shows pressure.

## Logger

Shadow events emit on the `permissions.shadow` logger at WARN level. The structured payload lives under `extra={'permission_event': {...}}` to avoid colliding with reserved `LogRecord` attributes (`module` is one — caught by the tests).

## Out of scope

- Wiring routers (E2.3+).
- `GET /api/me/access` (E2.17).
- Replacing inline `if user_role not in (...)` (Epic 6).

Closes a checkbox in #164 (E2.1). Epic itself remains open until all sub-tasks land.