### PR TITLE
feat(pos): per-order waiter attribution + auto-handoff (warocol.com#575)

### DIFF
--- a/app/models/table_member_assignment.py
+++ b/app/models/table_member_assignment.py
@@ -67,3 +67,18 @@ class OpenTableRequest(BaseModel):
                     "If absent, the session inherits the table's assigned_member_id via the resolver. "
                     "Ignored silently when waiter_attribution_enabled is off.",
     )
+
+
+class SetOrderServedByRequest(BaseModel):
+    """PATCH /api/pos/orders/{id}/served-by (warocol.com#575).
+
+    Per-order waiter attribution. Auto-handoff guard enforced server-side:
+    only the current `served_by_member_id` or supervisor+ can change it.
+    Use the body of POST /pos-cart/{id}/complete to set this at creation
+    time (no auto-handoff check there — order didn't exist yet).
+    """
+    member_id: Optional[UUID] = Field(
+        None,
+        description="Member to attribute as the server of this order. "
+                    "NULL clears (resolver falls back to session/table).",
+    )

--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -158,6 +158,7 @@ class CompleteOrderRequest(BaseModel):
     delivery_address_id: Optional[UUID] = Field(None, description="UUID of an addresses_profile row owned by customer_id. When set, this order is treated as a delivery and the comanda fires with source_type='delivery'.")
     scheduled_time: Optional[datetime] = Field(None, description="ISO datetime for scheduled delivery. NULL = ASAP. Forward-compatible: v1 UI sends NULL only.")
     delivery_instructions: Optional[str] = Field(None, description="Free-text notes for the courier (e.g. 'Tocar el timbre 2 veces').")
+    served_by_member_id: Optional[UUID] = Field(None, description="Issue warocol.com#575 — per-order waiter attribution. Pre-validated when set: must belong to tenant + be active. Silently ignored when waiter_attribution_enabled is OFF for the tenant.")
 
 
 @router.post("/{cart_id}/complete", dependencies=[Depends(require_module(Module.POS))])
@@ -192,6 +193,7 @@ async def complete_order(
         order_data.delivery_instructions,
         split_first_cash_received=order_data.split_first_cash_received,
         cash_received=order_data.cash_received,
+        served_by_member_id=order_data.served_by_member_id,
     )
 
 

--- a/app/routers/pos_context.py
+++ b/app/routers/pos_context.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 
 from app.core.middleware import require_valid_session
 from app.core.permissions import Module, require_module
-from app.models.table_member_assignment import SetSessionWaiterRequest
+from app.models.table_member_assignment import SetOrderServedByRequest, SetSessionWaiterRequest
 from app.services import table_assignments_service
 from app.services.pos_context_service import get_restaurant_context
 
@@ -61,6 +61,36 @@ async def set_session_waiter_endpoint(
     return await table_assignments_service.set_session_waiter(
         tenant_id=session.tenant_id,
         table_id=table_id,
+        member_id=body.member_id,
+        caller_user_id=session.user_id,
+        caller_role=session.role,
+    )
+
+
+@router.patch(
+    "/orders/{order_id}/served-by",
+    dependencies=[Depends(require_module(Module.POS))],
+)
+async def set_order_served_by_endpoint(
+    request: Request,
+    order_id: UUID,
+    body: SetOrderServedByRequest,
+):
+    """Set or clear the per-order waiter (warocol.com#575).
+
+    Used for bar/counter orders post-creation. Auto-handoff guard:
+      - 403 if caller is not the current served_by AND not supervisor+.
+      - 404 if the order doesn't exist or doesn't belong to this tenant.
+      - 404 if `member_id` doesn't belong to this tenant.
+      - 409 if `waiter_attribution_enabled` is off for the tenant.
+
+    To set the value at creation time, include `served_by_member_id` in
+    the body of POST /pos-cart/{id}/complete instead.
+    """
+    session = require_valid_session(request)
+    return await table_assignments_service.set_order_served_by(
+        tenant_id=session.tenant_id,
+        order_id=order_id,
         member_id=body.member_id,
         caller_user_id=session.user_id,
         caller_role=session.role,

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -855,6 +855,7 @@ async def complete_pos_order(
     *,
     split_first_cash_received: Optional[float] = None,
     cash_received: Optional[float] = None,
+    served_by_member_id: Optional[UUID] = None,
 ) -> dict:
     """
     Complete a POS order:
@@ -872,6 +873,31 @@ async def complete_pos_order(
 
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
+
+        # warocol.com#575 — Resolve served_by_member_id before the main transaction.
+        # If the feature flag is off for this tenant, silently ignore the field
+        # (idempotency). If on, validate that the member exists + belongs to the
+        # tenant + is active. Done outside the transaction to fail fast.
+        resolved_served_by: Optional[UUID] = None
+        if served_by_member_id is not None:
+            async with get_db_connection(use_transaction=False) as _conn:
+                toggle = await _conn.fetchval(
+                    "SELECT waiter_attribution_enabled FROM tenant_public_profiles WHERE tenant_id = $1",
+                    tenant_id,
+                )
+                if toggle:
+                    member_check = await _conn.fetchval(
+                        """
+                        SELECT id FROM tenant_members
+                        WHERE id = $1 AND tenant_id = $2 AND is_active = true AND terminated_at IS NULL
+                        """,
+                        served_by_member_id,
+                        tenant_id,
+                    )
+                    if member_check is None:
+                        raise NotFoundError("Member not found")
+                    resolved_served_by = served_by_member_id
+                # toggle OFF → leave resolved_served_by as None (silent ignore)
 
         async with get_db_connection() as conn:
             async with conn.transaction():
@@ -983,9 +1009,10 @@ async def complete_pos_order(
                         payment_method_id, discount_type, discount_value, discount_amount,
                         table_session_id,
                         delivery_address_id, scheduled_time, delivery_instructions,
-                        cash_received
+                        cash_received,
+                        served_by_member_id
                     )
-                    VALUES ($1, $2, $3, $4, $5, NOW(), $6, 'completed', $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+                    VALUES ($1, $2, $3, $4, $5, NOW(), $6, 'completed', $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
                     RETURNING id, order_number, created_at
                 """
                 order_row = await conn.fetchrow(
@@ -1007,6 +1034,7 @@ async def complete_pos_order(
                     scheduled_time,
                     delivery_instructions,
                     _orders_cash_received,
+                    resolved_served_by,
                 )
                 order_id = order_row['id']
                 order_number = order_row['order_number']

--- a/app/services/table_assignments_service.py
+++ b/app/services/table_assignments_service.py
@@ -305,3 +305,90 @@ async def set_session_waiter(
             "attended_by_member_role": member_role,
         },
     }
+
+
+async def set_order_served_by(
+    tenant_id: UUID,
+    order_id: UUID,
+    member_id: Optional[UUID],
+    caller_user_id: Optional[UUID],
+    caller_role: Optional[str],
+) -> Dict[str, Any]:
+    """Set or clear the per-order waiter (warocol.com#575).
+
+    Auto-handoff guard (reuses `can_reassign_waiter` from #574):
+      - No current `served_by` on the order → anyone with POS can set.
+      - Caller IS the current `served_by` → can hand off / clear.
+      - Caller is supervisor+ → can override.
+      - Else → 403 Forbidden.
+
+    Validations:
+      - `waiter_attribution_enabled = true` for the tenant (else 409)
+      - Order exists + belongs to tenant (else 404)
+      - `member_id`, if set, belongs to tenant + active (else 404)
+    """
+    await assert_waiter_attribution_enabled(tenant_id)
+
+    async with get_db_connection() as conn:
+        async with conn.transaction():
+            order_row = await conn.fetchrow(
+                """
+                SELECT id, served_by_member_id
+                FROM orders
+                WHERE id = $1 AND tenant_id = $2
+                FOR UPDATE
+                """,
+                order_id,
+                tenant_id,
+            )
+            if order_row is None:
+                raise HTTPException(status_code=404, detail="Order not found")
+
+            allowed = await can_reassign_waiter(
+                caller_user_id=caller_user_id,
+                caller_role=caller_role,
+                tenant_id=tenant_id,
+                current_waiter_member_id=order_row["served_by_member_id"],
+            )
+            if not allowed:
+                raise HTTPException(
+                    status_code=403,
+                    detail="Only the current server or a supervisor can reassign this order",
+                )
+
+            member_name: Optional[str] = None
+            member_role: Optional[str] = None
+            if member_id is not None:
+                member_row = await conn.fetchrow(
+                    """
+                    SELECT tm.id, tm.role, p.name
+                    FROM tenant_members tm
+                    JOIN profile p ON p.id = tm.user_id
+                    WHERE tm.id = $1
+                      AND tm.tenant_id = $2
+                      AND tm.is_active = true
+                      AND tm.terminated_at IS NULL
+                    """,
+                    member_id,
+                    tenant_id,
+                )
+                if member_row is None:
+                    raise HTTPException(status_code=404, detail="Member not found")
+                member_name = member_row["name"] or "Sin nombre"
+                member_role = member_row["role"]
+
+            await conn.execute(
+                "UPDATE orders SET served_by_member_id = $1, updated_at = now() WHERE id = $2",
+                member_id,
+                order_id,
+            )
+
+    return {
+        "success": True,
+        "data": {
+            "order_id": str(order_id),
+            "served_by_member_id": str(member_id) if member_id else None,
+            "served_by_member_name": member_name,
+            "served_by_member_role": member_role,
+        },
+    }

--- a/migrations/074_add_served_by_member_id_to_orders.sql
+++ b/migrations/074_add_served_by_member_id_to_orders.sql
@@ -1,0 +1,32 @@
+-- 074_add_served_by_member_id_to_orders.sql
+-- Issue warocol.com#575 — per-order waiter attribution.
+--
+-- Adds the third (and final) level of the waiter attribution resolver
+-- for the WARO waiter family:
+--   1. order.served_by_member_id          ← this migration (#575)
+--   2. table_session.attended_by_member_id (#574, migration 073)
+--   3. table.assigned_member_id            (#573, migration 071)
+--
+-- Used primarily by bar + counter modes where session-level override
+-- doesn't fit naturally:
+--   - Bar: session is perpetual, but each order has its own server.
+--   - Counter: no session at all, server is per-sale.
+--
+-- Mesa orders inherit from session/table via the resolver — this
+-- column stays NULL unless explicitly overridden.
+--
+-- ON DELETE SET NULL preserves the order's history if the member
+-- is later removed.
+
+ALTER TABLE orders
+    ADD COLUMN IF NOT EXISTS served_by_member_id UUID NULL
+    REFERENCES tenant_members(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_orders_served_by_member
+    ON orders(served_by_member_id)
+    WHERE served_by_member_id IS NOT NULL;
+
+COMMENT ON COLUMN orders.served_by_member_id IS
+    'Per-order waiter attribution (warocol.com#575). Used by bar/counter '
+    'modes where mesa-level (#573) and session-level (#574) override do '
+    'not fit. Resolver: order > session > table > NULL.';


### PR DESCRIPTION
## Summary

Closes the WARO waiter attribution family. Adds the third (and final) level of the resolver: per-order attribution for bar + counter modes.

**Stacked on api-warolabs#228** (which stacks on #227). GitHub will auto-retarget to `main` after both merge.

Paired with **warocol.com#575** (frontend).

## Stack

🐍 Python 3.9 + 🔵 FastAPI + 🟣 Postgres

## Final resolver after this PR

```sql
COALESCE(
  o.served_by_member_id,                  -- this PR (#575)
  ts.attended_by_member_id,               -- #574 (api-warolabs#228)
  t.assigned_member_id,                   -- #573 (api-warolabs#227)
  NULL
) AS effective_waiter
```

One SQL query answers "¿quién atendió esta orden?" across all 3 modes (mesa / barra / mostrador) with the granularity each mode actually needs.

## Migration (1, additive)

- `074_add_served_by_member_id_to_orders.sql` — nullable FK + partial index on non-NULL rows.

## Backend changes

| File | Type | Notes |
|---|---|---|
| `app/models/table_member_assignment.py` | modify | `SetOrderServedByRequest` Pydantic |
| `app/routers/pos_cart.py` | modify | `CompleteOrderRequest` extended + threaded |
| `app/services/pos_cart_service.py` | modify | `complete_pos_order` accepts `served_by_member_id` kwarg, pre-validates outside the main transaction (fail-fast), persists in INSERT |
| `app/services/table_assignments_service.py` | modify | New `set_order_served_by()` with auto-handoff |
| `app/routers/pos_context.py` | modify | New `PATCH /pos/orders/{id}/served-by` under `Module.POS` |

## Auto-handoff (post-creation)

Reuses the predicate from #574:
| Current `served_by_member_id` | Caller | Outcome |
|---|---|---|
| NULL | anyone with POS | allow (no one to displace) |
| set | owner / admin / supervisor | allow (override) |
| set | the same member | allow (handoff) |
| set | different member, not supervisor+ | **403** |

At creation time (via `complete_pos_order` body), no auto-handoff check — there's no prior attribution to displace.

## Order creation paths — what gets the new column

| Path | Behavior |
|---|---|
| `pos_cart.complete_pos_order` | Persists `served_by_member_id` when body sets it AND toggle ON. Silent ignore otherwise. **THIS is the path for bar + counter sales.** |
| `tables_service.add_tab_items` (mesa fire) | NULL. Mesa orders inherit from session/table via the resolver (#574 / #573). PATCH endpoint can override later. |
| `online_cart_service` | NULL — no cashier present at delivery. |
| `orders_service.create_manual_order` | NULL — admin/import flow. |

## Validations

- 409 when `waiter_attribution_enabled` off (PATCH only — creation silently ignores)
- 404 when order not found OR member not in tenant
- 403 when auto-handoff predicate fails (post-creation only)

## Python compat

Target 3.9. All new code uses `Optional[X]`, `List[X]`, `Dict[X, Y]` from `typing`. `py_compile` clean.

## Testing (manual smoke planned post-merge)

- [ ] Apply migration 074
- [ ] POST `/pos-cart/{id}/complete` with `served_by_member_id` → 200, persisted
- [ ] POST with toggle OFF + field → 200, field ignored silently
- [ ] POST with member from another tenant → 404
- [ ] PATCH `/pos/orders/{id}/served-by` as supervisor → 200
- [ ] PATCH as cashier when no current → 200
- [ ] PATCH as caller IS current → 200 (handoff)
- [ ] PATCH as different cashier → 403
- [ ] PATCH with toggle off → 409
- [ ] PATCH for non-existent order → 404

No unit tests added (mirrors project convention).

## Paired frontend

warocol.com#575 adds:
- Chip "Servido por: [Juan ▾]" in the cart panel header
- Visible only in bar + counter modes (mesa already handled by #574)
- Default value: NULL (cashier picks explicitly — design decision)

That PR depends on this endpoint to exist in main.

Closes warocol.com#575 (backend)