### PR TITLE
fix(invoicing): emit_invoice idempotency + current_number validation (#589)

### DIFF
--- a/app/routers/tenant_config.py
+++ b/app/routers/tenant_config.py
@@ -325,12 +325,36 @@ async def create_dian_resolution(request: Request, data: dict = Body(...)):
     except (TypeError, ValueError):
         raise HTTPException(status_code=422, detail="Formato de fecha inválido. Usa YYYY-MM-DD")
     document_type = data.get('document_type', 'invoice')
-    current_number = int(data.get('current_number', from_number - 1))
 
     if not prefix or not resolution_number or from_number <= 0 or to_number <= 0:
         raise HTTPException(status_code=422, detail="Prefijo, número de resolución y rango son requeridos")
     if from_number >= to_number:
         raise HTTPException(status_code=422, detail="El rango 'desde' debe ser menor que 'hasta'")
+
+    # Validate / seed current_number (warocol.com#589). The allocator in
+    # api-facturacion uses `next = current_number + 1`, so the correct initial
+    # state is `from_number - 1`. Default to that when the client omits the
+    # field. Reject any explicit value outside [from_number - 1, to_number] —
+    # values below would re-use already-validated DIAN numbers from previous
+    # resolutions and collide with Matias' history.
+    raw_current = data.get('current_number')
+    if raw_current is None:
+        current_number = from_number - 1
+    else:
+        current_number = int(raw_current)
+        if current_number < from_number - 1:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"current_number ({current_number}) debe ser >= from_number - 1 "
+                    f"({from_number - 1}). Valores menores reusarían números ya emitidos."
+                ),
+            )
+        if current_number > to_number:
+            raise HTTPException(
+                status_code=422,
+                detail=f"current_number ({current_number}) excede to_number ({to_number}).",
+            )
 
     async with get_db_connection() as conn:
         row_id = _uuid.uuid4()
@@ -380,6 +404,35 @@ async def update_dian_resolution(request: Request, resolution_id: str, data: dic
     except (TypeError, ValueError):
         raise HTTPException(status_code=422, detail="Formato de fecha inválido. Usa YYYY-MM-DD")
 
+    from_number = int(data.get('from_number', 0))
+    to_number = int(data.get('to_number', 0))
+    if from_number <= 0 or to_number <= 0:
+        raise HTTPException(status_code=422, detail="from_number y to_number son requeridos")
+    if from_number >= to_number:
+        raise HTTPException(status_code=422, detail="El rango 'desde' debe ser menor que 'hasta'")
+
+    # Same current_number validation as POST (warocol.com#589). Updates that
+    # set current_number below `from_number - 1` would reactivate the bug
+    # this issue fixed.
+    raw_current = data.get('current_number')
+    if raw_current is None:
+        current_number = from_number - 1
+    else:
+        current_number = int(raw_current)
+        if current_number < from_number - 1:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"current_number ({current_number}) debe ser >= from_number - 1 "
+                    f"({from_number - 1}). Valores menores reusarían números ya emitidos."
+                ),
+            )
+        if current_number > to_number:
+            raise HTTPException(
+                status_code=422,
+                detail=f"current_number ({current_number}) excede to_number ({to_number}).",
+            )
+
     async with get_db_connection() as conn:
         await conn.execute(
             """UPDATE dian_resolutions
@@ -388,8 +441,8 @@ async def update_dian_resolution(request: Request, resolution_id: str, data: dic
                WHERE id = $9::uuid AND tenant_id = $10""",
             data.get('resolution_number'), data.get('prefix', '').strip().upper(),
             date_from, date_to,
-            int(data.get('from_number', 0)), int(data.get('to_number', 0)),
-            int(data.get('current_number', 0)), data.get('document_type', 'invoice'),
+            from_number, to_number,
+            current_number, data.get('document_type', 'invoice'),
             resolution_id, tenant_id,
         )
 

--- a/app/services/facturacion_service.py
+++ b/app/services/facturacion_service.py
@@ -36,12 +36,15 @@ async def emit_invoice(
     Emit a DIAN electronic invoice for a completed POS order.
 
     Validates the order is completed, then delegates to api-facturacion.
-    Idempotent: calling twice returns the same accepted invoice.
+    Idempotent at the gateway: short-circuits when an accepted invoice
+    already exists for this order, and rejects re-tries when the previous
+    attempt failed with an un-recoverable Matias error (warocol.com#589).
 
     Raises:
         HTTPException 422 — order not found, not completed, or missing resolution
         HTTPException 503 — api-facturacion unreachable or timed out
-        HTTPException 409 — emission already in progress
+        HTTPException 409 — emission already in progress OR unrecoverable
+                            previous rejection (Matias "ya validado")
     """
     # Verify order exists, belongs to tenant, and is completed
     async with get_db_connection(use_transaction=False) as conn:
@@ -57,6 +60,46 @@ async def emit_invoice(
         raise HTTPException(
             status_code=422,
             detail=f"Invoice can only be emitted for completed orders (current status: {order['status']})",
+        )
+
+    # Pre-check existing electronic_invoices for this order (warocol.com#589).
+    # - If the latest is `accepted` → return it, no Matias call.
+    # - If the latest is `rejected` with the Matias "ya validado" signature
+    #   → 409 short-circuit so the cashier doesn't burn another resolution
+    #   number on a retry that will fail again. Recovery (fetch from Matias
+    #   + persist) is out of this layer's scope — handled in api-facturacion
+    #   in a follow-up.
+    # - Any other rejection signature is allowed to retry (e.g., missing NIT
+    #   that the cashier just fixed).
+    async with get_db_connection(use_transaction=False) as conn:
+        latest = await conn.fetchrow(
+            """SELECT status, invoice_number, prefix, error_message
+               FROM electronic_invoices
+               WHERE order_id = $1 AND tenant_id = $2
+               ORDER BY created_at DESC
+               LIMIT 1""",
+            UUID(order_id), UUID(tenant_id),
+        )
+
+    if latest and latest['status'] == 'accepted':
+        existing = await get_order_invoice(order_id, tenant_id)
+        if existing is not None:
+            logger.info(f"Invoice already accepted for order {order_id}, short-circuiting emit")
+            return existing
+
+    if (
+        latest
+        and latest['status'] == 'rejected'
+        and latest['error_message']
+        and 'ya se encuentra validado' in latest['error_message'].lower()
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"La factura {latest['prefix']}{latest['invoice_number']} ya está "
+                "validada en DIAN pero no se pudo descargar localmente. "
+                "Contacta soporte para reconciliar el documento."
+            ),
         )
 
     # Delegate to api-facturacion


### PR DESCRIPTION
## Summary

Two backend fixes for the recurring \"Matias API 400: ya se encuentra validado\" error documented in warocol.com#589:

1. **Gateway-level idempotency** in `emit_invoice`: short-circuit if the order already has an accepted invoice, and refuse to retry orders whose previous attempt was rejected with the Matias \"ya validado\" signature (was burning DIAN resolution numbers on every cashier click).

2. **DIAN resolution `current_number` validation** on POST/PUT: reject values below \`from_number - 1\` (the correct initial state) so the form on warocol.com /facturacion can't silently create resolutions that allocate already-validated numbers.

The third phase of the fix is a one-shot SQL data correction (`UPDATE dian_resolutions SET current_number = from_number - 1 WHERE current_number < from_number - 1 AND is_active`) — not part of this PR, executed by ops.

## Stack
🔵 FastAPI / 🐍 Python 3.9

## Changes
- `app/services/facturacion_service.py`: new pre-check block in `emit_invoice` querying `electronic_invoices` for the latest attempt. Accepted → return existing. Rejected-with-ya-validado → 409 with operator-friendly message. Other rejections still allow retry.
- `app/routers/tenant_config.py`: validate `current_number` against `[from_number - 1, to_number]` on both POST and PUT \`/dian-resolutions\`. POST already defaulted to \`from_number - 1\` when the field was omitted — kept that. Both endpoints now reject explicit values below the bound.

## Testing (manual)
- [ ] Happy path: POST /api/orders/{id}/invoice on a fresh order → api-facturacion called, 200.
- [ ] Accepted idempotency: same order, second click → 200 without an api-facturacion call (verify in logs).
- [ ] Recoverable-failed: order whose latest electronic_invoices row is \`status=rejected\` and \`error_message ILIKE '%ya se encuentra validado%'\` → 409 with the new Spanish message. No new row created.
- [ ] Other rejection still retries: order with rejected row + message like \"Falta NIT del cliente\" → api-facturacion called normally.
- [ ] Resolution POST without `current_number` field → defaults to `from_number - 1`. Works as before.
- [ ] Resolution POST with `current_number: 0` and `from_number: 5460` → 422 with \"debe ser >= from_number - 1\" message.
- [ ] Resolution PUT mirroring same validation.

Closes #589 (backend portion). Frontend PR in warocol.com follows.