### PR TITLE
fix(operaciones): update_toggle fails on fresh tenants (NOT NULL slug)

### DIFF
--- a/app/services/operaciones_context_service.py
+++ b/app/services/operaciones_context_service.py
@@ -60,9 +60,21 @@ async def update_toggle(
         )
 
     # Safe: column_name is validated against a hardcoded whitelist above.
+    #
+    # Hotfix (post-#573 family): the original UPSERT only inserted
+    # `tenant_id` + the toggle column, which fails for fresh tenants
+    # that don't have a `tenant_public_profiles` row yet because
+    # `slug` and `display_name` are NOT NULL with no defaults.
+    # We seed those required fields from the `tenants` table (which
+    # ALWAYS has both populated). For existing rows the ON CONFLICT
+    # branch ignores the seed values — only the toggle column is
+    # updated, so this is non-destructive for tenants with a real
+    # profile already configured.
     query = f"""
-        INSERT INTO tenant_public_profiles (tenant_id, {column_name})
-        VALUES ($1, $2)
+        INSERT INTO tenant_public_profiles (tenant_id, slug, display_name, {column_name})
+        SELECT t.id, t.slug, t.name, $2
+        FROM tenants t
+        WHERE t.id = $1
         ON CONFLICT (tenant_id) DO UPDATE
             SET {column_name} = EXCLUDED.{column_name},
                 updated_at = now()


### PR DESCRIPTION
## Summary

Hotfix for a pre-existing bug exposed by warocol.com#573 when toggling `waiter_attribution_enabled` on a tenant without an existing `tenant_public_profiles` row.

## The bug

`update_toggle()` did:
```sql
INSERT INTO tenant_public_profiles (tenant_id, <toggle_col>) VALUES ($1, $2)
ON CONFLICT (tenant_id) DO UPDATE SET ...
```

But `tenant_public_profiles.slug` and `display_name` are NOT NULL with no DB defaults. The INSERT path failed for fresh tenants:

```
NotNullViolationError: null value in column "slug" of relation 
"tenant_public_profiles" violates not-null constraint
```

This affected **5 of 16 tenants in dev** that never had a public profile configured. The same bug applies to ALL 6 toggles routed through `update_toggle` (kds, comandas, expediter, tables, auto_select_generic, **and** the new waiter_attribution). Nobody had hit it before because no fresh tenant tried a toggle.

## Fix

Seed `slug` + `display_name` from the `tenants` table (always populated, NOT NULL) when inserting the profile row:

```sql
INSERT INTO tenant_public_profiles (tenant_id, slug, display_name, <toggle_col>)
SELECT t.id, t.slug, t.name, $2
FROM tenants t
WHERE t.id = $1
ON CONFLICT (tenant_id) DO UPDATE SET ...
```

The ON CONFLICT branch is unchanged — existing tenants keep their custom slug/display_name. The seed values are only used for the initial INSERT.

`tenants.slug` is UNIQUE (matches `tenant_public_profiles.slug` UNIQUE), so the copy is safe.

## Validation

- `py_compile` clean
- Manual psql test on the offending tenant returned the expected row
- Fix verified end-to-end on local: toggle now persists `waiter_attribution_enabled = true` without errors

## Stack

🐍 Python 3.9 + 🔵 FastAPI + 🟣 Postgres

Refs warocol.com#573 (where this surfaced)