### PR TITLE
feat(permissions): gate FINANZAS group routers under Module.FINANZAS (#198)

### DIFF
--- a/app/routers/accounting.py
+++ b/app/routers/accounting.py
@@ -1,6 +1,7 @@
 from typing import Optional
 from uuid import UUID
-from fastapi import APIRouter, Request, Query
+from fastapi import Depends, APIRouter, Request, Query
+from app.core.permissions import Module, require_module
 from app.services.accounting_service import (
     get_accounts,
     create_account,
@@ -34,7 +35,7 @@ from app.models.accounting import (
 router = APIRouter()
 
 
-@router.get("/accounts", response_model=TenantAccountsListResponse)
+@router.get("/accounts", response_model=TenantAccountsListResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def list_accounts_endpoint(
     request: Request,
     account_class: Optional[str] = Query(None, alias="class"),
@@ -49,7 +50,7 @@ async def list_accounts_endpoint(
     return await get_accounts(request, account_class=account_class, account_type=account_type, active=active)
 
 
-@router.post("/accounts", response_model=TenantAccountResponse)
+@router.post("/accounts", response_model=TenantAccountResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def create_account_endpoint(request: Request, body: TenantAccountCreate):
     """
     Create a custom account for the current tenant.
@@ -59,7 +60,7 @@ async def create_account_endpoint(request: Request, body: TenantAccountCreate):
     return await create_account(request, body)
 
 
-@router.put("/accounts/{account_id}", response_model=TenantAccountResponse)
+@router.put("/accounts/{account_id}", response_model=TenantAccountResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def update_account_endpoint(request: Request, account_id: UUID, body: TenantAccountUpdate):
     """
     Update account name, active status, or is_detail flag.
@@ -69,7 +70,7 @@ async def update_account_endpoint(request: Request, account_id: UUID, body: Tena
     return await update_account(request, account_id, body)
 
 
-@router.delete("/accounts/{account_id}")
+@router.delete("/accounts/{account_id}", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def delete_account_endpoint(request: Request, account_id: UUID):
     """
     Soft-delete (deactivate) a custom account.
@@ -83,7 +84,7 @@ async def delete_account_endpoint(request: Request, account_id: UUID):
 # Journal Entries (#376)
 # ---------------------------------------------------------------------------
 
-@router.post("/journal-entries", response_model=JournalEntryResponse)
+@router.post("/journal-entries", response_model=JournalEntryResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def create_journal_entry_endpoint(request: Request, body: JournalEntryCreate):
     """
     Create a draft journal entry with lines.
@@ -93,7 +94,7 @@ async def create_journal_entry_endpoint(request: Request, body: JournalEntryCrea
     return await create_journal_entry(request, body)
 
 
-@router.get("/journal-entries", response_model=JournalEntriesListResponse)
+@router.get("/journal-entries", response_model=JournalEntriesListResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def list_journal_entries_endpoint(
     request: Request,
     status: Optional[str] = Query(None),
@@ -120,7 +121,7 @@ async def list_journal_entries_endpoint(
     )
 
 
-@router.get("/journal-entries/{entry_id}", response_model=JournalEntryResponse)
+@router.get("/journal-entries/{entry_id}", response_model=JournalEntryResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_journal_entry_endpoint(request: Request, entry_id: UUID):
     """
     Get a single journal entry with all its lines.
@@ -128,7 +129,7 @@ async def get_journal_entry_endpoint(request: Request, entry_id: UUID):
     return await get_journal_entry(request, entry_id)
 
 
-@router.post("/journal-entries/{entry_id}/post", response_model=JournalEntryResponse)
+@router.post("/journal-entries/{entry_id}/post", response_model=JournalEntryResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def post_journal_entry_endpoint(request: Request, entry_id: UUID):
     """
     Post a draft entry to the GL.
@@ -138,7 +139,7 @@ async def post_journal_entry_endpoint(request: Request, entry_id: UUID):
     return await post_journal_entry(request, entry_id)
 
 
-@router.post("/journal-entries/{entry_id}/void", response_model=JournalEntryResponse)
+@router.post("/journal-entries/{entry_id}/void", response_model=JournalEntryResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def void_journal_entry_endpoint(
     request: Request, entry_id: UUID, body: JournalEntryVoidRequest
 ):
@@ -154,7 +155,7 @@ async def void_journal_entry_endpoint(
 # Trial Balance (#379)
 # ---------------------------------------------------------------------------
 
-@router.get("/trial-balance", response_model=TrialBalanceResponse)
+@router.get("/trial-balance", response_model=TrialBalanceResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_trial_balance_endpoint(
     request: Request,
     period_start: str = Query(..., alias="periodStart", description="YYYY-MM-DD"),
@@ -181,7 +182,7 @@ async def get_trial_balance_endpoint(
 # P&L Statement (#383)
 # ---------------------------------------------------------------------------
 
-@router.get("/pl-statement", response_model=PLStatementResponse)
+@router.get("/pl-statement", response_model=PLStatementResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_pl_statement_endpoint(
     request: Request,
     year: int = Query(..., ge=2020, le=2100),
@@ -212,7 +213,7 @@ async def get_pl_statement_endpoint(
 # Provisions (#384)
 # ---------------------------------------------------------------------------
 
-@router.get("/provisions/preview", response_model=ProvisionsPreviewResponse)
+@router.get("/provisions/preview", response_model=ProvisionsPreviewResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def preview_provisions_endpoint(
     request: Request,
     year: int = Query(..., ge=2020, le=2100),
@@ -226,7 +227,7 @@ async def preview_provisions_endpoint(
     return await preview_provisions(request, year=year, month=month)
 
 
-@router.post("/provisions/post", response_model=ProvisionsPostResponse)
+@router.post("/provisions/post", response_model=ProvisionsPostResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def post_provisions_endpoint(
     request: Request,
     year: int = Query(..., ge=2020, le=2100),

--- a/app/routers/cartera.py
+++ b/app/routers/cartera.py
@@ -4,7 +4,8 @@ Endpoints for the accounts-receivable / portfolio view.
 
 Issue: https://github.com/uno0uno/warocol.com/issues/308
 """
-from fastapi import APIRouter, Request, Query
+from fastapi import Depends, APIRouter, Request, Query
+from app.core.permissions import Module, require_module
 from typing import Optional
 from uuid import UUID
 from app.services import cartera_service
@@ -12,7 +13,7 @@ from app.services import cartera_service
 router = APIRouter(prefix="/cartera", tags=["cartera"])
 
 
-@router.get("/summary")
+@router.get("/summary", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def cartera_summary(request: Request):
     """
     Global portfolio summary for the current tenant.
@@ -28,7 +29,7 @@ async def cartera_summary(request: Request):
     return await cartera_service.get_cartera_summary(request)
 
 
-@router.get("/customers")
+@router.get("/customers", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def list_cartera_customers(
     request: Request,
     status: Optional[str] = Query("all", description="Filter: all | overdue | current"),
@@ -66,7 +67,7 @@ async def list_cartera_customers(
     )
 
 
-@router.get("/customers/{customer_id}")
+@router.get("/customers/{customer_id}", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_customer_cartera(
     request: Request,
     customer_id: UUID,
@@ -85,7 +86,7 @@ async def get_customer_cartera(
     return await cartera_service.get_customer_cartera(request, customer_id)
 
 
-@router.get("/aging")
+@router.get("/aging", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def cartera_aging(request: Request):
     """
     Aging bucket report — computed at query time (no caching).

--- a/app/routers/cierre.py
+++ b/app/routers/cierre.py
@@ -4,7 +4,8 @@ Daily accounting close: preview (Cierre X) and final close wizard (Cierre Z).
 
 Issue: https://github.com/uno0uno/warocol.com/issues/311
 """
-from fastapi import APIRouter, Request, Response, Query
+from fastapi import Depends, APIRouter, Request, Response, Query
+from app.core.permissions import Module, require_module
 from typing import Optional
 from uuid import UUID
 from datetime import date, datetime
@@ -14,7 +15,7 @@ from app.services import cierre_service
 router = APIRouter(prefix="/cierre", tags=["cierre"])
 
 
-@router.get("/preview")
+@router.get("/preview", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def cierre_preview(
     request: Request,
     period_start: date = Query(..., alias="period_start"),
@@ -39,7 +40,7 @@ async def cierre_preview(
     )
 
 
-@router.post("")
+@router.post("", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def create_cierre(request: Request, body: CierreCreate):
     """
     Cierre Z — final daily close.
@@ -52,7 +53,7 @@ async def create_cierre(request: Request, body: CierreCreate):
     return await cierre_service.create_cierre(request, body)
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def list_cierres(
     request: Request,
     period_start: Optional[date] = Query(None, alias="period_start"),
@@ -65,7 +66,7 @@ async def list_cierres(
     return await cierre_service.list_cierres(request, period_start, period_end)
 
 
-@router.get("/mensual")
+@router.get("/mensual", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_cierre_mensual(
     request: Request,
     year:  int = Query(..., alias="year"),
@@ -78,7 +79,7 @@ async def get_cierre_mensual(
     return await cierre_service.get_cierre_mensual(request, year, month)
 
 
-@router.get("/mensual/{year}/{month}/status")
+@router.get("/mensual/{year}/{month}/status", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_monthly_period_status(
     year: int,
     month: int,
@@ -93,7 +94,7 @@ async def get_monthly_period_status(
     return await cierre_service.get_monthly_period(request, response, year, month)
 
 
-@router.post("/mensual/{year}/{month}/close")
+@router.post("/mensual/{year}/{month}/close", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def close_monthly_period_endpoint(
     year: int,
     month: int,
@@ -111,7 +112,7 @@ async def close_monthly_period_endpoint(
     return await cierre_service.close_monthly_period(request, response, year, month, notes)
 
 
-@router.get("/ultimo")
+@router.get("/ultimo", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_ultimo_cierre(request: Request):
     """
     Returns the most recent closed period for the tenant, or null if none exists.
@@ -120,7 +121,7 @@ async def get_ultimo_cierre(request: Request):
     return await cierre_service.get_ultimo_cierre(request)
 
 
-@router.get("/{cierre_id}")
+@router.get("/{cierre_id}", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_cierre(request: Request, cierre_id: UUID):
     """
     Full detail for a single closed period.
@@ -129,7 +130,7 @@ async def get_cierre(request: Request, cierre_id: UUID):
     return await cierre_service.get_cierre(request, cierre_id)
 
 
-@router.delete("/{cierre_id}")
+@router.delete("/{cierre_id}", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def delete_cierre(request: Request, cierre_id: UUID):
     """
     Soft-delete a closed period (sets deleted_at on accounting_period).

--- a/app/routers/credit.py
+++ b/app/routers/credit.py
@@ -4,7 +4,8 @@ Endpoints for managing credit sales — payment registration, history, and open-
 
 Issue: https://github.com/uno0uno/warocol.com/issues/294
 """
-from fastapi import APIRouter, Request, Query
+from fastapi import Depends, APIRouter, Request, Query
+from app.core.permissions import Module, require_module
 from typing import Optional
 from uuid import UUID
 from decimal import Decimal
@@ -22,7 +23,7 @@ class RegisterCreditPaymentRequest(BaseModel):
     payment_date: Optional[date] = Field(None, description="Payment date (defaults to now)")
 
 
-@router.post("/orders/{order_id}/payments")
+@router.post("/orders/{order_id}/payments", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def register_payment(
     request: Request,
     order_id: UUID,
@@ -47,7 +48,7 @@ async def register_payment(
     )
 
 
-@router.get("/orders/{order_id}/payments")
+@router.get("/orders/{order_id}/payments", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_payments(
     request: Request,
     order_id: UUID,
@@ -59,7 +60,7 @@ async def get_payments(
     return await credit_service.get_credit_payments(request, order_id)
 
 
-@router.get("/")
+@router.get("/", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def list_open_credits(
     request: Request,
     limit: int = Query(50, ge=1, le=200),

--- a/app/routers/expenses.py
+++ b/app/routers/expenses.py
@@ -1,18 +1,15 @@
-from fastapi import APIRouter, Request, Response, HTTPException, Query, File, UploadFile, Form
+from fastapi import Depends, APIRouter, Request, Response, Query, File, UploadFile
+from app.core.permissions import Module, require_module
 from uuid import UUID
 from typing import Optional, List
 from app.services.expenses_service import (
     get_expense_categories,
     get_expenses_list,
     get_expense_by_id,
-    create_expense,
-    update_expense,
     delete_expense,
     get_expense_history,
     get_recurring_instances,
     get_recurring_instance_by_id,
-    create_recurring_instance,
-    update_recurring_instance,
     upload_instance_attachments,
     delete_instance_attachment
 )
@@ -28,7 +25,7 @@ from app.models.expense import (
 
 router = APIRouter()
 
-@router.get("/categories", response_model=ExpenseCategoriesResponse)
+@router.get("/categories", response_model=ExpenseCategoriesResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_categories_endpoint(
     request: Request,
     response: Response
@@ -38,7 +35,7 @@ async def get_categories_endpoint(
     """
     return await get_expense_categories(request, response)
 
-@router.get("", response_model=ExpensesListResponse)
+@router.get("", response_model=ExpensesListResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_expenses_endpoint(
     request: Request,
     response: Response,
@@ -56,7 +53,7 @@ async def get_expenses_endpoint(
         request, response, page, limit, month_year, category_id, search, expense_type
     )
 
-@router.get("/{expense_id}", response_model=ExpenseResponse)
+@router.get("/{expense_id}", response_model=ExpenseResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_expense_by_id_endpoint(
     expense_id: UUID,
     request: Request,
@@ -67,7 +64,7 @@ async def get_expense_by_id_endpoint(
     """
     return await get_expense_by_id(request, response, expense_id)
 
-@router.post("/{expense_id}/attachments")
+@router.post("/{expense_id}/attachments", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def upload_expense_attachments_endpoint(
     expense_id: UUID,
     request: Request,
@@ -80,7 +77,7 @@ async def upload_expense_attachments_endpoint(
     from app.services.expenses_service import upload_expense_attachments
     return await upload_expense_attachments(request, response, expense_id, files)
 
-@router.post("", response_model=ExpenseResponse)
+@router.post("", response_model=ExpenseResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def create_expense_endpoint(
     expense_data: ExpenseCreate,
     request: Request,
@@ -93,7 +90,7 @@ async def create_expense_endpoint(
     from app.services.expenses_service import create_expense_json
     return await create_expense_json(request, response, expense_data)
 
-@router.put("/{expense_id}", response_model=ExpenseResponse)
+@router.put("/{expense_id}", response_model=ExpenseResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def update_expense_endpoint(
     expense_id: UUID,
     expense_data: ExpenseUpdate,
@@ -107,7 +104,7 @@ async def update_expense_endpoint(
     from app.services.expenses_service import update_expense_json
     return await update_expense_json(request, response, expense_id, expense_data)
 
-@router.delete("/{expense_id}")
+@router.delete("/{expense_id}", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def delete_expense_endpoint(
     expense_id: UUID,
     request: Request,
@@ -118,7 +115,7 @@ async def delete_expense_endpoint(
     """
     return await delete_expense(request, response, expense_id)
 
-@router.get("/{expense_id}/history")
+@router.get("/{expense_id}/history", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_expense_history_endpoint(
     expense_id: UUID,
     request: Request,
@@ -129,7 +126,7 @@ async def get_expense_history_endpoint(
     """
     return await get_expense_history(request, response, expense_id)
 
-@router.get("/{expense_id}/instances")
+@router.get("/{expense_id}/instances", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_expense_instances_endpoint(
     expense_id: UUID,
     request: Request,
@@ -140,7 +137,7 @@ async def get_expense_instances_endpoint(
     """
     return await get_recurring_instances(request, response, expense_id)
 
-@router.get("/instances/{instance_id}")
+@router.get("/instances/{instance_id}", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_instance_by_id_endpoint(
     instance_id: UUID,
     request: Request,
@@ -151,7 +148,7 @@ async def get_instance_by_id_endpoint(
     """
     return await get_recurring_instance_by_id(request, response, instance_id)
 
-@router.post("/{expense_id}/instances")
+@router.post("/{expense_id}/instances", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def create_expense_instance_endpoint(
     expense_id: UUID,
     instance_data: RecurringExpenseInstanceCreate,
@@ -167,7 +164,7 @@ async def create_expense_instance_endpoint(
         request, response, expense_id, instance_data
     )
 
-@router.put("/instances/{instance_id}")
+@router.put("/instances/{instance_id}", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def update_expense_instance_endpoint(
     instance_id: UUID,
     instance_data: RecurringExpenseInstanceUpdate,
@@ -182,7 +179,7 @@ async def update_expense_instance_endpoint(
         request, response, instance_id, instance_data
     )
 
-@router.post("/instances/{instance_id}/attachments")
+@router.post("/instances/{instance_id}/attachments", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def upload_instance_attachments_endpoint(
     instance_id: UUID,
     request: Request,
@@ -196,7 +193,7 @@ async def upload_instance_attachments_endpoint(
         request, response, instance_id, files
     )
 
-@router.delete("/instances/attachments/{attachment_id}")
+@router.delete("/instances/attachments/{attachment_id}", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def delete_instance_attachment_endpoint(
     attachment_id: UUID,
     request: Request,

--- a/app/routers/financial.py
+++ b/app/routers/financial.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Request, Response, Query
+from fastapi import Depends, APIRouter, Request, Response, Query
+from app.core.permissions import Module, require_module
 from datetime import datetime
 from typing import Optional
 from app.services.financial_service import get_tir_metrics, get_products_analysis, get_obstacles_analysis
@@ -6,7 +7,7 @@ from app.models.financial import TirMetricsResponse
 
 router = APIRouter()
 
-@router.get("/tir-metrics", response_model=TirMetricsResponse)
+@router.get("/tir-metrics", response_model=TirMetricsResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_tir_metrics_endpoint(
     request: Request, 
     response: Response,
@@ -23,7 +24,7 @@ async def get_tir_metrics_endpoint(
         timestamp=datetime.now()
     )
 
-@router.get("/products-analysis")
+@router.get("/products-analysis", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def products_analysis_endpoint(
     request: Request, 
     response: Response,
@@ -43,7 +44,7 @@ async def products_analysis_endpoint(
         "timestamp": datetime.now().isoformat()
     }
 
-@router.get("/obstacles-analysis")
+@router.get("/obstacles-analysis", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def obstacles_analysis_endpoint(
     request: Request, 
     response: Response,

--- a/app/routers/payment_methods.py
+++ b/app/routers/payment_methods.py
@@ -19,52 +19,49 @@ from app.models.payment_method import (
 finanzas_router = APIRouter(prefix="/finanzas/metodos-pago", tags=["payment-methods"])
 
 
-@finanzas_router.get("/grupos")
+@finanzas_router.get("/grupos", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def list_groups(request: Request):
     """List all payment method groups visible to the tenant (global defaults + custom)."""
     return await payment_method_service.list_groups(request)
 
 
-@finanzas_router.post("/grupos")
+@finanzas_router.post("/grupos", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def create_group(request: Request, body: CreateGroupRequest):
     """Create a custom payment method group for the tenant."""
     return await payment_method_service.create_group(request, body)
 
 
-@finanzas_router.patch("/grupos/{group_id}")
+@finanzas_router.patch("/grupos/{group_id}", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def patch_group(request: Request, group_id: UUID, body: PatchGroupRequest):
     """Update a custom group's name, sort_order, is_active, or triggers_cartera. Returns 403 for defaults."""
     return await payment_method_service.patch_group(request, group_id, body)
 
 
-@finanzas_router.get("")
+@finanzas_router.get("", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def list_methods(request: Request):
     """List all payment methods (subtypes) for the tenant."""
     return await payment_method_service.list_methods(request)
 
 
-@finanzas_router.post("")
+@finanzas_router.post("", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def create_method(request: Request, body: CreateMethodRequest):
     """Create a payment method (subtype) under a group."""
     return await payment_method_service.create_method(request, body)
 
 
-@finanzas_router.patch("/{method_id}")
+@finanzas_router.patch("/{method_id}", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def patch_method(request: Request, method_id: UUID, body: PatchMethodRequest):
     """Update a payment method's name, group, sort_order, or is_active."""
     return await payment_method_service.patch_method(request, method_id, body)
 
 
-@finanzas_router.delete("/{method_id}")
+@finanzas_router.delete("/{method_id}", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def delete_method(request: Request, method_id: UUID):
     """Soft delete a payment method (sets is_active = false)."""
     return await payment_method_service.delete_method(request, method_id)
 
 
 # ── POS read-only endpoint ─────────────────────────────────────────────────────
-# NOTE: finanzas_router endpoints above stay UNGATED in this PR — they get
-# Depends(require_module(Module.FINANZAS)) in E2.10 (#198). This file gets
-# touched twice across the rollout, intentionally per the audit doc §3.
 pos_router = APIRouter(prefix="/pos/payment-methods", tags=["pos"])
 
 

--- a/app/routers/salaries.py
+++ b/app/routers/salaries.py
@@ -4,6 +4,7 @@ Handles employee salary configuration and payment registration
 """
 import logging
 from fastapi import APIRouter, Request, UploadFile, File, Form, HTTPException, Depends
+from app.core.permissions import Module, require_module
 from typing import List, Optional
 from uuid import UUID
 from decimal import Decimal
@@ -12,7 +13,6 @@ from app.services.salary_service import (
     get_employees_with_salary,
     get_employee_salary_detail,
     configure_employee_salary,
-    record_salary_payment,
     record_salary_payment_json,
     get_salary_payments,
     get_payment_detail,
@@ -84,7 +84,7 @@ router = APIRouter()
 # EMPLOYEES ENDPOINTS
 # =============================================================================
 
-@router.get("/employees", response_model=EmployeesWithSalaryResponse)
+@router.get("/employees", response_model=EmployeesWithSalaryResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_employees_endpoint(request: Request):
     """
     Get all employees with their salary configuration
@@ -93,7 +93,7 @@ async def get_employees_endpoint(request: Request):
     return await get_employees_with_salary(request)
 
 
-@router.get("/employees/{employee_id}", response_model=EmployeeDetailResponse)
+@router.get("/employees/{employee_id}", response_model=EmployeeDetailResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_employee_detail_endpoint(request: Request, employee_id: UUID):
     """
     Get employee detail with salary config and payment history
@@ -101,7 +101,7 @@ async def get_employee_detail_endpoint(request: Request, employee_id: UUID):
     return await get_employee_salary_detail(request, employee_id)
 
 
-@router.post("/employees/{employee_id}/config", response_model=SalaryConfigResponse)
+@router.post("/employees/{employee_id}/config", response_model=SalaryConfigResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def configure_salary_endpoint(
     request: Request,
     employee_id: UUID,
@@ -117,7 +117,7 @@ async def configure_salary_endpoint(
 # PAYMENTS ENDPOINTS
 # =============================================================================
 
-@router.post("/payments", response_model=SalaryPaymentResponse)
+@router.post("/payments", response_model=SalaryPaymentResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def record_payment_endpoint(
     request: Request,
     payment_data: SalaryPaymentCreate
@@ -129,7 +129,7 @@ async def record_payment_endpoint(
     return await record_salary_payment_json(request, payment_data)
 
 
-@router.get("/payments", response_model=SalaryPaymentsListResponse)
+@router.get("/payments", response_model=SalaryPaymentsListResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_payments_endpoint(
     request: Request,
     employee_id: Optional[UUID] = None,
@@ -149,7 +149,7 @@ async def get_payments_endpoint(
     )
 
 
-@router.get("/payments/{payment_id}")
+@router.get("/payments/{payment_id}", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_payment_detail_endpoint(request: Request, payment_id: UUID):
     """
     Get payment detail with attachments and employee info
@@ -157,7 +157,7 @@ async def get_payment_detail_endpoint(request: Request, payment_id: UUID):
     return await get_payment_detail(request, payment_id)
 
 
-@router.delete("/payments/{payment_id}")
+@router.delete("/payments/{payment_id}", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def delete_payment_endpoint(request: Request, payment_id: UUID):
     """
     Delete a salary payment
@@ -165,7 +165,7 @@ async def delete_payment_endpoint(request: Request, payment_id: UUID):
     return await delete_salary_payment(request, payment_id)
 
 
-@router.put("/payments/{payment_id}", response_model=SalaryPaymentResponse)
+@router.put("/payments/{payment_id}", response_model=SalaryPaymentResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def update_payment_endpoint(
     request: Request,
     payment_id: UUID,
@@ -199,7 +199,7 @@ async def update_payment_endpoint(
     )
 
 
-@router.get("/payments/{payment_id}/history")
+@router.get("/payments/{payment_id}/history", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_payment_history_endpoint(
     request: Request,
     payment_id: UUID
@@ -210,7 +210,7 @@ async def get_payment_history_endpoint(
     return await get_salary_payment_history(request, payment_id)
 
 
-@router.post("/payments/{payment_id}/attachments")
+@router.post("/payments/{payment_id}/attachments", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def upload_payment_attachments_endpoint(
     payment_id: UUID,
     request: Request,
@@ -224,7 +224,7 @@ async def upload_payment_attachments_endpoint(
     return await upload_salary_payment_attachments(request, payment_id, files, label=label)
 
 
-@router.delete("/payments/attachments/{attachment_id}")
+@router.delete("/payments/attachments/{attachment_id}", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def delete_payment_attachment_endpoint(
     request: Request,
     attachment_id: UUID
@@ -239,7 +239,7 @@ async def delete_payment_attachment_endpoint(
 # PRIMA DE SERVICIOS ENDPOINTS
 # =============================================================================
 
-@router.post("/employees/{member_id}/prima", response_model=PrimaPaymentResponse)
+@router.post("/employees/{member_id}/prima", response_model=PrimaPaymentResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def post_prima_payment_endpoint(
     request: Request,
     member_id: UUID,
@@ -255,7 +255,7 @@ async def post_prima_payment_endpoint(
     return await record_prima_payment(request, member_id, data)
 
 
-@router.get("/employees/{member_id}/prima", response_model=PrimaPaymentListResponse)
+@router.get("/employees/{member_id}/prima", response_model=PrimaPaymentListResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_prima_payments_endpoint(
     request: Request,
     member_id: UUID,
@@ -270,7 +270,7 @@ async def get_prima_payments_endpoint(
 # CESANTÍAS ENDPOINTS
 # =============================================================================
 
-@router.post("/employees/{member_id}/cesantias", response_model=CesantiasPaymentResponse)
+@router.post("/employees/{member_id}/cesantias", response_model=CesantiasPaymentResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def post_cesantias_payment_endpoint(
     request: Request,
     member_id: UUID,
@@ -286,7 +286,7 @@ async def post_cesantias_payment_endpoint(
     return await record_cesantias_payment(request, member_id, data)
 
 
-@router.get("/employees/{member_id}/cesantias", response_model=CesantiasPaymentListResponse)
+@router.get("/employees/{member_id}/cesantias", response_model=CesantiasPaymentListResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_cesantias_payments_endpoint(
     request: Request,
     member_id: UUID,
@@ -301,7 +301,7 @@ async def get_cesantias_payments_endpoint(
 # INTERESES SOBRE CESANTÍAS ENDPOINTS
 # =============================================================================
 
-@router.post("/employees/{member_id}/int-cesantias", response_model=IntCesantiasPaymentResponse)
+@router.post("/employees/{member_id}/int-cesantias", response_model=IntCesantiasPaymentResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def post_int_cesantias_payment_endpoint(
     request: Request,
     member_id: UUID,
@@ -317,7 +317,7 @@ async def post_int_cesantias_payment_endpoint(
     return await record_int_cesantias_payment(request, member_id, data)
 
 
-@router.get("/employees/{member_id}/int-cesantias", response_model=IntCesantiasPaymentListResponse)
+@router.get("/employees/{member_id}/int-cesantias", response_model=IntCesantiasPaymentListResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_int_cesantias_payments_endpoint(
     request: Request,
     member_id: UUID,
@@ -332,7 +332,7 @@ async def get_int_cesantias_payments_endpoint(
 # VACACIONES ENDPOINTS
 # =============================================================================
 
-@router.post("/employees/{member_id}/vacaciones", response_model=VacacionesPaymentResponse)
+@router.post("/employees/{member_id}/vacaciones", response_model=VacacionesPaymentResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def post_vacaciones_payment_endpoint(
     request: Request,
     member_id: UUID,
@@ -345,7 +345,7 @@ async def post_vacaciones_payment_endpoint(
     return await record_vacaciones_payment(request, member_id, data)
 
 
-@router.get("/employees/{member_id}/vacaciones", response_model=VacacionesPaymentListResponse)
+@router.get("/employees/{member_id}/vacaciones", response_model=VacacionesPaymentListResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_vacaciones_payments_endpoint(
     request: Request,
     member_id: UUID,
@@ -356,7 +356,7 @@ async def get_vacaciones_payments_endpoint(
     return await get_vacaciones_payments(request, member_id)
 
 
-@router.post("/employees/{member_id}/dotacion", response_model=DotacionPaymentResponse)
+@router.post("/employees/{member_id}/dotacion", response_model=DotacionPaymentResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def post_dotacion_payment_endpoint(
     request: Request,
     member_id: UUID,
@@ -372,7 +372,7 @@ async def post_dotacion_payment_endpoint(
     return await record_dotacion_payment(request, member_id, data)
 
 
-@router.get("/employees/{member_id}/dotacion", response_model=DotacionPaymentListResponse)
+@router.get("/employees/{member_id}/dotacion", response_model=DotacionPaymentListResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_dotacion_payments_endpoint(
     request: Request,
     member_id: UUID,
@@ -387,7 +387,7 @@ async def get_dotacion_payments_endpoint(
 # PILA ENDPOINTS
 # =============================================================================
 
-@router.get("/pila/pending", response_model=PilaPendingResponse)
+@router.get("/pila/pending", response_model=PilaPendingResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_pila_pending_endpoint(request: Request):
     """
     Return periods with net positive SS liability in accounts 237005 and 237010.
@@ -396,7 +396,7 @@ async def get_pila_pending_endpoint(request: Request):
     return await get_pila_pending(request)
 
 
-@router.post("/pila", response_model=PilaPaymentResponse)
+@router.post("/pila", response_model=PilaPaymentResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def post_pila_payment_endpoint(
     request: Request,
     data: PilaPaymentCreate,
@@ -409,7 +409,7 @@ async def post_pila_payment_endpoint(
     return await record_pila_payment(request, data)
 
 
-@router.get("/pila", response_model=PilaPaymentListResponse)
+@router.get("/pila", response_model=PilaPaymentListResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_pila_payments_endpoint(request: Request):
     """
     List all PILA payments for the tenant, ordered by payment_date DESC.
@@ -421,7 +421,7 @@ async def get_pila_payments_endpoint(request: Request):
 # OVERTIME (HORAS EXTRAS) ENDPOINTS
 # =============================================================================
 
-@router.post("/employees/{member_id}/horas-extras", response_model=OvertimePaymentResponse)
+@router.post("/employees/{member_id}/horas-extras", response_model=OvertimePaymentResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def post_overtime_payment_endpoint(
     request: Request,
     member_id: UUID,
@@ -436,7 +436,7 @@ async def post_overtime_payment_endpoint(
     return await record_overtime_payment(request, member_id, data)
 
 
-@router.get("/employees/{member_id}/horas-extras", response_model=OvertimePaymentListResponse)
+@router.get("/employees/{member_id}/horas-extras", response_model=OvertimePaymentListResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_overtime_payments_endpoint(
     request: Request,
     member_id: UUID,
@@ -451,7 +451,7 @@ async def get_overtime_payments_endpoint(
 # LIQUIDACIÓN DE CONTRATO ENDPOINTS
 # =============================================================================
 
-@router.post("/employees/{member_id}/liquidacion/calculate", response_model=LiquidacionCalculateResponse)
+@router.post("/employees/{member_id}/liquidacion/calculate", response_model=LiquidacionCalculateResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def calculate_liquidacion_endpoint(
     request: Request,
     member_id: UUID,
@@ -464,7 +464,7 @@ async def calculate_liquidacion_endpoint(
     return await calculate_liquidacion(request, member_id, data)
 
 
-@router.post("/employees/{member_id}/liquidacion", response_model=LiquidacionResponse)
+@router.post("/employees/{member_id}/liquidacion", response_model=LiquidacionResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def record_liquidacion_endpoint(
     request: Request,
     member_id: UUID,
@@ -478,7 +478,7 @@ async def record_liquidacion_endpoint(
     return await record_liquidacion(request, member_id, data)
 
 
-@router.get("/employees/{member_id}/liquidacion", response_model=LiquidacionResponse)
+@router.get("/employees/{member_id}/liquidacion", response_model=LiquidacionResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_liquidacion_endpoint(
     request: Request,
     member_id: UUID,

--- a/docs/permissions-router-mapping.md
+++ b/docs/permissions-router-mapping.md
@@ -23,7 +23,7 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 
 | router_file | mount_prefix | endpoints | module | auth_today | notes |
 |---|---|---|---|---|---|
-| `accounting.py` | `/accounting` | 13 | **FINANZAS** | session | Chart of accounts CRUD, balance, P&L |
+| `accounting.py` | `/accounting` | 13 | **FINANZAS** | session | DONE en #198. Chart of accounts CRUD, balance, P&L |
 | `address_profile.py` | `/online/addresses` | 6 | **public** | none | Direcciones de delivery (clientes online) |
 | `admin_ingredients.py` | `/admin/ingredients` | 6 | **ABASTECIMIENTO** | session | Catálogo global de ingredientes |
 | `analytics.py` | `/analytics` | 6 | **ANALITICA** | session | Dashboard analítico, alertas |
@@ -31,18 +31,18 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 | `articles.py` | `/blog` | 3 | **public** | none | Blog público (lista + detalle) |
 | `auth.py` | `/auth` | 7 | **skip** | none | Login/sesión — corre SIN sesión |
 | `billing.py` | `/billing` | 10 | **MI_PLAN** | mixed | DONE en #185. Webhook + cron skip con `# NOTE:` |
-| `cartera.py` | `/cartera` | 4 | **FINANZAS** | session | Cartera (cuentas por cobrar) |
+| `cartera.py` | `/cartera` | 4 | **FINANZAS** | session | DONE en #198. Cartera (cuentas por cobrar) |
 | `categories.py` | `/menu/categories` | 2 | **MENU** | session | Listado con filtro global+tenant |
-| `cierre.py` | `/cierre` | 9 | **FINANZAS** | session | Cierre X/Z diario |
+| `cierre.py` | `/cierre` | 9 | **FINANZAS** | session | DONE en #198. Cierre X/Z diario |
 | `comandas.py` | `/api/comandas` | 11 | **POS** | session | KDS lifecycle. ⚠️ KDS-public paths via `?token=` middleware quedan sin gate (ver §1) |
 | `combos.py` | `/menu/combos` | 6 | **MENU** | session | Combo CRUD |
-| `credit.py` | `/credit` | 3 | **FINANZAS** | session | Pagos a crédito |
+| `credit.py` | `/credit` | 3 | **FINANZAS** | session | DONE en #198. Pagos a crédito |
 | `customer_portal.py` | `/customer` | 7 | **public** | none | Portal del cliente final (JWT customer, no sesión de operador) |
 | `customers.py` | `/customers` | 6 | **VENTAS** | session | Búsqueda + perfil de clientes (operador) |
 | `documents.py` | `/api/documents` | 4 | **FACTURACION** | session | Documentos electrónicos (lista, PDF/XML) |
-| `expenses.py` | `/finance/expenses` | 14 | **FINANZAS** | session | CRUD de gastos + categorías |
+| `expenses.py` | `/finance/expenses` | 14 | **FINANZAS** | session | DONE en #198. CRUD de gastos + categorías |
 | `facturacion.py` | `/api/acquirer + /api/facturacion + /api/payroll` | 3 | **FACTURACION** | session | 3 sub-routers (acquirer, catalog, payroll) — todos FACTURACION |
-| `financial.py` | (sin prefix) | 3 | **FINANZAS** | session | TIR, rentabilidad de productos |
+| `financial.py` | (sin prefix) | 3 | **FINANZAS** | session | DONE en #198. TIR, rentabilidad de productos |
 | `ingredient_purchase_units.py` | `/suppliers/ingredient-purchase-units` | 6 | **ABASTECIMIENTO** | session | Unidades de compra |
 | `ingredients.py` | `/suppliers/ingredients` | 10 | **ABASTECIMIENTO** | session | Custom ingredients + catálogo |
 | `inventory.py` | `/inventory` | 4 | **ABASTECIMIENTO** | session | Stock + ajustes |
@@ -56,14 +56,14 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 | `online_orders.py` | `/online/orders` | 4 | **VENTAS** | session | Operador gestiona pedidos online |
 | `online_verification.py` | `/online/otp` | 3 | **public** | none | OTP por email del cliente |
 | `orders.py` | `/orders` | 18 | **VENTAS** | session | Dashboard de ventas, métricas |
-| `payment_methods.py` | `/finanzas/metodos-pago + /pos/payment-methods` | 10 | **mixed** | session | Split: finanzas_router (FINANZAS) + pos_router (POS read-only) — ver §3 |
+| `payment_methods.py` | `/finanzas/metodos-pago + /pos/payment-methods` | 10 | **mixed** | session | DONE: finanzas_router → FINANZAS en #198 (7 endpoints); pos_router → POS en #188 (1 endpoint). Ver §3 |
 | `pos_cart.py` | `/pos/cart` | 11 | **POS** | session | Carrito POS, checkout |
 | `products.py` | `/menu/products` | 7 | **MENU** | session | Producto CRUD + receta + imagen |
 | `public_api.py` | `/v1` | 25 | **INTEGRACIONES** | api_key | API pública con API key (clientes externos) |
 | `public_restaurant.py` | `/public/restaurant` | 4 | **public** | none | Lista + detalle por slug |
 | `purchases.py` | `/suppliers/purchases` | 26 | **ABASTECIMIENTO** | session | Compras + estados + factura |
 | `recipe_bases.py` | `/menu/recipe-bases` | 5 | **MENU** | session | Templates de receta |
-| `salaries.py` | `/salaries` | 29 | **FINANZAS** | session | Nómina + prima + cesantías + PILA |
+| `salaries.py` | `/salaries` | 29 | **FINANZAS** | session | DONE en #198 (router más grande del Epic). Nómina + prima + cesantías + PILA |
 | `stations.py` | `/api/stations` | 15 | **OPERACIONES** | session | Estaciones de cocina + routing. ⚠️ KDS-token endpoints sin gate (ver §1) |
 | `supplier_portal.py` | `/supplier-portal` | 8 | **public** | token | Portal del proveedor (token, no sesión) |
 | `suppliers.py` | `/suppliers/providers` | 10 | **ABASTECIMIENTO** | session | Proveedor CRUD |
@@ -90,7 +90,7 @@ Total: **51 routers**, **~394 endpoints** (was 52/395 before #187 deleted `admin
 | **OPERACIONES** | stations + tenant_config (operaciones part) | 1+1 | E2.7 (#191) — pending |
 | **ABASTECIMIENTO** | admin_ingredients, ingredient_purchase_units, ingredients, inventory, purchases, suppliers | 6 | E2.8 (#195) — pending |
 | **ANALITICA** | analytics | 1 | E2.9 (#193) — pending |
-| **FINANZAS** | accounting, cartera, cierre, credit, expenses, financial, salaries + payment_methods/finanzas | 7+1 | E2.10 (#198) — pending |
+| **FINANZAS** | accounting, cartera, cierre, credit, expenses, financial, salaries + payment_methods/finanzas | 7+1 | ✅ E2.10 (#198) — DONE (82 endpoints gated; largest batch in Epic) |
 | **FACTURACION** | documents, facturacion (3 sub-routers), invoices, support_documents | 4 | E2.11 (#194) — pending |
 | **EQUIPO** | invitations (excl. /accept), tenants | 2 | E2.12 (#196) — pending |
 | **INTEGRACIONES** | api_tokens, public_api, v1_ordering | 3 | E2.13 (#197) — pending |
@@ -148,13 +148,13 @@ finanzas_router = APIRouter(prefix="/finanzas/metodos-pago", ...)  # 7 endpoints
 pos_router      = APIRouter(prefix="/pos/payment-methods", ...)    # 1 endpoint
 ```
 
-Both are mounted in `main.py`. Wiring strategy:
+Both are mounted in `main.py`. Wiring done:
 
-- `finanzas_router` → `Depends(require_module(Module.FINANZAS))` → goes in **E2.10** (#198).
-- `pos_router` → `Depends(require_module(Module.POS))` → goes in **E2.3** (#188).
+- ✅ `finanzas_router` → `Depends(require_module(Module.FINANZAS))` → **E2.10** (#198), all 7 endpoints.
+- ✅ `pos_router` → `Depends(require_module(Module.POS))` → **E2.3** (#188), 1 endpoint.
 
 Easier than splitting per-endpoint because the file already separates them
-into distinct router objects.
+into distinct router objects. Regression test in `tests/test_finanzas_permissions.py::test_cashier_role_passes_pos_router_under_enforce_regression` guards against accidental rewrites of the POS gate by future FINANZAS bulk-regex passes.
 
 ## §4. `tenant_config.py` — endpoint-level split required
 
@@ -231,6 +231,25 @@ flows. Alternatives considered:
 
 **Decision applied:** classify as POS. Revisit during shadow-mode rollout if
 logs show kitchen / supervisor roles being denied for legitimate use.
+
+## §8. FINANZAS caveats from #198
+
+Two decisions intentionally NOT made in E2.10 (#198):
+
+1. **SUPERVISOR does not have FINANZAS** in the matrix (`app/core/permissions.py:99-108`).
+   The issue body of #198 says "FINANZAS defaults to admin/supervisor", but the matrix
+   on `main` is the source of truth: only OWNER and ADMIN hold FINANZAS today. After
+   #198 merge, a SUPERVISOR session hitting any FINANZAS endpoint → 403. If product
+   later decides supervisors need read access (e.g. cierre dashboard), open a separate
+   issue and add `Module.FINANZAS` to `Role.SUPERVISOR` defaults — single-line matrix
+   change, no router edits required.
+
+2. **Salaries owner-only is a follow-up**, not part of #198. The issue body suggests
+   that creating / modifying salary configuration (`POST /salaries/employees/{id}/config`,
+   `POST /salaries/payments`, etc.) should be owner-only — not admin. That requires
+   per-endpoint `require_role(Role.OWNER)` style restrictions inside the salaries router,
+   which is a different mechanism than module gating. Track separately after shadow logs
+   surface any admin/supervisor activity on salary endpoints.
 
 ---
 

--- a/tests/test_finanzas_permissions.py
+++ b/tests/test_finanzas_permissions.py
@@ -1,0 +1,136 @@
+"""End-to-end smoke tests for FINANZAS group endpoints under require_module(FINANZAS).
+
+Sub-task E2.10 of Epic 2 (#198). Validates that:
+1. Owner role under enforce reaches the handler.
+2. Cashier role under enforce gets 403 (cashier lacks FINANZAS in default matrix).
+3. Regression guard: payment_methods.pos_router still works under POS module
+   for cashier role (proves the bulk regex did not accidentally rewrite the POS
+   gate at app/routers/payment_methods.py:68).
+
+Uses `accounting.py` as the representative FINANZAS router (largest after salaries).
+Pattern follows `tests/test_ventas_permissions.py` (#189 reference impl).
+"""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.core.permissions import Module
+from app.routers.accounting import router as accounting_router
+from app.routers.payment_methods import pos_router as payment_methods_pos_router
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_session(role):
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": role,
+    })
+
+
+def _enforce_db_ctx():
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+    return _ctx
+
+
+# ─── Tests ────────────────────────────────────────────────────────────
+
+
+def test_owner_role_passes_finanzas_endpoint_under_enforce():
+    """Owner reaches GET /accounting/accounts under enforce — dependency permits."""
+    session = _build_session(role="owner")
+    app = FastAPI()
+    app.include_router(accounting_router, prefix="/accounting")
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.routers.accounting.get_accounts",
+             new=AsyncMock(return_value={"success": True, "data": []}),
+         ):
+        client = TestClient(app)
+        response = client.get("/accounting/accounts")
+
+    # Handler reached → dependency permitted owner.
+    assert response.status_code == 200
+
+
+def test_cashier_role_denied_finanzas_endpoint_under_enforce():
+    """Cashier role hits 403 on FINANZAS — cashier holds only POS+VENTAS in matrix."""
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(accounting_router, prefix="/accounting")
+
+    cashier_modules = frozenset({Module.POS, Module.VENTAS})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ):
+        client = TestClient(app)
+        response = client.get("/accounting/accounts")
+
+    assert response.status_code == 403
+    assert "finanzas" in response.json()["detail"].lower()
+
+
+def test_cashier_role_passes_pos_router_under_enforce_regression():
+    """Regression guard: cashier still passes payment_methods.pos_router (POS module).
+
+    The bulk regex in this PR targeted `@finanzas_router.*` only. This test confirms
+    `@pos_router.get("", dependencies=[Depends(require_module(Module.POS))])` at
+    app/routers/payment_methods.py:68 still carries Module.POS — i.e. the regex
+    did not accidentally rewrite it.
+    """
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(payment_methods_pos_router)
+
+    cashier_modules = frozenset({Module.POS, Module.VENTAS})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ), \
+         patch(
+             "app.routers.payment_methods.payment_method_service.list_pos_methods",
+             new=AsyncMock(return_value={"success": True, "data": []}),
+         ):
+        client = TestClient(app)
+        response = client.get("/pos/payment-methods")
+
+    # If the regex had rewritten this decorator to FINANZAS, cashier would 403.
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary

Sub-task **E2.10** of Epic 2 (#164). Gates **82 endpoints** across **7 routers + 1 sub-router** under `Module.FINANZAS` — the **largest batch in the Epic** (62% bigger than ABASTECIMIENTO's #195).

| Router | Endpoints | Prefix |
|---|---:|---|
| `accounting.py` | 13 | `/accounting` |
| `cartera.py` | 4 | `/cartera` |
| `cierre.py` | 9 | `/cierre` |
| `credit.py` | 3 | `/credit` |
| `expenses.py` | 14 | `/finance/expenses` |
| `financial.py` | 3 | `/finance` |
| **`salaries.py`** | **29** | `/salaries` (largest single router in Epic) |
| `payment_methods.py` — `finanzas_router` only | 7 | `/finanzas/metodos-pago` |
| **TOTAL** | **82** | — |

`payment_methods.pos_router` (1 endpoint, `/pos/payment-methods`) was already gated `Module.POS` in #188 — untouched by this PR. A dedicated regression test guards against accidental rewrites by future bulk-regex passes.

## Stack
🔵 FastAPI

## Changes
- 8 router files — added `Depends(require_module(Module.FINANZAS))` to every `@router.*` (and `@finanzas_router.*` in `payment_methods.py`) decorator
- `tests/test_finanzas_permissions.py` — 3 tests (owner-allow, cashier-deny, POS regression guard)
- `docs/permissions-router-mapping.md` — rows marked DONE, §3 updated, **new §8** documents two intentional non-decisions
- Drive-by ruff auto-fix: 7 pre-existing unused imports removed (expenses.py + salaries.py)

## Two intentional non-decisions (audit doc §8)

1. **SUPERVISOR FINANZAS gap** — Issue body says "FINANZAS defaults to admin/supervisor" but the matrix on `main` only grants OWNER+ADMIN. Matrix is the source of truth → SUPERVISOR sessions will 403 on FINANZAS endpoints after merge. Single-line matrix change if product later needs supervisor read access.
2. **Salaries owner-only** — Issue body suggests stricter rules for salary creation/modification. Out of scope (different mechanism than module gating). Track via shadow logs post-merge.

## Testing
- `python3 -m pytest tests/test_finanzas_permissions.py tests/test_pos_permissions.py tests/test_ventas_permissions.py tests/test_billing_permissions.py -v` → **10/10 pass** (3 new + 7 regression)
- `ruff check` on all modified files → **clean**
- `python3 -m py_compile` on all 8 files → **all OK**
- `python3 -c "from app.main import app"` → loads OK

## Verification
- `grep -c "Module.FINANZAS"` per file = exactly the expected count (13/4/9/3/14/3/29/7 = 82 total)
- `@pos_router.get` decorator at `payment_methods.py:68` retains `Module.POS` (regression test validates)

Closes #198