### PR TITLE
feat(pos): per-session waiter override + auto-handoff (warocol.com#574)

### DIFF
--- a/app/core/permissions.py
+++ b/app/core/permissions.py
@@ -394,3 +394,59 @@ def require_module(module: Module) -> Callable[[Request], Awaitable[None]]:
         )
 
     return dependency
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Auto-handoff predicate for the waiter attribution family
+# (warocol.com#574 — POS session override; warocol.com#575 — order
+# attribution).
+# ─────────────────────────────────────────────────────────────────────
+async def can_reassign_waiter(
+    caller_user_id: Optional[UUID],
+    caller_role: Optional[str],
+    tenant_id: UUID,
+    current_waiter_member_id: Optional[UUID],
+) -> bool:
+    """Auto-handoff predicate.
+
+    Returns True if the caller is allowed to set/change a waiter
+    assignment given the current state. Caller is allowed when:
+
+      1. No one currently has the lock (`current_waiter_member_id` is
+         None — covers fresh sessions AND legacy rows with no opener).
+      2. Caller is supervisor or higher (OWNER/ADMIN/SUPERVISOR by
+         normalized role).
+      3. Caller IS the current waiter (handoff to another or release).
+
+    Returns False otherwise — typically a cashier trying to take a
+    table that already belongs to a different cashier.
+
+    Used by:
+      - `table_assignments_service.set_session_waiter` (#574)
+      - `table_assignments_service.set_order_served_by` (#575, future)
+    """
+    if current_waiter_member_id is None:
+        return True
+
+    if caller_role:
+        try:
+            normalized = normalize_role(caller_role)
+            if normalized in (Role.OWNER, Role.ADMIN, Role.SUPERVISOR):
+                return True
+        except ValueError:
+            pass
+
+    if caller_user_id is None:
+        return False
+
+    # Look up caller's tenant_member id and compare with the current waiter.
+    async with get_db_connection(use_transaction=False) as conn:
+        caller_member_id = await conn.fetchval(
+            """
+            SELECT id FROM tenant_members
+            WHERE user_id = $1 AND tenant_id = $2 AND is_active = true
+            """,
+            caller_user_id,
+            tenant_id,
+        )
+    return caller_member_id == current_waiter_member_id

--- a/app/models/table_member_assignment.py
+++ b/app/models/table_member_assignment.py
@@ -44,3 +44,26 @@ class AssignmentHistoryEntry(BaseModel):
     unassigned_at: Optional[datetime] = None
     assigned_by: Optional[UUID] = None
     assigned_by_name: Optional[str] = None
+
+
+class SetSessionWaiterRequest(BaseModel):
+    """PATCH /api/pos/tables/{id}/session-waiter (warocol.com#574)."""
+    member_id: Optional[UUID] = Field(
+        None,
+        description="Member to attribute as serving this session. "
+                    "NULL clears (session falls back to the table default via the resolver).",
+    )
+
+
+class OpenTableRequest(BaseModel):
+    """POST /tables/{id}/open body (warocol.com#574 extension — optional).
+
+    The endpoint accepted NO body before this. Body is fully optional;
+    when omitted, behaviour is identical to today.
+    """
+    attended_by_member_id: Optional[UUID] = Field(
+        None,
+        description="Optional initial waiter override for the session being opened. "
+                    "If absent, the session inherits the table's assigned_member_id via the resolver. "
+                    "Ignored silently when waiter_attribution_enabled is off.",
+    )

--- a/app/routers/pos_context.py
+++ b/app/routers/pos_context.py
@@ -7,11 +7,19 @@ needing MI_NEGOCIO (which stays owner-only by business rule).
 
 This is the BFF-style alternative to having POS pages fan out to multiple
 `/api/tenant/*` endpoints — see audit doc §4 for the rationale.
+
+Also exposes the per-session waiter mutation endpoint (warocol.com#574)
+under Module.POS so cashiers can hand off / take a table from the POS
+banner without needing OPERACIONES.
 """
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from app.core.middleware import require_valid_session
 from app.core.permissions import Module, require_module
+from app.models.table_member_assignment import SetSessionWaiterRequest
+from app.services import table_assignments_service
 from app.services.pos_context_service import get_restaurant_context
 
 router = APIRouter(prefix="/pos", tags=["POS Context"])
@@ -28,3 +36,32 @@ async def get_pos_restaurant_context(request: Request):
     if payload is None:
         raise HTTPException(status_code=404, detail="Tenant not found")
     return {"success": True, "data": payload}
+
+
+# ── Waiter attribution (warocol.com#574) ─────────────────────────────
+
+@router.patch(
+    "/tables/{table_id}/session-waiter",
+    dependencies=[Depends(require_module(Module.POS))],
+)
+async def set_session_waiter_endpoint(
+    request: Request,
+    table_id: UUID,
+    body: SetSessionWaiterRequest,
+):
+    """Set or clear the waiter attributed to a table's open session.
+
+    Auto-handoff guard applies (warocol.com#574):
+      - 403 if caller is not the current waiter AND not supervisor+.
+      - 404 if no open session for the table.
+      - 404 if `member_id` doesn't belong to this tenant.
+      - 409 if `waiter_attribution_enabled` is off for the tenant.
+    """
+    session = require_valid_session(request)
+    return await table_assignments_service.set_session_waiter(
+        tenant_id=session.tenant_id,
+        table_id=table_id,
+        member_id=body.member_id,
+        caller_user_id=session.user_id,
+        caller_role=session.role,
+    )

--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -10,6 +10,7 @@ from uuid import UUID
 from datetime import date
 from pydantic import BaseModel, Field
 from app.core.permissions import Module, require_module
+from app.models.table_member_assignment import OpenTableRequest
 from app.services import tables_service
 
 router = APIRouter(tags=["Tables"])
@@ -107,12 +108,24 @@ async def delete_table_permanent(request: Request, table_id: UUID):
 
 
 @router.post("/{table_id}/open", dependencies=[Depends(require_module(Module.POS))])
-async def open_session(request: Request, table_id: UUID):
+async def open_session(
+    request: Request,
+    table_id: UUID,
+    body: Optional[OpenTableRequest] = None,
+):
     """
     Open a new session for a table (status: free → open).
     Returns 409 if a session is already open.
+
+    Optional body (warocol.com#574) lets the cashier pre-set the
+    session-level waiter override (`attended_by_member_id`). When absent
+    OR when the tenant's `waiter_attribution_enabled` flag is off, the
+    session is created with NULL and the resolver inherits from
+    `tables.assigned_member_id`. Backward-compatible — clients that send
+    no body work as before.
     """
-    return await tables_service.open_session(request, table_id)
+    attended_by = body.attended_by_member_id if body else None
+    return await tables_service.open_session(request, table_id, attended_by)
 
 
 class CloseSessionRequest(BaseModel):

--- a/app/services/table_assignments_service.py
+++ b/app/services/table_assignments_service.py
@@ -1,13 +1,17 @@
-"""Waiter assignment service (warocol.com#573).
+"""Waiter assignment service (warocol.com#573, #574).
 
-Manages the default waiter assigned to each table:
-- `assign_member_to_table`: atomic transaction that closes the previous
-  period in `table_member_assignments`, opens a new one with snapshots,
-  and updates the `tables.assigned_member_id` pointer.
-- `get_assignment_history`: paginated history for a single table.
+Manages the default waiter assigned to each table AND the per-session
+override:
+- `assign_member_to_table` (#573): atomic transaction that closes the
+  previous period in `table_member_assignments`, opens a new one with
+  snapshots, and updates the `tables.assigned_member_id` pointer.
+- `get_assignment_history` (#573): paginated history for a single table.
+- `set_session_waiter` (#574): set/clear the per-session override on the
+  currently-open session for a table. Enforces auto-handoff: only the
+  current waiter or supervisor+ can reassign.
 
-Both are gated by `assert_waiter_attribution_enabled` to reject writes/
-reads when the feature flag is off for the tenant.
+All gated by `assert_waiter_attribution_enabled` to reject writes/reads
+when the feature flag is off for the tenant.
 
 All public functions are async; use `Optional[X]` and `List[X]` for
 Python 3.9 target compatibility.
@@ -17,6 +21,7 @@ from uuid import UUID
 
 from fastapi import HTTPException
 
+from app.core.permissions import can_reassign_waiter
 from app.database import get_db_connection
 from app.services.operaciones_context_service import assert_waiter_attribution_enabled
 
@@ -205,4 +210,98 @@ async def get_assignment_history(
         "data": entries,
         "limit": limit,
         "offset": offset,
+    }
+
+
+async def set_session_waiter(
+    tenant_id: UUID,
+    table_id: UUID,
+    member_id: Optional[UUID],
+    caller_user_id: Optional[UUID],
+    caller_role: Optional[str],
+) -> Dict[str, Any]:
+    """Set or clear the per-session waiter override (warocol.com#574).
+
+    The override lives on `table_sessions.attended_by_member_id`. When
+    NULL, the resolver falls back to `tables.assigned_member_id` (#573).
+
+    Auto-handoff guard (via `can_reassign_waiter`):
+      - No current waiter on the session → anyone with POS access can set.
+      - Caller IS the current waiter → can hand off to another or clear.
+      - Caller is supervisor+ → can override regardless.
+      - Else → 403 Forbidden.
+
+    Validations:
+      - `waiter_attribution_enabled = true` (else 409)
+      - Open session exists for the table (else 404)
+      - `member_id`, if set, belongs to the tenant and is active (else 404)
+    """
+    await assert_waiter_attribution_enabled(tenant_id)
+
+    async with get_db_connection() as conn:
+        async with conn.transaction():
+            # Lock the open session row to prevent racing PATCHes.
+            session_row = await conn.fetchrow(
+                """
+                SELECT id, attended_by_member_id
+                FROM table_sessions
+                WHERE table_id = $1 AND tenant_id = $2 AND closed_at IS NULL
+                FOR UPDATE
+                """,
+                table_id,
+                tenant_id,
+            )
+            if session_row is None:
+                raise HTTPException(status_code=404, detail="No open session for this table")
+
+            # Auto-handoff check
+            allowed = await can_reassign_waiter(
+                caller_user_id=caller_user_id,
+                caller_role=caller_role,
+                tenant_id=tenant_id,
+                current_waiter_member_id=session_row["attended_by_member_id"],
+            )
+            if not allowed:
+                raise HTTPException(
+                    status_code=403,
+                    detail="Only the current waiter or a supervisor can reassign this session",
+                )
+
+            # Validate incoming member if not clearing
+            member_name: Optional[str] = None
+            member_role: Optional[str] = None
+            if member_id is not None:
+                member_row = await conn.fetchrow(
+                    """
+                    SELECT tm.id, tm.role, p.name
+                    FROM tenant_members tm
+                    JOIN profile p ON p.id = tm.user_id
+                    WHERE tm.id = $1
+                      AND tm.tenant_id = $2
+                      AND tm.is_active = true
+                      AND tm.terminated_at IS NULL
+                    """,
+                    member_id,
+                    tenant_id,
+                )
+                if member_row is None:
+                    raise HTTPException(status_code=404, detail="Member not found")
+                member_name = member_row["name"] or "Sin nombre"
+                member_role = member_row["role"]
+
+            # Apply the change
+            await conn.execute(
+                "UPDATE table_sessions SET attended_by_member_id = $1 WHERE id = $2",
+                member_id,
+                session_row["id"],
+            )
+
+    return {
+        "success": True,
+        "data": {
+            "session_id": str(session_row["id"]),
+            "attended_by_member_id": str(member_id) if member_id else None,
+            "attended_by_member_name": member_name,
+            "attended_by_member_role": member_role,
+        },
     }

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -125,6 +125,13 @@ async def list_tables(request: Request, include_inactive: bool = False) -> dict:
                     ts.id            AS session_id,
                     ts.opened_at,
                     ts.opened_by_user_id,
+                    ts.attended_by_member_id AS session_attended_by_member_id,
+                    p_attended.name AS session_attended_by_member_name,
+                    tm_attended.role AS session_attended_by_member_role,
+                    -- Resolver: session override > table default > NULL
+                    COALESCE(ts.attended_by_member_id, t.assigned_member_id) AS effective_waiter_member_id,
+                    COALESCE(p_attended.name, p_assigned.name)               AS effective_waiter_member_name,
+                    COALESCE(tm_attended.role, tm_assigned.role)             AS effective_waiter_member_role,
                     EXTRACT(EPOCH FROM (now() - ts.opened_at)) / 60 AS session_duration_minutes,
                     COALESCE(
                         (SELECT SUM(o.total_amount)
@@ -165,6 +172,10 @@ async def list_tables(request: Request, include_inactive: bool = False) -> dict:
                     ON tm_assigned.id = t.assigned_member_id
                 LEFT JOIN profile p_assigned
                     ON p_assigned.id = tm_assigned.user_id
+                LEFT JOIN tenant_members tm_attended
+                    ON tm_attended.id = ts.attended_by_member_id
+                LEFT JOIN profile p_attended
+                    ON p_attended.id = tm_attended.user_id
                 WHERE t.tenant_id = $1
                   AND t.deleted_at IS NULL
                   AND (t.is_active = true OR $2)
@@ -478,10 +489,23 @@ async def delete_table_permanent(request: Request, table_id: UUID) -> dict:
         raise APIError(f"Error deleting table: {e}", status_code=500)
 
 
-async def open_session(request: Request, table_id: UUID) -> dict:
+async def open_session(
+    request: Request,
+    table_id: UUID,
+    attended_by_member_id: Optional[UUID] = None,
+) -> dict:
     """
     Open a new session for a table.
-    Returns 409 if a session is already open.
+
+    Optional `attended_by_member_id` (warocol.com#574) lets the cashier
+    pre-set the per-session waiter override at open time. If the tenant's
+    `waiter_attribution_enabled` flag is off OR the value is None, the
+    field is left NULL on the new row and the resolver falls back to
+    `tables.assigned_member_id`.
+
+    Returns 409 if a session is already open. Returns 404 if the table
+    doesn't exist or if `attended_by_member_id` doesn't belong to the
+    tenant.
     """
     try:
         session_context = require_valid_session(request)
@@ -489,6 +513,30 @@ async def open_session(request: Request, table_id: UUID) -> dict:
         user_id = session_context.user_id
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
+
+        # If a waiter override was requested, check the toggle is ON and
+        # the member belongs to the tenant. Done OUTSIDE the table lock
+        # to fail fast.
+        resolved_attended_by: Optional[UUID] = None
+        if attended_by_member_id is not None:
+            async with get_db_connection(use_transaction=False) as conn:
+                toggle = await conn.fetchval(
+                    "SELECT waiter_attribution_enabled FROM tenant_public_profiles WHERE tenant_id = $1",
+                    tenant_id,
+                )
+                if toggle:
+                    member_check = await conn.fetchval(
+                        """
+                        SELECT id FROM tenant_members
+                        WHERE id = $1 AND tenant_id = $2 AND is_active = true AND terminated_at IS NULL
+                        """,
+                        attended_by_member_id,
+                        tenant_id,
+                    )
+                    if member_check is None:
+                        raise NotFoundError("Member not found")
+                    resolved_attended_by = attended_by_member_id
+                # If toggle OFF: silently ignore the field (idempotent).
 
         async with get_db_connection() as conn:
             async with conn.transaction():
@@ -513,13 +561,14 @@ async def open_session(request: Request, table_id: UUID) -> dict:
                 # Create session
                 session_row = await conn.fetchrow(
                     """
-                    INSERT INTO table_sessions (table_id, tenant_id, opened_by_user_id)
-                    VALUES ($1, $2, $3)
+                    INSERT INTO table_sessions (table_id, tenant_id, opened_by_user_id, attended_by_member_id)
+                    VALUES ($1, $2, $3, $4)
                     RETURNING id, opened_at
                     """,
                     table_id,
                     tenant_id,
                     user_id,
+                    resolved_attended_by,
                 )
 
                 # Update table status
@@ -536,6 +585,7 @@ async def open_session(request: Request, table_id: UUID) -> dict:
                 "session_id": str(session_row["id"]),
                 "table_id": str(table_id),
                 "opened_at": session_row["opened_at"].isoformat(),
+                "attended_by_member_id": str(resolved_attended_by) if resolved_attended_by else None,
             },
         }
 
@@ -1106,6 +1156,13 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                     ts.id,
                     ts.opened_at,
                     ts.opened_by_user_id,
+                    ts.attended_by_member_id,
+                    p_attended.name AS attended_by_member_name,
+                    tm_attended.role AS attended_by_member_role,
+                    -- Resolver: session override > table default > NULL
+                    COALESCE(ts.attended_by_member_id, t.assigned_member_id) AS effective_waiter_member_id,
+                    COALESCE(p_attended.name, p_assigned.name)               AS effective_waiter_member_name,
+                    COALESCE(tm_attended.role, tm_assigned.role)             AS effective_waiter_member_role,
                     EXTRACT(EPOCH FROM (now() - ts.opened_at)) / 60 AS duration_minutes,
                     COALESCE(
                         (SELECT SUM(o.total_amount)
@@ -1120,6 +1177,15 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                         0
                     ) AS order_count
                 FROM table_sessions ts
+                JOIN tables t ON t.id = ts.table_id
+                LEFT JOIN tenant_members tm_attended
+                    ON tm_attended.id = ts.attended_by_member_id
+                LEFT JOIN profile p_attended
+                    ON p_attended.id = tm_attended.user_id
+                LEFT JOIN tenant_members tm_assigned
+                    ON tm_assigned.id = t.assigned_member_id
+                LEFT JOIN profile p_assigned
+                    ON p_assigned.id = tm_assigned.user_id
                 WHERE ts.table_id = $1
                   AND ts.tenant_id = $2
                   AND ts.closed_at IS NULL
@@ -1205,6 +1271,13 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                     "standard_tax": float(_std_tax),
                     "liquor_tax": float(_liq_tax),
                     "standard_tax_label": _tax_label,
+                    # Waiter attribution (warocol.com#574)
+                    "attended_by_member_id": str(session_row["attended_by_member_id"]) if session_row.get("attended_by_member_id") else None,
+                    "attended_by_member_name": session_row.get("attended_by_member_name"),
+                    "attended_by_member_role": session_row.get("attended_by_member_role"),
+                    "effective_waiter_member_id": str(session_row["effective_waiter_member_id"]) if session_row.get("effective_waiter_member_id") else None,
+                    "effective_waiter_member_name": session_row.get("effective_waiter_member_name"),
+                    "effective_waiter_member_role": session_row.get("effective_waiter_member_role"),
                 },
                 "orders": [
                     {
@@ -2006,6 +2079,11 @@ def _format_table_row(row: dict) -> dict:
         "assigned_member_id": str(row["assigned_member_id"]) if row.get("assigned_member_id") else None,
         "assigned_member_name": row.get("assigned_member_name"),
         "assigned_member_role": row.get("assigned_member_role"),
+        # Effective waiter (warocol.com#574) — resolved server-side via COALESCE
+        # of session.attended_by > table.assigned_member > NULL.
+        "effective_waiter_member_id": str(row["effective_waiter_member_id"]) if row.get("effective_waiter_member_id") else None,
+        "effective_waiter_member_name": row.get("effective_waiter_member_name"),
+        "effective_waiter_member_role": row.get("effective_waiter_member_role"),
     }
     if row["session_id"]:
         result["session"] = {
@@ -2014,6 +2092,10 @@ def _format_table_row(row: dict) -> dict:
             "duration_minutes": round(float(row["session_duration_minutes"]), 1),
             "running_total": float(row["running_total"]),
             "unfired_count": int(row["unfired_count"]) if row.get("unfired_count") is not None else 0,
+            # Session-level waiter override (warocol.com#574)
+            "attended_by_member_id": str(row["session_attended_by_member_id"]) if row.get("session_attended_by_member_id") else None,
+            "attended_by_member_name": row.get("session_attended_by_member_name"),
+            "attended_by_member_role": row.get("session_attended_by_member_role"),
         }
     return result
 

--- a/migrations/073_add_attended_by_member_id_to_table_sessions.sql
+++ b/migrations/073_add_attended_by_member_id_to_table_sessions.sql
@@ -1,0 +1,24 @@
+-- 073_add_attended_by_member_id_to_table_sessions.sql
+-- Issue warocol.com#574 — POS session-level waiter override + auto-handoff.
+--
+-- Adds a nullable FK from table_sessions to tenant_members for the
+-- "who is currently attending THIS session" override. The default
+-- (tables.assigned_member_id from migration 071/issue #573) is used
+-- when this column is NULL, resolved via COALESCE in app code.
+--
+-- ON DELETE SET NULL preserves the session if the member is removed.
+
+ALTER TABLE table_sessions
+    ADD COLUMN IF NOT EXISTS attended_by_member_id UUID NULL
+    REFERENCES tenant_members(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_table_sessions_attended_by
+    ON table_sessions(attended_by_member_id)
+    WHERE attended_by_member_id IS NOT NULL;
+
+COMMENT ON COLUMN table_sessions.attended_by_member_id IS
+    'Override of the default waiter for this specific session '
+    '(warocol.com#574). NULL = inherit from tables.assigned_member_id. '
+    'Set at open via POST body or changed mid-session via PATCH '
+    '/pos/tables/{id}/session-waiter. Auto-handoff rule enforced in '
+    'app code: only the current waiter or supervisor+ can reassign.';


### PR DESCRIPTION
## Summary

Extends the waiter attribution foundation from #227 (warocol.com#573) to POS-level operations: per-session override + auto-handoff predicate + mutation endpoint. Paired with **warocol.com#574** (frontend).

**Stacked on #227** — GitHub will auto-retarget to `main` after that merges.

## Stack

🐍 Python 3.9 + 🔵 FastAPI + 🟣 Postgres

## Changes

### Migration (1, additive)
- `073_add_attended_by_member_id_to_table_sessions.sql` — new nullable FK column

### Backend
| File | Type | Notes |
|---|---|---|
| `app/core/permissions.py` | modify | New `can_reassign_waiter()` async helper (auto-handoff predicate, reusable by warocol.com#575) |
| `app/models/table_member_assignment.py` | modify | `SetSessionWaiterRequest` + `OpenTableRequest` |
| `app/services/tables_service.py` | modify | `open_session` accepts optional `attended_by_member_id`. `list_tables` + `get_current_session` extended with SQL COALESCE resolver |
| `app/services/table_assignments_service.py` | modify | New `set_session_waiter()` with atomic transaction + auto-handoff guard |
| `app/routers/tables.py` | modify | POST /open accepts optional body (backward-compatible) |
| `app/routers/pos_context.py` | modify | New `PATCH /pos/tables/{id}/session-waiter` under `Module.POS` |

## The auto-handoff predicate

`can_reassign_waiter(caller_user_id, caller_role, tenant_id, current_waiter_member_id)`:

| State | Result |
|---|---|
| `current_waiter_member_id IS NULL` | allow (anyone with POS can take) |
| caller is owner / admin / supervisor | allow (override) |
| caller's `tenant_member.id == current_waiter_member_id` | allow (handoff) |
| else | deny → 403 |

Single source of truth, reused by warocol.com#575 (orders).

## Resolver

`list_tables` and `get_current_session` now denormalize the effective waiter at the SQL level:

```sql
COALESCE(ts.attended_by_member_id, t.assigned_member_id) AS effective_waiter_member_id
COALESCE(p_attended.name, p_assigned.name)               AS effective_waiter_member_name
COALESCE(tm_attended.role, tm_assigned.role)             AS effective_waiter_member_role
```

Frontend reads `effective_waiter_*` directly — no client-side resolver needed.

## Validations

- `assert_waiter_attribution_enabled` → 409 if toggle off
- Open session must exist → 404
- Member must belong to the tenant + active → 404
- Auto-handoff predicate → 403 if not allowed
- Optional `attended_by_member_id` in POST /open: validated when toggle ON, silently ignored when OFF

## Python compat

Target 3.9. All new code uses `Optional[X]`, `List[X]`, `Dict[X, Y]` from `typing`. `py_compile` clean.

## Migration safety

Additive `ALTER TABLE ADD COLUMN` with `IF NOT EXISTS`. Default NULL. Applied locally on dev DB without locks (table is small — 538 rows). 14 currently open sessions preserved unchanged.

## Testing (manual smoke planned post-merge)

- [ ] Apply migration 073
- [ ] POST /tables/{id}/open with body `{"attended_by_member_id": "<uuid>"}` → 200, session has the value
- [ ] POST /tables/{id}/open without body → 200, NULL (legacy behavior)
- [ ] POST /tables/{id}/open with toggle OFF + body → 200, field ignored
- [ ] PATCH /pos/tables/{id}/session-waiter as supervisor → 200
- [ ] PATCH as cashier when no current waiter → 200
- [ ] PATCH as cashier when caller IS current waiter → 200
- [ ] PATCH as different cashier → 403
- [ ] PATCH with toggle off → 409
- [ ] PATCH for non-existent session → 404
- [ ] GET /tables shows `effective_waiter_member_*` for sessions

No unit tests added (mirrors project convention).

## Paired frontend

warocol.com#574 adds:
- New `WaiterAssignModal.vue` at table-open time
- Chip in Mesa Banner with auto-handoff aware dropdown
- Waiter name on floor plan cards

That PR depends on these endpoints to exist in main.

Refs warocol.com#574, warocol.com#575 (next, reuses `can_reassign_waiter`)