### PR TITLE
feat(permissions): operaciones-context aggregator + 5 toggle endpoints (#210)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, combos, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, tenant_config, online_cart, online_verification, address_profile, analytics, online_orders, notifications, customer_portal, leads, waros, billing, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
+from app.routers import auth, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, combos, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, tenant_config, online_cart, online_verification, address_profile, analytics, online_orders, notifications, customer_portal, leads, waros, billing, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
 from app.config import settings
 from app.core.logging import setup_logging
 from app.core.exceptions import api_exception_handler, general_exception_handler, APIError
@@ -170,6 +170,7 @@ app.include_router(combos.router, prefix="/menu/combos", tags=["combos"])
 app.include_router(customers.router, prefix="/customers", tags=["customers"])
 app.include_router(pos_cart.router)
 app.include_router(pos_context.router)  # POS-scoped aggregator (BFF for /pos/restaurant-context)
+app.include_router(operaciones_context.router)  # OPERACIONES-scoped aggregator + 5 toggle PATCH endpoints
 app.include_router(online_cart.router)  # Public online ordering cart
 app.include_router(online_orders.router)  # Authenticated online orders management
 app.include_router(notifications.router)  # Authenticated notifications management

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -16,6 +16,7 @@ from app.routers import (
     customers,
     pos_cart,
     pos_context,
+    operaciones_context,
     orders,
     inventory,
     articles,

--- a/app/routers/operaciones_context.py
+++ b/app/routers/operaciones_context.py
@@ -1,0 +1,95 @@
+"""Operaciones Context Router.
+
+Audience-scoped aggregator + write surface for the operaciones pages
+(/operaciones/{comandas,mesas,personalizar}). Mirrors pos_context.py but
+gated under Module.OPERACIONES so supervisor/admin can read AND toggle
+operational features without needing MI_NEGOCIO (which stays owner-only).
+
+Five dedicated PATCH endpoints (one per toggle) — REST-friendly and easier
+to gate / observe than a single combined endpoint. The service layer's
+column whitelist guards against SQL injection.
+"""
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from app.core.middleware import require_valid_session
+from app.core.permissions import Module, require_module
+from app.services.operaciones_context_service import (
+    get_operaciones_context,
+    update_toggle,
+)
+
+router = APIRouter(prefix="/operaciones", tags=["Operaciones Context"])
+
+
+class ToggleRequest(BaseModel):
+    enabled: bool
+
+
+@router.get(
+    "/restaurant-context",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def get_operaciones_restaurant_context(request: Request):
+    """Aggregated tenant context for operaciones pages.
+
+    Same payload as the POS aggregator — supervisor/admin pages read the
+    same toggles and metadata as cashiers do.
+    """
+    session = require_valid_session(request)
+    payload = await get_operaciones_context(session.tenant_id)
+    if payload is None:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+    return {"success": True, "data": payload}
+
+
+@router.patch(
+    "/toggles/kds",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def toggle_kds_enabled(request: Request, body: ToggleRequest):
+    """Toggle `kds_enabled` on the tenant profile."""
+    session = require_valid_session(request)
+    return await update_toggle(session.tenant_id, "kds_enabled", body.enabled)
+
+
+@router.patch(
+    "/toggles/comandas",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def toggle_comandas_enabled(request: Request, body: ToggleRequest):
+    """Toggle `comandas_enabled` on the tenant profile."""
+    session = require_valid_session(request)
+    return await update_toggle(session.tenant_id, "comandas_enabled", body.enabled)
+
+
+@router.patch(
+    "/toggles/expediter",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def toggle_expediter_enabled(request: Request, body: ToggleRequest):
+    """Toggle `expediter_enabled` on the tenant profile."""
+    session = require_valid_session(request)
+    return await update_toggle(session.tenant_id, "expediter_enabled", body.enabled)
+
+
+@router.patch(
+    "/toggles/tables",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def toggle_tables_enabled(request: Request, body: ToggleRequest):
+    """Toggle `tables_enabled` on the tenant profile."""
+    session = require_valid_session(request)
+    return await update_toggle(session.tenant_id, "tables_enabled", body.enabled)
+
+
+@router.patch(
+    "/toggles/auto-select-generic",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def toggle_auto_select_generic(request: Request, body: ToggleRequest):
+    """Toggle `auto_select_generic_enabled` on the tenant profile."""
+    session = require_valid_session(request)
+    return await update_toggle(
+        session.tenant_id, "auto_select_generic_enabled", body.enabled
+    )

--- a/app/services/operaciones_context_service.py
+++ b/app/services/operaciones_context_service.py
@@ -1,0 +1,73 @@
+"""Operaciones audience aggregator + toggle writes.
+
+Mirrors the POS audience pattern (see pos_context_service): a single GET
+aggregator exposed under Module.OPERACIONES, plus dedicated PATCH helpers
+for the five operational toggles that supervisor/admin flip day-to-day from
+/operaciones/{comandas,mesas,personalizar}.
+
+The read payload is identical to the POS one — we delegate to
+`pos_context_service.get_restaurant_context` to keep one source of truth.
+Separate symbols + endpoint paths preserve clean audience boundaries (and
+make future divergence local to this module).
+
+The toggle writer parameterizes the column name dynamically; the
+`ALLOWED_TOGGLES` whitelist prevents SQL injection.
+"""
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from fastapi import HTTPException
+
+from app.database import get_db_connection
+from app.services.pos_context_service import get_restaurant_context as _pos_get_context
+
+
+ALLOWED_TOGGLES = frozenset({
+    "kds_enabled",
+    "comandas_enabled",
+    "expediter_enabled",
+    "tables_enabled",
+    "auto_select_generic_enabled",
+})
+
+
+async def get_operaciones_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
+    """Aggregated tenant context for the operaciones audience.
+
+    Same payload as the POS aggregator — supervisor/admin pages read the
+    same toggles and metadata as cashiers do, just at a different scope.
+    """
+    return await _pos_get_context(tenant_id)
+
+
+async def update_toggle(
+    tenant_id: UUID,
+    column_name: str,
+    enabled: bool,
+) -> Dict[str, Any]:
+    """Update a single boolean toggle on `tenant_public_profiles`.
+
+    `column_name` is dynamic but validated against `ALLOWED_TOGGLES`; any
+    value outside the whitelist raises 422 before any SQL runs. The UPSERT
+    keeps behaviour parity with `tenant_config_service.upsert_public_profile`
+    in case the row doesn't exist yet (fresh tenant).
+    """
+    if column_name not in ALLOWED_TOGGLES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unknown toggle: {column_name}",
+        )
+
+    # Safe: column_name is validated against a hardcoded whitelist above.
+    query = f"""
+        INSERT INTO tenant_public_profiles (tenant_id, {column_name})
+        VALUES ($1, $2)
+        ON CONFLICT (tenant_id) DO UPDATE
+            SET {column_name} = EXCLUDED.{column_name},
+                updated_at = now()
+    """
+
+    async with get_db_connection() as conn:
+        await conn.execute(query, tenant_id, enabled)
+
+    return {"success": True, "data": {column_name: enabled}}

--- a/docs/permissions-router-mapping.md
+++ b/docs/permissions-router-mapping.md
@@ -2,7 +2,7 @@
 
 **Status:** Source of truth for Epic 2 (#164) wiring sub-tasks (E2.3 → E2.16).
 **Origin:** [#186 audit](https://github.com/uno0uno/api-warolabs/issues/186).
-**Last updated:** 2026-05-11 (post #190 MENU + #191/#192 OPERACIONES/MI_NEGOCIO done).
+**Last updated:** 2026-05-11 (post #190 MENU + #191/#192 OPERACIONES/MI_NEGOCIO + #210 operaciones-context toggles done).
 
 This document maps each FastAPI router under `app/routers/` to the `Module`
 enum value it should be gated under via `Depends(require_module(Module.X))`,
@@ -19,7 +19,7 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 
 ---
 
-## Authoritative Table — 52 routers
+## Authoritative Table — 53 routers
 
 | router_file | mount_prefix | endpoints | module | auth_today | notes |
 |---|---|---|---|---|---|
@@ -71,6 +71,7 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 | `tables.py` | `/tables` | 19 | **POS** | session | Mesas + tab + sesión de mesa |
 | `tenant_config.py` | `/api/tenant` | 15 | **MI_NEGOCIO** | session | Owner-only. POS consume `/api/pos/restaurant-context` aggregator (ver §4). DONE en #192. |
 | `pos_context.py` | `/pos/restaurant-context` | 1 | **POS** | session | BFF-style aggregator de tenant context para POS. Introducido en E2.7/E2.15. |
+| `operaciones_context.py` | `/operaciones/restaurant-context + /operaciones/toggles/*` | 6 | **OPERACIONES** | session | Aggregator + 5 PATCH toggle endpoints (kds, comandas, expediter, tables, auto-select-generic). Introducido en #210 (enforce prep). |
 | `tenants.py` | `/tenants` | 5 | **EQUIPO** | session | Tenant create + member CRUD |
 | `v1_ordering.py` | `/v1/cart + /v1/addresses + /v1/otp + /v1/customer + /v1/product` | 7 | **INTEGRACIONES** | api_key | V1 ordering API (clientes externos) |
 | `waros.py` | `/admin/waros` | 8 | **POS** | session | Sistema de loyalty (puntos WaRo) |
@@ -80,7 +81,7 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 
 ## Coverage Summary
 
-Total: **52 routers**, **~395 endpoints** (added `pos_context.py` in #191/#192 for the BFF aggregator; was 51/394 after #187 deleted `admin_orders.py`).
+Total: **53 routers**, **~401 endpoints** (added `operaciones_context.py` in #210 — 6 endpoints — for the OPERACIONES aggregator + toggles; was 52/395 after #191/#192).
 
 | Module | Routers | Sub-task | Status |
 |---|---|---|---|
@@ -88,7 +89,7 @@ Total: **52 routers**, **~395 endpoints** (added `pos_context.py` in #191/#192 f
 | **VENTAS** | customers, online_orders, orders | 3 | ✅ E2.4 (#189) — DONE (28 endpoints gated, no exclusions) |
 | **DESPACHO** | (no routers — placeholder, like EVENTOS) | 0 | ✅ E2.5 (#187) — DONE (deleted dead `admin_orders.py`) |
 | **MENU** | categories, combos, menu, modifiers, products, recipe_bases | 6 | E2.6 (#190) — pending |
-| **OPERACIONES** | stations | 1 | ✅ E2.7 (#191) — DONE (14 endpoints gated, 1 KDS-public excluded) |
+| **OPERACIONES** | stations, operaciones_context | 2 | ✅ E2.7 (#191) + #210 — DONE (14 stations endpoints + 6 operaciones-context endpoints, 1 KDS-public excluded) |
 | **ABASTECIMIENTO** | admin_ingredients, ingredient_purchase_units, ingredients, inventory, purchases, suppliers | 6 | E2.8 (#195) — pending |
 | **ANALITICA** | analytics | 1 | E2.9 (#193) — pending |
 | **FINANZAS** | accounting, cartera, cierre, credit, expenses, financial, salaries + payment_methods/finanzas | 7+1 | E2.10 (#198) — pending |

--- a/tests/test_operaciones_context_permissions.py
+++ b/tests/test_operaciones_context_permissions.py
@@ -1,0 +1,192 @@
+"""End-to-end smoke tests for the operaciones-context router (#210).
+
+Validates the BFF aggregator + 5 toggle PATCH endpoints introduced as the
+enforce-prep follow-up to #191/#192 (#209). MI_NEGOCIO stays owner-only;
+supervisor/admin read and toggle operational features via OPERACIONES.
+
+Coverage:
+1. Supervisor reaches GET /api/operaciones/restaurant-context (read).
+2. Kitchen denied on the GET (proves the gate).
+3. Cashier denied on a PATCH toggle (proves OPERACIONES, not POS, is the gate).
+4. Supervisor passes a PATCH toggle and the service receives correct args.
+5. update_toggle rejects an unknown column name with 422 (whitelist guard).
+
+Pairs with `tests/test_pos_permissions.py` (#209 reference impl).
+"""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.core.permissions import Module
+from app.routers.operaciones_context import router as operaciones_context_router
+from app.services.operaciones_context_service import update_toggle
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_session(role):
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": role,
+    })
+
+
+def _enforce_db_ctx():
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+    return _ctx
+
+
+# ─── Tests ────────────────────────────────────────────────────────────
+
+
+def test_supervisor_passes_operaciones_context_under_enforce():
+    """Supervisor reaches GET /operaciones/restaurant-context under enforce."""
+    session = _build_session(role="supervisor")
+    app = FastAPI()
+    app.include_router(operaciones_context_router)
+
+    supervisor_modules = frozenset({
+        Module.POS, Module.VENTAS, Module.DESPACHO, Module.MENU,
+        Module.OPERACIONES, Module.ABASTECIMIENTO, Module.ANALITICA,
+    })
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.operaciones_context.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=supervisor_modules),
+         ), \
+         patch(
+             "app.routers.operaciones_context.get_operaciones_context",
+             new=AsyncMock(return_value={
+                 "display_name": "Demo",
+                 "kds_enabled": True,
+                 "comandas_enabled": True,
+                 "expediter_enabled": False,
+                 "tables_enabled": True,
+                 "accepts_online_orders": False,
+                 "auto_select_generic_enabled": False,
+                 "fiscal_data": {},
+                 "tax_config": {},
+                 "invoicing_ready": False,
+             }),
+         ):
+        client = TestClient(app)
+        response = client.get("/operaciones/restaurant-context")
+
+    assert response.status_code == 200
+    assert response.json()["data"]["display_name"] == "Demo"
+
+
+def test_kitchen_denied_operaciones_context_under_enforce():
+    """Kitchen hits 403 on operaciones GET — kitchen lacks OPERACIONES."""
+    session = _build_session(role="kitchen")
+    app = FastAPI()
+    app.include_router(operaciones_context_router)
+
+    kitchen_modules = frozenset({Module.DESPACHO})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.operaciones_context.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=kitchen_modules),
+         ):
+        client = TestClient(app)
+        response = client.get("/operaciones/restaurant-context")
+
+    assert response.status_code == 403
+    assert "operaciones" in response.json()["detail"].lower()
+
+
+def test_cashier_denied_operaciones_toggle_under_enforce():
+    """Cashier hits 403 on PATCH /operaciones/toggles/kds — POS != OPERACIONES."""
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(operaciones_context_router)
+
+    cashier_modules = frozenset({Module.POS, Module.VENTAS, Module.MENU})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.operaciones_context.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ):
+        client = TestClient(app)
+        response = client.patch("/operaciones/toggles/kds", json={"enabled": True})
+
+    assert response.status_code == 403
+    assert "operaciones" in response.json()["detail"].lower()
+
+
+def test_supervisor_passes_toggle_kds_under_enforce():
+    """Supervisor toggles kds_enabled; service receives the right column + value."""
+    session = _build_session(role="supervisor")
+    app = FastAPI()
+    app.include_router(operaciones_context_router)
+
+    supervisor_modules = frozenset({
+        Module.POS, Module.VENTAS, Module.OPERACIONES,
+    })
+    toggle_stub = AsyncMock(return_value={"success": True, "data": {"kds_enabled": True}})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.operaciones_context.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=supervisor_modules),
+         ), \
+         patch(
+             "app.routers.operaciones_context.update_toggle",
+             new=toggle_stub,
+         ):
+        client = TestClient(app)
+        response = client.patch("/operaciones/toggles/kds", json={"enabled": True})
+
+    assert response.status_code == 200
+    assert response.json()["data"]["kds_enabled"] is True
+    # Service was invoked with (tenant_id, "kds_enabled", True).
+    args, _ = toggle_stub.call_args
+    assert args[1] == "kds_enabled"
+    assert args[2] is True
+
+
+@pytest.mark.asyncio
+async def test_update_toggle_rejects_unknown_column():
+    """Whitelist guard: unknown column name raises 422 before any SQL."""
+    with pytest.raises(HTTPException) as excinfo:
+        await update_toggle(uuid4(), "not_a_real_column", True)
+
+    assert excinfo.value.status_code == 422
+    assert "Unknown toggle" in excinfo.value.detail


### PR DESCRIPTION
## Summary

Enforce-prep follow-up to #191/#192 (PR #209). MI_NEGOCIO stays owner-only; supervisor/admin keep their write surface for the 5 operational toggles via dedicated PATCH endpoints under OPERACIONES.

## Stack
🔵 FastAPI

## Base branch
This PR targets **`feat/permissions-operaciones-mi-negocio`** (#209 branch), not `main` — it depends on #209 being merged first. After #209 lands in main, retarget this PR to `main`.

## New backend surface

```
GET   /api/operaciones/restaurant-context           → Module.OPERACIONES
PATCH /api/operaciones/toggles/kds                  → Module.OPERACIONES
PATCH /api/operaciones/toggles/comandas             → Module.OPERACIONES
PATCH /api/operaciones/toggles/expediter            → Module.OPERACIONES
PATCH /api/operaciones/toggles/tables               → Module.OPERACIONES
PATCH /api/operaciones/toggles/auto-select-generic  → Module.OPERACIONES
```

Total: 1 GET + 5 PATCH = 6 endpoints.

## Architecture decisions
- **Read aggregator delegates to pos_context** — `get_operaciones_context` calls into `pos_context_service.get_restaurant_context` so both audiences see identical payload, single source of truth.
- **Dynamic UPDATE protected by whitelist** — `update_toggle(column_name, value)` validates against `ALLOWED_TOGGLES` (hardcoded set of 5 names) before any SQL touches the connection; unknown column raises `HTTPException(422)`. Test included.
- **One PATCH per toggle** — REST-friendly, route-level observable, gate semantics clear, no ambiguous partial updates.

## Tests — 29/29 pass

`tests/test_operaciones_context_permissions.py` (5 new):
- Supervisor passes `GET /operaciones/restaurant-context`
- Kitchen denied `GET` (proves the gate)
- Cashier denied `PATCH /toggles/kds` (proves OPERACIONES, not POS, is the gate)
- Supervisor passes `PATCH /toggles/kds`; service called with correct args
- `update_toggle` raises 422 on unknown column name (whitelist guard)

Plus 24 existing regression tests.

## Audit doc updates
- New row: `operaciones_context.py` (1 GET + 5 PATCH, OPERACIONES)
- OPERACIONES coverage summary now lists `stations + operaciones_context`
- Totals bumped: 53 routers / ~401 endpoints

## Test plan
- [x] `ruff check` clean
- [x] `python3 -m py_compile` clean (Python 3.9 target — uses `Optional`, no `X | Y`)
- [x] `pytest tests/test_*_permissions.py` — 29/29 pass
- [ ] **After both #209 + this PR + warocol.com frontend PR merge**: manual test as supervisor toggling KDS in `/operaciones/comandas` reflects on `/pos/index`, cashier curl-ing `/api/operaciones/toggles/*` returns 403.

## Frontend PR
Paired warocol.com PR cuts 4 pages over to the new endpoints (`pages/operaciones/{comandas,mesas,personalizar}.vue` + `pages/ventas/[id].vue`). Linked below once opened.

Closes #210