### PR TITLE
feat(permissions): gate FACTURACION group routers under Module.FACTURACION (#194)

### DIFF
--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -9,10 +9,11 @@ they read electronic_invoices directly from DB and generate R2 presigned URLs.
 POST /{track_id}/resend-email is a stub until api-facturacion implements
 the resend endpoint.
 """
-from fastapi import APIRouter, HTTPException, Request, Query
+from fastapi import APIRouter, Depends, HTTPException, Request, Query
 from typing import Any, Dict, Optional
 from uuid import UUID
 from app.core.middleware import require_valid_session
+from app.core.permissions import Module, require_module
 from app.services import facturacion_service
 
 router = APIRouter(prefix="/api/documents", tags=["Document Management"])
@@ -20,7 +21,7 @@ router = APIRouter(prefix="/api/documents", tags=["Document Management"])
 _STUB_DETAIL = "Not yet available — api-facturacion endpoint pending"
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(require_module(Module.FACTURACION))])
 async def list_documents(
     request: Request,
     prefix: Optional[str] = Query(None, description="Filter by invoice prefix (e.g. SETP)"),
@@ -50,7 +51,7 @@ async def list_documents(
     )
 
 
-@router.post("/{track_id}/resend-email")
+@router.post("/{track_id}/resend-email", dependencies=[Depends(require_module(Module.FACTURACION))])
 async def resend_document_email(
     request: Request,
     track_id: UUID,
@@ -64,7 +65,7 @@ async def resend_document_email(
     raise HTTPException(status_code=503, detail=_STUB_DETAIL)
 
 
-@router.get("/{track_id}/pdf")
+@router.get("/{track_id}/pdf", dependencies=[Depends(require_module(Module.FACTURACION))])
 async def get_document_pdf(
     request: Request,
     track_id: UUID,
@@ -85,7 +86,7 @@ async def get_document_pdf(
     return {"pdf_url": pdf_url, "expires_in": 3600}
 
 
-@router.get("/{track_id}/xml")
+@router.get("/{track_id}/xml", dependencies=[Depends(require_module(Module.FACTURACION))])
 async def get_document_xml(
     request: Request,
     track_id: UUID,

--- a/app/routers/facturacion.py
+++ b/app/routers/facturacion.py
@@ -6,11 +6,12 @@ Acquirer lookup, catalog queries, and payroll documents.
 All endpoints are stubs until api-facturacion implements the
 corresponding upstream endpoints.
 """
-from fastapi import APIRouter, HTTPException, Request, Query
+from fastapi import APIRouter, Depends, HTTPException, Request, Query
 from typing import Any, Dict, Optional
 from uuid import UUID
 from pydantic import BaseModel, Field
 from app.core.middleware import require_valid_session
+from app.core.permissions import Module, require_module
 
 _STUB_DETAIL = "Not yet available — api-facturacion endpoint pending"
 
@@ -18,7 +19,7 @@ _STUB_DETAIL = "Not yet available — api-facturacion endpoint pending"
 acquirer_router = APIRouter(prefix="/api/acquirer", tags=["Facturacion"])
 
 
-@acquirer_router.get("")
+@acquirer_router.get("", dependencies=[Depends(require_module(Module.FACTURACION))])
 async def lookup_acquirer(
     request: Request,
     type: Optional[str] = Query(None, description="Document type (e.g. 31 = NIT)"),
@@ -37,7 +38,7 @@ async def lookup_acquirer(
 catalog_router = APIRouter(prefix="/api/facturacion", tags=["Facturacion"])
 
 
-@catalog_router.get("/catalog/{name}")
+@catalog_router.get("/catalog/{name}", dependencies=[Depends(require_module(Module.FACTURACION))])
 async def get_catalog(
     request: Request,
     name: str,
@@ -68,7 +69,7 @@ class PayrollVoidRequest(BaseModel):
     reason: Optional[str] = Field(None, description="Reason for voiding payroll")
 
 
-@payroll_router.post("/emit")
+@payroll_router.post("/emit", dependencies=[Depends(require_module(Module.FACTURACION))])
 async def emit_payroll(
     request: Request,
     body: PayrollEmitRequest,
@@ -82,7 +83,7 @@ async def emit_payroll(
     raise HTTPException(status_code=503, detail=_STUB_DETAIL)
 
 
-@payroll_router.post("/{payroll_id}/replace")
+@payroll_router.post("/{payroll_id}/replace", dependencies=[Depends(require_module(Module.FACTURACION))])
 async def replace_payroll(
     request: Request,
     payroll_id: UUID,
@@ -97,7 +98,7 @@ async def replace_payroll(
     raise HTTPException(status_code=503, detail=_STUB_DETAIL)
 
 
-@payroll_router.post("/{payroll_id}/void")
+@payroll_router.post("/{payroll_id}/void", dependencies=[Depends(require_module(Module.FACTURACION))])
 async def void_payroll(
     request: Request,
     payroll_id: UUID,

--- a/app/routers/invoices.py
+++ b/app/routers/invoices.py
@@ -14,6 +14,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 from app.core.dependencies import require_invoicing_ready
 from app.core.middleware import require_valid_session
+from app.core.permissions import Module, require_module
 
 router = APIRouter(prefix="/api/invoices", tags=["Invoices"])
 
@@ -33,7 +34,7 @@ class RAdianEventRequest(BaseModel):
     event_code: str = Field(..., description="RADIAN event code: 030 | 031 | 032 | 033")
 
 
-@router.post("/{invoice_id}/credit-note")
+@router.post("/{invoice_id}/credit-note", dependencies=[Depends(require_module(Module.FACTURACION))])
 async def emit_credit_note(
     request: Request,
     invoice_id: UUID,
@@ -51,7 +52,7 @@ async def emit_credit_note(
     raise HTTPException(status_code=503, detail=_STUB_DETAIL)
 
 
-@router.post("/{invoice_id}/debit-note")
+@router.post("/{invoice_id}/debit-note", dependencies=[Depends(require_module(Module.FACTURACION))])
 async def emit_debit_note(
     request: Request,
     invoice_id: UUID,
@@ -69,7 +70,7 @@ async def emit_debit_note(
     raise HTTPException(status_code=503, detail=_STUB_DETAIL)
 
 
-@router.post("/{invoice_id}/events")
+@router.post("/{invoice_id}/events", dependencies=[Depends(require_module(Module.FACTURACION))])
 async def emit_radian_event(
     request: Request,
     invoice_id: UUID,
@@ -85,7 +86,7 @@ async def emit_radian_event(
     raise HTTPException(status_code=503, detail=_STUB_DETAIL)
 
 
-@router.get("/{invoice_id}/events")
+@router.get("/{invoice_id}/events", dependencies=[Depends(require_module(Module.FACTURACION))])
 async def get_radian_events(
     request: Request,
     invoice_id: UUID,

--- a/app/routers/support_documents.py
+++ b/app/routers/support_documents.py
@@ -6,11 +6,12 @@ DIAN support documents (documento soporte de pago a no obligados a facturar).
 Note: These endpoints are stubs until api-facturacion implements
 /support-document/emit and /support-document/adjust.
 """
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from typing import Any, Dict, Optional
 from uuid import UUID
 from pydantic import BaseModel, Field
 from app.core.middleware import require_valid_session
+from app.core.permissions import Module, require_module
 
 router = APIRouter(prefix="/api/support-documents", tags=["Support Documents"])
 
@@ -28,7 +29,7 @@ class SupportDocumentAdjustRequest(BaseModel):
     amount: Optional[float] = Field(None, description="Adjusted amount")
 
 
-@router.post("/emit")
+@router.post("/emit", dependencies=[Depends(require_module(Module.FACTURACION))])
 async def emit_support_document(
     request: Request,
     body: SupportDocumentEmitRequest,
@@ -42,7 +43,7 @@ async def emit_support_document(
     raise HTTPException(status_code=503, detail=_STUB_DETAIL)
 
 
-@router.post("/{doc_id}/adjust")
+@router.post("/{doc_id}/adjust", dependencies=[Depends(require_module(Module.FACTURACION))])
 async def adjust_support_document(
     request: Request,
     doc_id: UUID,

--- a/docs/permissions-router-mapping.md
+++ b/docs/permissions-router-mapping.md
@@ -2,7 +2,7 @@
 
 **Status:** Source of truth for Epic 2 (#164) wiring sub-tasks (E2.3 → E2.16).
 **Origin:** [#186 audit](https://github.com/uno0uno/api-warolabs/issues/186).
-**Last updated:** 2026-05-09 (initial commit, post #185 / E2.14 done).
+**Last updated:** 2026-05-11 (post #194 E2.11 FACTURACION done; facturacion.py endpoint count corrected 3→5).
 
 This document maps each FastAPI router under `app/routers/` to the `Module`
 enum value it should be gated under via `Depends(require_module(Module.X))`,
@@ -39,15 +39,15 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 | `credit.py` | `/credit` | 3 | **FINANZAS** | session | Pagos a crédito |
 | `customer_portal.py` | `/customer` | 7 | **public** | none | Portal del cliente final (JWT customer, no sesión de operador) |
 | `customers.py` | `/customers` | 6 | **VENTAS** | session | Búsqueda + perfil de clientes (operador) |
-| `documents.py` | `/api/documents` | 4 | **FACTURACION** | session | Documentos electrónicos (lista, PDF/XML) |
+| `documents.py` | `/api/documents` | 4 | **FACTURACION** | session | Documentos electrónicos (lista, PDF/XML). DONE en #194. |
 | `expenses.py` | `/finance/expenses` | 14 | **FINANZAS** | session | CRUD de gastos + categorías |
-| `facturacion.py` | `/api/acquirer + /api/facturacion + /api/payroll` | 3 | **FACTURACION** | session | 3 sub-routers (acquirer, catalog, payroll) — todos FACTURACION |
+| `facturacion.py` | `/api/acquirer + /api/facturacion + /api/payroll` | 5 | **FACTURACION** | session | 3 sub-routers (acquirer 1ep, catalog 1ep, payroll 3eps) — todos FACTURACION, todos stubs 503 hasta wired api-facturacion (#129). DONE en #194. |
 | `financial.py` | (sin prefix) | 3 | **FINANZAS** | session | TIR, rentabilidad de productos |
 | `ingredient_purchase_units.py` | `/suppliers/ingredient-purchase-units` | 6 | **ABASTECIMIENTO** | session | Unidades de compra |
 | `ingredients.py` | `/suppliers/ingredients` | 10 | **ABASTECIMIENTO** | session | Custom ingredients + catálogo |
 | `inventory.py` | `/inventory` | 4 | **ABASTECIMIENTO** | session | Stock + ajustes |
 | `invitations.py` | `/invitations` | 4 | **EQUIPO** | session | ⚠️ `/invitations/accept` es token-público (ver §2) |
-| `invoices.py` | `/api/invoices` | 4 | **FACTURACION** | session | Notas crédito/débito, RADIAN |
+| `invoices.py` | `/api/invoices` | 4 | **FACTURACION** | session | Notas crédito/débito, RADIAN (stubs 503). DONE en #194. |
 | `leads.py` | `/leads` | 2 | **public** | none | Captura de leads (homepage) |
 | `menu.py` | `/menu` | 1 | **MENU** | session | Name-check genérico |
 | `modifiers.py` | `/menu/modifier-groups` | 6 | **MENU** | session | Grupos de modificadores |
@@ -67,7 +67,7 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 | `stations.py` | `/api/stations` | 15 | **OPERACIONES** | session | Estaciones de cocina + routing. ⚠️ KDS-token endpoints sin gate (ver §1) |
 | `supplier_portal.py` | `/supplier-portal` | 8 | **public** | token | Portal del proveedor (token, no sesión) |
 | `suppliers.py` | `/suppliers/providers` | 10 | **ABASTECIMIENTO** | session | Proveedor CRUD |
-| `support_documents.py` | `/api/support-documents` | 2 | **FACTURACION** | session | DIAN documento soporte |
+| `support_documents.py` | `/api/support-documents` | 2 | **FACTURACION** | session | DIAN documento soporte (stubs 503). DONE en #194. |
 | `tables.py` | `/tables` | 19 | **POS** | session | Mesas + tab + sesión de mesa |
 | `tenant_config.py` | `/api/tenant` | 15 | **mixed** | session | Split obligatorio: OPERACIONES + MI_NEGOCIO — ver §4 |
 | `tenants.py` | `/tenants` | 5 | **EQUIPO** | session | Tenant create + member CRUD |
@@ -79,7 +79,7 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 
 ## Coverage Summary
 
-Total: **51 routers**, **~394 endpoints** (was 52/395 before #187 deleted `admin_orders.py`).
+Total: **51 routers**, **~396 endpoints** (corrected facturacion.py count from 3 to 5 in #194; was 52/395 before #187 deleted `admin_orders.py`).
 
 | Module | Routers | Sub-task | Status |
 |---|---|---|---|
@@ -91,7 +91,7 @@ Total: **51 routers**, **~394 endpoints** (was 52/395 before #187 deleted `admin
 | **ABASTECIMIENTO** | admin_ingredients, ingredient_purchase_units, ingredients, inventory, purchases, suppliers | 6 | E2.8 (#195) — pending |
 | **ANALITICA** | analytics | 1 | E2.9 (#193) — pending |
 | **FINANZAS** | accounting, cartera, cierre, credit, expenses, financial, salaries + payment_methods/finanzas | 7+1 | E2.10 (#198) — pending |
-| **FACTURACION** | documents, facturacion (3 sub-routers), invoices, support_documents | 4 | E2.11 (#194) — pending |
+| **FACTURACION** | documents, facturacion (3 sub-routers), invoices, support_documents | 4 | ✅ E2.11 (#194) — DONE (15 endpoints gated: 4 documents + 5 facturacion + 4 invoices + 2 support_documents; 12 of 15 are stubs awaiting api-facturacion #129) |
 | **EQUIPO** | invitations (excl. /accept), tenants | 2 | E2.12 (#196) — pending |
 | **INTEGRACIONES** | api_tokens, public_api, v1_ordering | 3 | E2.13 (#197) — pending |
 | **MI_PLAN** | billing | 1 | ✅ E2.14 (#185, PR #202) — DONE |

--- a/tests/test_facturacion_permissions.py
+++ b/tests/test_facturacion_permissions.py
@@ -1,0 +1,112 @@
+"""End-to-end smoke tests for FACTURACION group endpoints under require_module(FACTURACION).
+
+Sub-task E2.11 of Epic 2 (#194). Validates that:
+1. Owner role under enforce reaches the documents handler.
+2. Cashier role under enforce gets 403 (cashier lacks FACTURACION —
+   FACTURACION is admin-only in the default matrix).
+
+Scope covers 4 files / 15 endpoints (documents.py, facturacion.py with its
+3 sub-routers, invoices.py, support_documents.py). 12 of 15 are stub 503s
+waiting for api-facturacion upstream (issue #129); 3 endpoints in
+documents.py are live. The gate is applied identically to all 15.
+
+POS checkout invoice emit is unaffected — it routes through
+`/api/orders/{id}/invoice` (gated under VENTAS in #189), NOT through
+any endpoint in this PR's scope.
+
+Pairs with `tests/test_analitica_permissions.py` (#193 reference impl).
+"""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.core.permissions import Module
+from app.routers.documents import router as documents_router
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_session(role):
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": role,
+    })
+
+
+def _enforce_db_ctx():
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+    return _ctx
+
+
+# ─── Tests ────────────────────────────────────────────────────────────
+
+
+def test_owner_role_passes_facturacion_endpoint_under_enforce():
+    """Owner reaches GET /api/documents under enforce — dependency permits."""
+    session = _build_session(role="owner")
+    app = FastAPI()
+    app.include_router(documents_router)
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.routers.documents.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.routers.documents.facturacion_service.get_documents_list",
+             new=AsyncMock(return_value={"data": [], "total": 0}),
+         ):
+        client = TestClient(app)
+        response = client.get("/api/documents")
+
+    # Handler reached → dependency permitted owner.
+    assert response.status_code == 200
+
+
+def test_cashier_role_denied_facturacion_endpoint_under_enforce():
+    """Cashier role hits 403 on FACTURACION — cashier lacks FACTURACION in default matrix."""
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(documents_router)
+
+    # Stub get_role_modules to return cashier's default set (POS + VENTAS only).
+    cashier_modules = frozenset({Module.POS, Module.VENTAS})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.routers.documents.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ):
+        client = TestClient(app)
+        response = client.get("/api/documents")
+
+    assert response.status_code == 403
+    assert "facturacion" in response.json()["detail"].lower()


### PR DESCRIPTION
## Summary

Sub-task **E2.11** of Epic 2 (#164). Gates 15 endpoints across 4 files (`documents.py`, `facturacion.py` with 3 sub-routers, `invoices.py`, `support_documents.py`) under `Module.FACTURACION`. Admin-only by matrix; no frontend changes; no POS checkout impact.

## Stack
🔵 FastAPI

## Endpoints gated

| File | Endpoints | Live? |
|---|---|---|
| `documents.py` (`/api/documents`) | 4 | 3 live + 1 stub |
| `facturacion.py` (3 sub-routers: `/api/acquirer`, `/api/facturacion`, `/api/payroll`) | 5 | 0 live (all stubs) |
| `invoices.py` (`/api/invoices`) | 4 | 0 live (all stubs) |
| `support_documents.py` (`/api/support-documents`) | 2 | 0 live (all stubs) |
| **Total** | **15** | **3 live + 12 stubs** |

12 of 15 are stubs returning 503, waiting for the `api-facturacion` upstream service (issue #129). Gating them now is forward-prep — when stubs become real, no second-pass PR.

## POS invoice flow — verified unaffected

The POS checkout's "Generar factura electrónica DIAN" button calls **`POST /api/orders/{id}/invoice`** (lives in `orders.py`, gated under `Module.VENTAS` in #189). The cashier keeps full access via VENTAS, and the PDF URL comes back in that same response (no follow-up `/api/documents/*` call). See the clarification comment in #194 for the trace.

## Role matrix — no change

`Module.FACTURACION` is already in:
- `Role.OWNER` (all modules)
- `Role.ADMIN` defaults

And NOT in:
- `Role.SUPERVISOR`, `Role.CASHIER`, `Role.KITCHEN`

Desired admin-only access pattern was already encoded.

## Tests — 19/19 pass

`tests/test_facturacion_permissions.py` (new, 2 tests):
- Owner passes `GET /api/documents` under enforce
- Cashier denied `GET /api/documents` under enforce (proves the gate; "facturacion" appears in detail)

Plus 17 existing regression tests across POS, VENTAS, billing, and dependency layer.

## Audit doc corrections

- `facturacion.py` endpoint count: **3 → 5** (was wrong since the doc was first written — the 3 sub-routers expose 1+1+3 endpoints, not 1+1+1).
- All 4 router rows marked "DONE en #194".
- Coverage Summary: FACTURACION → ✅ DONE.
- Totals: 51 routers / **~396 endpoints** (was 51/394 before the count fix).

## Test plan
- [x] `ruff check` clean
- [x] `python3 -m py_compile` clean (Python 3.9 target — Optional/UUID typing only, no `X | Y`)
- [x] `pytest tests/test_*_permissions.py tests/test_permissions_dependency.py` — 19/19 pass
- [ ] Manual after deploy: admin loads `/ventas/facturas` → list + PDF download work
- [ ] Manual: cashier curl `/api/documents` with session cookie → 403 with "facturacion" in detail
- [ ] Manual: cashier emits invoice from POS checkout → still works (calls `/api/orders/{id}/invoice`, VENTAS)
- [ ] Manual: supervisor curl `/api/invoices/{id}/events` → 403

Closes #194