### PR TITLE
feat(permissions): gate ABASTECIMIENTO group routers under Module.ABASTECIMIENTO (#195)

### DIFF
--- a/app/routers/admin_ingredients.py
+++ b/app/routers/admin_ingredients.py
@@ -22,10 +22,11 @@ import logging
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 
 from app.core.middleware import require_valid_session
+from app.core.permissions import Module, require_module
 from app.database import get_db_connection
 
 logger = logging.getLogger(__name__)
@@ -70,7 +71,7 @@ class SimilarIngredient(BaseModel):
 
 # ── Endpoints ─────────────────────────────────────────────────────────────────
 
-@router.get("")
+@router.get("", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def list_global_ingredients(
     request: Request,
     search: Optional[str] = Query(default=None, description="Filter by name (case-insensitive)"),
@@ -144,7 +145,7 @@ async def list_global_ingredients(
     }
 
 
-@router.get("/{ingredient_id}/variants")
+@router.get("/{ingredient_id}/variants", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def list_ingredient_variants(
     ingredient_id: UUID,
     request: Request,
@@ -183,7 +184,7 @@ async def list_ingredient_variants(
     }
 
 
-@router.post("/validate-base", status_code=200)
+@router.post("/validate-base", status_code=200, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def validate_base_name(
     body: ValidateBaseRequest,
     request: Request,
@@ -239,7 +240,7 @@ async def validate_base_name(
     return {"verdict": "create", "similar": candidates, "suggested": None}
 
 
-@router.post("", status_code=201)
+@router.post("", status_code=201, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def create_global_ingredient(
     body: CreateIngredientRequest,
     request: Request,
@@ -351,7 +352,7 @@ async def create_global_ingredient(
     }
 
 
-@router.post("/{ingredient_id}/set-base", status_code=200)
+@router.post("/{ingredient_id}/set-base", status_code=200, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def assign_base(
     ingredient_id: UUID,
     body: SetBaseRequest,
@@ -434,7 +435,7 @@ async def assign_base(
     }
 
 
-@router.delete("/{ingredient_id}/set-base", status_code=200)
+@router.delete("/{ingredient_id}/set-base", status_code=200, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def remove_base(
     ingredient_id: UUID,
     request: Request,

--- a/app/routers/ingredient_purchase_units.py
+++ b/app/routers/ingredient_purchase_units.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, Request, Response, Query, Path
+from fastapi import APIRouter, Depends, Request, Response, Query, Path
 from typing import Optional
 from uuid import UUID
+from app.core.permissions import Module, require_module
 from app.services.ingredient_purchase_units_service import (
     get_all_purchase_units,
     get_purchase_units_by_ingredient,
@@ -19,7 +20,7 @@ from app.models.ingredient import (
 router = APIRouter()
 
 
-@router.get("", response_model=IngredientPurchaseUnitsListResponse)
+@router.get("", response_model=IngredientPurchaseUnitsListResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def list_purchase_units_endpoint(
     request: Request,
     response: Response,
@@ -38,7 +39,7 @@ async def list_purchase_units_endpoint(
     )
 
 
-@router.get("/ingredient/{ingredient_id}", response_model=IngredientPurchaseUnitsListResponse)
+@router.get("/ingredient/{ingredient_id}", response_model=IngredientPurchaseUnitsListResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_ingredient_purchase_units_endpoint(
     request: Request,
     response: Response,
@@ -54,7 +55,7 @@ async def get_ingredient_purchase_units_endpoint(
     )
 
 
-@router.get("/{purchase_unit_id}", response_model=IngredientPurchaseUnitResponse)
+@router.get("/{purchase_unit_id}", response_model=IngredientPurchaseUnitResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_purchase_unit_endpoint(
     request: Request,
     response: Response,
@@ -67,7 +68,7 @@ async def get_purchase_unit_endpoint(
     return await get_purchase_unit_by_id(request, response, purchase_unit_id)
 
 
-@router.post("", response_model=IngredientPurchaseUnitResponse, status_code=201)
+@router.post("", response_model=IngredientPurchaseUnitResponse, status_code=201, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def create_purchase_unit_endpoint(
     request: Request,
     response: Response,
@@ -93,7 +94,7 @@ async def create_purchase_unit_endpoint(
     return await create_purchase_unit(request, response, purchase_unit_data)
 
 
-@router.put("/{purchase_unit_id}", response_model=IngredientPurchaseUnitResponse)
+@router.put("/{purchase_unit_id}", response_model=IngredientPurchaseUnitResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def update_purchase_unit_endpoint(
     request: Request,
     response: Response,
@@ -109,7 +110,7 @@ async def update_purchase_unit_endpoint(
     return await update_purchase_unit(request, response, purchase_unit_id, purchase_unit_data)
 
 
-@router.delete("/{purchase_unit_id}")
+@router.delete("/{purchase_unit_id}", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def delete_purchase_unit_endpoint(
     request: Request,
     response: Response,

--- a/app/routers/ingredients.py
+++ b/app/routers/ingredients.py
@@ -1,15 +1,16 @@
-from fastapi import APIRouter, Request, Response, Query, Body, HTTPException
+from fastapi import APIRouter, Depends, Request, Response, Query, Body, HTTPException
 from typing import Any, Dict, Optional
 from uuid import UUID
+from app.core.middleware import require_valid_session
+from app.core.permissions import Module, require_module
 from app.services.ingredients_service import get_ingredients_list, update_ingredient_unit_weight, match_ingredient_by_name, create_tenant_ingredient, update_tenant_ingredient, archive_tenant_ingredient, restore_tenant_ingredient, hard_delete_tenant_ingredient
 from app.models.ingredient import IngredientsListResponse, TenantIngredientCreate, TenantIngredientUpdate
 from app.database import get_db_connection
-from app.core.middleware import require_valid_session
 
 router = APIRouter()
 
 
-@router.post("", status_code=201)
+@router.post("", status_code=201, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def create_custom_ingredient(
     body: TenantIngredientCreate,
     request: Request,
@@ -32,7 +33,7 @@ async def create_custom_ingredient(
     return {"success": True, "data": data}
 
 
-@router.get("/match")
+@router.get("/match", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def match_ingredient(
     name: str = Query(..., min_length=1),
     threshold: float = Query(default=0.35, ge=0.1, le=1.0)
@@ -48,7 +49,7 @@ async def match_ingredient(
     return {"success": True, "data": match}
 
 
-@router.get("", response_model=IngredientsListResponse)
+@router.get("", response_model=IngredientsListResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_ingredients_endpoint(
     request: Request,
     response: Response,
@@ -72,7 +73,7 @@ async def get_ingredients_endpoint(
     )
 
 
-@router.get("/{ingredient_id}")
+@router.get("/{ingredient_id}", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_ingredient_by_id(ingredient_id: UUID):
     """
     Fetch a single ingredient by its UUID.
@@ -98,7 +99,7 @@ async def get_ingredient_by_id(ingredient_id: UUID):
     }
 
 
-@router.patch("/{ingredient_id}/archive", status_code=200)
+@router.patch("/{ingredient_id}/archive", status_code=200, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def archive_ingredient_endpoint(
     ingredient_id: UUID,
     request: Request,
@@ -114,7 +115,7 @@ async def archive_ingredient_endpoint(
     return await archive_tenant_ingredient(str(ingredient_id), str(session_context.tenant_id))
 
 
-@router.patch("/{ingredient_id}/restore", status_code=200)
+@router.patch("/{ingredient_id}/restore", status_code=200, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def restore_ingredient_endpoint(
     ingredient_id: UUID,
     request: Request,
@@ -129,7 +130,7 @@ async def restore_ingredient_endpoint(
     return await restore_tenant_ingredient(str(ingredient_id), str(session_context.tenant_id))
 
 
-@router.delete("/{ingredient_id}", status_code=200)
+@router.delete("/{ingredient_id}", status_code=200, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def delete_ingredient_endpoint(
     ingredient_id: UUID,
     request: Request,
@@ -144,7 +145,7 @@ async def delete_ingredient_endpoint(
     return await hard_delete_tenant_ingredient(str(ingredient_id), str(session_context.tenant_id))
 
 
-@router.patch("/{ingredient_id}", status_code=200)
+@router.patch("/{ingredient_id}", status_code=200, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def update_custom_ingredient(
     ingredient_id: UUID,
     body: TenantIngredientUpdate,
@@ -166,7 +167,7 @@ async def update_custom_ingredient(
     return {"success": True, "data": data}
 
 
-@router.patch("/{ingredient_id}/unit-weight")
+@router.patch("/{ingredient_id}/unit-weight", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def patch_ingredient_unit_weight(
     ingredient_id: UUID,
     request: Request,
@@ -181,7 +182,7 @@ async def patch_ingredient_unit_weight(
     return await update_ingredient_unit_weight(request, response, ingredient_id, unit_weight_gr)
 
 
-@router.get("/{ingredient_id}/variants")
+@router.get("/{ingredient_id}/variants", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def list_ingredient_variants(
     ingredient_id: UUID,
     request: Request,

--- a/app/routers/inventory.py
+++ b/app/routers/inventory.py
@@ -2,15 +2,16 @@
 Inventory Router
 Endpoints for inventory management and stock tracking
 """
-from fastapi import APIRouter, Request, Response, Query
+from fastapi import APIRouter, Depends, Request, Response, Query
 from typing import Optional
 from uuid import UUID
+from app.core.permissions import Module, require_module
 from app.services import inventory_service
 
 router = APIRouter(prefix="/inventory", tags=["Inventory"])
 
 
-@router.get("/stock")
+@router.get("/stock", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_inventory_stock(
     request: Request,
     response: Response,
@@ -42,7 +43,7 @@ async def get_inventory_stock(
     )
 
 
-@router.get("/movements")
+@router.get("/movements", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_inventory_movements(
     request: Request,
     response: Response,
@@ -74,7 +75,7 @@ async def get_inventory_movements(
     )
 
 
-@router.get("/stock/{ingredient_id}")
+@router.get("/stock/{ingredient_id}", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_ingredient_stock(
     request: Request,
     response: Response,
@@ -96,7 +97,7 @@ async def get_ingredient_stock(
     )
 
 
-@router.post("/adjustments")
+@router.post("/adjustments", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def create_inventory_adjustment(
     request: Request,
     response: Response

--- a/app/routers/purchases.py
+++ b/app/routers/purchases.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, BackgroundTasks, Request, Response, Query, Form, File, UploadFile
+from fastapi import APIRouter, BackgroundTasks, Depends, Request, Response, Query, Form, File, UploadFile
 from uuid import UUID
 from typing import Optional, List
+from app.core.permissions import Module, require_module
 from app.services.purchases_service import (
     get_purchases_list,
     get_purchase_by_id,
@@ -28,29 +29,22 @@ from app.services.direct_purchase_service import (
     get_direct_purchases_list,
     get_direct_purchase_by_id,
     get_supplier_catalog_prices,
-    get_supplier_catalog_prices,
     update_direct_purchase,
     upload_direct_purchase_attachments
 )
 from app.services.analytics_service import run_anomaly_checks_for_purchase
 from app.core.middleware import require_valid_session
 from app.models.purchase import (
-    Purchase,
     PurchaseCreate,
     PurchaseUpdate,
     PurchaseResponse,
     PurchasesListResponse,
     # State transition models
     ConfirmPurchaseData,
-    ShipPurchaseData,
-    ReceivePurchaseData,
-    InvoicePurchaseData,
-    PayPurchaseData,
     CancelPurchaseData,
     # History and attachment models
     StatusHistoryResponse,
     AttachmentsResponse,
-    PurchaseAttachmentCreate,
     PurchaseAttachmentCreate,
     DirectPurchaseCreate,
     DirectPurchaseUpdate
@@ -59,7 +53,7 @@ from app.models.purchase import (
 router = APIRouter()
 
 
-@router.post("/extract-invoice")
+@router.post("/extract-invoice", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def extract_invoice(
     request: Request,
     file: UploadFile = File(...)
@@ -72,7 +66,7 @@ async def extract_invoice(
     return await extract_invoice_data(request, file)
 
 
-@router.get("/scan-usage")
+@router.get("/scan-usage", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_scan_usage_endpoint(request: Request):
     """
     Returns current period scan quota usage for the authenticated tenant.
@@ -100,7 +94,7 @@ async def get_scan_usage_endpoint(request: Request):
         return await get_scan_usage(tenant_id, conn)
 
 
-@router.get("/next-number")
+@router.get("/next-number", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_next_purchase_number(
     request: Request,
     response: Response
@@ -145,7 +139,7 @@ async def get_next_purchase_number(
 # DIRECT PURCHASES ENDPOINTS (Compras Directas - WR-CD-XXXX)
 # =============================================================================
 
-@router.get("/direct")
+@router.get("/direct", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_direct_purchases_endpoint(
     request: Request,
     response: Response,
@@ -172,7 +166,7 @@ async def get_direct_purchases_endpoint(
     )
 
 
-@router.post("/direct")
+@router.post("/direct", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def create_direct_purchase_endpoint(
     purchase_data: DirectPurchaseCreate,
     request: Request,
@@ -221,7 +215,7 @@ async def create_direct_purchase_endpoint(
     return result
 
 
-@router.get("/direct/next-number")
+@router.get("/direct/next-number", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_next_direct_purchase_number(
     request: Request,
     response: Response
@@ -267,7 +261,7 @@ async def get_next_direct_purchase_number(
         }
 
 
-@router.get("/direct/{purchase_id}")
+@router.get("/direct/{purchase_id}", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_direct_purchase_endpoint(
     purchase_id: UUID,
     request: Request,
@@ -283,7 +277,7 @@ async def get_direct_purchase_endpoint(
     )
 
 
-@router.put("/direct/{purchase_id}")
+@router.put("/direct/{purchase_id}", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def update_direct_purchase_endpoint(
     purchase_id: UUID,
     purchase_data: DirectPurchaseUpdate,
@@ -295,7 +289,6 @@ async def update_direct_purchase_endpoint(
     Updates purchase items and metadata. Use separate endpoints for file uploads.
     """
     # Import locally to avoid circular imports if any, keeping with existing pattern
-    from app.services.direct_purchase_service import update_direct_purchase
     
     # Map Pydantic model to function arguments
     return await update_direct_purchase(
@@ -313,7 +306,7 @@ async def update_direct_purchase_endpoint(
     )
 
 
-@router.post("/direct/{purchase_id}/attachments")
+@router.post("/direct/{purchase_id}/attachments", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def upload_direct_purchase_attachments_endpoint(
     purchase_id: UUID,
     request: Request,
@@ -341,7 +334,7 @@ async def upload_direct_purchase_attachments_endpoint(
     )
 
 
-@router.get("/suppliers/{supplier_id}/catalog")
+@router.get("/suppliers/{supplier_id}/catalog", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_supplier_catalog_endpoint(
     supplier_id: UUID,
     request: Request,
@@ -363,7 +356,7 @@ async def get_supplier_catalog_endpoint(
 # REGULAR PURCHASES ENDPOINTS (Órdenes de Compra - WR-XXXX)
 # =============================================================================
 
-@router.get("", response_model=PurchasesListResponse)
+@router.get("", response_model=PurchasesListResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_purchases_endpoint(
     request: Request,
     response: Response,
@@ -384,7 +377,7 @@ async def get_purchases_endpoint(
         request, response, page, limit, search, search_field, status, supplier_id, payment_status, date_filter
     )
 
-@router.get("/{purchase_id}", response_model=PurchaseResponse)
+@router.get("/{purchase_id}", response_model=PurchaseResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_purchase_endpoint(
     purchase_id: UUID,
     request: Request,
@@ -395,7 +388,7 @@ async def get_purchase_endpoint(
     """
     return await get_purchase_by_id(request, response, purchase_id)
 
-@router.post("", response_model=PurchaseResponse)
+@router.post("", response_model=PurchaseResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def create_purchase_endpoint(
     purchase_data: PurchaseCreate,
     request: Request,
@@ -406,7 +399,7 @@ async def create_purchase_endpoint(
     """
     return await create_purchase(request, response, purchase_data)
 
-@router.put("/{purchase_id}", response_model=PurchaseResponse)
+@router.put("/{purchase_id}", response_model=PurchaseResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def update_purchase_endpoint(
     purchase_id: UUID,
     purchase_data: PurchaseUpdate,
@@ -423,7 +416,7 @@ async def update_purchase_endpoint(
 # STATE TRANSITION ENDPOINTS
 # =============================================================================
 
-@router.post("/{purchase_id}/confirm")
+@router.post("/{purchase_id}/confirm", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def confirm_purchase_endpoint(
     purchase_id: UUID,
     data: ConfirmPurchaseData,
@@ -436,7 +429,7 @@ async def confirm_purchase_endpoint(
     """
     return await transition_to_confirmed(request, response, purchase_id, data)
 
-@router.post("/{purchase_id}/ship")
+@router.post("/{purchase_id}/ship", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def ship_purchase_endpoint(
     purchase_id: UUID,
     request: Request,
@@ -465,7 +458,7 @@ async def ship_purchase_endpoint(
         files=files
     )
 
-@router.post("/{purchase_id}/receive")
+@router.post("/{purchase_id}/receive", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def receive_purchase_endpoint(
     purchase_id: UUID,
     request: Request,
@@ -493,7 +486,7 @@ async def receive_purchase_endpoint(
     )
 
 
-@router.post("/{purchase_id}/invoice")
+@router.post("/{purchase_id}/invoice", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def invoice_purchase_endpoint(
     purchase_id: UUID,
     request: Request,
@@ -528,7 +521,7 @@ async def invoice_purchase_endpoint(
         files=files
     )
 
-@router.post("/{purchase_id}/pay")
+@router.post("/{purchase_id}/pay", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def pay_purchase_endpoint(
     purchase_id: UUID,
     request: Request,
@@ -557,7 +550,7 @@ async def pay_purchase_endpoint(
         files=files
     )
 
-@router.post("/{purchase_id}/cancel")
+@router.post("/{purchase_id}/cancel", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def cancel_purchase_endpoint(
     purchase_id: UUID,
     data: CancelPurchaseData,
@@ -574,7 +567,7 @@ async def cancel_purchase_endpoint(
 # STATUS HISTORY AND ATTACHMENTS
 # =============================================================================
 
-@router.get("/{purchase_id}/history", response_model=StatusHistoryResponse)
+@router.get("/{purchase_id}/history", response_model=StatusHistoryResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_purchase_history_endpoint(
     purchase_id: UUID,
     request: Request,
@@ -586,7 +579,7 @@ async def get_purchase_history_endpoint(
     """
     return await get_purchase_status_history(request, response, purchase_id)
 
-@router.get("/{purchase_id}/transitions/{transition_id}")
+@router.get("/{purchase_id}/transitions/{transition_id}", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_transition_detail_endpoint(
     purchase_id: UUID,
     transition_id: UUID,
@@ -599,7 +592,7 @@ async def get_transition_detail_endpoint(
     """
     return await get_transition_detail(request, response, purchase_id, transition_id)
 
-@router.get("/{purchase_id}/attachments", response_model=AttachmentsResponse)
+@router.get("/{purchase_id}/attachments", response_model=AttachmentsResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_purchase_attachments_endpoint(
     purchase_id: UUID,
     request: Request,
@@ -611,7 +604,7 @@ async def get_purchase_attachments_endpoint(
     """
     return await get_purchase_attachments(request, response, purchase_id)
 
-@router.post("/{purchase_id}/transitions/{transition_id}/attachments")
+@router.post("/{purchase_id}/transitions/{transition_id}/attachments", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def create_transition_attachment_endpoint(
     purchase_id: UUID,
     transition_id: UUID,
@@ -625,7 +618,7 @@ async def create_transition_attachment_endpoint(
     from app.services.purchase_tracking_service import upload_transition_attachments
     return await upload_transition_attachments(request, response, purchase_id, transition_id, files)
 
-@router.post("/{purchase_id}/attachments")
+@router.post("/{purchase_id}/attachments", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def create_purchase_attachment_endpoint(
     purchase_id: UUID,
     attachment_data: PurchaseAttachmentCreate,
@@ -640,7 +633,7 @@ async def create_purchase_attachment_endpoint(
     attachment_data.purchase_id = purchase_id
     return await create_purchase_attachment(request, response, attachment_data)
 
-@router.post("/{purchase_id}/complete-quotation")
+@router.post("/{purchase_id}/complete-quotation", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def complete_quotation_endpoint(
     purchase_id: UUID,
     data: dict,

--- a/app/routers/suppliers.py
+++ b/app/routers/suppliers.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, Request, Response, HTTPException, Query
+from fastapi import APIRouter, Depends, Request, Response, Query
 from uuid import UUID
 from typing import Optional
+from app.core.permissions import Module, require_module
 from app.services.suppliers_service import (
     get_suppliers_list,
     get_supplier_by_id,
@@ -16,14 +17,12 @@ from app.services.payment_agreements_service import (
     delete_payment_agreement
 )
 from app.models.supplier import (
-    Supplier,
     SupplierCreate,
     SupplierUpdate,
     SupplierResponse,
     SuppliersListResponse
 )
 from app.models.payment_agreement import (
-    PaymentAgreement,
     PaymentAgreementCreate,
     PaymentAgreementUpdate,
     PaymentAgreementResponse,
@@ -32,7 +31,7 @@ from app.models.payment_agreement import (
 
 router = APIRouter()
 
-@router.get("", response_model=SuppliersListResponse)
+@router.get("", response_model=SuppliersListResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_suppliers_endpoint(
     request: Request,
     response: Response,
@@ -51,7 +50,7 @@ async def get_suppliers_endpoint(
         request, response, page, limit, search, search_field, is_active, payment_terms
     )
 
-@router.get("/{supplier_id}", response_model=SupplierResponse)
+@router.get("/{supplier_id}", response_model=SupplierResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_supplier_endpoint(
     supplier_id: UUID,
     request: Request,
@@ -62,7 +61,7 @@ async def get_supplier_endpoint(
     """
     return await get_supplier_by_id(request, response, supplier_id)
 
-@router.post("", response_model=SupplierResponse)
+@router.post("", response_model=SupplierResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def create_supplier_endpoint(
     supplier_data: SupplierCreate,
     request: Request,
@@ -73,7 +72,7 @@ async def create_supplier_endpoint(
     """
     return await create_supplier(request, response, supplier_data)
 
-@router.put("/{supplier_id}", response_model=SupplierResponse)
+@router.put("/{supplier_id}", response_model=SupplierResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def update_supplier_endpoint(
     supplier_id: UUID,
     supplier_data: SupplierUpdate,
@@ -85,7 +84,7 @@ async def update_supplier_endpoint(
     """
     return await update_supplier(request, response, supplier_id, supplier_data)
 
-@router.delete("/{supplier_id}")
+@router.delete("/{supplier_id}", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def delete_supplier_endpoint(
     supplier_id: UUID,
     request: Request,
@@ -98,7 +97,7 @@ async def delete_supplier_endpoint(
 
 # Payment Agreements Endpoints
 
-@router.get("/{supplier_id}/payment-agreements", response_model=PaymentAgreementsListResponse)
+@router.get("/{supplier_id}/payment-agreements", response_model=PaymentAgreementsListResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_payment_agreements_endpoint(
     supplier_id: UUID,
     request: Request,
@@ -109,7 +108,7 @@ async def get_payment_agreements_endpoint(
     """
     return await get_payment_agreements_list(request, response, supplier_id)
 
-@router.get("/{supplier_id}/payment-agreements/{agreement_id}", response_model=PaymentAgreementResponse)
+@router.get("/{supplier_id}/payment-agreements/{agreement_id}", response_model=PaymentAgreementResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def get_payment_agreement_endpoint(
     supplier_id: UUID,
     agreement_id: UUID,
@@ -121,7 +120,7 @@ async def get_payment_agreement_endpoint(
     """
     return await get_payment_agreement_by_id(request, response, supplier_id, agreement_id)
 
-@router.post("/{supplier_id}/payment-agreements", response_model=PaymentAgreementResponse)
+@router.post("/{supplier_id}/payment-agreements", response_model=PaymentAgreementResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def create_payment_agreement_endpoint(
     supplier_id: UUID,
     agreement_data: PaymentAgreementCreate,
@@ -133,7 +132,7 @@ async def create_payment_agreement_endpoint(
     """
     return await create_payment_agreement(request, response, supplier_id, agreement_data)
 
-@router.put("/{supplier_id}/payment-agreements/{agreement_id}", response_model=PaymentAgreementResponse)
+@router.put("/{supplier_id}/payment-agreements/{agreement_id}", response_model=PaymentAgreementResponse, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def update_payment_agreement_endpoint(
     supplier_id: UUID,
     agreement_id: UUID,
@@ -146,7 +145,7 @@ async def update_payment_agreement_endpoint(
     """
     return await update_payment_agreement(request, response, supplier_id, agreement_id, agreement_data)
 
-@router.delete("/{supplier_id}/payment-agreements/{agreement_id}")
+@router.delete("/{supplier_id}/payment-agreements/{agreement_id}", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
 async def delete_payment_agreement_endpoint(
     supplier_id: UUID,
     agreement_id: UUID,

--- a/docs/permissions-router-mapping.md
+++ b/docs/permissions-router-mapping.md
@@ -2,7 +2,7 @@
 
 **Status:** Source of truth for Epic 2 (#164) wiring sub-tasks (E2.3 → E2.16).
 **Origin:** [#186 audit](https://github.com/uno0uno/api-warolabs/issues/186).
-**Last updated:** 2026-05-09 (initial commit, post #185 / E2.14 done).
+**Last updated:** 2026-05-11 (post #195 E2.8 ABASTECIMIENTO done — 62 endpoints, largest batch).
 
 This document maps each FastAPI router under `app/routers/` to the `Module`
 enum value it should be gated under via `Depends(require_module(Module.X))`,
@@ -25,7 +25,7 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 |---|---|---|---|---|---|
 | `accounting.py` | `/accounting` | 13 | **FINANZAS** | session | Chart of accounts CRUD, balance, P&L |
 | `address_profile.py` | `/online/addresses` | 6 | **public** | none | Direcciones de delivery (clientes online) |
-| `admin_ingredients.py` | `/admin/ingredients` | 6 | **ABASTECIMIENTO** | session | Catálogo global de ingredientes |
+| `admin_ingredients.py` | `/admin/ingredients` | 6 | **ABASTECIMIENTO** | session | Catálogo global de ingredientes. DONE en #195. |
 | `analytics.py` | `/analytics` | 6 | **ANALITICA** | session | Dashboard analítico, alertas |
 | `api_tokens.py` | `/api-tokens` | 6 | **INTEGRACIONES** | session | API token CRUD + scopes |
 | `articles.py` | `/blog` | 3 | **public** | none | Blog público (lista + detalle) |
@@ -43,9 +43,9 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 | `expenses.py` | `/finance/expenses` | 14 | **FINANZAS** | session | CRUD de gastos + categorías |
 | `facturacion.py` | `/api/acquirer + /api/facturacion + /api/payroll` | 3 | **FACTURACION** | session | 3 sub-routers (acquirer, catalog, payroll) — todos FACTURACION |
 | `financial.py` | (sin prefix) | 3 | **FINANZAS** | session | TIR, rentabilidad de productos |
-| `ingredient_purchase_units.py` | `/suppliers/ingredient-purchase-units` | 6 | **ABASTECIMIENTO** | session | Unidades de compra |
-| `ingredients.py` | `/suppliers/ingredients` | 10 | **ABASTECIMIENTO** | session | Custom ingredients + catálogo |
-| `inventory.py` | `/inventory` | 4 | **ABASTECIMIENTO** | session | Stock + ajustes |
+| `ingredient_purchase_units.py` | `/suppliers/ingredient-purchase-units` | 6 | **ABASTECIMIENTO** | session | Unidades de compra. DONE en #195. |
+| `ingredients.py` | `/suppliers/ingredients` | 10 | **ABASTECIMIENTO** | session | Custom ingredients + catálogo. DONE en #195. |
+| `inventory.py` | `/inventory` | 4 | **ABASTECIMIENTO** | session | Stock + ajustes. DONE en #195. |
 | `invitations.py` | `/invitations` | 4 | **EQUIPO** | session | ⚠️ `/invitations/accept` es token-público (ver §2) |
 | `invoices.py` | `/api/invoices` | 4 | **FACTURACION** | session | Notas crédito/débito, RADIAN |
 | `leads.py` | `/leads` | 2 | **public** | none | Captura de leads (homepage) |
@@ -61,12 +61,12 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 | `products.py` | `/menu/products` | 7 | **MENU** | session | Producto CRUD + receta + imagen |
 | `public_api.py` | `/v1` | 25 | **INTEGRACIONES** | api_key | API pública con API key (clientes externos) |
 | `public_restaurant.py` | `/public/restaurant` | 4 | **public** | none | Lista + detalle por slug |
-| `purchases.py` | `/suppliers/purchases` | 26 | **ABASTECIMIENTO** | session | Compras + estados + factura |
+| `purchases.py` | `/suppliers/purchases` | 26 | **ABASTECIMIENTO** | session | Compras + estados + factura. DONE en #195 (largest router in Epic). |
 | `recipe_bases.py` | `/menu/recipe-bases` | 5 | **MENU** | session | Templates de receta |
 | `salaries.py` | `/salaries` | 29 | **FINANZAS** | session | Nómina + prima + cesantías + PILA |
 | `stations.py` | `/api/stations` | 15 | **OPERACIONES** | session | Estaciones de cocina + routing. ⚠️ KDS-token endpoints sin gate (ver §1) |
 | `supplier_portal.py` | `/supplier-portal` | 8 | **public** | token | Portal del proveedor (token, no sesión) |
-| `suppliers.py` | `/suppliers/providers` | 10 | **ABASTECIMIENTO** | session | Proveedor CRUD |
+| `suppliers.py` | `/suppliers/providers` | 10 | **ABASTECIMIENTO** | session | Proveedor CRUD. DONE en #195. |
 | `support_documents.py` | `/api/support-documents` | 2 | **FACTURACION** | session | DIAN documento soporte |
 | `tables.py` | `/tables` | 19 | **POS** | session | Mesas + tab + sesión de mesa |
 | `tenant_config.py` | `/api/tenant` | 15 | **mixed** | session | Split obligatorio: OPERACIONES + MI_NEGOCIO — ver §4 |
@@ -88,7 +88,7 @@ Total: **51 routers**, **~394 endpoints** (was 52/395 before #187 deleted `admin
 | **DESPACHO** | (no routers — placeholder, like EVENTOS) | 0 | ✅ E2.5 (#187) — DONE (deleted dead `admin_orders.py`) |
 | **MENU** | categories, combos, menu, modifiers, products, recipe_bases | 6 | E2.6 (#190) — pending |
 | **OPERACIONES** | stations + tenant_config (operaciones part) | 1+1 | E2.7 (#191) — pending |
-| **ABASTECIMIENTO** | admin_ingredients, ingredient_purchase_units, ingredients, inventory, purchases, suppliers | 6 | E2.8 (#195) — pending |
+| **ABASTECIMIENTO** | admin_ingredients, ingredient_purchase_units, ingredients, inventory, purchases, suppliers | 6 | ✅ E2.8 (#195) — DONE (62 endpoints gated; largest batch in Epic; no exclusions) |
 | **ANALITICA** | analytics | 1 | E2.9 (#193) — pending |
 | **FINANZAS** | accounting, cartera, cierre, credit, expenses, financial, salaries + payment_methods/finanzas | 7+1 | E2.10 (#198) — pending |
 | **FACTURACION** | documents, facturacion (3 sub-routers), invoices, support_documents | 4 | E2.11 (#194) — pending |

--- a/tests/test_abastecimiento_permissions.py
+++ b/tests/test_abastecimiento_permissions.py
@@ -1,0 +1,107 @@
+"""End-to-end smoke tests for ABASTECIMIENTO group endpoints under require_module(ABASTECIMIENTO).
+
+Sub-task E2.8 of Epic 2 (#195). Validates that:
+1. Owner role under enforce reaches the suppliers/ingredients handler.
+2. Cashier role under enforce gets 403 (cashier lacks ABASTECIMIENTO —
+   admin + supervisor only in the default matrix).
+
+Scope covers 6 files / 62 endpoints (admin_ingredients, ingredient_purchase_units,
+ingredients, inventory, purchases, suppliers). The gate is applied uniformly to
+every endpoint; smoke tests pick the highest-volume one to validate the pattern.
+
+Pairs with `tests/test_facturacion_permissions.py` (#194 reference impl).
+"""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.core.permissions import Module
+from app.routers.ingredients import router as ingredients_router
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_session(role):
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": role,
+    })
+
+
+def _enforce_db_ctx():
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+    return _ctx
+
+
+# ─── Tests ────────────────────────────────────────────────────────────
+
+
+def test_owner_role_passes_abastecimiento_endpoint_under_enforce():
+    """Owner reaches GET /suppliers/ingredients under enforce — dependency permits."""
+    session = _build_session(role="owner")
+    app = FastAPI()
+    app.include_router(ingredients_router, prefix="/suppliers/ingredients")
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.routers.ingredients.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.routers.ingredients.get_ingredients_list",
+             new=AsyncMock(return_value={"data": [], "total": 0}),
+         ):
+        client = TestClient(app)
+        response = client.get("/suppliers/ingredients")
+
+    # Handler reached → dependency permitted owner.
+    assert response.status_code == 200
+
+
+def test_cashier_role_denied_abastecimiento_endpoint_under_enforce():
+    """Cashier role hits 403 on ABASTECIMIENTO — cashier lacks ABASTECIMIENTO in default matrix."""
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(ingredients_router, prefix="/suppliers/ingredients")
+
+    # Stub get_role_modules to return cashier's default set (POS + VENTAS only).
+    cashier_modules = frozenset({Module.POS, Module.VENTAS})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.routers.ingredients.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ):
+        client = TestClient(app)
+        response = client.get("/suppliers/ingredients")
+
+    assert response.status_code == 403
+    assert "abastecimiento" in response.json()["detail"].lower()


### PR DESCRIPTION
## Summary

Sub-task **E2.8** of Epic 2 (#164). Gates the **62 endpoints across 6 files** under `Module.ABASTECIMIENTO` — the **largest gating batch** in the Epic so far. Admin + supervisor access by matrix; no frontend changes; no matrix edits.

## Stack
🔵 FastAPI

## Endpoints gated (counts verified)

| Router | Endpoints | Mount prefix |
|---|---|---|
| `admin_ingredients.py` | 6 | `/admin/ingredients` |
| `ingredient_purchase_units.py` | 6 | `/suppliers/ingredient-purchase-units` |
| `ingredients.py` | 10 | `/suppliers/ingredients` |
| `inventory.py` | 4 | `/inventory` |
| **`purchases.py`** | **26** | `/suppliers/purchases` |
| `suppliers.py` | 10 | `/suppliers/providers` |
| **Total** | **62** | — |

```
$ grep -c "Module.ABASTECIMIENTO" app/routers/{admin_ingredients,ingredient_purchase_units,ingredients,inventory,purchases,suppliers}.py
# 6 + 6 + 10 + 4 + 26 + 10 = 62 ✅
```

## Role matrix — no change

- `Role.OWNER` (all modules)
- `Role.ADMIN` defaults — already includes `Module.ABASTECIMIENTO`
- `Role.SUPERVISOR` defaults — already includes `Module.ABASTECIMIENTO` (kitchen managers handle inventory)
- `Role.CASHIER`, `Role.KITCHEN` — correctly excluded

## Implementation method

All 62 decorators are single-line (verified via grep). Bulk Python regex transformation applied uniformly:

```python
pattern = re.compile(r'^(@router\.(?:get|post|put|patch|delete)\([^)]*?)(\)\s*)$', re.MULTILINE)
new_src = pattern.subn(r'\1, dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])', src)
```

Followed by post-edit `grep -c` verification to confirm 62 references — the acceptance criterion called out in the plan.

## Drive-by cleanup (ruff auto-fix)

Ruff flagged **11 pre-existing** unused/duplicate imports in `purchases.py` and `suppliers.py` that were sitting in the codebase before this PR (not introduced by gating):

- `purchases.py`: duplicate `get_supplier_catalog_prices`, unused `update_direct_purchase`, `Purchase`, `ShipPurchaseData`, etc.
- `suppliers.py`: unused `PaymentAgreement`.

Removed via `ruff check --fix`. All deletions verified safe — names had no consumers in file scope.

## Tests — 19/19 pass

`tests/test_abastecimiento_permissions.py` (new, 2 tests):
- Owner passes `GET /suppliers/ingredients` under enforce
- Cashier denied (proves the gate; "abastecimiento" appears in detail)

Plus 17 existing regression tests across POS, VENTAS, billing, dependency layer.

## Audit doc updates

- All 6 router rows marked "DONE en #195"
- Coverage Summary: ABASTECIMIENTO → ✅ DONE (62 endpoints; largest batch in Epic; no exclusions)
- `purchases.py` row tagged "largest router in Epic" for future reference
- Last-updated date bumped

## Indirect cashier risk flagged for shadow-mode watchlist

The cashier holds `Module.MENU` (since #190) and could navigate to `/menu/productos/crear` or `/menu/productos/{id}`, which uses `UiIngredientSearchInput` → fires `GET /api/suppliers/ingredients`. After this PR lands, that call returns 403 for cashier and the ingredient-search dropdown stays empty. The page still renders; only the search degrades silently.

**Fix is route-hiding in the sidebar** (Epic 4 / frontend RBAC), not in this PR's scope. Shadow logs will flag if observed in production.

## Test plan
- [x] `ruff check` clean (after auto-fix of pre-existing errors)
- [x] `python3 -m py_compile` clean (Python 3.9 target)
- [x] `pytest tests/test_*_permissions.py tests/test_permissions_dependency.py` — 19/19 pass
- [x] `grep -c "Module.ABASTECIMIENTO"` total = 62 ✅
- [ ] Manual after deploy: admin → `/abastecimiento/compras-directas` loads + purchases list works
- [ ] Manual: cashier → curl `/api/suppliers/ingredients` with cookie → 403 with "abastecimiento" in detail
- [ ] Manual: kitchen → curl `/api/inventory/stock` → 403
- [ ] Shadow log watchlist: monitor for `/api/suppliers/ingredients` 403s from cashier (would indicate `/menu/productos/*` navigation)

Closes #195