### PR TITLE
feat(permissions): gate EQUIPO group routers under Module.EQUIPO (#196)

### DIFF
--- a/app/routers/invitations.py
+++ b/app/routers/invitations.py
@@ -1,5 +1,6 @@
 import logging
-from fastapi import APIRouter, Request, Response
+from fastapi import APIRouter, Depends, Request, Response
+from app.core.permissions import Module, require_module
 from app.services.invitation_service import (
     send_invitation,
     accept_invitation,
@@ -19,7 +20,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.post("/send", response_model=SendInvitationResponse)
+@router.post("/send", response_model=SendInvitationResponse, dependencies=[Depends(require_module(Module.EQUIPO))])
 async def send_invitation_endpoint(request: Request, payload: SendInvitationRequest):
     """
     Send team invitation email
@@ -28,6 +29,11 @@ async def send_invitation_endpoint(request: Request, payload: SendInvitationRequ
     return await send_invitation(request, payload)
 
 
+# NOTE: NOT gated under EQUIPO — this is a token-public endpoint. The invitee
+# accepts via emailed token before they have a session in the tenant. Already
+# listed in `app/main.py:59` public_endpoints allowlist so the middleware
+# bypasses session validation entirely. Frontend consumer:
+# pages/auth/accept-invitation.vue:174.
 @router.post("/accept", response_model=AcceptInvitationResponse)
 async def accept_invitation_endpoint(request: Request, response: Response, payload: AcceptInvitationRequest):
     """
@@ -37,7 +43,7 @@ async def accept_invitation_endpoint(request: Request, response: Response, paylo
     return await accept_invitation(request, response, payload.token)
 
 
-@router.get("/pending", response_model=PendingInvitationsResponse)
+@router.get("/pending", response_model=PendingInvitationsResponse, dependencies=[Depends(require_module(Module.EQUIPO))])
 async def get_pending_invitations_endpoint(request: Request):
     """
     Get pending invitations for current tenant
@@ -46,7 +52,7 @@ async def get_pending_invitations_endpoint(request: Request):
     return await get_pending_invitations(request)
 
 
-@router.delete("/{invitation_id}", response_model=CancelInvitationResponse)
+@router.delete("/{invitation_id}", response_model=CancelInvitationResponse, dependencies=[Depends(require_module(Module.EQUIPO))])
 async def cancel_invitation_endpoint(request: Request, invitation_id: str):
     """
     Cancel a pending invitation

--- a/app/routers/tenants.py
+++ b/app/routers/tenants.py
@@ -1,10 +1,15 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
+from app.core.permissions import Module, require_module
 from app.services.tenants_service import get_user_tenants, get_tenant_members, delete_tenant_member, update_member_role, create_tenant
 from app.models.auth import UserTenantsResponse
 from app.models.tenant import TenantMembersResponse, DeleteMemberResponse, UpdateMemberRoleRequest, UpdateMemberRoleResponse, TenantCreate, TenantCreateResponse
 
 router = APIRouter()
 
+# NOTE: NOT gated under EQUIPO — this is the onboarding / add-new-tenant flow.
+# Callers may have no current tenant (role=null) or non-owner roles wanting to
+# start their own tenant. Gating would block legitimate self-service signup.
+# The service makes the caller superuser of the newly created tenant.
 @router.post("", response_model=TenantCreateResponse)
 async def create_tenant_endpoint(request: Request, body: TenantCreate):
     """
@@ -15,6 +20,11 @@ async def create_tenant_endpoint(request: Request, body: TenantCreate):
     return await create_tenant(request, body)
 
 
+# NOTE: NOT gated under EQUIPO — this is the sidebar tenant-switcher endpoint
+# called by every authenticated user regardless of role. Frontend consumer:
+# stores/tenants.ts:59 (populates DashboardTenantSelector.vue for cashier
+# through owner). Gating under owner-only EQUIPO would break the switcher
+# for all non-owner roles with multiple tenant memberships.
 @router.get("/user-tenants", response_model=UserTenantsResponse)
 async def get_user_tenants_endpoint(request: Request):
     """
@@ -23,7 +33,7 @@ async def get_user_tenants_endpoint(request: Request):
     """
     return await get_user_tenants(request)
 
-@router.get("/members", response_model=TenantMembersResponse)
+@router.get("/members", response_model=TenantMembersResponse, dependencies=[Depends(require_module(Module.EQUIPO))])
 async def get_tenant_members_endpoint(request: Request):
     """
     Get members of the current tenant
@@ -31,7 +41,7 @@ async def get_tenant_members_endpoint(request: Request):
     """
     return await get_tenant_members(request)
 
-@router.delete("/members/{member_id}", response_model=DeleteMemberResponse)
+@router.delete("/members/{member_id}", response_model=DeleteMemberResponse, dependencies=[Depends(require_module(Module.EQUIPO))])
 async def delete_tenant_member_endpoint(request: Request, member_id: str):
     """
     Remove a member from the current tenant
@@ -41,7 +51,7 @@ async def delete_tenant_member_endpoint(request: Request, member_id: str):
     return await delete_tenant_member(request, member_id)
 
 
-@router.put("/members/{member_id}/role", response_model=UpdateMemberRoleResponse)
+@router.put("/members/{member_id}/role", response_model=UpdateMemberRoleResponse, dependencies=[Depends(require_module(Module.EQUIPO))])
 async def update_member_role_endpoint(request: Request, member_id: str, body: UpdateMemberRoleRequest):
     """
     Update a member's role in the current tenant

--- a/docs/permissions-router-mapping.md
+++ b/docs/permissions-router-mapping.md
@@ -2,7 +2,7 @@
 
 **Status:** Source of truth for Epic 2 (#164) wiring sub-tasks (E2.3 → E2.16).
 **Origin:** [#186 audit](https://github.com/uno0uno/api-warolabs/issues/186).
-**Last updated:** 2026-05-09 (initial commit, post #185 / E2.14 done).
+**Last updated:** 2026-05-11 (post #196 E2.12 EQUIPO done; added §9 for self-service exclusions in tenants.py).
 
 This document maps each FastAPI router under `app/routers/` to the `Module`
 enum value it should be gated under via `Depends(require_module(Module.X))`,
@@ -46,7 +46,7 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 | `ingredient_purchase_units.py` | `/suppliers/ingredient-purchase-units` | 6 | **ABASTECIMIENTO** | session | Unidades de compra |
 | `ingredients.py` | `/suppliers/ingredients` | 10 | **ABASTECIMIENTO** | session | Custom ingredients + catálogo |
 | `inventory.py` | `/inventory` | 4 | **ABASTECIMIENTO** | session | Stock + ajustes |
-| `invitations.py` | `/invitations` | 4 | **EQUIPO** | session | ⚠️ `/invitations/accept` es token-público (ver §2) |
+| `invitations.py` | `/invitations` | 4 | **EQUIPO** | session | ⚠️ `/invitations/accept` es token-público (ver §2). DONE en #196 (3 of 4 gated). |
 | `invoices.py` | `/api/invoices` | 4 | **FACTURACION** | session | Notas crédito/débito, RADIAN |
 | `leads.py` | `/leads` | 2 | **public** | none | Captura de leads (homepage) |
 | `menu.py` | `/menu` | 1 | **MENU** | session | Name-check genérico |
@@ -70,7 +70,7 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 | `support_documents.py` | `/api/support-documents` | 2 | **FACTURACION** | session | DIAN documento soporte |
 | `tables.py` | `/tables` | 19 | **POS** | session | Mesas + tab + sesión de mesa |
 | `tenant_config.py` | `/api/tenant` | 15 | **mixed** | session | Split obligatorio: OPERACIONES + MI_NEGOCIO — ver §4 |
-| `tenants.py` | `/tenants` | 5 | **EQUIPO** | session | Tenant create + member CRUD |
+| `tenants.py` | `/tenants` | 5 | **EQUIPO** | session | Tenant create + member CRUD. ⚠️ `POST ""` y `GET /user-tenants` excluidos (self-service, ver §9). DONE en #196 (3 of 5 gated). |
 | `v1_ordering.py` | `/v1/cart + /v1/addresses + /v1/otp + /v1/customer + /v1/product` | 7 | **INTEGRACIONES** | api_key | V1 ordering API (clientes externos) |
 | `waros.py` | `/admin/waros` | 8 | **POS** | session | Sistema de loyalty (puntos WaRo) |
 | `webhooks.py` | `/api/webhooks` | 1 | **skip** | signature | Bridge a api-facturacion (signature-verified, no sesión) |
@@ -92,7 +92,7 @@ Total: **51 routers**, **~394 endpoints** (was 52/395 before #187 deleted `admin
 | **ANALITICA** | analytics | 1 | E2.9 (#193) — pending |
 | **FINANZAS** | accounting, cartera, cierre, credit, expenses, financial, salaries + payment_methods/finanzas | 7+1 | E2.10 (#198) — pending |
 | **FACTURACION** | documents, facturacion (3 sub-routers), invoices, support_documents | 4 | E2.11 (#194) — pending |
-| **EQUIPO** | invitations (excl. /accept), tenants | 2 | E2.12 (#196) — pending |
+| **EQUIPO** | invitations (excl. /accept), tenants (excl. POST "" + /user-tenants) | 2 | ✅ E2.12 (#196) — DONE (6 endpoints gated; 3 self-service / public excluded) |
 | **INTEGRACIONES** | api_tokens, public_api, v1_ordering | 3 | E2.13 (#197) — pending |
 | **MI_PLAN** | billing | 1 | ✅ E2.14 (#185, PR #202) — DONE |
 | **MI_NEGOCIO** | tenant_config (mi_negocio part) | 1 | E2.15 (#199) — pending |
@@ -137,9 +137,9 @@ E2.7 (#191) lands.
 ## §2. `/invitations/accept` is token-public
 
 `POST /invitations/accept` accepts an invitation by token — the invitee has
-no operator session yet. The endpoint is already in the middleware allowlist.
-When wiring `EQUIPO` in E2.12 (#196), exclude `/accept` and gate the other
-3 endpoints (`send`, `list`, `cancel`) only.
+no operator session yet. The endpoint is already in the middleware allowlist
+(`app/main.py:59`). Excluded from the EQUIPO gate in #196 with an explicit
+`# NOTE:` block. Frontend consumer: `pages/auth/accept-invitation.vue:174`.
 
 ## §3. `payment_methods.py` exports two routers
 
@@ -203,6 +203,29 @@ How to verify a candidate is dead before deleting:
 grep -rn '<endpoint-path>' . --include='*.vue' --include='*.ts' --include='*.js' --include='*.py' --include='*.json'
 # expect: only the router file itself + main.py mount
 ```
+
+## §9. `tenants.py` — self-service endpoints excluded from EQUIPO
+
+EQUIPO is owner-only by matrix, but 2 of the 5 endpoints in `tenants.py`
+serve cross-role audiences and were excluded from the gate in #196 with
+explicit `# NOTE:` blocks:
+
+- **`POST /tenants`** — onboarding / add-new-tenant flow. The caller may
+  have no current tenant (role=null) or a non-owner role wanting to start
+  their own tenant. The service makes the caller superuser of the newly
+  created tenant. Gating under EQUIPO would block legitimate signup.
+- **`GET /tenants/user-tenants`** — sidebar tenant switcher. Called by
+  every authenticated user from `stores/tenants.ts:59` regardless of role,
+  populating `DashboardTenantSelector.vue`. Gating under owner-only EQUIPO
+  would break the switcher for cashier / kitchen / admin / supervisor with
+  multiple tenant memberships.
+
+The remaining 3 endpoints in `tenants.py` (`/members` GET + DELETE + role
+PUT) are correctly gated under EQUIPO since they are admin-only team
+management operations consumed by `pages/equipo/miembros.vue`.
+
+A regression test in `tests/test_equipo_permissions.py::test_cashier_passes_user_tenants_exclusion_under_enforce`
+guards against accidental future gating of `/user-tenants`.
 
 ## §6. `auth.py` and `webhooks.py` — explicit skips
 

--- a/tests/test_equipo_permissions.py
+++ b/tests/test_equipo_permissions.py
@@ -1,0 +1,149 @@
+"""End-to-end smoke tests for EQUIPO group endpoints under require_module(EQUIPO).
+
+Sub-task E2.12 of Epic 2 (#196). Validates that:
+1. Owner role under enforce reaches a gated tenants/members endpoint.
+2. Cashier role under enforce gets 403 on the gated endpoint (EQUIPO is
+   owner-only by matrix; cashier/admin/supervisor/kitchen all lack it).
+3. **Exclusion regression test**: cashier successfully reaches
+   GET /tenants/user-tenants under enforce — proves the sidebar tenant
+   switcher exclusion works for non-owner roles.
+
+Scope: 2 files, 9 total endpoints (6 gated, 3 excluded):
+  - tenants.py: 3 gated (/members CRUD), 2 excluded (POST "", /user-tenants)
+  - invitations.py: 3 gated (/send, /pending, DELETE), 1 excluded (/accept)
+
+The 3rd test is critical regression protection — if anyone later
+accidentally gates /user-tenants under EQUIPO, the sidebar tenant
+switcher would 403 for every non-owner role across all WARO tenants.
+
+Pairs with `tests/test_abastecimiento_permissions.py` (#195 reference impl).
+"""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.core.permissions import Module
+from app.routers.tenants import router as tenants_router
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_session(role):
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": role,
+    })
+
+
+def _enforce_db_ctx():
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+    return _ctx
+
+
+# ─── Tests ────────────────────────────────────────────────────────────
+
+
+def test_owner_role_passes_equipo_endpoint_under_enforce():
+    """Owner reaches GET /tenants/members under enforce — dependency permits."""
+    session = _build_session(role="owner")
+    app = FastAPI()
+    app.include_router(tenants_router, prefix="/tenants")
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.routers.tenants.get_tenant_members",
+             new=AsyncMock(return_value={"data": [], "total": 0}),
+         ):
+        client = TestClient(app)
+        response = client.get("/tenants/members")
+
+    # Handler reached → dependency permitted owner.
+    assert response.status_code == 200
+
+
+def test_cashier_role_denied_equipo_endpoint_under_enforce():
+    """Cashier role hits 403 on EQUIPO — cashier lacks EQUIPO in default matrix."""
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(tenants_router, prefix="/tenants")
+
+    # Stub get_role_modules to return cashier's default set (POS + VENTAS only).
+    cashier_modules = frozenset({Module.POS, Module.VENTAS})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ):
+        client = TestClient(app)
+        response = client.get("/tenants/members")
+
+    assert response.status_code == 403
+    assert "equipo" in response.json()["detail"].lower()
+
+
+def test_cashier_passes_user_tenants_exclusion_under_enforce():
+    """Cashier reaches GET /tenants/user-tenants under enforce — EXCLUSION test.
+
+    This endpoint is NOT gated under EQUIPO because the sidebar tenant
+    switcher (stores/tenants.ts:59) fires it for every authenticated user.
+    Gating it would break the switcher for cashier/kitchen/admin/supervisor.
+
+    This test catches accidental regression — if anyone adds the dependency
+    later, this test fails and the sidebar protection is enforced at the
+    test layer.
+    """
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(tenants_router, prefix="/tenants")
+
+    cashier_modules = frozenset({Module.POS, Module.VENTAS})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ), \
+         patch(
+             "app.routers.tenants.get_user_tenants",
+             new=AsyncMock(return_value={"success": True, "data": []}),
+         ):
+        client = TestClient(app)
+        response = client.get("/tenants/user-tenants")
+
+    # NO 403 — handler reached, cashier passed because endpoint is ungated.
+    # If this asserts != 200, someone gated /user-tenants by mistake and the
+    # sidebar tenant switcher would break for every non-owner role.
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary

Sub-task **E2.12** of Epic 2 (#164). Gates **6 of 9 endpoints** across `invitations.py` and `tenants.py` under `Module.EQUIPO`; explicitly excludes 3 endpoints with `# NOTE:` blocks because they serve cross-role flows.

## Stack
🔵 FastAPI

## Endpoint breakdown

### 🔒 Gated under EQUIPO (6 endpoints)

| Method | Path | Role surface |
|---|---|---|
| POST | `/invitations/send` | Owner only |
| GET | `/invitations/pending` | Owner only |
| DELETE | `/invitations/{invitation_id}` | Owner only |
| GET | `/tenants/members` | Owner only |
| DELETE | `/tenants/members/{member_id}` | Owner only |
| PUT | `/tenants/members/{member_id}/role` | Owner only |

### ❌ Explicitly excluded (3 endpoints with `# NOTE:` blocks)

| Method | Path | Why excluded |
|---|---|---|
| POST | `/invitations/accept` | Token-public; invitee has no session yet. Already in middleware allowlist (`main.py:59`). Consumer: `pages/auth/accept-invitation.vue:174`. |
| POST | `/tenants` | Onboarding flow; caller may have `role=null` or non-owner role. Service makes caller superuser of newly created tenant. Gating would block signup. |
| GET | `/tenants/user-tenants` | Sidebar tenant switcher. Called by **every authenticated user** from `stores/tenants.ts:59` regardless of role, populating `DashboardTenantSelector.vue`. Gating would break the switcher for cashier / kitchen / admin / supervisor. |

## Role matrix — no change

`Module.EQUIPO` is **owner-only** by design:
- `Role.OWNER` (all modules)
- `Role.ADMIN`, `Role.SUPERVISOR`, `Role.CASHIER`, `Role.KITCHEN` — none have `EQUIPO`

Confirmed in `app/core/permissions.py`. No matrix edits needed.

## Defense in depth

5 inline `if user_role not in ('admin', 'superuser')` checks remain in service layer per issue body:
- `app/services/invitation_service.py:78,370,432` — send, pending, cancel
- `app/services/tenants_service.py:184,251` — delete member, change role

Outer gate (EQUIPO module) + inner check (admin/superuser role) — both must pass. Epic 6 will eventually unify these into the gate alone.

## Tests — 20/20 pass

`tests/test_equipo_permissions.py` (new, **3 tests**):
1. Owner passes `GET /tenants/members` under enforce (canonical allow)
2. Cashier denied `GET /tenants/members` under enforce (canonical deny; "equipo" in detail)
3. **`test_cashier_passes_user_tenants_exclusion_under_enforce`** — cashier reaches `GET /tenants/user-tenants` → 200. **Critical regression guard**: if anyone later accidentally gates `/user-tenants`, the sidebar tenant switcher breaks for every non-owner role; this test catches it before merge.

Plus 17 existing regression tests (POS, VENTAS, billing, dependency).

## Audit doc updates

- `invitations.py` + `tenants.py` rows marked **DONE en #196** with exclusion notes inline
- Coverage Summary: **EQUIPO** → ✅ DONE (6 gated + 3 excluded)
- §2 expanded with consumer reference for `/invitations/accept`
- **§9 NEW**: documents `tenants.py` self-service exclusions (`POST ""` + `/user-tenants`) with consumer references and pointer to the regression test
- Last-updated date bumped

## Test plan
- [x] `grep -c "Module.EQUIPO" app/routers/invitations.py app/routers/tenants.py` = **6** ✅
- [x] `ruff check` clean
- [x] `python3 -m py_compile` clean (Python 3.9 target)
- [x] `pytest tests/test_*_permissions.py tests/test_permissions_dependency.py` — **20/20 pass**
- [ ] Manual after deploy: cashier → sidebar tenant switcher loads (`GET /tenants/user-tenants` returns 200)
- [ ] Manual: cashier → curl `/tenants/members` → 403 with "equipo" in detail
- [ ] Manual: owner → `/equipo/miembros` loads + member CRUD works
- [ ] Manual: anonymous (no session) → `POST /invitations/accept` with valid token → succeeds

Closes #196