### PR TITLE
fix(pos-context): filter aggregator members to staff roles only

### DIFF
--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -55,6 +55,7 @@ JOIN profile p ON p.id = tm.user_id
 WHERE tm.tenant_id = $1
   AND tm.is_active = true
   AND tm.terminated_at IS NULL
+  AND tm.role IN ('superuser', 'admin', 'employee', 'member')
 ORDER BY p.name
 """
 


### PR DESCRIPTION
## Summary

The `members[]` array embedded in `/pos/restaurant-context` and `/operaciones/restaurant-context` was returning every active row in `tenant_members` — including `customer` and any other non-staff roles. Frontend waiter-attribution dropdowns were showing customers as selectable meseros.

Apply the same whitelist that `/api/tenants/members` (the source of `/equipo/miembros`) already enforces: `superuser`, `admin`, `employee`, `member`.

## Changes
- `app/services/pos_context_service.py`: add `AND tm.role IN ('superuser', 'admin', 'employee', 'member')` to `_MEMBERS_QUERY`.

## Test plan
- [ ] `/api/pos/restaurant-context` → `data.members` includes only staff roles.
- [ ] `/api/operaciones/restaurant-context` → same.
- [ ] MesaPanel mesero picker on `/operaciones/mesas` shows only staff (no customers).
- [ ] Existing waiter-attribution flows (#573/#574/#575) still work.