### PR TITLE
feat(permissions): gate analytics router under Module.ANALITICA (#193)

### DIFF
--- a/app/routers/analytics.py
+++ b/app/routers/analytics.py
@@ -2,16 +2,17 @@
 Analytics Router
 Endpoints for analytics dashboard data
 """
-from fastapi import APIRouter, Request, Query
+from fastapi import APIRouter, Depends, Request, Query
 from typing import Optional
 from uuid import UUID
+from app.core.permissions import Module, require_module
 from app.services import analytics_service
 from app.models.data_quality import DataQualityAlertResolve
 
 router = APIRouter(prefix="/analytics", tags=["Analytics"])
 
 
-@router.get("/menu-analysis")
+@router.get("/menu-analysis", dependencies=[Depends(require_module(Module.ANALITICA))])
 async def get_menu_analysis(
     request: Request,
     date_from: Optional[str] = Query(None),
@@ -40,7 +41,7 @@ async def get_menu_analysis(
     )
 
 
-@router.get("/food-cost")
+@router.get("/food-cost", dependencies=[Depends(require_module(Module.ANALITICA))])
 async def get_food_cost(
     request: Request,
     date_from: Optional[str] = Query(None),
@@ -60,7 +61,7 @@ async def get_food_cost(
     )
 
 
-@router.get("/alerts")
+@router.get("/alerts", dependencies=[Depends(require_module(Module.ANALITICA))])
 async def get_alerts(
     request: Request,
     limit: int = Query(10, ge=1, le=50)
@@ -83,7 +84,7 @@ async def get_alerts(
     )
 
 
-@router.get("/data-quality")
+@router.get("/data-quality", dependencies=[Depends(require_module(Module.ANALITICA))])
 async def get_data_quality(request: Request):
     """
     Scan 30-day purchase history for price anomalies and return quality score.
@@ -101,7 +102,7 @@ async def get_data_quality(request: Request):
     return await analytics_service.get_data_quality(request)
 
 
-@router.patch("/data-quality/{alert_id}/resolve")
+@router.patch("/data-quality/{alert_id}/resolve", dependencies=[Depends(require_module(Module.ANALITICA))])
 async def resolve_data_quality_alert(
     alert_id: UUID,
     resolve_data: DataQualityAlertResolve,
@@ -131,7 +132,7 @@ async def resolve_data_quality_alert(
     )
 
 
-@router.get("/kitchen")
+@router.get("/kitchen", dependencies=[Depends(require_module(Module.ANALITICA))])
 async def get_kitchen_metrics(
     request: Request,
     date_from: Optional[str] = Query(None),

--- a/docs/permissions-router-mapping.md
+++ b/docs/permissions-router-mapping.md
@@ -2,7 +2,7 @@
 
 **Status:** Source of truth for Epic 2 (#164) wiring sub-tasks (E2.3 → E2.16).
 **Origin:** [#186 audit](https://github.com/uno0uno/api-warolabs/issues/186).
-**Last updated:** 2026-05-09 (initial commit, post #185 / E2.14 done).
+**Last updated:** 2026-05-11 (post #193 E2.9 ANALITICA done; articles.py confirmed public).
 
 This document maps each FastAPI router under `app/routers/` to the `Module`
 enum value it should be gated under via `Depends(require_module(Module.X))`,
@@ -26,7 +26,7 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 | `accounting.py` | `/accounting` | 13 | **FINANZAS** | session | Chart of accounts CRUD, balance, P&L |
 | `address_profile.py` | `/online/addresses` | 6 | **public** | none | Direcciones de delivery (clientes online) |
 | `admin_ingredients.py` | `/admin/ingredients` | 6 | **ABASTECIMIENTO** | session | Catálogo global de ingredientes |
-| `analytics.py` | `/analytics` | 6 | **ANALITICA** | session | Dashboard analítico, alertas |
+| `analytics.py` | `/analytics` | 6 | **ANALITICA** | session | Dashboard analítico, alertas. DONE en #193. |
 | `api_tokens.py` | `/api-tokens` | 6 | **INTEGRACIONES** | session | API token CRUD + scopes |
 | `articles.py` | `/blog` | 3 | **public** | none | Blog público (lista + detalle) |
 | `auth.py` | `/auth` | 7 | **skip** | none | Login/sesión — corre SIN sesión |
@@ -89,7 +89,7 @@ Total: **51 routers**, **~394 endpoints** (was 52/395 before #187 deleted `admin
 | **MENU** | categories, combos, menu, modifiers, products, recipe_bases | 6 | E2.6 (#190) — pending |
 | **OPERACIONES** | stations + tenant_config (operaciones part) | 1+1 | E2.7 (#191) — pending |
 | **ABASTECIMIENTO** | admin_ingredients, ingredient_purchase_units, ingredients, inventory, purchases, suppliers | 6 | E2.8 (#195) — pending |
-| **ANALITICA** | analytics | 1 | E2.9 (#193) — pending |
+| **ANALITICA** | analytics | 1 | ✅ E2.9 (#193) — DONE (6 endpoints gated; `articles.py` confirmed public, stays ungated) |
 | **FINANZAS** | accounting, cartera, cierre, credit, expenses, financial, salaries + payment_methods/finanzas | 7+1 | E2.10 (#198) — pending |
 | **FACTURACION** | documents, facturacion (3 sub-routers), invoices, support_documents | 4 | E2.11 (#194) — pending |
 | **EQUIPO** | invitations (excl. /accept), tenants | 2 | E2.12 (#196) — pending |

--- a/tests/test_analitica_permissions.py
+++ b/tests/test_analitica_permissions.py
@@ -1,0 +1,104 @@
+"""End-to-end smoke tests for ANALITICA group endpoints under require_module(ANALITICA).
+
+Sub-task E2.9 of Epic 2 (#193). Validates that:
+1. Owner role under enforce reaches an analytics handler.
+2. Kitchen role under enforce gets 403 (kitchen lacks ANALITICA — default matrix
+   only grants it to OWNER, ADMIN, SUPERVISOR).
+
+`articles.py` is NOT covered here — it's the public blog (no session required),
+explicitly out of scope for this PR (audit doc classifies it as `public`).
+
+Pairs with `tests/test_menu_permissions.py` (#190 reference impl).
+"""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.core.permissions import Module
+from app.routers.analytics import router as analytics_router
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_session(role):
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": role,
+    })
+
+
+def _enforce_db_ctx():
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+    return _ctx
+
+
+# ─── Tests ────────────────────────────────────────────────────────────
+
+
+def test_owner_role_passes_analitica_endpoint_under_enforce():
+    """Owner reaches GET /analytics/menu-analysis under enforce — dependency permits."""
+    session = _build_session(role="owner")
+    app = FastAPI()
+    app.include_router(analytics_router)
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.routers.analytics.analytics_service.get_menu_analysis",
+             new=AsyncMock(return_value={"data": []}),
+         ):
+        client = TestClient(app)
+        response = client.get("/analytics/menu-analysis")
+
+    # Handler reached → dependency permitted owner.
+    assert response.status_code == 200
+
+
+def test_kitchen_role_denied_analitica_endpoint_under_enforce():
+    """Kitchen role hits 403 on ANALITICA — kitchen lacks ANALITICA in default matrix."""
+    session = _build_session(role="kitchen")
+    app = FastAPI()
+    app.include_router(analytics_router)
+
+    # Stub get_role_modules to return kitchen's default set (DESPACHO only).
+    kitchen_modules = frozenset({Module.DESPACHO})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=kitchen_modules),
+         ):
+        client = TestClient(app)
+        response = client.get("/analytics/menu-analysis")
+
+    assert response.status_code == 403
+    assert "analitica" in response.json()["detail"].lower()


### PR DESCRIPTION
## Summary

Sub-task **E2.9** of Epic 2 (#164). Gates the 6 endpoints in `analytics.py` under `Module.ANALITICA`. `articles.py` confirmed as public blog (per audit doc) and excluded from this PR.

## Stack
🔵 FastAPI

## Endpoints gated under `Module.ANALITICA`

| Method | Path | Consumer |
|---|---|---|
| GET | `/analytics/menu-analysis` | `pages/analitica/rentabilidad.vue` |
| GET | `/analytics/food-cost` | `pages/analitica/rentabilidad.vue` |
| GET | `/analytics/alerts` | (no frontend consumer found — flagged for cleanup follow-up) |
| GET | `/analytics/data-quality` | `composables/useDataQualityStatus.ts` (sidebar) + `pages/abastecimiento/calidad-datos.vue` |
| PATCH | `/analytics/data-quality/{id}/resolve` | `components/data-quality/CorrectAlertModal.vue` |
| GET | `/analytics/kitchen` | `pages/analitica/cocina.vue` |

## Why `articles.py` is not in scope

- All 3 endpoints (`GET /blog`, `GET /blog/{slug}`, `GET /blog/{article_id}/related`) use `get_tenant_context` (middleware-only, no session)
- Handler docstrings explicitly call them "Public endpoint"
- Service returns "published and active articles" only — no admin write surface
- Audit doc (post-#186) correctly classifies as `public`

The Epic body's listing of `articles.py` under ANALITICA was a draft error, resolved by the audit doc. The audit doc is the authoritative source.

## Role matrix — no change

Module.ANALITICA is already in:
- `Role.OWNER` (all modules)
- `Role.ADMIN` defaults
- `Role.SUPERVISOR` defaults

And NOT in:
- `Role.CASHIER` ({POS, VENTAS} only)
- `Role.KITCHEN` ({DESPACHO} only)

Desired access pattern already encoded — no matrix edit needed.

## Paired frontend PR

`warocol.com` PR (linked once opened) conditions `composables/useDataQualityStatus.ts` on role. Without this, the sidebar's data-quality poll fires for cashier/kitchen sessions every 5 min and generates 403 spam after this PR lands (the composable runs unconditionally for every authenticated user, polling `/analytics/data-quality`).

## Tests — 19/19 pass

`tests/test_analitica_permissions.py` (new, 2 tests):
- Owner passes `GET /analytics/menu-analysis` under enforce
- Kitchen denied `GET /analytics/menu-analysis` under enforce (proves the gate; "analitica" appears in detail)

Plus 17 existing regression tests across POS, VENTAS, MENU dependency, billing, and the dependency layer itself.

## Audit doc updates

- `analytics.py` row: appended "DONE en #193" note
- Coverage Summary row for ANALITICA: flipped to ✅ DONE with note about articles.py staying public
- Last-updated date bumped

## Follow-up flagged

`/analytics/alerts` has no frontend consumer (verified via grep). Possible dead code — same pattern as #185/#187/#190/#199 deletions. **Not in scope** for this gating PR; will surface as a separate cleanup issue if confirmed via shadow logs.

## Test plan
- [x] `ruff check` clean
- [x] `python3 -m py_compile` clean (Python 3.9 target — Optional/UUID only, no `X | Y`)
- [x] `pytest tests/test_*_permissions.py tests/test_permissions_dependency.py` — 19/19 pass
- [ ] Manual after both PRs merge: cashier → no 403 in network tab from /analytics/data-quality (sidebar composable disabled by role)
- [ ] Manual after both PRs merge: admin/supervisor → analytics pages load + sidebar badge works as before

Closes #193