### PR TITLE
fix(invoicing): time-bound 'ya validado' short-circuit so stuck orders can reach the retry loop (warocol.com#596)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -93,6 +93,13 @@ class Settings(BaseSettings):
     # api-facturacion microservice — DIAN electronic invoicing (issue #128)
     facturacion_api_url: str = Field(default='http://api-facturacion:8001', alias='FACTURACION_API_URL')
 
+    # warocol.com#596 — grace window for the "ya validado" short-circuit in
+    # emit_invoice. A repeated emit on a rejected-as-validado order is 409'd
+    # only if the previous rejection is younger than this many minutes.
+    # Older rejections fall through to api-facturacion so the retry loop
+    # (api-facturacion#21) can recover the order.
+    dian_short_circuit_grace_minutes: int = Field(default=5, alias='DIAN_SHORT_CIRCUIT_GRACE_MINUTES')
+
     class Config:
         env_file = ".env"
         extra = "ignore"  # Ignore extra environment variables

--- a/app/services/facturacion_service.py
+++ b/app/services/facturacion_service.py
@@ -16,6 +16,7 @@ directly and generate R2 presigned URLs locally (api-warolabs has R2 credentials
 """
 import httpx
 import logging
+from datetime import datetime, timezone, timedelta
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 from fastapi import HTTPException
@@ -65,15 +66,15 @@ async def emit_invoice(
     # Pre-check existing electronic_invoices for this order (warocol.com#589).
     # - If the latest is `accepted` → return it, no Matias call.
     # - If the latest is `rejected` with the Matias "ya validado" signature
-    #   → 409 short-circuit so the cashier doesn't burn another resolution
-    #   number on a retry that will fail again. Recovery (fetch from Matias
-    #   + persist) is out of this layer's scope — handled in api-facturacion
-    #   in a follow-up.
+    #   AND younger than `dian_short_circuit_grace_minutes` → 409 to protect
+    #   against double-click. Older rejections fall through so the
+    #   api-facturacion retry loop (api-facturacion#21, warocol.com#596) can
+    #   take over.
     # - Any other rejection signature is allowed to retry (e.g., missing NIT
     #   that the cashier just fixed).
     async with get_db_connection(use_transaction=False) as conn:
         latest = await conn.fetchrow(
-            """SELECT status, invoice_number, prefix, error_message
+            """SELECT status, invoice_number, prefix, error_message, created_at
                FROM electronic_invoices
                WHERE order_id = $1 AND tenant_id = $2
                ORDER BY created_at DESC
@@ -92,13 +93,14 @@ async def emit_invoice(
         and latest['status'] == 'rejected'
         and latest['error_message']
         and 'ya se encuentra validado' in latest['error_message'].lower()
+        and (datetime.now(timezone.utc) - latest['created_at'])
+            < timedelta(minutes=settings.dian_short_circuit_grace_minutes)
     ):
         raise HTTPException(
             status_code=409,
             detail=(
-                f"La factura {latest['prefix']}{latest['invoice_number']} ya está "
-                "validada en DIAN pero no se pudo descargar localmente. "
-                "Contacta soporte para reconciliar el documento."
+                f"La factura {latest['prefix']}{latest['invoice_number']} acaba de "
+                "rechazarse en DIAN. Esperá unos segundos antes de reintentar."
             ),
         )
 

--- a/tests/test_emit_short_circuit.py
+++ b/tests/test_emit_short_circuit.py
@@ -1,0 +1,191 @@
+"""
+Tests for the time-bounded "ya validado" short-circuit in
+app.services.facturacion_service.emit_invoice (warocol.com#596).
+
+emit_invoice opens two DB connections in sequence:
+  1. order existence/status check
+  2. latest electronic_invoices lookup
+
+We patch `get_db_connection` to return a sequenced ConnCtx that yields the
+right row on each call, then assert on either the raised HTTPException or
+the fact that httpx.AsyncClient.post was invoked (i.e. the request fell
+through to the api-facturacion proxy).
+"""
+from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.services import facturacion_service
+
+
+_TENANT_ID = '93b3e582-34fa-44a6-8d0f-bf82a3608727'
+_ORDER_ID = str(uuid4())
+
+
+class _SeqConnCtx:
+    """Context manager that returns a different `conn.fetchrow` row each call.
+
+    `rows` is iterated lazily as the production code calls `get_db_connection`
+    repeatedly. Each `__aenter__` returns a fresh fake conn pre-configured to
+    return the next row.
+    """
+
+    def __init__(self, rows):
+        self._iter = iter(rows)
+
+    async def __aenter__(self):
+        conn = MagicMock()
+        conn.fetchrow = AsyncMock(return_value=next(self._iter))
+        return conn
+
+    async def __aexit__(self, *_):
+        return False
+
+
+def _patch_db(rows):
+    """Patch `get_db_connection` to yield the supplied rows in order."""
+    ctx = _SeqConnCtx(rows)
+    return patch(
+        'app.services.facturacion_service.get_db_connection',
+        lambda *args, **kwargs: ctx,
+    )
+
+
+def _order_row(status: str = 'completed'):
+    return {'id': UUID(_ORDER_ID), 'status': status}
+
+
+def _latest_invoice_row(
+    status: str = 'rejected',
+    error_message: str = 'Matias API 400: ya se encuentra validado.',
+    created_at: datetime = None,
+    invoice_number: int = 5462,
+    prefix: str = 'LZT',
+):
+    if created_at is None:
+        created_at = datetime.now(timezone.utc)
+    return {
+        'status':         status,
+        'invoice_number': invoice_number,
+        'prefix':         prefix,
+        'error_message':  error_message,
+        'created_at':     created_at,
+    }
+
+
+@pytest.mark.asyncio
+async def test_recent_rejected_still_409():
+    """`created_at` 60s ago → still inside grace window → 409 with new copy."""
+    rows = [
+        _order_row(),
+        _latest_invoice_row(
+            created_at=datetime.now(timezone.utc) - timedelta(seconds=60),
+        ),
+    ]
+    with _patch_db(rows):
+        with pytest.raises(HTTPException) as exc_info:
+            await facturacion_service.emit_invoice(_ORDER_ID, _TENANT_ID, 'pos')
+
+    assert exc_info.value.status_code == 409
+    # New copy — must not still mention "Contacta soporte" or "no se pudo descargar".
+    assert 'acaba de' in exc_info.value.detail.lower()
+    assert 'esperá' in exc_info.value.detail.lower() or 'espera' in exc_info.value.detail.lower()
+    assert 'contacta soporte' not in exc_info.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_old_rejected_falls_through_to_proxy():
+    """`created_at` 10min ago → outside grace window → request reaches api-facturacion."""
+    rows = [
+        _order_row(),
+        _latest_invoice_row(
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=10),
+        ),
+    ]
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.is_success = True
+    fake_resp.json = MagicMock(return_value={'status': 'accepted', 'cufe': 'CUFE_OK'})
+    fake_resp.text = '{"status":"accepted"}'
+
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=fake_resp)
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=False)
+
+    with _patch_db(rows), patch(
+        'app.services.facturacion_service.httpx.AsyncClient',
+        return_value=fake_client,
+    ):
+        result = await facturacion_service.emit_invoice(_ORDER_ID, _TENANT_ID, 'pos')
+
+    # Request escaped the gate and hit the proxy with the expected payload.
+    fake_client.post.assert_awaited_once()
+    posted_url = fake_client.post.await_args.args[0]
+    assert posted_url.endswith('/invoice/emit')
+    assert result == {'status': 'accepted', 'cufe': 'CUFE_OK'}
+
+
+@pytest.mark.asyncio
+async def test_other_rejection_falls_through_regardless_of_age():
+    """Recent rejection with a *non-ya-validado* reason still falls through."""
+    rows = [
+        _order_row(),
+        _latest_invoice_row(
+            error_message='Matias API 400: Falta NIT del cliente',
+            created_at=datetime.now(timezone.utc) - timedelta(seconds=10),
+        ),
+    ]
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.is_success = True
+    fake_resp.json = MagicMock(return_value={'status': 'accepted'})
+    fake_resp.text = '{"status":"accepted"}'
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=fake_resp)
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=False)
+
+    with _patch_db(rows), patch(
+        'app.services.facturacion_service.httpx.AsyncClient',
+        return_value=fake_client,
+    ):
+        await facturacion_service.emit_invoice(_ORDER_ID, _TENANT_ID, 'pos')
+
+    fake_client.post.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_accepted_short_circuits_to_existing_invoice():
+    """A previously accepted invoice → returns it without calling api-facturacion."""
+    rows = [
+        _order_row(),
+        _latest_invoice_row(
+            status='accepted',
+            error_message=None,
+        ),
+    ]
+
+    existing_payload = {'invoice_number': 5460, 'cufe': 'CUFE_PRE', 'status': 'accepted'}
+
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock()
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=False)
+
+    with _patch_db(rows), patch(
+        'app.services.facturacion_service.get_order_invoice',
+        new=AsyncMock(return_value=existing_payload),
+    ), patch(
+        'app.services.facturacion_service.httpx.AsyncClient',
+        return_value=fake_client,
+    ):
+        result = await facturacion_service.emit_invoice(_ORDER_ID, _TENANT_ID, 'pos')
+
+    assert result == existing_payload
+    fake_client.post.assert_not_awaited()


### PR DESCRIPTION
## Summary

Companion to api-facturacion#21 (the auto-skip + retry loop). The unconditional 409 added in warocol.com#589 still protects against cashier double-click, but with the loop now live it leaves any order with a previous "ya validado" rejected row permanently stuck — the request never reaches api-facturacion. This narrows the short-circuit to a configurable grace window so older rejections fall through and the loop can recover them.

## Stack
🔵 FastAPI + 🐍 Python 3.9

## Changes

### `app/config.py`
- New setting `dian_short_circuit_grace_minutes: int = 5` (env `DIAN_SHORT_CIRCUIT_GRACE_MINUTES`).

### `app/services/facturacion_service.py`
- Import `datetime`, `timezone`, `timedelta`.
- Widen the latest-`electronic_invoices` `SELECT` to include `created_at` (without this column the new comparison would `KeyError` and 500).
- Time-bound the 409: only triggers when the rejected-"ya validado" row is younger than the grace window.
- Rewrite the 409 detail to match the new meaning: `"La factura {prefix}{number} acaba de rechazarse en DIAN. Esperá unos segundos antes de reintentar."` (instead of the now-misleading `"Contacta soporte para reconciliar"`).

### `tests/test_emit_short_circuit.py` (new)
4 cases, all unit (no DB needed — mock `get_db_connection` + `httpx.AsyncClient`):
- `test_recent_rejected_still_409` — `created_at = now - 60s` → 409 with new copy, "Contacta soporte" must NOT appear.
- `test_old_rejected_falls_through_to_proxy` — `created_at = now - 10min` → `httpx.AsyncClient.post` is called, the response is returned to the caller.
- `test_other_rejection_falls_through_regardless_of_age` — recent rejected with `error_message='Falta NIT'` → still falls through, today's behaviour preserved.
- `test_accepted_short_circuits_to_existing_invoice` — accepted invoice path untouched, `httpx.post` NOT called.

## Test Plan

- [x] `python3 -m py_compile app/config.py app/services/facturacion_service.py tests/test_emit_short_circuit.py` — clean.
- [x] `pytest tests/test_emit_short_circuit.py tests/test_invoicing_readiness.py -v` — **19/19 pass** (4 new + 15 existing).
- [ ] After deploy: re-emit LZT-5462 from `/ventas/{id}` → expect the request to reach api-facturacion → the loop walks past collisions → accepted invoice (or 409 with the "intentos consecutivos" message, which is api-facturacion#21's territory).

## Operational note

The grace window is env-configurable so ops can tune in prod without a redeploy:
```bash
# /home/saifer/api-warocol.com/.env  → restart container
DIAN_SHORT_CIRCUIT_GRACE_MINUTES=5   # default
```

## Closes

warocol.com#596 (full epic: warocol.com#592).