### PR TITLE
feat(permissions): gate INTEGRACIONES group routers under Module.INTEGRACIONES (#197)

### DIFF
--- a/app/routers/api_tokens.py
+++ b/app/routers/api_tokens.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
+from app.core.permissions import Module, require_module
 from app.services.api_tokens_service import (
     create_api_token,
     list_api_tokens,
@@ -19,7 +20,7 @@ from app.models.api_token import (
 router = APIRouter()
 
 
-@router.post("", response_model=ApiTokenCreatedResponse)
+@router.post("", response_model=ApiTokenCreatedResponse, dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def create_api_token_endpoint(request: Request, body: ApiTokenCreate):
     """
     Crea un nuevo API token para el tenant actual.
@@ -32,7 +33,7 @@ async def create_api_token_endpoint(request: Request, body: ApiTokenCreate):
     return await create_api_token(request, body)
 
 
-@router.get("", response_model=ApiTokenListResponse)
+@router.get("", response_model=ApiTokenListResponse, dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def list_api_tokens_endpoint(request: Request):
     """
     Lista todos los API tokens del tenant actual.
@@ -42,7 +43,7 @@ async def list_api_tokens_endpoint(request: Request):
     return await list_api_tokens(request)
 
 
-@router.get("/scopes")
+@router.get("/scopes", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_available_scopes():
     """
     Retorna la lista de scopes disponibles para API tokens.
@@ -65,7 +66,7 @@ async def get_available_scopes():
     }
 
 
-@router.patch("/{token_id}", response_model=ApiTokenUpdateResponse)
+@router.patch("/{token_id}", response_model=ApiTokenUpdateResponse, dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def update_api_token_endpoint(request: Request, token_id: str, body: ApiTokenUpdateRequest):
     """
     Actualiza un API token (nombre, scopes, estado activo).
@@ -81,7 +82,7 @@ async def update_api_token_endpoint(request: Request, token_id: str, body: ApiTo
     )
 
 
-@router.post("/{token_id}/revoke", response_model=ApiTokenDeleteResponse)
+@router.post("/{token_id}/revoke", response_model=ApiTokenDeleteResponse, dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def revoke_api_token_endpoint(request: Request, token_id: str):
     """
     Revoca (desactiva) un API token.
@@ -94,7 +95,7 @@ async def revoke_api_token_endpoint(request: Request, token_id: str):
     return await revoke_api_token(request, token_id)
 
 
-@router.delete("/{token_id}", response_model=ApiTokenDeleteResponse)
+@router.delete("/{token_id}", response_model=ApiTokenDeleteResponse, dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def delete_api_token_endpoint(request: Request, token_id: str):
     """
     Elimina permanentemente un API token.

--- a/app/routers/public_api.py
+++ b/app/routers/public_api.py
@@ -2,10 +2,11 @@
 Public API Router
 Endpoints for external integrations authenticated via API tokens
 """
-from fastapi import APIRouter, HTTPException, Request, Query
+from fastapi import APIRouter, Depends, HTTPException, Request, Query
 from pydantic import BaseModel, Field
 from typing import List, Optional, Dict, Any
 from uuid import UUID
+from app.core.permissions import Module, require_module
 from app.services import public_api_service, public_restaurant_service
 
 router = APIRouter(prefix="/v1", tags=["Public API"])
@@ -111,7 +112,7 @@ class CustomerOrdersRequest(BaseModel):
     includeItems: bool = Field(default=False, description="Include line items per order")
 
 
-@router.get("/restaurant")
+@router.get("/restaurant", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_restaurant_profile(request: Request) -> Dict[str, Any]:
     """
     Retorna el perfil público del restaurante asociado al API key.
@@ -131,7 +132,7 @@ async def get_restaurant_profile(request: Request) -> Dict[str, Any]:
     return {"success": True, "data": profile}
 
 
-@router.get("/menu")
+@router.get("/menu", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_restaurant_menu(
     request: Request,
     category_id: Optional[UUID] = Query(default=None, description="Optional: filter by category ID")
@@ -152,7 +153,7 @@ async def get_restaurant_menu(
     return {"success": True, "data": menu}
 
 
-@router.post("/sales")
+@router.post("/sales", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_sales(request: Request, body: SalesQueryRequest):
     """
     Obtiene la lista de ventas (ordenes) del tenant autenticado.
@@ -177,7 +178,7 @@ async def get_sales(request: Request, body: SalesQueryRequest):
     )
 
 
-@router.post("/sales/metrics")
+@router.post("/sales/metrics", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_sales_metrics(request: Request, body: MetricsQueryRequest):
     """
     Obtiene metricas de ventas del tenant autenticado.
@@ -211,7 +212,7 @@ async def get_sales_metrics(request: Request, body: MetricsQueryRequest):
     )
 
 
-@router.post("/sales/detail")
+@router.post("/sales/detail", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_sale(request: Request, body: SaleDetailRequest):
     """
     Obtiene el detalle de una venta especifica incluyendo items y modificadores.
@@ -225,7 +226,7 @@ async def get_sale(request: Request, body: SaleDetailRequest):
     return await public_api_service.get_sale_by_id(request, UUID(body.orderId))
 
 
-@router.post("/menu/products")
+@router.post("/menu/products", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_menu_products(request: Request, body: MenuProductsRequest):
     """
     Obtiene la lista de productos del menu con ingredientes, recetas base y modificadores.
@@ -248,7 +249,7 @@ async def get_menu_products(request: Request, body: MenuProductsRequest):
     )
 
 
-@router.post("/menu/recipes")
+@router.post("/menu/recipes", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_menu_recipes(request: Request, body: MenuRecipesRequest):
     """
     Obtiene la lista de recetas base con sus ingredientes.
@@ -267,7 +268,7 @@ async def get_menu_recipes(request: Request, body: MenuRecipesRequest):
     )
 
 
-@router.post("/menu/modifiers")
+@router.post("/menu/modifiers", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_menu_modifiers(request: Request, body: MenuModifiersRequest):
     """
     Obtiene la lista de grupos de modificadores con sus opciones e ingredientes.
@@ -285,7 +286,7 @@ async def get_menu_modifiers(request: Request, body: MenuModifiersRequest):
     )
 
 
-@router.post("/customers")
+@router.post("/customers", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_customers(request: Request, body: CustomersListRequest):
     """
     Obtiene la lista de clientes del tenant autenticado, ordenados por total gastado.
@@ -309,7 +310,7 @@ async def get_customers(request: Request, body: CustomersListRequest):
     )
 
 
-@router.post("/customers/detail")
+@router.post("/customers/detail", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_customer_detail(request: Request, body: CustomerDetailRequest):
     """
     Obtiene el perfil, estadisticas y resumen de WaRos de un cliente especifico.
@@ -331,7 +332,7 @@ async def get_customer_detail(request: Request, body: CustomerDetailRequest):
     )
 
 
-@router.post("/customers/orders")
+@router.post("/customers/orders", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_customer_orders(request: Request, body: CustomerOrdersRequest):
     """
     Obtiene el historial de pedidos paginado de un cliente especifico, en todas las fuentes (POS, online, manual).
@@ -360,7 +361,7 @@ async def get_customer_orders(request: Request, body: CustomerOrdersRequest):
     )
 
 
-@router.post("/customers/metrics")
+@router.post("/customers/metrics", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_customers_metrics(request: Request, body: CustomerMetricsRequest):
     """
     Obtiene metricas agregadas de clientes del tenant autenticado.
@@ -491,7 +492,7 @@ class WarosAnalyticsRequest(BaseModel):
 # Analytics endpoints
 # ---------------------------------------------------------------------------
 
-@router.post("/analytics/menu-analysis")
+@router.post("/analytics/menu-analysis", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_analytics_menu_analysis(request: Request, body: AnalyticsMenuAnalysisRequest):
     """
     Obtiene el analisis BCG del menu (estrellas, vacas, interrogantes, perros).
@@ -510,7 +511,7 @@ async def get_analytics_menu_analysis(request: Request, body: AnalyticsMenuAnaly
     )
 
 
-@router.post("/analytics/food-cost")
+@router.post("/analytics/food-cost", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_analytics_food_cost(request: Request, body: AnalyticsFoodCostRequest):
     """
     Obtiene el analisis de food cost por producto.
@@ -531,7 +532,7 @@ async def get_analytics_food_cost(request: Request, body: AnalyticsFoodCostReque
     )
 
 
-@router.post("/analytics/alerts")
+@router.post("/analytics/alerts", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_analytics_alerts(request: Request, body: AnalyticsAlertsRequest):
     """
     Obtiene alertas operacionales e inventario del tenant.
@@ -548,7 +549,7 @@ async def get_analytics_alerts(request: Request, body: AnalyticsAlertsRequest):
     )
 
 
-@router.post("/analytics/data-quality")
+@router.post("/analytics/data-quality", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_analytics_data_quality(request: Request):
     """
     Obtiene el reporte de calidad de datos del tenant.
@@ -562,7 +563,7 @@ async def get_analytics_data_quality(request: Request):
     return await public_api_service.get_analytics_data_quality(request)
 
 
-@router.post("/analytics/cohort")
+@router.post("/analytics/cohort", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_analytics_cohort(request: Request, body: AnalyticsCohortRequest):
     """
     Retorna la matriz de retención por cohorte de adquisición.
@@ -596,7 +597,7 @@ async def get_analytics_cohort(request: Request, body: AnalyticsCohortRequest):
     )
 
 
-@router.post("/analytics/rfm")
+@router.post("/analytics/rfm", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_analytics_rfm(request: Request, body: AnalyticsRFMRequest):
     """
     Retorna la segmentación RFM (Recency, Frequency, Monetary) de los clientes del tenant.
@@ -626,7 +627,7 @@ async def get_analytics_rfm(request: Request, body: AnalyticsRFMRequest):
 # Financial endpoints
 # ---------------------------------------------------------------------------
 
-@router.post("/financial/products")
+@router.post("/financial/products", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_financial_products(request: Request, body: FinancialProductsRequest):
     """
     Obtiene el analisis financiero de productos (margen, costo, rentabilidad).
@@ -650,7 +651,7 @@ async def get_financial_products(request: Request, body: FinancialProductsReques
 # WaRos endpoints
 # ---------------------------------------------------------------------------
 
-@router.post("/waros/customer-summary")
+@router.post("/waros/customer-summary", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_waros_customer_summary(request: Request, body: WarosCustomerSummaryRequest):
     """
     Obtiene el resumen de WaRos (wallet) de un cliente especifico.
@@ -667,7 +668,7 @@ async def get_waros_customer_summary(request: Request, body: WarosCustomerSummar
     )
 
 
-@router.post("/waros/balances")
+@router.post("/waros/balances", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_waros_customers_balances(request: Request, body: WarosCustomersBalancesRequest):
     """
     Obtiene los balances de WaRos para multiples clientes en batch.
@@ -685,7 +686,7 @@ async def get_waros_customers_balances(request: Request, body: WarosCustomersBal
     )
 
 
-@router.post("/waros/estimate")
+@router.post("/waros/estimate", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_waros_estimate(request: Request, body: WarosEstimateRequest):
     """
     Estima cuantos WaRos se ganarian por una compra de determinado monto.
@@ -704,7 +705,7 @@ async def get_waros_estimate(request: Request, body: WarosEstimateRequest):
     )
 
 
-@router.post("/analytics/churn-risk")
+@router.post("/analytics/churn-risk", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_analytics_churn_risk(request: Request, body: AnalyticsChurnRiskRequest):
     """
     Clientes en riesgo de churn basado en su patron de visitas historico.
@@ -727,7 +728,7 @@ async def get_analytics_churn_risk(request: Request, body: AnalyticsChurnRiskReq
     )
 
 
-@router.post("/waros/customer-history")
+@router.post("/waros/customer-history", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_waros_customer_history(request: Request, body: WarosCustomerHistoryRequest):
     """
     Historial paginado de transacciones de WaRos para un cliente especifico.
@@ -748,7 +749,7 @@ async def get_waros_customer_history(request: Request, body: WarosCustomerHistor
     )
 
 
-@router.post("/analytics/waros")
+@router.post("/analytics/waros", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_analytics_waros(request: Request, body: WarosAnalyticsRequest):
     """
     Analytics agregado de WaRos: puntos emitidos, canjeados, tasa de redencion y miembros activos.

--- a/app/routers/v1_ordering.py
+++ b/app/routers/v1_ordering.py
@@ -3,10 +3,11 @@ V1 Ordering Router
 Cart, address, OTP, and customer-validate endpoints authenticated via API key.
 tenant_id is injected from the API key context — never exposed to callers.
 """
-from fastapi import APIRouter, Depends, Request, Query, Response
+from fastapi import APIRouter, Depends, Request, Response
 from typing import List, Optional
 from uuid import UUID
 from pydantic import BaseModel, EmailStr, Field
+from app.core.permissions import Module, require_module
 from app.services import online_cart_service, address_profile_service, otp_service
 from app.services.public_api_service import validate_api_key_auth
 from app.services import public_restaurant_service
@@ -26,7 +27,7 @@ class V1BatchCreateCartRequest(BaseModel):
     order_type: str = Field(default='delivery', pattern='^(delivery|pickup|dine-in)$')
 
 
-@router.post("/batch")
+@router.post("/batch", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def create_cart_batch(request: Request, body: V1BatchCreateCartRequest):
     """
     Create cart and add all items in batch.
@@ -44,7 +45,7 @@ async def create_cart_batch(request: Request, body: V1BatchCreateCartRequest):
     )
 
 
-@router.get("/session/{session_id}")
+@router.get("/session/{session_id}", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_cart_by_session(session_id: str, request: Request):
     """
     Get active cart by session ID.
@@ -61,7 +62,7 @@ async def get_cart_by_session(session_id: str, request: Request):
     )
 
 
-@router.put("/{cart_id}/delivery")
+@router.put("/{cart_id}/delivery", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def update_delivery_info(cart_id: UUID, request: Request, delivery_info: DeliveryInfoUpdate):
     """
     Update delivery information for a cart.
@@ -79,7 +80,7 @@ async def update_delivery_info(cart_id: UUID, request: Request, delivery_info: D
     )
 
 
-@router.delete("/{cart_id}/items/{item_id}")
+@router.delete("/{cart_id}/items/{item_id}", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def delete_cart_item(cart_id: UUID, item_id: UUID, request: Request):
     """
     Delete a specific item from a cart.
@@ -91,7 +92,7 @@ async def delete_cart_item(cart_id: UUID, item_id: UUID, request: Request):
     return await online_cart_service.delete_cart_item(cart_id=cart_id, item_id=item_id)
 
 
-@router.delete("/{cart_id}")
+@router.delete("/{cart_id}", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def clear_cart(cart_id: UUID, request: Request):
     """
     Clear all items from a cart.
@@ -103,7 +104,7 @@ async def clear_cart(cart_id: UUID, request: Request):
     return await online_cart_service.clear_cart(cart_id=cart_id)
 
 
-@router.post("/{cart_id}/verify")
+@router.post("/{cart_id}/verify", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def verify_cart(
     cart_id: UUID,
     request: Request,
@@ -131,7 +132,7 @@ async def verify_cart(
     )
 
 
-@router.post("/{cart_id}/checkout")
+@router.post("/{cart_id}/checkout", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def checkout_cart_v1(cart_id: UUID, request: Request):
     """
     Finalize a verified cart as a confirmed order.
@@ -155,7 +156,7 @@ async def checkout_cart_v1(cart_id: UUID, request: Request):
 # ---------------------------------------------------------------------------
 
 
-@address_router.post("")
+@address_router.post("", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def create_address(request: Request, address: AddressProfileCreate):
     """
     Create a new delivery address for a customer.
@@ -183,7 +184,7 @@ async def create_address(request: Request, address: AddressProfileCreate):
     )
 
 
-@address_router.get("/customer/{customer_id}")
+@address_router.get("/customer/{customer_id}", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def get_customer_addresses(customer_id: UUID, request: Request):
     """
     Get all addresses for a customer, ordered by default-first then newest.
@@ -195,7 +196,7 @@ async def get_customer_addresses(customer_id: UUID, request: Request):
     return await address_profile_service.get_customer_addresses(customer_id)
 
 
-@address_router.put("/{address_id}")
+@address_router.put("/{address_id}", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def update_address(
     address_id: UUID,
     customer_id: UUID,
@@ -220,7 +221,7 @@ async def update_address(
     )
 
 
-@address_router.delete("/{address_id}")
+@address_router.delete("/{address_id}", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def delete_address(address_id: UUID, customer_id: UUID, request: Request):
     """
     Delete an address. If the deleted address was the default and others exist,
@@ -235,7 +236,7 @@ async def delete_address(address_id: UUID, customer_id: UUID, request: Request):
     return await address_profile_service.delete_address(address_id, customer_id)
 
 
-@address_router.patch("/{address_id}/set-default")
+@address_router.patch("/{address_id}/set-default", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def set_default_address(address_id: UUID, customer_id: UUID, request: Request):
     """
     Set an address as the customer's default. Unsets all other addresses as default.
@@ -272,7 +273,7 @@ class V1ResendOTPRequest(BaseModel):
     cart_id: Optional[UUID] = None
 
 
-@otp_router.post("/send")
+@otp_router.post("/send", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def v1_send_otp(request: Request, body: V1SendOTPRequest):
     """
     Send OTP code via email.
@@ -284,7 +285,7 @@ async def v1_send_otp(request: Request, body: V1SendOTPRequest):
     return await otp_service.send_otp_email(email=body.email, cart_id=body.cart_id)
 
 
-@otp_router.post("/verify")
+@otp_router.post("/verify", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def v1_verify_otp(request: Request, body: V1VerifyOTPRequest, response: Response):
     """
     Verify OTP code.
@@ -313,7 +314,7 @@ async def v1_verify_otp(request: Request, body: V1VerifyOTPRequest, response: Re
     return result
 
 
-@otp_router.post("/resend")
+@otp_router.post("/resend", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def v1_resend_otp(request: Request, body: V1ResendOTPRequest):
     """
     Resend OTP code. Cooldown: 60 seconds between resends.
@@ -343,7 +344,7 @@ class V1ValidateCustomerRequest(BaseModel):
     cart_total: float = 0.0
 
 
-@customer_router_v1.post("/validate")
+@customer_router_v1.post("/validate", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def v1_validate_customer(request: Request, body: V1ValidateCustomerRequest):
     """
     Validate customer eligibility to place an order.
@@ -360,7 +361,7 @@ async def v1_validate_customer(request: Request, body: V1ValidateCustomerRequest
     )
 
 
-@product_router_v1.get("/{product_id}")
+@product_router_v1.get("/{product_id}", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
 async def v1_get_product_detail(product_id: UUID, request: Request):
     """
     Get full product details including modifier groups.

--- a/docs/permissions-router-mapping.md
+++ b/docs/permissions-router-mapping.md
@@ -2,7 +2,7 @@
 
 **Status:** Source of truth for Epic 2 (#164) wiring sub-tasks (E2.3 → E2.16).
 **Origin:** [#186 audit](https://github.com/uno0uno/api-warolabs/issues/186).
-**Last updated:** 2026-05-09 (initial commit, post #185 / E2.14 done).
+**Last updated:** 2026-05-11 (post #197 E2.13 INTEGRACIONES done; v1_ordering.py count fix 7→17; added §10 documenting api-key bypass via require_module early-return).
 
 This document maps each FastAPI router under `app/routers/` to the `Module`
 enum value it should be gated under via `Depends(require_module(Module.X))`,
@@ -27,7 +27,7 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 | `address_profile.py` | `/online/addresses` | 6 | **public** | none | Direcciones de delivery (clientes online) |
 | `admin_ingredients.py` | `/admin/ingredients` | 6 | **ABASTECIMIENTO** | session | Catálogo global de ingredientes |
 | `analytics.py` | `/analytics` | 6 | **ANALITICA** | session | Dashboard analítico, alertas |
-| `api_tokens.py` | `/api-tokens` | 6 | **INTEGRACIONES** | session | API token CRUD + scopes |
+| `api_tokens.py` | `/api-tokens` | 6 | **INTEGRACIONES** | session | API token CRUD + scopes. DONE en #197. |
 | `articles.py` | `/blog` | 3 | **public** | none | Blog público (lista + detalle) |
 | `auth.py` | `/auth` | 7 | **skip** | none | Login/sesión — corre SIN sesión |
 | `billing.py` | `/billing` | 10 | **MI_PLAN** | mixed | DONE en #185. Webhook + cron skip con `# NOTE:` |
@@ -59,7 +59,7 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 | `payment_methods.py` | `/finanzas/metodos-pago + /pos/payment-methods` | 10 | **mixed** | session | Split: finanzas_router (FINANZAS) + pos_router (POS read-only) — ver §3 |
 | `pos_cart.py` | `/pos/cart` | 11 | **POS** | session | Carrito POS, checkout |
 | `products.py` | `/menu/products` | 7 | **MENU** | session | Producto CRUD + receta + imagen |
-| `public_api.py` | `/v1` | 25 | **INTEGRACIONES** | api_key | API pública con API key (clientes externos) |
+| `public_api.py` | `/v1` | 25 | **INTEGRACIONES** | api_key | API pública con API key (clientes externos). DONE en #197 (api-key callers bypass via early-return, ver §10). |
 | `public_restaurant.py` | `/public/restaurant` | 4 | **public** | none | Lista + detalle por slug |
 | `purchases.py` | `/suppliers/purchases` | 26 | **ABASTECIMIENTO** | session | Compras + estados + factura |
 | `recipe_bases.py` | `/menu/recipe-bases` | 5 | **MENU** | session | Templates de receta |
@@ -71,7 +71,7 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 | `tables.py` | `/tables` | 19 | **POS** | session | Mesas + tab + sesión de mesa |
 | `tenant_config.py` | `/api/tenant` | 15 | **mixed** | session | Split obligatorio: OPERACIONES + MI_NEGOCIO — ver §4 |
 | `tenants.py` | `/tenants` | 5 | **EQUIPO** | session | Tenant create + member CRUD |
-| `v1_ordering.py` | `/v1/cart + /v1/addresses + /v1/otp + /v1/customer + /v1/product` | 7 | **INTEGRACIONES** | api_key | V1 ordering API (clientes externos) |
+| `v1_ordering.py` | `/v1/cart + /v1/addresses + /v1/otp + /v1/customer + /v1/product` | 17 | **INTEGRACIONES** | api_key | V1 ordering API (5 sub-routers: cart 7, address 5, otp 3, customer 1, product 1). DONE en #197 (count fix 7→17; api-key bypass §10). |
 | `waros.py` | `/admin/waros` | 8 | **POS** | session | Sistema de loyalty (puntos WaRo) |
 | `webhooks.py` | `/api/webhooks` | 1 | **skip** | signature | Bridge a api-facturacion (signature-verified, no sesión) |
 
@@ -79,7 +79,7 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 
 ## Coverage Summary
 
-Total: **51 routers**, **~394 endpoints** (was 52/395 before #187 deleted `admin_orders.py`).
+Total: **51 routers**, **~404 endpoints** (corrected v1_ordering.py count 7→17 in #197; was 51/394 before count fix).
 
 | Module | Routers | Sub-task | Status |
 |---|---|---|---|
@@ -93,7 +93,7 @@ Total: **51 routers**, **~394 endpoints** (was 52/395 before #187 deleted `admin
 | **FINANZAS** | accounting, cartera, cierre, credit, expenses, financial, salaries + payment_methods/finanzas | 7+1 | E2.10 (#198) — pending |
 | **FACTURACION** | documents, facturacion (3 sub-routers), invoices, support_documents | 4 | E2.11 (#194) — pending |
 | **EQUIPO** | invitations (excl. /accept), tenants | 2 | E2.12 (#196) — pending |
-| **INTEGRACIONES** | api_tokens, public_api, v1_ordering | 3 | E2.13 (#197) — pending |
+| **INTEGRACIONES** | api_tokens, public_api, v1_ordering | 3 | ✅ E2.13 (#197) — DONE (48 endpoints gated; api-key callers bypass via require_module early-return on invalid session, ver §10) |
 | **MI_PLAN** | billing | 1 | ✅ E2.14 (#185, PR #202) — DONE |
 | **MI_NEGOCIO** | tenant_config (mi_negocio part) | 1 | E2.15 (#199) — pending |
 | **EVENTOS** | (no routers exist) | 0 | E2.16 (#200) — no-op |
@@ -203,6 +203,48 @@ How to verify a candidate is dead before deleting:
 grep -rn '<endpoint-path>' . --include='*.vue' --include='*.ts' --include='*.js' --include='*.py' --include='*.json'
 # expect: only the router file itself + main.py mount
 ```
+
+## §10. API-key callers bypass `require_module` via early-return (#197)
+
+`public_api.py` (25 endpoints) and `v1_ordering.py` (17 endpoints across 5
+sub-routers) are authenticated via API keys (`Authorization: Bearer waro_sk_...`
+or `X-API-Key` header). The middleware at `app/core/middleware.py:163-194`
+validates the key and sets `request.state.tenant_context` — **but never sets
+`request.state.session_context`**.
+
+`get_session_context(request)` (middleware.py:528-532) returns an empty
+`SessionContext()` for API-key requests, which has `is_valid=False`.
+`require_module()` short-circuits on that condition (permissions.py:339-343):
+
+> "Sessions that aren't valid at all return early so `require_valid_session`
+> (still called inside handlers) can raise 401 with its own message."
+
+**Effect**: gating `/api-tokens`, `/v1/*` endpoints under INTEGRACIONES is
+safe — the gate is a complete no-op for API-key calls, which pass through
+to the handler. The handler then runs `validate_api_key_auth(request, scope)`
+which enforces scope-based authorization at the token level (`read`, `write`,
+`orders:read`, `products:write`, etc.).
+
+**Defense in depth**:
+- Outer gate (`require_module`) — gates session-authenticated callers
+- Inner check (`validate_api_key_auth`) — enforces scopes on API-key callers
+- Both coexist without conflict. The gate is a no-op for API-key flow; the
+  scope check is a no-op for session flow.
+
+This pattern is **forward-prep**: if any of these endpoints is ever called
+by an operator session (instead of API key), the gate enforces INTEGRACIONES
+correctly without needing a second-pass PR.
+
+**Test guarding the early-return**:
+\`tests/test_integraciones_permissions.py::test_api_key_request_bypasses_gate_under_enforce\`
+asserts that a request with no SessionContext reaches `/v1/cart/batch` under
+enforce mode. If anyone later tightens the gate to deny invalid sessions
+instead of bypassing them, every API-key caller in production would 403;
+this test catches it before merge.
+
+The audit doc's earlier "Open questions" entry asking whether to plumb a role
+into API keys or skip those routers is **resolved by this finding**: neither
+is necessary.
 
 ## §6. `auth.py` and `webhooks.py` — explicit skips
 

--- a/tests/test_integraciones_permissions.py
+++ b/tests/test_integraciones_permissions.py
@@ -1,0 +1,154 @@
+"""End-to-end smoke tests for INTEGRACIONES group endpoints under require_module(INTEGRACIONES).
+
+Sub-task E2.13 of Epic 2 (#197). Validates that:
+1. Owner role under enforce reaches a gated session-authenticated endpoint.
+2. Cashier role under enforce gets 403 on the gated session endpoint (cashier
+   lacks INTEGRACIONES — admin + owner only by matrix).
+3. **API-key bypass test**: a request with NO SessionContext (mimicking an
+   API-key call) successfully reaches a /v1/* handler under enforce. Proves
+   the `require_module` early-return behavior protects API-key callers.
+
+Scope: 3 files, 48 endpoints total — api_tokens.py (6, session), public_api.py
+(25, api_key), v1_ordering.py (17 across 5 sub-routers, api_key).
+
+The 3rd test documents the architecture: API-key middleware sets
+`request.state.tenant_context` only, NEVER `request.state.session_context`.
+`get_session_context()` returns an empty `SessionContext()` with `is_valid=False`,
+which `require_module()` short-circuits on (permissions.py:339-343). So gating
+all 48 endpoints is safe — api-key requests pass via the early-return.
+
+Pairs with `tests/test_equipo_permissions.py` (#196 reference impl).
+"""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.core.permissions import Module
+from app.routers.api_tokens import router as api_tokens_router
+from app.routers.v1_ordering import router as v1_cart_router
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_session(role):
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": role,
+    })
+
+
+def _enforce_db_ctx():
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+    return _ctx
+
+
+# ─── Tests ────────────────────────────────────────────────────────────
+
+
+def test_owner_role_passes_integraciones_endpoint_under_enforce():
+    """Owner reaches GET /api-tokens under enforce — dependency permits."""
+    session = _build_session(role="owner")
+    app = FastAPI()
+    app.include_router(api_tokens_router, prefix="/api-tokens")
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.routers.api_tokens.list_api_tokens",
+             new=AsyncMock(return_value={"data": [], "total": 0}),
+         ):
+        client = TestClient(app)
+        response = client.get("/api-tokens")
+
+    # Handler reached → dependency permitted owner.
+    assert response.status_code == 200
+
+
+def test_cashier_role_denied_integraciones_endpoint_under_enforce():
+    """Cashier role hits 403 on INTEGRACIONES — cashier lacks INTEGRACIONES in default matrix."""
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(api_tokens_router, prefix="/api-tokens")
+
+    # Stub get_role_modules to return cashier's default set (POS + VENTAS only).
+    cashier_modules = frozenset({Module.POS, Module.VENTAS})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ):
+        client = TestClient(app)
+        response = client.get("/api-tokens")
+
+    assert response.status_code == 403
+    assert "integraciones" in response.json()["detail"].lower()
+
+
+def test_api_key_request_bypasses_gate_under_enforce():
+    """API-key request (no SessionContext) reaches /v1/cart handler under enforce.
+
+    Mimics the production API-key flow: the api-key middleware sets
+    `request.state.tenant_context` only — never `request.state.session_context`.
+    `get_session_context()` therefore returns an empty `SessionContext()` with
+    `is_valid=False`, and `require_module()` short-circuits via the early-return
+    documented in permissions.py:339-343.
+
+    This test guards against accidental future changes to the early-return —
+    if anyone tightens the gate to deny invalid sessions instead of bypassing,
+    every API-key caller in production would 403. This test catches it before
+    merge.
+    """
+    invalid_session = SessionContext()  # empty / is_valid=False — mimics no-session API-key request
+    app = FastAPI()
+    app.include_router(v1_cart_router)
+
+    with patch("app.core.middleware.get_session_context", return_value=invalid_session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.routers.v1_ordering.validate_api_key_auth",
+             return_value=(str(uuid4()), {"scopes": ["read"]}),
+         ), \
+         patch(
+             "app.routers.v1_ordering.online_cart_service.create_cart_with_batch_items",
+             new=AsyncMock(return_value={"success": True, "data": {"session_id": "test"}}),
+         ):
+        client = TestClient(app)
+        response = client.post(
+            "/v1/cart/batch",
+            json={"items": [], "order_type": "delivery"},
+        )
+
+    # No 403 — handler reached because the gate early-returns on invalid sessions.
+    # If this asserts != 200, the early-return behavior is broken and every
+    # API-key caller in prod would 403.
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary

Sub-task **E2.13** of Epic 2 (#164). Gates **48 endpoints across 3 routers** under `Module.INTEGRACIONES`. **Resolves the audit doc's open question** about API-key callers — no middleware changes needed; the existing `require_module` early-return on invalid sessions naturally bypasses API-key requests.

## Stack
🔵 FastAPI

## Endpoints gated (counts verified)

| Router | Endpoints | Auth | Sub-routers |
|---|---|---|---|
| `api_tokens.py` | 6 | session | 1 |
| `public_api.py` | 25 | api_key | 1 |
| `v1_ordering.py` | **17** (count fix from audit's 7) | api_key | **5** (cart 7, address 5, otp 3, customer 1, product 1) |
| **Total** | **48** | — | 7 |

```
$ grep -c "Module.INTEGRACIONES" app/routers/{api_tokens,public_api,v1_ordering}.py
# 6 + 25 + 17 = 48 ✅
```

## 🔑 Audit doc's "open question" resolved

The audit doc raised:
> "API key callers today have role=None. After enforce, every API-key call would 403. Either (a) skip these routers, or (b) plumb a role into validate_api_key output."

**Neither is needed.** Reading `require_module()` carefully (permissions.py:339-343):

> "Sessions that aren't valid at all return early so `require_valid_session` (still called inside handlers) can raise 401 with its own message."

The API-key middleware (`middleware.py:163-194`) only sets `request.state.tenant_context` — **never `session_context`**. `get_session_context()` returns `SessionContext()` with `is_valid=False`. `require_module()` short-circuits on that condition → **gate is a no-op for API-key calls**.

This is documented in **§10 NEW** of the audit doc.

## Defense in depth — orthogonal layers

- **Outer gate** (`require_module`): gates session-authenticated callers. No-op for API-key.
- **Inner check** (`validate_api_key_auth(request, scope)`): enforces token-level scopes (`read`, `write`, `orders:read`, etc.) on API-key callers. No-op for session.

They coexist without conflict. Forward-prep: if any of these endpoints is ever called by an operator session, the gate enforces INTEGRACIONES correctly without a follow-up PR.

## webhooks.py — confirmed out of scope

Issue body lists `webhooks.py` in scope, but it's correctly classified as `skip` in the audit doc — signature-verified external Matias bridge, no session, no API key. Plan ignores it. PR description clarifies upfront so reviewers don't re-raise.

## Role matrix — no change

`Module.INTEGRACIONES` is in `Role.OWNER` (all) and `Role.ADMIN` defaults. `SUPERVISOR`, `CASHIER`, `KITCHEN` correctly excluded. No matrix edits.

## Tests — 20/20 pass

`tests/test_integraciones_permissions.py` (new, **3 tests**):
1. Owner passes `GET /api-tokens` under enforce (canonical allow)
2. Cashier denied `GET /api-tokens` under enforce (canonical deny; "integraciones" in detail)
3. **`test_api_key_request_bypasses_gate_under_enforce`** — request with NO `SessionContext` reaches `POST /v1/cart/batch` under enforce. **Critical regression guard**: if anyone later tightens the gate to deny invalid sessions instead of bypassing them, every API-key caller in production would 403; this test catches it before merge.

Plus 17 existing regression tests (POS, VENTAS, billing, dependency).

## Audit doc updates

- **`v1_ordering.py` endpoint count CORRECTED 7 → 17** — audit only counted `cart_router`; missed the other 4 sub-routers (address, otp, customer, product)
- All 3 router rows marked **DONE en #197** with notes
- Coverage Summary: **INTEGRACIONES** → ✅ DONE (48 endpoints; api-key bypass)
- **§10 NEW**: documents the api-key-bypass architecture with references to `permissions.py:339-343` + `middleware.py:163-194`; explains defense-in-depth; points to the regression test
- Totals bumped: 51 routers / **~404 endpoints** (was 51/394 before count fix)
- Resolves the previous "Open questions" entry about API-key callers
- Last-updated date bumped

## Drive-by cleanup

Removed 1 pre-existing unused import (`Query` in `api_tokens.py`) flagged by ruff after the edits. Same precedent as #195's drive-by cleanup.

## Test plan
- [x] `grep -c "Module.INTEGRACIONES"` total = **48** ✅
- [x] `ruff check` clean (after drive-by fix of 1 pre-existing error)
- [x] `python3 -m py_compile` clean (Python 3.9 target)
- [x] `pytest tests/test_*_permissions.py tests/test_permissions_dependency.py` — **20/20 pass**
- [ ] Manual after deploy: admin → `/integraciones` page loads + token CRUD works
- [ ] Manual: cashier → curl `/api-tokens` with session cookie → 403 with "integraciones" in detail
- [ ] Manual: external client → `POST /v1/cart/batch` with `X-API-Key: waro_sk_...` → succeeds (bypass works)
- [ ] Manual: invalid API key → 401 (validate_api_key_auth catches it inside handler)

Closes #197