### PR TITLE
feat(permissions): add GET /me/access endpoint surfacing role + modules + enforcement_mode (#200)

### DIFF
--- a/app/core/permissions.py
+++ b/app/core/permissions.py
@@ -251,7 +251,7 @@ _shadow_logger = logging.getLogger("permissions.shadow")
 VALID_MODES = frozenset({"disabled", "shadow", "enforce"})
 
 
-async def _get_enforcement_mode(tenant_id: UUID) -> str:
+async def get_enforcement_mode(tenant_id: UUID) -> str:
     """Resolve `tenants.permissions_enforcement_mode` for a tenant.
 
     Cached for 60s. Defaults to `'disabled'` if the row is missing or the
@@ -362,7 +362,7 @@ def require_module(module: Module) -> Callable[[Request], Awaitable[None]]:
         if not tenant_id:
             return  # no tenant resolved → cannot gate; let handler decide
 
-        mode = await _get_enforcement_mode(tenant_id)
+        mode = await get_enforcement_mode(tenant_id)
         if mode == "disabled":
             return
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, combos, ingredient_purchase_units, customers, pos_cart, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, tenant_config, online_cart, online_verification, address_profile, analytics, online_orders, notifications, customer_portal, leads, waros, billing, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
+from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, combos, ingredient_purchase_units, customers, pos_cart, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, tenant_config, online_cart, online_verification, address_profile, analytics, online_orders, notifications, customer_portal, leads, waros, billing, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
 from app.config import settings
 from app.core.logging import setup_logging
 from app.core.exceptions import api_exception_handler, general_exception_handler, APIError
@@ -154,6 +154,7 @@ app.middleware("http")(session_validation_middleware)
 
 # Include API routers
 app.include_router(auth.router, prefix="/auth", tags=["auth"])
+app.include_router(me.router, prefix="/me", tags=["me"])
 app.include_router(tenants.router, prefix="/tenants", tags=["tenants"])
 app.include_router(financial.router, prefix="/finance", tags=["financial"])
 app.include_router(ingredients.router, prefix="/suppliers/ingredients", tags=["ingredients"])

--- a/app/models/me.py
+++ b/app/models/me.py
@@ -1,0 +1,21 @@
+from typing import List, Optional
+from pydantic import BaseModel
+
+
+class AccessResponse(BaseModel):
+    """Effective access map for the current session.
+
+    Drives Epic 4 frontend sidebar / route gating. Surfaces three things
+    derived from the session and tenant configuration:
+
+    - `role`: the user's role string in the active tenant (None if the user
+      has no membership row yet — e.g. fresh-tenant owner pre-bootstrap,
+      KDS-token synthetic session).
+    - `modules`: sorted list of module string values the user can access,
+      already accounting for tenant-specific overrides.
+    - `enforcement_mode`: the tenant's current permissions mode, one of
+      'disabled' | 'shadow' | 'enforce'.
+    """
+    role: Optional[str] = None
+    modules: List[str] = []
+    enforcement_mode: str = "disabled"

--- a/app/routers/me.py
+++ b/app/routers/me.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends, Request
+from app.core.middleware import SessionContext, require_valid_session
+from app.core.permissions import get_enforcement_mode, get_role_modules
+from app.models.me import AccessResponse
+
+router = APIRouter()
+
+
+@router.get("/access", response_model=AccessResponse)
+async def get_my_access(
+    request: Request,
+    session: SessionContext = Depends(require_valid_session),
+) -> AccessResponse:
+    """Return effective access map for the current session.
+
+    Drives Epic 4 frontend sidebar / route gating. Always reachable by any
+    authenticated user — no Module gate on purpose: this endpoint IS the
+    source of truth for those gates and cannot gate itself.
+
+    Short-circuits when `session.tenant_id` or `session.role` is None so
+    edge-case sessions (fresh-tenant owners pre-membership, KDS-token
+    synthetic sessions) get a coherent empty-modules response instead of
+    a crash from `get_role_modules`.
+    """
+    if session.tenant_id is None:
+        return AccessResponse(
+            role=session.role,
+            modules=[],
+            enforcement_mode="disabled",
+        )
+
+    enforcement_mode = await get_enforcement_mode(session.tenant_id)
+
+    if session.role is None:
+        return AccessResponse(
+            role=None,
+            modules=[],
+            enforcement_mode=enforcement_mode,
+        )
+
+    modules = await get_role_modules(session.tenant_id, session.role)
+    return AccessResponse(
+        role=session.role,
+        modules=sorted(m.value for m in modules),
+        enforcement_mode=enforcement_mode,
+    )

--- a/docs/permissions-router-mapping.md
+++ b/docs/permissions-router-mapping.md
@@ -19,7 +19,7 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 
 ---
 
-## Authoritative Table — 51 routers
+## Authoritative Table — 52 routers
 
 | router_file | mount_prefix | endpoints | module | auth_today | notes |
 |---|---|---|---|---|---|
@@ -49,6 +49,7 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 | `invitations.py` | `/invitations` | 4 | **EQUIPO** | session | ⚠️ `/invitations/accept` es token-público (ver §2) |
 | `invoices.py` | `/api/invoices` | 4 | **FACTURACION** | session | Notas crédito/débito, RADIAN |
 | `leads.py` | `/leads` | 2 | **public** | none | Captura de leads (homepage) |
+| `me.py` | `/me` | 1 | **skip** | session | DONE en #200. Endpoint público a usuarios autenticados — surfacing del propio access map (role + modules + enforcement_mode) para Epic 4 |
 | `menu.py` | `/menu` | 1 | **MENU** | session | Name-check genérico |
 | `modifiers.py` | `/menu/modifier-groups` | 6 | **MENU** | session | Grupos de modificadores |
 | `notifications.py` | `/notifications` | 4 | **POS** | session | Notificaciones operador (SSE) — ver ambigüedad en §7 |
@@ -79,7 +80,7 @@ wired against this catalog was `billing.py` in #185 (E2.14, MI_PLAN).
 
 ## Coverage Summary
 
-Total: **51 routers**, **~394 endpoints** (was 52/395 before #187 deleted `admin_orders.py`).
+Total: **52 routers**, **~395 endpoints** (was 51/394 before #200 added `me.py`).
 
 | Module | Routers | Sub-task | Status |
 |---|---|---|---|
@@ -98,7 +99,7 @@ Total: **51 routers**, **~394 endpoints** (was 52/395 before #187 deleted `admin
 | **MI_NEGOCIO** | tenant_config (mi_negocio part) | 1 | E2.15 (#199) — pending |
 | **EVENTOS** | (no routers exist) | 0 | E2.16 (#200) — no-op |
 | **public** | address_profile, articles, customer_portal, leads, online_cart, online_verification, public_restaurant, supplier_portal | 8 | n/a — never gated |
-| **skip** | auth, webhooks | 2 | n/a — explicit exclusion |
+| **skip** | auth, me, webhooks | 3 | n/a — explicit exclusion (auth + webhooks pre-session; me surfaces own access map and cannot self-gate) |
 | **mixed (split-by-endpoint)** | payment_methods, tenant_config | 2 | split across two sub-tasks |
 
 ---

--- a/tests/test_billing_permissions.py
+++ b/tests/test_billing_permissions.py
@@ -91,7 +91,7 @@ def test_owner_role_passes_billing_under_enforce():
     @asynccontextmanager
     async def _enforce_db():
         conn = MagicMock()
-        # _get_enforcement_mode reads the first conn it gets — return 'enforce'.
+        # get_enforcement_mode reads the first conn it gets — return 'enforce'.
         conn.fetchval = AsyncMock(return_value="enforce")
         conn.fetchrow = AsyncMock(return_value=None)
         conn.fetch = AsyncMock(return_value=[])

--- a/tests/test_me_access.py
+++ b/tests/test_me_access.py
@@ -1,0 +1,190 @@
+"""Tests for GET /me/access — surfaces effective role + modules + enforcement_mode.
+
+Sub-task E2.17 of Epic 2 (#200). Validates that:
+1. Owner role under enforce reaches the handler and gets ALL modules.
+2. Cashier role returns only ["pos", "ventas"] (sorted).
+3. Session with role=None short-circuits to empty modules without crashing.
+4. Tenant with enforcement_mode='disabled' is reported correctly.
+5. Tenant with enforcement_mode='enforce' is reported correctly.
+6. Unauthenticated request returns 401 (require_valid_session raises).
+
+The endpoint itself is intentionally ungated by Module — it IS the source of
+truth for those gates and cannot gate itself. Tests confirm that no Module
+dependency stands between the caller and the response.
+"""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.core.permissions import Module
+from app.routers.me import router as me_router
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_session(role, tenant_id=None):
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": tenant_id or uuid4(),
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": role,
+    })
+
+
+def _mock_db_ctx(enforcement_mode="disabled"):
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value=enforcement_mode)
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+    return _ctx
+
+
+# ─── Tests ────────────────────────────────────────────────────────────
+
+
+def test_owner_returns_all_modules():
+    """Owner sees the full module set, sorted alphabetically."""
+    session = _build_session(role="owner")
+    app = FastAPI()
+    app.include_router(me_router, prefix="/me")
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.me.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_mock_db_ctx("disabled")):
+        client = TestClient(app)
+        response = client.get("/me/access")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["role"] == "owner"
+    # Owner gets every module in the enum, sorted.
+    expected = sorted(m.value for m in Module)
+    assert body["modules"] == expected
+    assert body["enforcement_mode"] == "disabled"
+
+
+def test_cashier_returns_pos_ventas_only():
+    """Cashier sees only [pos, ventas] per DEFAULT_ROLE_MODULES."""
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(me_router, prefix="/me")
+
+    cashier_modules = frozenset({Module.POS, Module.VENTAS})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.me.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_mock_db_ctx("disabled")), \
+         patch(
+             "app.routers.me.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ):
+        client = TestClient(app)
+        response = client.get("/me/access")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["role"] == "cashier"
+    assert body["modules"] == ["pos", "ventas"]
+
+
+def test_null_role_returns_empty_modules():
+    """Session with role=None (KDS-token, fresh tenant) returns empty modules without crash."""
+    session = _build_session(role=None)
+    app = FastAPI()
+    app.include_router(me_router, prefix="/me")
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.me.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_mock_db_ctx("shadow")):
+        client = TestClient(app)
+        response = client.get("/me/access")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["role"] is None
+    assert body["modules"] == []
+    # enforcement_mode still reported — tenant_id was present, only role was None.
+    assert body["enforcement_mode"] == "shadow"
+
+
+def test_enforcement_mode_disabled_reported():
+    """Tenant in 'disabled' mode reports it in the response."""
+    session = _build_session(role="admin")
+    app = FastAPI()
+    app.include_router(me_router, prefix="/me")
+
+    admin_modules = frozenset({Module.POS, Module.VENTAS, Module.FINANZAS})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.me.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_mock_db_ctx("disabled")), \
+         patch(
+             "app.routers.me.get_role_modules",
+             new=AsyncMock(return_value=admin_modules),
+         ):
+        client = TestClient(app)
+        response = client.get("/me/access")
+
+    assert response.status_code == 200
+    assert response.json()["enforcement_mode"] == "disabled"
+
+
+def test_enforcement_mode_enforce_reported():
+    """Tenant in 'enforce' mode reports it in the response."""
+    session = _build_session(role="admin")
+    app = FastAPI()
+    app.include_router(me_router, prefix="/me")
+
+    admin_modules = frozenset({Module.POS, Module.VENTAS, Module.FINANZAS})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.me.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_mock_db_ctx("enforce")), \
+         patch(
+             "app.routers.me.get_role_modules",
+             new=AsyncMock(return_value=admin_modules),
+         ):
+        client = TestClient(app)
+        response = client.get("/me/access")
+
+    assert response.status_code == 200
+    assert response.json()["enforcement_mode"] == "enforce"
+
+
+def test_unauthenticated_returns_401():
+    """No valid session → require_valid_session raises → 401."""
+    from app.core.exceptions import api_exception_handler, APIError
+
+    app = FastAPI()
+    app.add_exception_handler(APIError, api_exception_handler)
+    app.include_router(me_router, prefix="/me")
+
+    # Empty SessionContext is is_valid=False
+    empty_session = SessionContext()
+
+    with patch("app.core.middleware.get_session_context", return_value=empty_session):
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/me/access")
+
+    assert response.status_code == 401

--- a/tests/test_permissions_dependency.py
+++ b/tests/test_permissions_dependency.py
@@ -65,7 +65,7 @@ def _patch_get_session(session):
 
 
 def _patch_enforcement_mode(mode):
-    """Stub the DB call inside `_get_enforcement_mode` to return `mode`."""
+    """Stub the DB call inside `get_enforcement_mode` to return `mode`."""
     @asynccontextmanager
     async def _ctx():
         conn = MagicMock()


### PR DESCRIPTION
## Summary

Sub-task **E2.17** of Epic 2 (#164). Adds a single, small endpoint that gives the frontend everything it needs to drive sidebar visibility and route gating in Epic 4.

Frontend path: `GET /api/me/access` → Nuxt proxy strips `/api` → backend `GET /me/access`.

Response:
```json
{
  "role": "owner" | "admin" | "cashier" | "kitchen" | null,
  "modules": ["pos", "ventas", ...],
  "enforcement_mode": "disabled" | "shadow" | "enforce"
}
```

## Stack
🔵 FastAPI (Python 3.9 target, verified)

## Changes

| File | Type | What |
|---|---|---|
| `app/models/me.py` | new | `AccessResponse` pydantic model (`Optional[str]` / `List[str]` — Python 3.9 compat) |
| `app/routers/me.py` | new | `GET /access` endpoint with null-handling short-circuits |
| `app/main.py` | modify | Import + mount at `prefix=\"/me\"` |
| `app/core/permissions.py` | modify | Rename `_get_enforcement_mode` → `get_enforcement_mode` (public; second caller from another module) |
| `tests/test_me_access.py` | new | 6 tests (owner all modules / cashier pos+ventas / null role / disabled mode / enforce mode / 401 unauth) |
| `tests/test_billing_permissions.py` | modify | Cosmetic comment update for renamed helper |
| `tests/test_permissions_dependency.py` | modify | Cosmetic comment update for renamed helper |
| `docs/permissions-router-mapping.md` | modify | +1 row for `me.py`, totals 51→52, skip summary expanded |

## Design notes

- **No Module gate on this endpoint** — by design. It IS the source of truth for module gates and cannot gate itself. Documented in audit doc as `**skip**` alongside `auth` and `webhooks`.
- **Null `session.role` / `session.tenant_id` short-circuit** — fresh-tenant owners pre-membership and KDS-token synthetic sessions get a coherent empty-modules response instead of crashing `get_role_modules`.
- **Rename `_get_enforcement_mode` → `get_enforcement_mode`** — drive-by hygiene. The helper now has a caller from a different module (`me.py`), so the leading-underscore \"module-private\" convention no longer applies. Matches the public shape of `get_role_modules`.
- **Cached on the hot path** — both underlying helpers cache (300s / 60s respectively), so Epic 4 can call `/api/me/access` per page-load without DB pressure.

## Testing
- `python3 -m pytest tests/test_me_access.py tests/test_pos_permissions.py tests/test_ventas_permissions.py tests/test_billing_permissions.py tests/test_permissions_dependency.py -v` → **23/23 pass** (6 new + 17 regression)
- `ruff check` on all new/modified files → **clean**
- `python3 -m py_compile` on all new/modified files → **all OK**
- `python3 -c \"from app.main import app\"` → loads OK
- Endpoint registered: `/me/access` confirmed via app introspection

## No frontend changes in this PR

Epic 4 consumes `/api/me/access` next. Two existing readers of `/api/auth/session` (`composables/useDataQualityStatus.ts` + `pages/equipo/miembros.vue`) keep working — their migration to `/api/me/access` is Epic 4 scope.

Closes #200