### PR TITLE
feat(permissions): gate POS group routers under Module.POS (E2.3)

### DIFF
--- a/app/routers/comandas.py
+++ b/app/routers/comandas.py
@@ -5,9 +5,10 @@ Authenticated endpoints for kitchen operators to manage order lifecycle.
 Issue: https://github.com/uno0uno/warocol.com/issues/413
 Issue: https://github.com/uno0uno/warocol.com/issues/416
 """
-from fastapi import APIRouter, Request, Query
+from fastapi import APIRouter, Depends, Request, Query
 from typing import Optional
 from uuid import UUID
+from app.core.permissions import Module, require_module
 from app.services import comandas_service
 from app.models.comanda import ComandaStatusUpdateRequest, ComandaItemStatusUpdateRequest, BulkComandaStatusUpdateRequest
 
@@ -21,7 +22,10 @@ router = APIRouter(tags=["KDS / Comandas"])
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-@router.get("/active")
+@router.get(
+    "/active",
+    dependencies=[Depends(require_module(Module.POS))],
+)
 async def list_active_comandas(
     request: Request,
     station_id: Optional[UUID] = Query(None, description="Filter by kitchen station"),
@@ -38,7 +42,10 @@ async def list_active_comandas(
     )
 
 
-@router.get("/history")
+@router.get(
+    "/history",
+    dependencies=[Depends(require_module(Module.POS))],
+)
 async def list_comanda_history(
     request: Request,
     date_from: Optional[str] = Query(None, description="ISO format date from"),
@@ -57,7 +64,10 @@ async def list_comanda_history(
     )
 
 
-@router.get("/summary")
+@router.get(
+    "/summary",
+    dependencies=[Depends(require_module(Module.POS))],
+)
 async def get_comanda_summary(
     request: Request,
     date_from: Optional[str] = Query(None),
@@ -69,7 +79,10 @@ async def get_comanda_summary(
     return await comandas_service.get_comanda_summary(request, date_from, date_to)
 
 
-@router.get("/stats")
+@router.get(
+    "/stats",
+    dependencies=[Depends(require_module(Module.POS))],
+)
 async def get_stats_endpoint(
     request: Request,
     date: Optional[str] = Query(None, description="ISO date YYYY-MM-DD, defaults to today"),
@@ -82,6 +95,11 @@ async def get_stats_endpoint(
     return await comandas_service.get_daily_stats(request, date, station_id)
 
 
+# NOTE: KDS-direct endpoint — synthetic session via ?token= middleware
+# bypass has role=None and would always 403 under require_module.
+# Frontend KDS calls this from pages/cocina/[id].vue:53 with ?station_id=&token=.
+# DO NOT add Depends(require_module(...)) here. Operator path keeps
+# require_valid_session() inside the service for defense in depth.
 @router.get("")
 async def list_comandas(
     request: Request,
@@ -102,7 +120,10 @@ async def list_comandas(
     )
 
 
-@router.patch("/bulk-status")
+@router.patch(
+    "/bulk-status",
+    dependencies=[Depends(require_module(Module.POS))],
+)
 async def bulk_update_comanda_status(
     request: Request,
     body: BulkComandaStatusUpdateRequest,
@@ -115,7 +136,10 @@ async def bulk_update_comanda_status(
     return await comandas_service.bulk_update_comanda_status(request, body.comanda_ids, body.status)
 
 
-@router.get("/{comanda_id}")
+@router.get(
+    "/{comanda_id}",
+    dependencies=[Depends(require_module(Module.POS))],
+)
 async def get_comanda_detail(
     request: Request,
     comanda_id: UUID,
@@ -127,6 +151,10 @@ async def get_comanda_detail(
     return await comandas_service.get_comanda_detail(request, comanda_id)
 
 
+# NOTE: KDS-direct endpoint — frontend calls this from
+# components/cocina/ComandaCard.vue:72 with ?token= when the cook marks a
+# comanda as ready. Synthetic session has role=None, so require_module
+# would always 403. DO NOT gate. Service-level transition rules still apply.
 @router.patch("/{comanda_id}/status")
 async def update_comanda_status(
     request: Request,
@@ -144,7 +172,10 @@ async def update_comanda_status(
     return await comandas_service.update_comanda_status(request, comanda_id, body.status)
 
 
-@router.post("/{comanda_id}/deliver")
+@router.post(
+    "/{comanda_id}/deliver",
+    dependencies=[Depends(require_module(Module.POS))],
+)
 async def deliver_comanda(
     request: Request,
     comanda_id: UUID
@@ -156,7 +187,10 @@ async def deliver_comanda(
     return await comandas_service.update_comanda_status(request, comanda_id, 'delivered')
 
 
-@router.post("/{comanda_id}/recall")
+@router.post(
+    "/{comanda_id}/recall",
+    dependencies=[Depends(require_module(Module.POS))],
+)
 async def recall_comanda(
     request: Request,
     comanda_id: UUID
@@ -168,6 +202,10 @@ async def recall_comanda(
     return await comandas_service.recall_comanda(request, comanda_id)
 
 
+# NOTE: KDS-direct endpoint — frontend calls this from
+# components/cocina/ItemRow.vue:24 with ?token= when the cook marks an
+# individual item ready. Synthetic session has role=None, so
+# require_module would always 403. DO NOT gate.
 @router.patch("/{comanda_id}/items/{item_id}/status")
 async def update_comanda_item_status(
     request: Request,

--- a/app/routers/notifications.py
+++ b/app/routers/notifications.py
@@ -4,11 +4,12 @@ Authenticated endpoints for restaurant operators to manage notifications.
 """
 import asyncio
 import asyncpg
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from uuid import UUID
 from app.config import settings
 from app.core.middleware import require_valid_session
+from app.core.permissions import Module, require_module
 from app.services import notifications_service
 
 router = APIRouter(prefix="/notifications", tags=["notifications"])
@@ -50,7 +51,10 @@ async def _remove_listener_if_empty(channel: str) -> None:
             _channel_locks.pop(channel, None)
 
 
-@router.get("/stream")
+@router.get(
+    "/stream",
+    dependencies=[Depends(require_module(Module.POS))],
+)
 async def notification_stream(request: Request):
     """
     SSE endpoint — keeps connection open and pushes new order notifications in real time.
@@ -96,7 +100,10 @@ async def notification_stream(request: Request):
     )
 
 
-@router.get("")
+@router.get(
+    "",
+    dependencies=[Depends(require_module(Module.POS))],
+)
 async def get_notifications(request: Request):
     """
     List last 50 unread notifications for the authenticated tenant.
@@ -106,7 +113,10 @@ async def get_notifications(request: Request):
     return await notifications_service.get_unread_notifications(request)
 
 
-@router.patch("/{notification_id}/read")
+@router.patch(
+    "/{notification_id}/read",
+    dependencies=[Depends(require_module(Module.POS))],
+)
 async def mark_read(request: Request, notification_id: UUID):
     """
     Mark a single notification as read.
@@ -118,7 +128,10 @@ async def mark_read(request: Request, notification_id: UUID):
     return await notifications_service.mark_notification_read(request, notification_id)
 
 
-@router.post("/read-all")
+@router.post(
+    "/read-all",
+    dependencies=[Depends(require_module(Module.POS))],
+)
 async def mark_all_read(request: Request):
     """
     Mark all unread notifications as read for the authenticated tenant.

--- a/app/routers/payment_methods.py
+++ b/app/routers/payment_methods.py
@@ -4,8 +4,9 @@ CRUD for payment method groups and methods, plus POS read-only endpoint.
 
 Issue: https://github.com/uno0uno/warocol.com/issues/331
 """
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from uuid import UUID
+from app.core.permissions import Module, require_module
 from app.services import payment_method_service
 from app.models.payment_method import (
     CreateGroupRequest,
@@ -61,10 +62,13 @@ async def delete_method(request: Request, method_id: UUID):
 
 
 # ── POS read-only endpoint ─────────────────────────────────────────────────────
+# NOTE: finanzas_router endpoints above stay UNGATED in this PR — they get
+# Depends(require_module(Module.FINANZAS)) in E2.10 (#198). This file gets
+# touched twice across the rollout, intentionally per the audit doc §3.
 pos_router = APIRouter(prefix="/pos/payment-methods", tags=["pos"])
 
 
-@pos_router.get("")
+@pos_router.get("", dependencies=[Depends(require_module(Module.POS))])
 async def list_pos_methods(request: Request):
     """POS: returns active groups with their active methods nested inside."""
     return await payment_method_service.list_pos_methods(request)

--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -2,7 +2,7 @@
 POS Cart Router
 Endpoints for managing POS cart persistence
 """
-from fastapi import APIRouter, Request, Query
+from fastapi import APIRouter, Depends, Request, Query
 from typing import List, Optional, Any, Dict
 from uuid import UUID
 from datetime import date, datetime
@@ -10,6 +10,7 @@ from pydantic import BaseModel, EmailStr, Field
 from app.services import pos_cart_service
 from app.services.email_helpers import send_pos_receipt_email
 from app.core.middleware import require_valid_session
+from app.core.permissions import Module, require_module
 
 router = APIRouter(prefix="/pos/cart", tags=["POS Cart"])
 
@@ -33,7 +34,7 @@ class BatchAddItemsRequest(BaseModel):
     customer_id: Optional[UUID] = None  # Opcional - si no se pasa, se crea carrito anónimo
 
 
-@router.post("/batch")
+@router.post("/batch", dependencies=[Depends(require_module(Module.POS))])
 async def create_cart_with_items_batch(
     request: Request,
     batch: BatchAddItemsRequest
@@ -50,7 +51,7 @@ async def create_cart_with_items_batch(
     )
 
 
-@router.get("/{customer_id}")
+@router.get("/{customer_id}", dependencies=[Depends(require_module(Module.POS))])
 async def get_cart(
     request: Request,
     customer_id: UUID,
@@ -66,7 +67,7 @@ async def get_cart(
     )
 
 
-@router.post("/{cart_id}/items")
+@router.post("/{cart_id}/items", dependencies=[Depends(require_module(Module.POS))])
 async def add_item(
     request: Request,
     cart_id: UUID,
@@ -93,7 +94,7 @@ class UpdateItemRequest(BaseModel):
     notes: Optional[str] = None
 
 
-@router.put("/{cart_id}/items/{item_id}")
+@router.put("/{cart_id}/items/{item_id}", dependencies=[Depends(require_module(Module.POS))])
 async def update_item(
     request: Request,
     cart_id: UUID,
@@ -114,7 +115,7 @@ async def update_item(
     )
 
 
-@router.delete("/{cart_id}/items/{item_id}")
+@router.delete("/{cart_id}/items/{item_id}", dependencies=[Depends(require_module(Module.POS))])
 async def remove_item(
     request: Request,
     cart_id: UUID,
@@ -130,7 +131,7 @@ async def remove_item(
     )
 
 
-@router.delete("/{cart_id}")
+@router.delete("/{cart_id}", dependencies=[Depends(require_module(Module.POS))])
 async def clear_cart(
     request: Request,
     cart_id: UUID
@@ -159,7 +160,7 @@ class CompleteOrderRequest(BaseModel):
     delivery_instructions: Optional[str] = Field(None, description="Free-text notes for the courier (e.g. 'Tocar el timbre 2 veces').")
 
 
-@router.post("/{cart_id}/complete")
+@router.post("/{cart_id}/complete", dependencies=[Depends(require_module(Module.POS))])
 async def complete_order(
     request: Request,
     cart_id: UUID,
@@ -194,7 +195,7 @@ async def complete_order(
     )
 
 
-@router.post("/{cart_id}/fire")
+@router.post("/{cart_id}/fire", dependencies=[Depends(require_module(Module.POS))])
 async def fire_pos_cart(request: Request, cart_id: UUID):
     """
     Explicitly fire all 'new' items in a POS cart/order to the kitchen.
@@ -237,7 +238,7 @@ class AddPaymentResponse(BaseModel):
     payment_id: str
 
 
-@router.post("/receipt-email")
+@router.post("/receipt-email", dependencies=[Depends(require_module(Module.POS))])
 async def send_receipt_email(request: Request, receipt_data: SendReceiptRequest):
     """
     Send a POS receipt email on demand.
@@ -268,7 +269,7 @@ async def send_receipt_email(request: Request, receipt_data: SendReceiptRequest)
     return {"success": success}
 
 
-@router.post("/{cart_id}/payments", response_model=None)
+@router.post("/{cart_id}/payments", response_model=None, dependencies=[Depends(require_module(Module.POS))])
 async def add_cart_payment(
     cart_id: str,
     payment_data: AddPaymentRequest,
@@ -288,7 +289,7 @@ async def add_cart_payment(
     )
 
 
-@router.get("/{cart_id}/tax-preview")
+@router.get("/{cart_id}/tax-preview", dependencies=[Depends(require_module(Module.POS))])
 async def get_cart_tax_preview(
     request: Request,
     cart_id: UUID,

--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -4,11 +4,12 @@ CRUD and session lifecycle endpoints for restaurant table management.
 
 Issue: https://github.com/uno0uno/warocol.com/issues/298
 """
-from fastapi import APIRouter, Request, Query
+from fastapi import APIRouter, Depends, Request, Query
 from typing import Optional, List
 from uuid import UUID
 from datetime import date
 from pydantic import BaseModel, Field
+from app.core.permissions import Module, require_module
 from app.services import tables_service
 
 router = APIRouter(tags=["Tables"])
@@ -46,7 +47,7 @@ class UpdateTabItemRequest(BaseModel):
     quantity: int = Field(..., ge=1)
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(require_module(Module.POS))])
 async def list_tables(request: Request, include_inactive: bool = Query(False)):
     """
     List tables for the tenant.
@@ -56,7 +57,7 @@ async def list_tables(request: Request, include_inactive: bool = Query(False)):
     return await tables_service.list_tables(request, include_inactive=include_inactive)
 
 
-@router.post("")
+@router.post("", dependencies=[Depends(require_module(Module.POS))])
 async def create_table(request: Request, body: CreateTableRequest):
     """
     Create a new table for the tenant.
@@ -64,7 +65,7 @@ async def create_table(request: Request, body: CreateTableRequest):
     return await tables_service.create_table(request, body.name, body.capacity)
 
 
-@router.put("/{table_id}")
+@router.put("/{table_id}", dependencies=[Depends(require_module(Module.POS))])
 async def update_table(request: Request, table_id: UUID, body: UpdateTableRequest):
     """
     Update a table's name and/or capacity.
@@ -73,7 +74,7 @@ async def update_table(request: Request, table_id: UUID, body: UpdateTableReques
     return await tables_service.update_table(request, table_id, body.name, body.capacity)
 
 
-@router.patch("/{table_id}/activate")
+@router.patch("/{table_id}/activate", dependencies=[Depends(require_module(Module.POS))])
 async def activate_table(request: Request, table_id: UUID):
     """
     Re-activate a deactivated table (is_active = true).
@@ -83,7 +84,7 @@ async def activate_table(request: Request, table_id: UUID):
     return await tables_service.activate_table(request, table_id)
 
 
-@router.patch("/{table_id}/deactivate")
+@router.patch("/{table_id}/deactivate", dependencies=[Depends(require_module(Module.POS))])
 async def deactivate_table(request: Request, table_id: UUID):
     """
     Temporarily deactivate a table (is_active = false).
@@ -93,7 +94,7 @@ async def deactivate_table(request: Request, table_id: UUID):
     return await tables_service.deactivate_table(request, table_id)
 
 
-@router.delete("/{table_id}")
+@router.delete("/{table_id}", dependencies=[Depends(require_module(Module.POS))])
 async def delete_table_permanent(request: Request, table_id: UUID):
     """
     Permanently remove a table.
@@ -105,7 +106,7 @@ async def delete_table_permanent(request: Request, table_id: UUID):
     return await tables_service.delete_table_permanent(request, table_id)
 
 
-@router.post("/{table_id}/open")
+@router.post("/{table_id}/open", dependencies=[Depends(require_module(Module.POS))])
 async def open_session(request: Request, table_id: UUID):
     """
     Open a new session for a table (status: free → open).
@@ -134,7 +135,7 @@ class AddSessionPaymentRequest(BaseModel):
     cash_received: Optional[float] = Field(None, description="Issue #524 — cash handed over for this payment when payment_method='cash'. Must be >= amount.")
 
 
-@router.post("/{table_id}/close")
+@router.post("/{table_id}/close", dependencies=[Depends(require_module(Module.POS))])
 async def close_session(request: Request, table_id: UUID, body: CloseSessionRequest = CloseSessionRequest()):
     """
     Close the active session (status: open/bill_requested → free).
@@ -160,7 +161,7 @@ async def close_session(request: Request, table_id: UUID, body: CloseSessionRequ
     )
 
 
-@router.post("/{table_id}/payments")
+@router.post("/{table_id}/payments", dependencies=[Depends(require_module(Module.POS))])
 async def add_session_payment(request: Request, table_id: UUID, body: AddSessionPaymentRequest):
     """
     Add a partial payment to an open mesa session's split payment.
@@ -174,7 +175,7 @@ async def add_session_payment(request: Request, table_id: UUID, body: AddSession
     )
 
 
-@router.get("/{table_id}/current")
+@router.get("/{table_id}/current", dependencies=[Depends(require_module(Module.POS))])
 async def get_current_session(request: Request, table_id: UUID):
     """
     Get the open session for a table with all linked orders and running total.
@@ -183,7 +184,7 @@ async def get_current_session(request: Request, table_id: UUID):
     return await tables_service.get_current_session(request, table_id)
 
 
-@router.post("/{table_id}/tab/add")
+@router.post("/{table_id}/tab/add", dependencies=[Depends(require_module(Module.POS))])
 async def add_tab_items(request: Request, table_id: UUID, body: TabAddRequest):
     """
     Add items to the running tab for a table session.
@@ -206,19 +207,19 @@ async def add_tab_items(request: Request, table_id: UUID, body: TabAddRequest):
     return await tables_service.add_tab_items(request, table_id, items)
 
 
-@router.delete("/{table_id}/tab/items/{order_item_id}")
+@router.delete("/{table_id}/tab/items/{order_item_id}", dependencies=[Depends(require_module(Module.POS))])
 async def remove_tab_item(request: Request, table_id: UUID, order_item_id: UUID):
     """Remove an order item from the running tab."""
     return await tables_service.remove_tab_item(request, table_id, order_item_id)
 
 
-@router.patch("/{table_id}/tab/items/{order_item_id}")
+@router.patch("/{table_id}/tab/items/{order_item_id}", dependencies=[Depends(require_module(Module.POS))])
 async def update_tab_item_quantity(request: Request, table_id: UUID, order_item_id: UUID, body: UpdateTabItemRequest):
     """Update the quantity of an order item in the running tab."""
     return await tables_service.update_tab_item_quantity(request, table_id, order_item_id, body.quantity)
 
 
-@router.delete("/{table_id}/tab")
+@router.delete("/{table_id}/tab", dependencies=[Depends(require_module(Module.POS))])
 async def clear_tab(request: Request, table_id: UUID):
     """
     Delete all pending orders for the active session without closing it.
@@ -227,7 +228,7 @@ async def clear_tab(request: Request, table_id: UUID):
     return await tables_service.clear_tab(request, table_id)
 
 
-@router.post("/{table_id}/bill")
+@router.post("/{table_id}/bill", dependencies=[Depends(require_module(Module.POS))])
 async def request_bill(request: Request, table_id: UUID):
     """
     Mark a table as bill_requested (status: open → bill_requested).
@@ -236,7 +237,7 @@ async def request_bill(request: Request, table_id: UUID):
     return await tables_service.request_bill(request, table_id)
 
 
-@router.post("/{table_id}/fire")
+@router.post("/{table_id}/fire", dependencies=[Depends(require_module(Module.POS))])
 async def fire_table_items(request: Request, table_id: UUID):
     """
     Explicitly fire all 'new' items in the table session to the kitchen.
@@ -245,7 +246,7 @@ async def fire_table_items(request: Request, table_id: UUID):
     return await tables_service.fire_table_items(request, table_id)
 
 
-@router.delete("/{table_id}/session")
+@router.delete("/{table_id}/session", dependencies=[Depends(require_module(Module.POS))])
 async def discard_session(request: Request, table_id: UUID):
     """
     Discard the active session: hard-delete all pending orders/items,
@@ -257,7 +258,7 @@ async def discard_session(request: Request, table_id: UUID):
     return await tables_service.discard_table_session(request, table_id)
 
 
-@router.post("/{table_id}/session/reopen")
+@router.post("/{table_id}/session/reopen", dependencies=[Depends(require_module(Module.POS))])
 async def reopen_session(request: Request, table_id: UUID):
     """
     Reopen the most recent non-discarded closed session for a table.
@@ -273,7 +274,7 @@ class MoveTableRequest(BaseModel):
     target_table_id: UUID
 
 
-@router.post("/{source_table_id}/move")
+@router.post("/{source_table_id}/move", dependencies=[Depends(require_module(Module.POS))])
 async def move_table_session(request: Request, source_table_id: UUID, body: MoveTableRequest):
     """
     Transfer all pending orders from source table's open session to target table.

--- a/app/routers/waros.py
+++ b/app/routers/waros.py
@@ -6,9 +6,10 @@ All endpoints require a valid tenant session.
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 
+from app.core.permissions import Module, require_module
 from app.services import waros_service
 
 router = APIRouter(prefix="/admin/waros", tags=["Waros"])
@@ -39,7 +40,7 @@ class AssignBody(BaseModel):
 
 # ── Endpoints ────────────────────────────────────────────────────────────────
 
-@router.get("/rules")
+@router.get("/rules", dependencies=[Depends(require_module(Module.POS))])
 async def get_rules(request: Request):
     """
     Get all earning rules for the tenant.
@@ -49,7 +50,7 @@ async def get_rules(request: Request):
     return await waros_service.get_rules(request)
 
 
-@router.put("/rules/{rule_type}")
+@router.put("/rules/{rule_type}", dependencies=[Depends(require_module(Module.POS))])
 async def upsert_rule(rule_type: str, body: RuleBody, request: Request):
     """
     Create or update an earning rule for the tenant.
@@ -68,7 +69,7 @@ async def upsert_rule(rule_type: str, body: RuleBody, request: Request):
     )
 
 
-@router.patch("/rules/{rule_type}/toggle")
+@router.patch("/rules/{rule_type}/toggle", dependencies=[Depends(require_module(Module.POS))])
 async def toggle_rule(rule_type: str, request: Request):
     """
     Toggle is_active for a rule without changing its config.
@@ -82,7 +83,7 @@ async def toggle_rule(rule_type: str, request: Request):
     return await waros_service.toggle_rule(request, rule_type=rule_type)
 
 
-@router.patch("/config")
+@router.patch("/config", dependencies=[Depends(require_module(Module.POS))])
 async def update_global_config(body: GlobalConfigBody, request: Request):
     """
     Enable or disable the entire Waros system for the tenant.
@@ -91,7 +92,7 @@ async def update_global_config(body: GlobalConfigBody, request: Request):
     return await waros_service.update_global_config(request, is_enabled=body.is_enabled)
 
 
-@router.get("/estimate")
+@router.get("/estimate", dependencies=[Depends(require_module(Module.POS))])
 async def estimate_waros(
     request: Request,
     total_amount: float = Query(..., description="Cart total in COP", gt=0),
@@ -113,7 +114,7 @@ async def estimate_waros(
     return await waros_service.estimate_waros(request, total_amount, parsed_customer_id)
 
 
-@router.get("/customers/balances")
+@router.get("/customers/balances", dependencies=[Depends(require_module(Module.POS))])
 async def get_customers_balances(
     request: Request,
     profile_ids: str = Query(..., description="Comma-separated profile UUIDs (max 500)"),
@@ -139,7 +140,7 @@ async def get_customers_balances(
     return await waros_service.get_customers_balances(request, ids)
 
 
-@router.get("/customers/{profile_id}/summary")
+@router.get("/customers/{profile_id}/summary", dependencies=[Depends(require_module(Module.POS))])
 async def get_customer_summary(profile_id: UUID, request: Request):
     """
     Waros summary for a single customer: balance + last 5 transactions.
@@ -148,7 +149,7 @@ async def get_customer_summary(profile_id: UUID, request: Request):
     return await waros_service.get_customer_summary(request, profile_id)
 
 
-@router.post("/assign")
+@router.post("/assign", dependencies=[Depends(require_module(Module.POS))])
 async def assign_waros(body: AssignBody, request: Request):
     """
     Manually award or deduct Waros from a customer.

--- a/docs/permissions-router-mapping.md
+++ b/docs/permissions-router-mapping.md
@@ -83,7 +83,7 @@ Total: **51 routers**, **~394 endpoints** (was 52/395 before #187 deleted `admin
 
 | Module | Routers | Sub-task | Status |
 |---|---|---|---|
-| **POS** | comandas, notifications, pos_cart, tables, waros + payment_methods/pos | 5+1 | E2.3 (#188) — pending |
+| **POS** | comandas, notifications, pos_cart, tables, waros + payment_methods/pos | 5+1 | ✅ E2.3 (#188) — DONE (51 endpoints gated, 3 KDS-direct excluded) |
 | **VENTAS** | customers, online_orders, orders | 3 | E2.4 (#189) — pending |
 | **DESPACHO** | (no routers — placeholder, like EVENTOS) | 0 | ✅ E2.5 (#187) — DONE (deleted dead `admin_orders.py`) |
 | **MENU** | categories, combos, menu, modifiers, products, recipe_bases | 6 | E2.6 (#190) — pending |
@@ -120,9 +120,19 @@ KDS-consumed endpoints must NOT receive the dependency, because the synthetic
 session has no role and would always be denied. Per-endpoint exclusion is
 mandatory — DO NOT use router-level `dependencies=[]`.
 
-The exact endpoint list to exclude lives in the KDS dashboard code on the
-front_nuxt side; the wiring PRs (E2.3, E2.7) will enumerate them after
-re-reading the KDS components and the `comandas.py` / `stations.py` files.
+**Confirmed exclusions in `comandas.py`** (post-E2.3, see #188):
+
+| Endpoint | Frontend caller |
+|---|---|
+| `GET /api/comandas` | `pages/cocina/[id].vue:53` (with `?station_id=&token=`) |
+| `PATCH /api/comandas/{id}/status` | `components/cocina/ComandaCard.vue:72` (with `?token=`) |
+| `PATCH /api/comandas/{id}/items/{item_id}/status` | `components/cocina/ItemRow.vue:24` (with `?token=`) |
+
+Each carries an explicit `# NOTE:` block above its decorator referencing
+the consumer file/line and the reason for the exclusion.
+
+`stations.py` follows the same pattern — exclusions to be enumerated when
+E2.7 (#191) lands.
 
 ## §2. `/invitations/accept` is token-public
 

--- a/tests/test_pos_permissions.py
+++ b/tests/test_pos_permissions.py
@@ -1,0 +1,130 @@
+"""End-to-end smoke tests for POS group endpoints under require_module(POS).
+
+Sub-task E2.3 of Epic 2 (#188). Validates that:
+1. Owner role under enforce reaches the handler.
+2. Kitchen role under enforce gets 403 (kitchen lacks POS in default matrix).
+3. KDS-direct synthetic session (role=None) passes the EXCLUDED comandas
+   endpoints — proves the `# NOTE:` exclusions actually leave them ungated.
+
+Pairs with `test_billing_permissions.py` (#185 / E2.14 reference impl).
+"""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.core.permissions import Module
+from app.routers.tables import router as tables_router
+from app.routers.comandas import router as comandas_router
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_session(role):
+    """Build a SessionContext with the given role."""
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": role,
+    })
+
+
+def _enforce_db_ctx():
+    """Async context manager whose .fetchval returns 'enforce'."""
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+    return _ctx
+
+
+# ─── Tests ────────────────────────────────────────────────────────────
+
+
+def test_owner_role_passes_pos_endpoint_under_enforce():
+    """Owner reaches GET /tables under enforce — dependency permits."""
+    session = _build_session(role="owner")
+    app = FastAPI()
+    app.include_router(tables_router, prefix="/tables")
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.routers.tables.tables_service.list_tables",
+             new=AsyncMock(return_value={"tables": []}),
+         ):
+        client = TestClient(app)
+        response = client.get("/tables")
+
+    # Handler reached → dependency permitted.
+    assert response.status_code == 200
+
+
+def test_kitchen_role_denied_pos_endpoint_under_enforce():
+    """Kitchen role hits 403 on POS endpoint — kitchen lacks POS in default matrix."""
+    session = _build_session(role="kitchen")
+    app = FastAPI()
+    app.include_router(tables_router, prefix="/tables")
+
+    # Stub get_role_modules to return kitchen's default set (DESPACHO only).
+    kitchen_modules = frozenset({Module.DESPACHO})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=kitchen_modules),
+         ):
+        client = TestClient(app)
+        response = client.get("/tables")
+
+    assert response.status_code == 403
+    assert "pos" in response.json()["detail"].lower()
+
+
+def test_kds_synthetic_session_passes_excluded_comandas_endpoint():
+    """KDS-style session (role=None) passes the EXCLUDED `GET /comandas`.
+
+    The endpoint at comandas.py line 86 (now ~line 90 after the # NOTE:
+    block) carries no `Depends(require_module)`. With `role=None` and
+    enforce mode, the dependency would 403 — but it's not registered, so
+    the request reaches the handler.
+    """
+    session = _build_session(role=None)
+    app = FastAPI()
+    app.include_router(comandas_router, prefix="/api/comandas")
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch(
+             "app.routers.comandas.comandas_service.get_comandas_for_kds",
+             new=AsyncMock(return_value={"data": []}),
+         ):
+        client = TestClient(app)
+        response = client.get("/api/comandas")
+
+    # No 403 — handler reached, role=None passed because endpoint is ungated.
+    assert response.status_code == 200


### PR DESCRIPTION
Sub-task E2.3 of Epic 2 (#164). High-traffic batch — first real shadow-mode signal.

## Stack
🔵 FastAPI · 🐍 Python 3.9

## Summary

Cables `Depends(require_module(Module.POS))` on **51 operator-facing endpoints** across 6 routers, with explicit `# NOTE:` exclusions on **3 KDS-direct endpoints** in `comandas.py`.

> ⚠️ **Scope correction**: the issue body lists 4 routers (incl. `online_orders`). The audit doc (#186) — source of truth post-#187 — lists 6 routers. `online_orders` belongs in E2.4 / VENTAS. This PR follows the doc.

## Routers wired

| Router | Gated | Excluded (KDS-direct) | Notes |
|---|---|---|---|
| `comandas.py` | 8 | **3** with `# NOTE:` | Operator/expediter writes, KDS reads/writes excluded |
| `notifications.py` | 4 | 0 | SSE stream + read CRUD |
| `pos_cart.py` | 11 | 0 | Cart lifecycle + checkout |
| `tables.py` | 19 | 0 | Largest file — table CRUD + tab session lifecycle |
| `waros.py` | 8 | 0 | Loyalty points config |
| `payment_methods.py` | 1 | 0 | pos_router only; finanzas_router UNTOUCHED (→ E2.10) |
| **TOTAL** | **51** | **3** | |

## KDS-direct exclusions in `comandas.py`

Verified by grep against the KDS frontend:

| Endpoint | Caller |
|---|---|
| `GET /api/comandas` | `pages/cocina/[id].vue:53` (with `?station_id=&token=`) |
| `PATCH /api/comandas/{id}/status` | `components/cocina/ComandaCard.vue:72` (with `?token=`) |
| `PATCH /api/comandas/{id}/items/{item_id}/status` | `components/cocina/ItemRow.vue:24` (with `?token=`) |

Each has a `# NOTE:` block above the decorator referencing the consumer + reason. The synthetic session injected by the `?token=` middleware bypass has `role=None`, which would always 403 under `require_module`.

## Matrix effect post-enforce

| Role | POS access | Change |
|---|---|---|
| owner / admin / supervisor / cashier | ✅ | none |
| **kitchen** | ❌ | ⚠️ kitchen lacks POS in default matrix → `/tables`, `/notifications`, `/pos_cart`, `/waros`, `/pos/payment-methods` will 403 for kitchen role |
| customer | ❌ | none (n/a) |

KDS path unaffected (uses `?token=` not session).

## Tests

`tests/test_pos_permissions.py` (NEW, 3 cases):
- ✅ owner → `GET /tables` under enforce → 200 (handler reached).
- ✅ kitchen → `GET /tables` under enforce → 403 (kitchen lacks POS).
- ✅ role=None synthetic → `GET /api/comandas` (excluded) → 200 (passes ungated).

## Validation

- ✅ `python -m py_compile` clean on all 6 routers.
- ✅ App boots: 429 routes (unchanged from before).
- ✅ 57/57 permission tests pass (Epic 1 + E2.1 + E2.14 + E2.3).
- ✅ Full backend suite: **515 passed**, 6 skipped, 1 unrelated flaky (`test_emit_invoice_requires_auth` — pre-existing, passes in isolation).

## Audit doc

`docs/permissions-router-mapping.md` updated:
- E2.3 marked DONE in the Coverage Summary.
- §1 now lists the 3 confirmed KDS-direct exclusions with file:line consumers.

## Two-touch rationale on `payment_methods.py`

`payment_methods.py` exports two routers (`finanzas_router` + `pos_router`). This PR only adds the dependency to the `pos_router` GET endpoint. The `finanzas_router` (7 endpoints) gets `Module.FINANZAS` in E2.10 (#198). Reviewer should NOT request adding both at once — splitting matches the rollout design (per audit doc §3).

## Operationally safe to deploy

Every tenant remains on `permissions_enforcement_mode='disabled'` (Epic 1 default). The new dependency returns silently for everyone until a tenant is manually flipped to `'shadow'` as the rollout phase begins.

Closes #188