### PR TITLE
feat(permissions): gate VENTAS group routers under Module.VENTAS (E2.4)

### DIFF
--- a/app/routers/customers.py
+++ b/app/routers/customers.py
@@ -1,8 +1,9 @@
 """
 Customers Router - HTTP endpoints for customer management
 """
-from fastapi import APIRouter, Request, Query
+from fastapi import APIRouter, Depends, Request, Query
 from uuid import UUID
+from app.core.permissions import Module, require_module
 from app.services.customers_service import (
     search_or_create_customer,
     search_customer_by_phone,
@@ -24,7 +25,7 @@ from app.models.customer import (
 router = APIRouter()
 
 
-@router.post("/search-or-create", response_model=CustomerResponse, status_code=200)
+@router.post("/search-or-create", response_model=CustomerResponse, status_code=200, dependencies=[Depends(require_module(Module.VENTAS))])
 async def search_or_create_customer_endpoint(
     request: Request,
     customer_data: CustomerSearchOrCreate
@@ -53,7 +54,7 @@ async def search_or_create_customer_endpoint(
     return await search_or_create_customer(request, customer_data)
 
 
-@router.get("/search", response_model=CustomerSearchResponse, status_code=200)
+@router.get("/search", response_model=CustomerSearchResponse, status_code=200, dependencies=[Depends(require_module(Module.VENTAS))])
 async def search_customer_endpoint(
     request: Request,
     phone_number: str = Query(..., min_length=7, max_length=20, description="Phone number to search")
@@ -76,7 +77,7 @@ async def search_customer_endpoint(
     return await search_customer_by_phone(request, phone_number)
 
 
-@router.get("/search-by-query", response_model=CustomerQuerySearchResponse, status_code=200)
+@router.get("/search-by-query", response_model=CustomerQuerySearchResponse, status_code=200, dependencies=[Depends(require_module(Module.VENTAS))])
 async def search_customers_by_query_endpoint(
     request: Request,
     q: str = Query(..., min_length=1, max_length=100, description="Partial name or phone to search"),
@@ -98,7 +99,7 @@ async def search_customers_by_query_endpoint(
     return await search_customers_by_query(request, q, limit)
 
 
-@router.patch("/{customer_id}", response_model=CustomerUpdateResponse, status_code=200)
+@router.patch("/{customer_id}", response_model=CustomerUpdateResponse, status_code=200, dependencies=[Depends(require_module(Module.VENTAS))])
 async def update_customer_endpoint(
     request: Request,
     customer_id: UUID,
@@ -111,7 +112,7 @@ async def update_customer_endpoint(
     return await update_customer(request, customer_id, update_data)
 
 
-@router.get("/{customer_id}", response_model=CustomerUpdateResponse, status_code=200)
+@router.get("/{customer_id}", response_model=CustomerUpdateResponse, status_code=200, dependencies=[Depends(require_module(Module.VENTAS))])
 async def get_customer_by_id_endpoint(
     request: Request,
     customer_id: UUID,
@@ -123,7 +124,7 @@ async def get_customer_by_id_endpoint(
     return await get_customer_by_id(request, customer_id)
 
 
-@router.get("/{customer_id}/insights", response_model=CustomerInsightsResponse, status_code=200)
+@router.get("/{customer_id}/insights", response_model=CustomerInsightsResponse, status_code=200, dependencies=[Depends(require_module(Module.VENTAS))])
 async def get_customer_insights_endpoint(
     request: Request,
     customer_id: UUID

--- a/app/routers/online_orders.py
+++ b/app/routers/online_orders.py
@@ -2,10 +2,11 @@
 Online Orders Router
 Authenticated endpoints for restaurant operators to manage online orders.
 """
-from fastapi import APIRouter, Request, Query
+from fastapi import APIRouter, Depends, Request, Query
 from typing import Optional, Literal
 from uuid import UUID
 from pydantic import BaseModel
+from app.core.permissions import Module, require_module
 from app.services import online_orders_service
 
 router = APIRouter(prefix="/online/orders", tags=["Online Orders (Authenticated)"])
@@ -17,7 +18,7 @@ class UpdateOrderStatusRequest(BaseModel):
     auto_complete: bool = False
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(require_module(Module.VENTAS))])
 async def list_online_orders(
     request: Request,
     status: Optional[str] = Query(None, description="Filter by status: pending, confirmed, preparing, delivered, cancelled"),
@@ -39,7 +40,7 @@ async def list_online_orders(
     )
 
 
-@router.get("/{order_id}/status-history")
+@router.get("/{order_id}/status-history", dependencies=[Depends(require_module(Module.VENTAS))])
 async def get_online_order_status_history(
     request: Request,
     order_id: UUID,
@@ -48,7 +49,7 @@ async def get_online_order_status_history(
     return await online_orders_service.get_order_status_history(request, order_id)
 
 
-@router.get("/{order_id}")
+@router.get("/{order_id}", dependencies=[Depends(require_module(Module.VENTAS))])
 async def get_online_order_detail(
     request: Request,
     order_id: UUID,
@@ -64,7 +65,7 @@ async def get_online_order_detail(
     return await online_orders_service.get_online_order_by_id(request, order_id)
 
 
-@router.patch("/{order_id}/status")
+@router.patch("/{order_id}/status", dependencies=[Depends(require_module(Module.VENTAS))])
 async def update_online_order_status(
     request: Request,
     order_id: UUID,

--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -6,14 +6,15 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Query
 from typing import Optional, List
 from uuid import UUID
 from pydantic import BaseModel, Field
-from app.services import orders_service, facturacion_service
 from app.core.dependencies import require_invoicing_ready
 from app.core.middleware import require_valid_session
+from app.core.permissions import Module, require_module
+from app.services import orders_service, facturacion_service
 
 router = APIRouter(prefix="/orders", tags=["Orders"])
 
 
-@router.get("/dashboard")
+@router.get("/dashboard", dependencies=[Depends(require_module(Module.VENTAS))])
 async def get_orders_dashboard(
     request: Request,
     payment_method: Optional[str] = Query(None),
@@ -35,7 +36,7 @@ async def get_orders_dashboard(
     )
 
 
-@router.get("/metrics")
+@router.get("/metrics", dependencies=[Depends(require_module(Module.VENTAS))])
 async def get_orders_metrics(
     request: Request,
     date_from: Optional[str] = Query(None),
@@ -51,7 +52,7 @@ async def get_orders_metrics(
     )
 
 
-@router.get("/sales-flow")
+@router.get("/sales-flow", dependencies=[Depends(require_module(Module.VENTAS))])
 async def get_sales_flow(
     request: Request,
     date_from: Optional[str] = Query(None),
@@ -81,7 +82,7 @@ async def get_sales_flow(
     )
 
 
-@router.post("/export")
+@router.post("/export", dependencies=[Depends(require_module(Module.VENTAS))])
 async def export_orders(
     request: Request,
     search: Optional[str] = Query(None),
@@ -108,7 +109,7 @@ async def export_orders(
     )
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(require_module(Module.VENTAS))])
 async def get_orders(
     request: Request,
     limit: int = Query(50, ge=1, le=250),
@@ -141,7 +142,7 @@ async def get_orders(
     )
 
 
-@router.get("/customers")
+@router.get("/customers", dependencies=[Depends(require_module(Module.VENTAS))])
 async def get_customers(
     request: Request,
     date_from: Optional[str] = Query(None),
@@ -176,7 +177,7 @@ async def get_customers(
     )
 
 
-@router.get("/customers/{customer_id}")
+@router.get("/customers/{customer_id}", dependencies=[Depends(require_module(Module.VENTAS))])
 async def get_customer_detail(
     request: Request,
     customer_id: UUID,
@@ -229,7 +230,7 @@ class CreateManualOrderRequest(BaseModel):
     items: List[ManualOrderItem] = Field(min_length=1)
 
 
-@router.post("/manual")
+@router.post("/manual", dependencies=[Depends(require_module(Module.VENTAS))])
 async def create_manual_order(
     request: Request,
     data: CreateManualOrderRequest
@@ -248,7 +249,7 @@ async def create_manual_order(
     )
 
 
-@router.get("/products-sold")
+@router.get("/products-sold", dependencies=[Depends(require_module(Module.VENTAS))])
 async def get_products_sold(
     request: Request,
     date_from: Optional[str] = Query(None),
@@ -274,7 +275,7 @@ async def get_products_sold(
     )
 
 
-@router.get("/{order_id}")
+@router.get("/{order_id}", dependencies=[Depends(require_module(Module.VENTAS))])
 async def get_order(
     request: Request,
     order_id: UUID
@@ -297,7 +298,7 @@ class BulkUpdateStatusRequest(BaseModel):
     customer_id: Optional[str] = Field(None, description="UUID of customer to associate")
 
 
-@router.patch("/bulk-status")
+@router.patch("/bulk-status", dependencies=[Depends(require_module(Module.VENTAS))])
 async def bulk_update_order_status(
     request: Request,
     body: BulkUpdateStatusRequest
@@ -306,7 +307,7 @@ async def bulk_update_order_status(
     return await orders_service.bulk_update_order_status(request, body.order_ids, body.status, body.payment_method, body.customer_id)
 
 
-@router.patch("/{order_id}/status")
+@router.patch("/{order_id}/status", dependencies=[Depends(require_module(Module.VENTAS))])
 async def update_order_status(
     request: Request,
     order_id: UUID,
@@ -318,7 +319,7 @@ async def update_order_status(
     return await orders_service.update_order_status(request, order_id, body.status, body.payment_method)
 
 
-@router.get("/{order_id}/items")
+@router.get("/{order_id}/items", dependencies=[Depends(require_module(Module.VENTAS))])
 async def get_order_items(
     request: Request,
     order_id: UUID
@@ -329,7 +330,7 @@ async def get_order_items(
     return await orders_service.get_order_items(request, order_id)
 
 
-@router.delete("/{order_id}/items/{item_id}")
+@router.delete("/{order_id}/items/{item_id}", dependencies=[Depends(require_module(Module.VENTAS))])
 async def delete_order_item(
     request: Request,
     order_id: UUID,
@@ -342,7 +343,7 @@ async def delete_order_item(
     return await orders_service.delete_order_item(request, order_id, item_id)
 
 
-@router.delete("/{order_id}/items/{item_id}/modifiers/{modifier_id}")
+@router.delete("/{order_id}/items/{item_id}/modifiers/{modifier_id}", dependencies=[Depends(require_module(Module.VENTAS))])
 async def delete_order_item_modifier(
     request: Request,
     order_id: UUID,
@@ -358,7 +359,7 @@ async def delete_order_item_modifier(
 
 # ── Electronic invoicing (issue #128) ─────────────────────────────────────────
 
-@router.post("/{order_id}/invoice", tags=["Invoices"])
+@router.post("/{order_id}/invoice", tags=["Invoices"], dependencies=[Depends(require_module(Module.VENTAS))])
 async def emit_order_invoice(
     request: Request,
     order_id: UUID,
@@ -383,7 +384,7 @@ async def emit_order_invoice(
     )
 
 
-@router.get("/{order_id}/invoice", tags=["Invoices"])
+@router.get("/{order_id}/invoice", tags=["Invoices"], dependencies=[Depends(require_module(Module.VENTAS))])
 async def get_order_invoice(
     request: Request,
     order_id: UUID,
@@ -404,7 +405,7 @@ async def get_order_invoice(
     return result
 
 
-@router.get("/{order_id}/invoice/dian-status", tags=["Invoices"])
+@router.get("/{order_id}/invoice/dian-status", tags=["Invoices"], dependencies=[Depends(require_module(Module.VENTAS))])
 async def get_order_invoice_dian_status(
     request: Request,
     order_id: UUID,

--- a/docs/permissions-router-mapping.md
+++ b/docs/permissions-router-mapping.md
@@ -84,7 +84,7 @@ Total: **51 routers**, **~394 endpoints** (was 52/395 before #187 deleted `admin
 | Module | Routers | Sub-task | Status |
 |---|---|---|---|
 | **POS** | comandas, notifications, pos_cart, tables, waros + payment_methods/pos | 5+1 | ✅ E2.3 (#188) — DONE (51 endpoints gated, 3 KDS-direct excluded) |
-| **VENTAS** | customers, online_orders, orders | 3 | E2.4 (#189) — pending |
+| **VENTAS** | customers, online_orders, orders | 3 | ✅ E2.4 (#189) — DONE (28 endpoints gated, no exclusions) |
 | **DESPACHO** | (no routers — placeholder, like EVENTOS) | 0 | ✅ E2.5 (#187) — DONE (deleted dead `admin_orders.py`) |
 | **MENU** | categories, combos, menu, modifiers, products, recipe_bases | 6 | E2.6 (#190) — pending |
 | **OPERACIONES** | stations + tenant_config (operaciones part) | 1+1 | E2.7 (#191) — pending |

--- a/tests/test_ventas_permissions.py
+++ b/tests/test_ventas_permissions.py
@@ -1,0 +1,106 @@
+"""End-to-end smoke tests for VENTAS group endpoints under require_module(VENTAS).
+
+Sub-task E2.4 of Epic 2 (#189). Validates that:
+1. Owner role under enforce reaches the handler.
+2. Kitchen role under enforce gets 403 (kitchen lacks VENTAS in default
+   matrix — same matrix gap surfaced by E2.3 / POS).
+
+No KDS-passthrough test needed: VENTAS routers (customers, online_orders,
+orders) have NO endpoint exclusions — all 28 endpoints are gated.
+
+Pairs with `tests/test_pos_permissions.py` (#188 reference impl).
+"""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.core.permissions import Module
+from app.routers.orders import router as orders_router
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_session(role):
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": role,
+    })
+
+
+def _enforce_db_ctx():
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+    return _ctx
+
+
+# ─── Tests ────────────────────────────────────────────────────────────
+
+
+def test_owner_role_passes_ventas_endpoint_under_enforce():
+    """Owner reaches GET /orders/dashboard under enforce — dependency permits."""
+    session = _build_session(role="owner")
+    app = FastAPI()
+    app.include_router(orders_router)
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.routers.orders.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.routers.orders.orders_service.get_orders_dashboard",
+             new=AsyncMock(return_value={"data": []}),
+         ):
+        client = TestClient(app)
+        response = client.get("/orders/dashboard")
+
+    # Handler reached → dependency permitted owner.
+    assert response.status_code == 200
+
+
+def test_kitchen_role_denied_ventas_endpoint_under_enforce():
+    """Kitchen role hits 403 on VENTAS — kitchen lacks VENTAS in default matrix."""
+    session = _build_session(role="kitchen")
+    app = FastAPI()
+    app.include_router(orders_router)
+
+    # Stub get_role_modules to return kitchen's default set (DESPACHO only).
+    kitchen_modules = frozenset({Module.DESPACHO})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.routers.orders.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=kitchen_modules),
+         ):
+        client = TestClient(app)
+        response = client.get("/orders/dashboard")
+
+    assert response.status_code == 403
+    assert "ventas" in response.json()["detail"].lower()


### PR DESCRIPTION
Sub-task E2.4 of Epic 2 (#164). Mid-sized batch — third real wiring after E2.14 (billing) and E2.3 (POS).

## Stack
🔵 FastAPI · 🐍 Python 3.9

## Summary

Cables \`Depends(require_module(Module.VENTAS))\` on **28 operator-facing endpoints** across 3 routers. **No exclusions** — VENTAS has no KDS-public or anonymous-customer endpoints.

> ⚠️ **Scope correction**: the issue body lists 2 routers (\`orders, online_cart\`). The audit doc (#186) — source of truth post-#187 — lists 3 routers (\`customers, online_orders, orders\`). \`online_cart\` is \`public\` (anonymous customer cart) and excluded from RBAC. This PR follows the doc.

## Routers wired

| Router | Gated | Notes |
|---|---|---|
| \`customers.py\` | 6 | Operator search / profile / insights |
| \`online_orders.py\` | 4 | Operator manages online orders |
| \`orders.py\` | 18 | Sales dashboard + flow + invoice ops |
| **TOTAL** | **28** | |

Invoice endpoints in \`orders.py\` (lines 361, 386, 407, \`tags=["Invoices"]\`) classified as VENTAS because their path is \`/orders/{id}/invoice/*\`. If shadow logs flag roles with FACTURACION but not VENTAS hitting them, revisit in a follow-up.

## Matrix effect post-enforce

| Role | VENTAS access | Change |
|---|---|---|
| owner / admin / supervisor / cashier | ✅ | none |
| **kitchen** | ❌ | ⚠️ kitchen lacks VENTAS — \`/orders/*\`, \`/customers/*\`, \`/online/orders/*\` will 403 (same gap as POS #188) |
| customer | ❌ | none (n/a) |

## Tests

\`tests/test_ventas_permissions.py\` (NEW, 2 cases — no KDS test since VENTAS has no exclusions):
- ✅ owner → \`GET /orders/dashboard\` under enforce → 200 (handler reached).
- ✅ kitchen → \`GET /orders/dashboard\` under enforce → 403 (kitchen lacks VENTAS).

## Validation

- ✅ \`python -m py_compile\` clean on all 3 routers.
- ✅ App boots: 429 routes (unchanged).
- ✅ **59/59** permission tests pass (Epic 1 + E2.1 + E2.14 + E2.3 + E2.4).

## Audit doc

\`docs/permissions-router-mapping.md\` updated: E2.4 marked DONE in the Coverage Summary.

## Operationally safe to deploy

Every tenant remains on \`permissions_enforcement_mode='disabled'\` (Epic 1 default). The new dependency returns silently for everyone until a tenant is manually flipped to \`'shadow'\` as the rollout phase begins.

Closes #189