### PR TITLE
feat(operaciones): waiter attribution foundation — toggle + default per table + history (warocol.com#573)

### DIFF
--- a/app/models/table_member_assignment.py
+++ b/app/models/table_member_assignment.py
@@ -1,0 +1,46 @@
+"""Pydantic models for the waiter-attribution family (warocol.com#573).
+
+Three shapes:
+- AssignMemberRequest: PATCH body for assigning a member to a table.
+- AssignmentHistoryEntry: one row from the history endpoint.
+- MemberSummary: lightweight member entry embedded in the aggregator
+  responses so cashiers/supervisors don't need access to the EQUIPO-gated
+  /tenants/members endpoint.
+"""
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class AssignMemberRequest(BaseModel):
+    """PATCH /api/operaciones/tables/{id}/assigned-member"""
+    member_id: Optional[UUID] = Field(
+        None,
+        description="Member UUID to assign as default waiter. NULL clears the assignment.",
+    )
+
+
+class MemberSummary(BaseModel):
+    """Lightweight member entry embedded in /api/{pos,operaciones}/restaurant-context."""
+    id: UUID
+    name: str
+    role: str
+
+
+class AssignmentHistoryEntry(BaseModel):
+    """One row in the GET /api/operaciones/tables/{id}/assignment-history response.
+
+    Snapshots (member_name, member_role) are taken at assignment time and
+    survive member deletion. `member_id` may be NULL if the member was
+    removed since (FK is ON DELETE SET NULL).
+    """
+    id: UUID
+    member_id: Optional[UUID] = None
+    member_name: Optional[str] = None
+    member_role: Optional[str] = None
+    assigned_at: datetime
+    unassigned_at: Optional[datetime] = None
+    assigned_by: Optional[UUID] = None
+    assigned_by_name: Optional[str] = None

--- a/app/models/tenant_public_profile.py
+++ b/app/models/tenant_public_profile.py
@@ -83,6 +83,15 @@ class TenantPublicProfileBase(BaseModel):
                     "without touching the KDS. Requires comandas_enabled=true."
     )
 
+    # Waiter attribution family feature flag (warocol.com#573)
+    waiter_attribution_enabled: bool = Field(
+        False,
+        description="When true, surfaces the waiter assignment family of features: "
+                    "admin panel in /operaciones/comandas (#573), POS mesa override "
+                    "(#574), and bar/counter order attribution (#575). Independent "
+                    "of tables_enabled — bar/counter modes work without tables."
+    )
+
 class TenantPublicProfileCreate(TenantPublicProfileBase):
     """Create tenant public profile"""
     tenant_id: UUID = Field(..., description="Tenant ID")
@@ -121,6 +130,7 @@ class TenantPublicProfileUpdate(BaseModel):
     kds_enabled: Optional[bool] = None
     auto_select_generic_enabled: Optional[bool] = None
     expediter_enabled: Optional[bool] = None
+    waiter_attribution_enabled: Optional[bool] = None
 
 class TenantPublicProfile(TenantPublicProfileBase):
     """Complete tenant public profile with all fields"""

--- a/app/routers/operaciones_context.py
+++ b/app/routers/operaciones_context.py
@@ -9,11 +9,15 @@ Five dedicated PATCH endpoints (one per toggle) — REST-friendly and easier
 to gate / observe than a single combined endpoint. The service layer's
 column whitelist guards against SQL injection.
 """
-from fastapi import APIRouter, Depends, HTTPException, Request
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 
 from app.core.middleware import require_valid_session
 from app.core.permissions import Module, require_module
+from app.models.table_member_assignment import AssignMemberRequest
+from app.services import table_assignments_service
 from app.services.operaciones_context_service import (
     get_operaciones_context,
     update_toggle,
@@ -92,4 +96,73 @@ async def toggle_auto_select_generic(request: Request, body: ToggleRequest):
     session = require_valid_session(request)
     return await update_toggle(
         session.tenant_id, "auto_select_generic_enabled", body.enabled
+    )
+
+
+# ── Waiter attribution family (warocol.com#573) ─────────────────────────
+
+@router.patch(
+    "/toggles/waiter-attribution",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def toggle_waiter_attribution_enabled(request: Request, body: ToggleRequest):
+    """Toggle `waiter_attribution_enabled` on the tenant profile.
+
+    Controls the visibility of the waiter assignment family of features
+    (admin panel here in #573, POS mesa override in #574, bar/counter
+    order attribution in #575).
+    """
+    session = require_valid_session(request)
+    return await update_toggle(
+        session.tenant_id, "waiter_attribution_enabled", body.enabled
+    )
+
+
+@router.patch(
+    "/tables/{table_id}/assigned-member",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def assign_member_to_table_endpoint(
+    request: Request,
+    table_id: UUID,
+    body: AssignMemberRequest,
+):
+    """Set or clear the default waiter for a table (warocol.com#573).
+
+    Atomic: closes the previous open period in the history table, opens
+    a new one with member snapshots, and updates the fast pointer on
+    `tables.assigned_member_id`. Rejects bar tables (400), unknown
+    tables/members (404), and when the feature flag is off (409).
+    """
+    session = require_valid_session(request)
+    return await table_assignments_service.assign_member_to_table(
+        tenant_id=session.tenant_id,
+        table_id=table_id,
+        member_id=body.member_id,
+        assigned_by_user_id=session.user_id,
+    )
+
+
+@router.get(
+    "/tables/{table_id}/assignment-history",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def get_table_assignment_history(
+    request: Request,
+    table_id: UUID,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+):
+    """Paginated history of waiter assignments for a table.
+
+    Most recent first. Includes denormalized snapshots of member name /
+    role so the response is correct even if the member was deleted
+    after the assignment.
+    """
+    session = require_valid_session(request)
+    return await table_assignments_service.get_assignment_history(
+        tenant_id=session.tenant_id,
+        table_id=table_id,
+        limit=limit,
+        offset=offset,
     )

--- a/app/services/operaciones_context_service.py
+++ b/app/services/operaciones_context_service.py
@@ -28,6 +28,7 @@ ALLOWED_TOGGLES = frozenset({
     "expediter_enabled",
     "tables_enabled",
     "auto_select_generic_enabled",
+    "waiter_attribution_enabled",  # warocol.com#573
 })
 
 
@@ -71,3 +72,22 @@ async def update_toggle(
         await conn.execute(query, tenant_id, enabled)
 
     return {"success": True, "data": {column_name: enabled}}
+
+
+async def assert_waiter_attribution_enabled(tenant_id: UUID) -> None:
+    """Raise 409 if `waiter_attribution_enabled` is False for this tenant.
+
+    Used by mutation endpoints in the waiter-attribution family
+    (warocol.com#573/#574/#575) to reject writes when the owner has the
+    feature disabled — even if the caller bypasses the UI gate.
+    """
+    async with get_db_connection(use_transaction=False) as conn:
+        row = await conn.fetchrow(
+            "SELECT waiter_attribution_enabled FROM tenant_public_profiles WHERE tenant_id = $1",
+            tenant_id,
+        )
+    if not row or not row["waiter_attribution_enabled"]:
+        raise HTTPException(
+            status_code=409,
+            detail="Waiter attribution is disabled for this tenant",
+        )

--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -24,6 +24,7 @@ SELECT
     tpp.tables_enabled,
     tpp.accepts_online_orders,
     tpp.auto_select_generic_enabled,
+    tpp.waiter_attribution_enabled,
     fd.nit,
     fd.business_name,
     fd.type_organization_id,
@@ -47,18 +48,34 @@ WHERE t.id = $1
 """
 
 
+_MEMBERS_QUERY = """
+SELECT tm.id, p.name, tm.role
+FROM tenant_members tm
+JOIN profile p ON p.id = tm.user_id
+WHERE tm.tenant_id = $1
+  AND tm.is_active = true
+  AND tm.terminated_at IS NULL
+ORDER BY p.name
+"""
+
+
 async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
     """Aggregate the POS-relevant tenant data.
 
     Returns None if the tenant does not exist. Missing rows in the joined
     tables surface as None values inside the payload — POS pages handle
     that gracefully (defaults / blank fields).
+
+    Includes a `members` list (active tenant members) for the waiter-
+    attribution family (warocol.com#573/#574/#575). Embedded here so
+    cashiers/supervisors can populate waiter dropdowns without needing
+    Module.EQUIPO access (which gates /api/tenants/members).
     """
     async with get_db_connection(use_transaction=False) as conn:
         row = await conn.fetchrow(_CONTEXT_QUERY, tenant_id)
-
-    if row is None:
-        return None
+        if row is None:
+            return None
+        members_rows = await conn.fetch(_MEMBERS_QUERY, tenant_id)
 
     readiness = await get_readiness(tenant_id)
     invoicing_ready = bool(readiness and readiness.get('ready'))
@@ -71,6 +88,7 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
         'tables_enabled': bool(row['tables_enabled']) if row['tables_enabled'] is not None else False,
         'accepts_online_orders': bool(row['accepts_online_orders']) if row['accepts_online_orders'] is not None else False,
         'auto_select_generic_enabled': bool(row['auto_select_generic_enabled']) if row['auto_select_generic_enabled'] is not None else False,
+        'waiter_attribution_enabled': bool(row['waiter_attribution_enabled']) if row['waiter_attribution_enabled'] is not None else False,
         'fiscal_data': {
             'nit': row['nit'],
             'business_name': row['business_name'],
@@ -91,4 +109,12 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
             'liquor_tax_applicable': bool(row['liquor_tax_applicable']) if row['liquor_tax_applicable'] is not None else False,
         },
         'invoicing_ready': invoicing_ready,
+        'members': [
+            {
+                'id': str(r['id']),
+                'name': r['name'] or 'Sin nombre',
+                'role': r['role'],
+            }
+            for r in members_rows
+        ],
     }

--- a/app/services/table_assignments_service.py
+++ b/app/services/table_assignments_service.py
@@ -1,0 +1,208 @@
+"""Waiter assignment service (warocol.com#573).
+
+Manages the default waiter assigned to each table:
+- `assign_member_to_table`: atomic transaction that closes the previous
+  period in `table_member_assignments`, opens a new one with snapshots,
+  and updates the `tables.assigned_member_id` pointer.
+- `get_assignment_history`: paginated history for a single table.
+
+Both are gated by `assert_waiter_attribution_enabled` to reject writes/
+reads when the feature flag is off for the tenant.
+
+All public functions are async; use `Optional[X]` and `List[X]` for
+Python 3.9 target compatibility.
+"""
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from fastapi import HTTPException
+
+from app.database import get_db_connection
+from app.services.operaciones_context_service import assert_waiter_attribution_enabled
+
+
+async def assign_member_to_table(
+    tenant_id: UUID,
+    table_id: UUID,
+    member_id: Optional[UUID],
+    assigned_by_user_id: Optional[UUID],
+) -> Dict[str, Any]:
+    """Set or clear the default waiter for a table.
+
+    Atomic transaction:
+      1. Close the currently open assignment period for the table.
+      2. Insert a new period row with snapshots of member name/role
+         (so the history row survives member deletion).
+      3. Update `tables.assigned_member_id` pointer for fast reads.
+
+    Validations:
+      - `waiter_attribution_enabled = true` for the tenant (else 409).
+      - Table belongs to tenant, is active, not deleted (else 404).
+      - Table is NOT a bar (else 400).
+      - If `member_id` is set, the member belongs to the tenant and is
+        active (else 404).
+    """
+    # 1. Toggle must be ON.
+    await assert_waiter_attribution_enabled(tenant_id)
+
+    async with get_db_connection() as conn:
+        async with conn.transaction():
+            # 2. Validate the table.
+            table_row = await conn.fetchrow(
+                """
+                SELECT id, is_bar, is_active, deleted_at
+                FROM tables
+                WHERE id = $1 AND tenant_id = $2
+                """,
+                table_id,
+                tenant_id,
+            )
+            if table_row is None or table_row["deleted_at"] is not None or not table_row["is_active"]:
+                raise HTTPException(status_code=404, detail="Table not found")
+            if table_row["is_bar"]:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Bar tables cannot have an assigned waiter",
+                )
+
+            # 3. Validate the incoming member (when not clearing).
+            member_name: Optional[str] = None
+            member_role: Optional[str] = None
+            if member_id is not None:
+                member_row = await conn.fetchrow(
+                    """
+                    SELECT tm.id, tm.role, p.name
+                    FROM tenant_members tm
+                    JOIN profile p ON p.id = tm.user_id
+                    WHERE tm.id = $1
+                      AND tm.tenant_id = $2
+                      AND tm.is_active = true
+                      AND tm.terminated_at IS NULL
+                    """,
+                    member_id,
+                    tenant_id,
+                )
+                if member_row is None:
+                    raise HTTPException(status_code=404, detail="Member not found")
+                member_name = member_row["name"] or "Sin nombre"
+                member_role = member_row["role"]
+
+            # 4. Close the previous open period (if any).
+            await conn.execute(
+                """
+                UPDATE table_member_assignments
+                SET unassigned_at = now()
+                WHERE table_id = $1 AND unassigned_at IS NULL
+                """,
+                table_id,
+            )
+
+            # 5. Insert the new period (even if member_id is NULL — records
+            #    the "unassigned" transition for audit completeness).
+            if member_id is not None:
+                await conn.execute(
+                    """
+                    INSERT INTO table_member_assignments
+                        (tenant_id, table_id, member_id, member_name, member_role, assigned_by)
+                    VALUES ($1, $2, $3, $4, $5, $6)
+                    """,
+                    tenant_id,
+                    table_id,
+                    member_id,
+                    member_name,
+                    member_role,
+                    assigned_by_user_id,
+                )
+
+            # 6. Update the fast-lookup pointer on the tables row.
+            await conn.execute(
+                """
+                UPDATE tables
+                SET assigned_member_id = $1
+                WHERE id = $2
+                """,
+                member_id,
+                table_id,
+            )
+
+    return {
+        "success": True,
+        "data": {
+            "table_id": str(table_id),
+            "assigned_member_id": str(member_id) if member_id else None,
+            "assigned_member_name": member_name,
+            "assigned_member_role": member_role,
+        },
+    }
+
+
+async def get_assignment_history(
+    tenant_id: UUID,
+    table_id: UUID,
+    limit: int = 50,
+    offset: int = 0,
+) -> Dict[str, Any]:
+    """Return paginated history of waiter assignments for a single table.
+
+    Most recent first. Snapshots (member_name, member_role) come directly
+    from the history row — not from a JOIN with `tenant_members` — so the
+    response is correct even if the member was deleted afterwards.
+
+    Validations:
+      - `waiter_attribution_enabled = true` for the tenant (else 409).
+      - Table belongs to tenant (else 404).
+    """
+    await assert_waiter_attribution_enabled(tenant_id)
+
+    async with get_db_connection(use_transaction=False) as conn:
+        table_check = await conn.fetchval(
+            "SELECT 1 FROM tables WHERE id = $1 AND tenant_id = $2",
+            table_id,
+            tenant_id,
+        )
+        if table_check is None:
+            raise HTTPException(status_code=404, detail="Table not found")
+
+        rows = await conn.fetch(
+            """
+            SELECT
+                tma.id,
+                tma.member_id,
+                tma.member_name,
+                tma.member_role,
+                tma.assigned_at,
+                tma.unassigned_at,
+                tma.assigned_by,
+                p.name AS assigned_by_name
+            FROM table_member_assignments tma
+            LEFT JOIN profile p ON p.id = tma.assigned_by
+            WHERE tma.table_id = $1 AND tma.tenant_id = $2
+            ORDER BY tma.assigned_at DESC
+            LIMIT $3 OFFSET $4
+            """,
+            table_id,
+            tenant_id,
+            limit,
+            offset,
+        )
+
+    entries: List[Dict[str, Any]] = [
+        {
+            "id": str(r["id"]),
+            "member_id": str(r["member_id"]) if r["member_id"] else None,
+            "member_name": r["member_name"],
+            "member_role": r["member_role"],
+            "assigned_at": r["assigned_at"].isoformat() if r["assigned_at"] else None,
+            "unassigned_at": r["unassigned_at"].isoformat() if r["unassigned_at"] else None,
+            "assigned_by": str(r["assigned_by"]) if r["assigned_by"] else None,
+            "assigned_by_name": r["assigned_by_name"],
+        }
+        for r in rows
+    ]
+
+    return {
+        "success": True,
+        "data": entries,
+        "limit": limit,
+        "offset": offset,
+    }

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -119,6 +119,9 @@ async def list_tables(request: Request, include_inactive: bool = False) -> dict:
                     t.is_active,
                     t.is_bar,
                     t.created_at,
+                    t.assigned_member_id,
+                    p_assigned.name AS assigned_member_name,
+                    tm_assigned.role AS assigned_member_role,
                     ts.id            AS session_id,
                     ts.opened_at,
                     ts.opened_by_user_id,
@@ -158,6 +161,10 @@ async def list_tables(request: Request, include_inactive: bool = False) -> dict:
                     ON ts.table_id = t.id
                     AND ts.tenant_id = $1
                     AND ts.closed_at IS NULL
+                LEFT JOIN tenant_members tm_assigned
+                    ON tm_assigned.id = t.assigned_member_id
+                LEFT JOIN profile p_assigned
+                    ON p_assigned.id = tm_assigned.user_id
                 WHERE t.tenant_id = $1
                   AND t.deleted_at IS NULL
                   AND (t.is_active = true OR $2)
@@ -1994,6 +2001,11 @@ def _format_table_row(row: dict) -> dict:
         "session": None,
         "last_closed_at": row["last_closed_at"].isoformat() if row.get("last_closed_at") else None,
         "last_closed_session_id": str(row["last_closed_session_id"]) if row.get("last_closed_session_id") else None,
+        # Default waiter assignment (warocol.com#573) — denormalized for the
+        # admin panel + future POS surfaces without an extra round-trip.
+        "assigned_member_id": str(row["assigned_member_id"]) if row.get("assigned_member_id") else None,
+        "assigned_member_name": row.get("assigned_member_name"),
+        "assigned_member_role": row.get("assigned_member_role"),
     }
     if row["session_id"]:
         result["session"] = {

--- a/migrations/070_add_waiter_attribution_enabled_to_tenant_public_profiles.sql
+++ b/migrations/070_add_waiter_attribution_enabled_to_tenant_public_profiles.sql
@@ -1,0 +1,19 @@
+-- 070_add_waiter_attribution_enabled_to_tenant_public_profiles.sql
+-- Issue warocol.com#573 — feat(operaciones): asignar mesero por mesa para trazabilidad
+--
+-- Adds a per-tenant boolean flag that controls visibility of the waiter
+-- attribution UI family: admin panel in /operaciones/comandas (#573),
+-- POS mesa override (warocol.com#574), and bar/counter order attribution
+-- (warocol.com#575).
+--
+-- Default false to preserve current behavior. Independent of
+-- tables_enabled — the bar/counter flow (#575) works without tables.
+
+ALTER TABLE tenant_public_profiles
+    ADD COLUMN IF NOT EXISTS waiter_attribution_enabled BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN tenant_public_profiles.waiter_attribution_enabled IS
+    'Waiter attribution feature flag (warocol.com#573). When true, surfaces '
+    'the "Mesero por mesa" admin panel + POS UX for assigning members to '
+    'tables, sessions, and orders. Independent of tables_enabled — '
+    'bar/counter modes (#575) work without tables.';

--- a/migrations/071_add_assigned_member_id_to_tables.sql
+++ b/migrations/071_add_assigned_member_id_to_tables.sql
@@ -1,0 +1,24 @@
+-- 071_add_assigned_member_id_to_tables.sql
+-- Issue warocol.com#573 — default waiter assignment per table.
+--
+-- Adds a nullable FK pointer from tables to tenant_members. The actual
+-- audit trail of who-was-assigned-when lives in table_member_assignments
+-- (migration 072) with denormalized snapshots; this column is the fast
+-- "current default" lookup.
+--
+-- ON DELETE SET NULL preserves the table row if the member is removed;
+-- the history table preserves the audit via snapshots.
+
+ALTER TABLE tables
+    ADD COLUMN IF NOT EXISTS assigned_member_id UUID NULL
+    REFERENCES tenant_members(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_tables_assigned_member
+    ON tables(assigned_member_id)
+    WHERE assigned_member_id IS NOT NULL;
+
+COMMENT ON COLUMN tables.assigned_member_id IS
+    'Default waiter assigned to this table (warocol.com#573). NULL = no '
+    'default. Bars (is_bar = true) should never have this set (enforced '
+    'in application code, not DB constraint). Full history with snapshots '
+    'lives in table_member_assignments.';

--- a/migrations/072_create_table_member_assignments.sql
+++ b/migrations/072_create_table_member_assignments.sql
@@ -1,0 +1,39 @@
+-- 072_create_table_member_assignments.sql
+-- Issue warocol.com#573 — append-only history of waiter assignments per table.
+--
+-- Period model: each row represents one period a specific member was the
+-- assigned default for a table. `assigned_at` is always set; `unassigned_at`
+-- becomes set when the assignment changes (closing the previous period).
+-- The latest open row (unassigned_at IS NULL) is the current default —
+-- mirrored fast in `tables.assigned_member_id` (migration 071).
+--
+-- Snapshots of member_name + member_role preserve auditability even if
+-- the member is deleted from tenant_members later.
+
+CREATE TABLE IF NOT EXISTS table_member_assignments (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id     UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    table_id      UUID NOT NULL REFERENCES tables(id) ON DELETE CASCADE,
+    member_id     UUID NULL REFERENCES tenant_members(id) ON DELETE SET NULL,
+    member_name   VARCHAR(200),
+    member_role   VARCHAR(50),
+    assigned_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    unassigned_at TIMESTAMPTZ NULL,
+    assigned_by   UUID NULL REFERENCES profile(id) ON DELETE SET NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tma_table_history
+    ON table_member_assignments(table_id, assigned_at DESC);
+
+-- Partial index: fast lookup of current assignment per table
+CREATE INDEX IF NOT EXISTS idx_tma_current_per_table
+    ON table_member_assignments(table_id) WHERE unassigned_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_tma_tenant
+    ON table_member_assignments(tenant_id);
+
+COMMENT ON TABLE table_member_assignments IS
+    'Append-only history of default waiter assignments per table '
+    '(warocol.com#573). Period model: each row spans one continuous '
+    'assignment, with snapshots that survive member deletion.';


### PR DESCRIPTION
## Summary

Backend foundation for the waiter attribution family. Adds the schema (3 additive migrations), Pydantic models, service layer, and 3 router endpoints. Paired with frontend PR in warocol.com#573 (panel admin in /operaciones/comandas).

Independent of tables_enabled — works in bar/counter modes via warocol.com#575.

Refs: **warocol.com#573**, warocol.com#574, warocol.com#575.

## Stack

🐍 Python 3.9 + 🔵 FastAPI + 🟣 Postgres

## Changes

### Migrations (3, all additive)
- `070_add_waiter_attribution_enabled_to_tenant_public_profiles.sql` — toggle column
- `071_add_assigned_member_id_to_tables.sql` — fast pointer to current waiter
- `072_create_table_member_assignments.sql` — append-only history with period model + member snapshots

### Backend code
| File | Type | Notes |
|---|---|---|
| `app/models/tenant_public_profile.py` | modify | New `waiter_attribution_enabled` Pydantic field |
| `app/models/table_member_assignment.py` | create | `AssignMemberRequest`, `MemberSummary`, `AssignmentHistoryEntry` |
| `app/services/operaciones_context_service.py` | modify | Add to `ALLOWED_TOGGLES` whitelist + new `assert_waiter_attribution_enabled` helper |
| `app/services/pos_context_service.py` | modify | Aggregator returns `waiter_attribution_enabled` + embedded `members[]` (active members, embedded so cashiers don't need `/tenants/members` which is under Module.EQUIPO) |
| `app/services/table_assignments_service.py` | create | `assign_member_to_table` (atomic txn) + `get_assignment_history` (paginated) |
| `app/services/tables_service.py` | modify | `list_tables` SELECT extended with `assigned_member_id` + denormalized name + role |
| `app/routers/operaciones_context.py` | modify | 3 new endpoints under `Module.OPERACIONES` |

### Router endpoints (all under `Module.OPERACIONES`)
- `PATCH /operaciones/toggles/waiter-attribution` — toggle on/off (uses existing `update_toggle` helper)
- `PATCH /operaciones/tables/{id}/assigned-member` — set/clear default for a table (atomic: closes prev period, opens new, updates pointer)
- `GET /operaciones/tables/{id}/assignment-history?limit&offset` — paginated history (50 default, max 200)

## Safety / validations

- Feature flag must be ON in mutation paths (`assert_waiter_attribution_enabled` → 409 otherwise).
- Table belongs to tenant + active + not deleted (404) + not `is_bar` (400).
- Member belongs to tenant + active (404).
- Toggle column whitelist preserved (SQL injection guard).
- All DB operations on writes wrapped in transactions.
- Snapshots in history table survive `tenant_members` row deletion (ON DELETE SET NULL on `member_id`).

## Python compat

Target: Python 3.9 (per Dockerfile). Verified clean:
- All new code uses `Optional[X]`, `List[X]`, `Dict[X, Y]` from `typing` (no PEP 604 `X | None`).
- No `match`/`case`, no `tomllib`, no `asyncio.TaskGroup`.
- `python3 -m py_compile` passes for all 7 changed/new files.

## Migration safety

All 3 are `ADD COLUMN` / `CREATE TABLE` with `IF NOT EXISTS` clauses. Zero data destruction. Defaults preserve current behavior:
- `waiter_attribution_enabled` defaults to `false` — no UI change until owner flips it.
- `assigned_member_id` defaults to `NULL` — no impact on existing tables.
- `table_member_assignments` starts empty.

Verified locally on dev DB: 3 ALTER/CREATE ran without locks (small row counts — `tenant_public_profiles` has 11 rows, `tables` has 52).

## Testing (manual smoke planned post-merge)

- [ ] Apply migrations on a tenant DB
- [ ] PATCH waiter-attribution toggle (verify UPSERT for tenants without `tenant_public_profiles` row yet)
- [ ] Assign a member to a non-bar table → 200 + history row created
- [ ] Assign with toggle OFF → 409
- [ ] Assign to a bar table → 400
- [ ] Assign with member from another tenant → 404
- [ ] Get history → returns rows with snapshots
- [ ] Verify `GET /api/tables` now includes `assigned_member_id` + name

No unit tests added in this PR (mirrors convention of recent feature PRs in this repo: #178, #175, #173, #167). If review requires tests they can be a follow-up.

## Paired frontend

The frontend PR (warocol.com#573) adds:
- New toggle UI in `/operaciones/comandas`
- Panel "Mesero por mesa" with dropdowns per table
- `MesaAssignmentHistoryModal` for viewing the audit log

That PR depends on these endpoints to exist in main — recommend merging this first.

Closes warocol.com#573 (backend portion)