### PR TITLE
fix(suppliers): structured 409 on delete-supplier with dependents (warocol.com#597)

### DIFF
--- a/app/services/suppliers_service.py
+++ b/app/services/suppliers_service.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional, Dict, Any, List
 from uuid import UUID
 from datetime import time
+import asyncpg
 from fastapi import Request, Response, HTTPException
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
@@ -511,24 +512,64 @@ async def delete_supplier(
         async with get_db_connection() as conn:
             # Verify supplier exists and belongs to tenant
             existing_supplier = await conn.fetchrow("""
-                SELECT id FROM tenant_suppliers 
+                SELECT id FROM tenant_suppliers
                 WHERE id = $1 AND tenant_id = $2
             """, supplier_id, tenant_id)
-            
+
             if not existing_supplier:
                 raise HTTPException(status_code=404, detail="Supplier not found")
-            
-            # Delete supplier
-            await conn.execute("""
-                DELETE FROM tenant_suppliers 
-                WHERE id = $1 AND tenant_id = $2
-            """, supplier_id, tenant_id)
-            
+
+            # Pre-count RESTRICT dependents so the client gets an actionable
+            # 409 instead of a generic 500 from a deferred FK violation.
+            # supplier_payment_agreements is ON DELETE CASCADE — not counted.
+            deps = await conn.fetchrow(
+                """
+                SELECT
+                    COALESCE((SELECT COUNT(*) FROM tenant_purchases       WHERE supplier_id = $1), 0) AS purchases,
+                    COALESCE((SELECT COUNT(*) FROM tenant_supplier_prices WHERE supplier_id = $1), 0) AS supplier_prices
+                """,
+                supplier_id,
+            )
+            if deps["purchases"] > 0 or deps["supplier_prices"] > 0:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "code": "supplier_has_dependents",
+                        "counts": {
+                            "purchases": deps["purchases"],
+                            "supplier_prices": deps["supplier_prices"],
+                        },
+                        "message": "El proveedor tiene registros asociados que impiden su eliminación.",
+                    },
+                )
+
+            try:
+                await conn.execute("""
+                    DELETE FROM tenant_suppliers
+                    WHERE id = $1 AND tenant_id = $2
+                """, supplier_id, tenant_id)
+            except asyncpg.exceptions.ForeignKeyViolationError as fk_err:
+                # Defense-in-depth: a future FK without ON DELETE CASCADE would
+                # land here instead of leaking a generic 500. Pre-count above
+                # covers the known cases; this protects against schema drift.
+                logger.warning(
+                    "FK violation deleting supplier %s after pre-count passed: %s",
+                    supplier_id,
+                    fk_err,
+                )
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "code": "supplier_has_dependents_unknown",
+                        "message": "El proveedor tiene registros asociados que impiden su eliminación.",
+                    },
+                )
+
             return {
                 "success": True,
                 "message": "Supplier deleted successfully"
             }
-            
+
     except AuthenticationError:
         raise
     except HTTPException:

--- a/tests/test_suppliers.py
+++ b/tests/test_suppliers.py
@@ -146,6 +146,37 @@ class TestSupplierCRUD:
         response = await client.delete(f"/suppliers/providers/{fake_id}")
         assert response.status_code in [404, 401, 403, 500]
 
+    @pytest.mark.asyncio
+    async def test_delete_supplier_409_response_shape(self, client: AsyncClient):
+        """Validate the 409 response body when a supplier has FK dependents."""
+        list_response = await client.get("/suppliers/providers?limit=50")
+        if list_response.status_code != 200:
+            pytest.skip("list endpoint unauthenticated in this run")
+
+        data = list_response.json()
+        for supplier in data.get("data", []):
+            response = await client.delete(
+                f"/suppliers/providers/{supplier['id']}"
+            )
+            if response.status_code == 409:
+                body = response.json()
+                assert "detail" in body
+                detail = body["detail"]
+                assert isinstance(detail, dict)
+                assert detail.get("code") in (
+                    "supplier_has_dependents",
+                    "supplier_has_dependents_unknown",
+                )
+                assert "message" in detail
+                if detail["code"] == "supplier_has_dependents":
+                    assert "counts" in detail
+                    counts = detail["counts"]
+                    assert isinstance(counts.get("purchases"), int)
+                    assert isinstance(counts.get("supplier_prices"), int)
+                    assert counts["purchases"] + counts["supplier_prices"] > 0
+                return
+        pytest.skip("no supplier with FK dependents present in this DB")
+
 
 class TestPaymentAgreementsEndpoint:
     """Test supplier payment agreements endpoint"""


### PR DESCRIPTION
## Summary
Replaces the generic 500 "Error interno del servidor" with a structured 409 when deleting a supplier that has FK dependents.

- Pre-counts `tenant_purchases` and `tenant_supplier_prices` (both RESTRICT) before issuing the DELETE.
- Returns `{ code, counts: { purchases, supplier_prices }, message }` so the frontend can render an actionable modal.
- `supplier_payment_agreements` is ON DELETE CASCADE — not a blocker, not counted.
- Defense-in-depth `asyncpg.ForeignKeyViolationError` catch handles any future FK that bypasses the pre-count (`code: "supplier_has_dependents_unknown"`).

Verified live against prod via `pg_constraint`: only 3 FKs reference `tenant_suppliers.id`; the two RESTRICT FKs are now both surfaced.

## Stack
FastAPI + Python 3.9 (verified compat: `Dict`, `Optional` from `typing`, no PEP 604/585)

## Changes
- `app/services/suppliers_service.py`: pre-count + structured 409 + FK violation catch.
- `tests/test_suppliers.py`: shape test for 409 detail (skips gracefully when no seed).

## Pairs with
uno0uno/warocol.com#597 — must deploy together with the frontend modal PR.

## Test plan
- [x] `python3 -m py_compile app/services/suppliers_service.py` passes
- [ ] Delete a supplier with 0 dependents → 200 OK
- [ ] Delete a supplier with 1+ purchases → 409 with `detail.counts.purchases > 0`
- [ ] Delete a supplier with 1+ supplier_prices → 409 with `detail.counts.supplier_prices > 0`
- [ ] Logs no longer mask FK violations with 500