### PR TITLE
feat(dian): forward-only counter + sequence-gaps audit + multi-resolution priority (warocol.com#592)

### DIFF
--- a/app/routers/tenant_config.py
+++ b/app/routers/tenant_config.py
@@ -434,6 +434,24 @@ async def update_dian_resolution(request: Request, resolution_id: str, data: dic
             )
 
     async with get_db_connection() as conn:
+        # warocol.com#592 — Forward-only invariant: current_number can never
+        # decrease. The DB trigger `dian_resolutions_no_rewind_trigger` will
+        # block it at the storage layer, but we surface a friendlier 422 here
+        # before the UPDATE rather than a generic 500 from the trigger.
+        existing = await conn.fetchrow(
+            "SELECT current_number FROM dian_resolutions WHERE id = $1::uuid AND tenant_id = $2",
+            resolution_id, tenant_id,
+        )
+        if existing is not None and current_number < existing['current_number']:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"current_number ({current_number}) no puede ser menor que el actual "
+                    f"({existing['current_number']}). DIAN prohíbe reutilizar números — "
+                    "el contador solo avanza."
+                ),
+            )
+
         await conn.execute(
             """UPDATE dian_resolutions
                SET resolution_number = $1, prefix = $2, date_from = $3, date_to = $4,
@@ -474,6 +492,118 @@ async def toggle_dian_resolution(request: Request, resolution_id: str):
         )
 
     return {'success': True, 'data': {'is_active': new_state}}
+
+
+@router.get("/dian-resolutions/gaps", dependencies=[Depends(require_module(Module.MI_NEGOCIO))])
+async def list_dian_sequence_gaps(
+    request: Request,
+    resolution_id: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+):
+    """List sequence gaps for the active tenant (warocol.com#592).
+
+    Returns the audit trail of DIAN numbers that were allocated but never
+    accepted by Matias. Each row is permanently retired — DIAN forbids
+    number reuse. Filterable by resolution.
+    """
+    from app.core.middleware import require_valid_session
+    from app.database import get_db_connection
+
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+
+    if limit > 200:
+        limit = 200
+
+    params = [tenant_id, limit, offset]
+    resolution_clause = ""
+    if resolution_id:
+        resolution_clause = " AND g.resolution_id = $4::uuid"
+        params.append(resolution_id)
+
+    query = f"""
+        SELECT
+            g.id, g.resolution_id, g.prefix, g.skipped_number, g.reason,
+            g.matias_response, g.original_attempt_order_id, g.created_at,
+            r.resolution_number, r.from_number, r.to_number,
+            o.order_number AS original_order_number
+        FROM dian_sequence_gaps g
+        JOIN dian_resolutions r ON r.id = g.resolution_id
+        LEFT JOIN orders o ON o.id = g.original_attempt_order_id
+        WHERE g.tenant_id = $1{resolution_clause}
+        ORDER BY g.created_at DESC
+        LIMIT $2 OFFSET $3
+    """
+
+    async with get_db_connection(use_transaction=False) as conn:
+        rows = await conn.fetch(query, *params)
+        total = await conn.fetchval(
+            "SELECT COUNT(*) FROM dian_sequence_gaps WHERE tenant_id = $1",
+            tenant_id,
+        )
+
+    return {
+        'success': True,
+        'total': total,
+        'limit': limit,
+        'offset': offset,
+        'data': [
+            {
+                'id': str(r['id']),
+                'resolution_id': str(r['resolution_id']),
+                'resolution_number': r['resolution_number'],
+                'prefix': r['prefix'],
+                'skipped_number': r['skipped_number'],
+                'reason': r['reason'],
+                'matias_response': r['matias_response'],
+                'original_attempt_order_id': (
+                    str(r['original_attempt_order_id']) if r['original_attempt_order_id'] else None
+                ),
+                'original_order_number': r['original_order_number'],
+                'from_number': r['from_number'],
+                'to_number': r['to_number'],
+                'created_at': r['created_at'].isoformat() if r['created_at'] else None,
+            }
+            for r in rows
+        ],
+    }
+
+
+@router.get("/dian-resolutions/gaps-summary", dependencies=[Depends(require_module(Module.MI_NEGOCIO))])
+async def dian_gaps_summary(request: Request):
+    """Aggregate gap counts for the active tenant (warocol.com#592).
+
+    Returns counts for the last 24h / 7d / 30d windows. The frontend
+    uses this to surface a range-burn alert on the resolutions card.
+    """
+    from app.core.middleware import require_valid_session
+    from app.database import get_db_connection
+
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+
+    async with get_db_connection(use_transaction=False) as conn:
+        row = await conn.fetchrow(
+            """SELECT
+                   COUNT(*) FILTER (WHERE created_at > now() - interval '24 hours') AS last_24h,
+                   COUNT(*) FILTER (WHERE created_at > now() - interval '7 days')   AS last_7d,
+                   COUNT(*) FILTER (WHERE created_at > now() - interval '30 days')  AS last_30d,
+                   COUNT(*)                                                          AS total
+               FROM dian_sequence_gaps
+               WHERE tenant_id = $1""",
+            tenant_id,
+        )
+
+    return {
+        'success': True,
+        'data': {
+            'last_24h': row['last_24h'] or 0,
+            'last_7d': row['last_7d'] or 0,
+            'last_30d': row['last_30d'] or 0,
+            'total': row['total'] or 0,
+        },
+    }
 
 
 @router.get("/facturacion-status", dependencies=[Depends(require_module(Module.MI_NEGOCIO))])

--- a/app/routers/webhooks.py
+++ b/app/routers/webhooks.py
@@ -7,11 +7,14 @@ POST /api/webhooks/matias  → proxies raw body + signature header to
 No session auth — Matias calls this from the internet.
 Raw body is forwarded unmodified so api-facturacion can verify HMAC-SHA256.
 """
+import json
 import httpx
 import logging
+from uuid import UUID
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from app.config import settings
+from app.database import get_db_connection
 
 logger = logging.getLogger(__name__)
 
@@ -25,9 +28,40 @@ async def matias_webhook_bridge(request: Request):
 
     Forwards raw body + X-Matias-Signature header unchanged.
     Always returns 200 to prevent Matias retry storms.
+
+    Defensive gap check (warocol.com#592): if the webhook references a
+    `(tenant, prefix, number)` that we already logged as a permanent skip
+    in `dian_sequence_gaps`, we log a WARNING so the audit trail surfaces
+    the suspicious reconciliation attempt. Authoritative dedup must happen
+    in api-facturacion (which owns the electronic_invoices write path) —
+    this layer is just an early alarm.
     """
     body = await request.body()
     signature = request.headers.get("X-Matias-Signature", "")
+
+    # warocol.com#592 — best-effort gap correlation. Wrapped in broad
+    # try/except: this MUST NOT interfere with the proxy to api-facturacion.
+    try:
+        payload = json.loads(body) if body else {}
+        invoice_number = payload.get("invoice_number")
+        prefix = payload.get("prefix")
+        tenant_id_hint = payload.get("tenant_id")
+        if invoice_number and prefix and tenant_id_hint:
+            async with get_db_connection(use_transaction=False) as conn:
+                gap = await conn.fetchrow(
+                    """SELECT 1 FROM dian_sequence_gaps
+                       WHERE tenant_id = $1 AND prefix = $2 AND skipped_number = $3
+                       LIMIT 1""",
+                    UUID(str(tenant_id_hint)), str(prefix), int(invoice_number),
+                )
+            if gap:
+                logger.warning(
+                    "Matias webhook for %s%s references a logged sequence gap "
+                    "for tenant %s — api-facturacion must dedup, not persist.",
+                    prefix, invoice_number, tenant_id_hint,
+                )
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.debug("Webhook gap-check best-effort failed: %s", exc)
 
     url = f"{settings.facturacion_api_url.rstrip('/')}/webhooks/matias"
 

--- a/migrations/075_dian_sequence_gaps.sql
+++ b/migrations/075_dian_sequence_gaps.sql
@@ -1,0 +1,85 @@
+-- 075_dian_sequence_gaps.sql
+-- Issue warocol.com#592 — auto-skip + retry on Matias "ya validado" with
+-- multi-resolution fallback. This migration installs the foundations the
+-- api-facturacion retry loop will rely on.
+--
+-- Forward-only constraint clarification from #592 design review:
+--   "Reusing numbering that has been reversed by annulment is an
+--    infraction subject to sanctions (DIAN)."
+--   → current_number must only advance. Never rewind. Never reuse a
+--     number that was logged in dian_sequence_gaps.
+--
+-- Schema changes (all non-destructive ADD/CREATE per CLAUDE.md):
+--   1. CHECK constraint on dian_resolutions.current_number range.
+--   2. BEFORE UPDATE trigger blocking any decrement.
+--   3. Drop the old single-active UNIQUE index; allow multi-active per
+--      (tenant, prefix) ordered by a new `priority` column. (DROP INDEX
+--      is non-destructive in data terms — no rows deleted.)
+--   4. New `priority` column on dian_resolutions (default 100).
+--   5. New `dian_sequence_gaps` audit table with UNIQUE
+--      (tenant_id, prefix, skipped_number) to enforce single-use globally.
+--
+-- See: https://github.com/uno0uno/warocol.com/issues/592
+
+-- 1. Counter range check.
+ALTER TABLE dian_resolutions
+  ADD CONSTRAINT dian_resolutions_counter_within_range
+  CHECK (current_number >= from_number - 1 AND current_number <= to_number);
+
+-- 2. Forward-only counter trigger.
+CREATE OR REPLACE FUNCTION dian_resolutions_no_rewind() RETURNS trigger AS $$
+BEGIN
+  IF NEW.current_number < OLD.current_number THEN
+    RAISE EXCEPTION
+      'current_number cannot decrease (was %, attempted %). DIAN forbids number reuse.',
+      OLD.current_number, NEW.current_number
+      USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER dian_resolutions_no_rewind_trigger
+  BEFORE UPDATE OF current_number ON dian_resolutions
+  FOR EACH ROW EXECUTE FUNCTION dian_resolutions_no_rewind();
+
+-- 3 + 4. Multi-resolution fallback: drop the single-active UNIQUE
+--   index and add `priority`. Highest priority wins when api-facturacion
+--   allocates the next number.
+DROP INDEX IF EXISTS idx_dian_resolutions_active_prefix;
+
+ALTER TABLE dian_resolutions
+  ADD COLUMN priority integer NOT NULL DEFAULT 100;
+
+CREATE INDEX idx_dian_resolutions_active_priority
+  ON dian_resolutions(tenant_id, prefix, priority DESC, from_number ASC)
+  WHERE is_active = true;
+
+-- 5. Sequence gaps audit table.
+CREATE TABLE dian_sequence_gaps (
+  id                        uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id                 uuid NOT NULL REFERENCES tenants(id),
+  resolution_id             uuid NOT NULL REFERENCES dian_resolutions(id),
+  prefix                    varchar(10) NOT NULL,
+  skipped_number            integer NOT NULL,
+  reason                    varchar(50) NOT NULL,
+  matias_response           jsonb,
+  original_attempt_order_id uuid REFERENCES orders(id),
+  created_at                timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT dian_gaps_no_reuse UNIQUE (tenant_id, prefix, skipped_number)
+);
+
+CREATE INDEX idx_dian_gaps_tenant_created ON dian_sequence_gaps(tenant_id, created_at DESC);
+CREATE INDEX idx_dian_gaps_resolution ON dian_sequence_gaps(resolution_id);
+
+COMMENT ON TABLE dian_sequence_gaps IS
+  'Audit trail of DIAN invoice numbers that were allocated but never accepted '
+  'by Matias/DIAN. Each row represents a number permanently retired from the '
+  'sequence — DIAN forbids reuse so this table is the legal justification '
+  'for any gap an auditor finds. See warocol.com#592.';
+
+COMMENT ON COLUMN dian_sequence_gaps.reason IS
+  'Why the number was skipped: matias_ya_validado, matias_500, network_timeout, etc.';
+
+COMMENT ON COLUMN dian_sequence_gaps.matias_response IS
+  'Full Matias error payload at the time of skip — DIAN audit-grade evidence.';


### PR DESCRIPTION
## Summary

Foundations for the auto-skip + retry pattern tracked in `warocol.com#592`.

This PR ships only the schema, gap audit endpoints, and webhook early-warning hooks. The actual retry loop on Matias "ya validado" lives in api-facturacion (separate repo) and will land in PR B.

## Changes

### Migration `075_dian_sequence_gaps.sql`
- `CHECK` on `dian_resolutions.current_number` (must be within `from_number-1..to_number`).
- `BEFORE UPDATE` trigger `dian_resolutions_no_rewind_trigger` blocking any decrement — DIAN forbids reusing reversed numbers; the counter only advances.
- `DROP INDEX idx_dian_resolutions_active_prefix` (single-active UNIQUE) + new `priority` column on `dian_resolutions` to allow multiple active resolutions per `(tenant, prefix)`, highest priority wins.
- New `dian_sequence_gaps` audit table with `UNIQUE (tenant_id, prefix, skipped_number)` — globally enforces single-use of every skipped number.

Pre-flight: verified `SELECT COUNT(*) FROM dian_resolutions WHERE current_number < from_number - 1 OR current_number > to_number` is 0 on prod — the new CHECK does not break any row.

### `app/routers/tenant_config.py`
- `PUT /dian-resolutions/{id}`: friendly 422 if a user tries to decrease `current_number`, before the DB trigger fires.
- `GET /dian-resolutions/gaps` (MI_NEGOCIO): paginated audit list, filterable by `resolution_id`, `limit≤200`. Filtered by `session.tenant_id`.
- `GET /dian-resolutions/gaps-summary` (MI_NEGOCIO): 24h / 7d / 30d / total counts — drives the range-burn alert on the frontend.

### `app/routers/webhooks.py`
- Best-effort: when Matias calls our public webhook bridge, look up `(tenant_id, prefix, invoice_number)` in `dian_sequence_gaps` and log a WARNING if it matches a logged skip. Authoritative dedup must still happen in api-facturacion (the owner of `electronic_invoices`). Wrapped in broad try/except — never blocks the proxy.

## Out of scope

- PR B (api-facturacion retry loop) — separate repo.
- PR C (frontend audit page + range-burn alert) — coming next in `warocol.com`.

## Test plan

- [x] Python 3.9 compile clean (`python3 -m py_compile` on both files).
- [ ] Apply migration 075 in dev → confirm CHECK + trigger + UNIQUE all fire correctly.
- [ ] `PUT /dian-resolutions/{id}` with `current_number` below stored value → 422.
- [ ] `GET /dian-resolutions/gaps` returns rows filtered by tenant (cross-tenant isolation).
- [ ] Webhook bridge: send a Matias payload referencing a row in `dian_sequence_gaps` → check WARNING log.

Closes warocol.com#592 (partially — schema + audit only).