### PR TITLE
feat(documents): wire /resend-email + add /send-email-to endpoints (warocol.com#598)

### DIFF
--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -1,24 +1,49 @@
 """
 Documents Router — bridge to api-facturacion (issue #129)
 
-Document management: list, PDF/XML download, and email resend.
+Document management: list, PDF/XML download, and email send.
 
 GET  /  and GET /{track_id}/pdf and GET /{track_id}/xml are live —
 they read electronic_invoices directly from DB and generate R2 presigned URLs.
 
-POST /{track_id}/resend-email is a stub until api-facturacion implements
-the resend endpoint.
+POST /{track_id}/resend-email and POST /{track_id}/send-email-to proxy
+to api-facturacion which talks to Matias. Both enforce tenant ownership
+on the electronic_invoices row before forwarding (warocol.com#598).
 """
-from fastapi import APIRouter, Depends, HTTPException, Request, Query
 from typing import Any, Dict, Optional
 from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Query
+from pydantic import BaseModel, EmailStr, Field
+
 from app.core.middleware import require_valid_session
 from app.core.permissions import Module, require_module
+from app.database import get_db_connection
 from app.services import facturacion_service
 
 router = APIRouter(prefix="/api/documents", tags=["Document Management"])
 
-_STUB_DETAIL = "Not yet available — api-facturacion endpoint pending"
+
+async def _assert_invoice_belongs_to_tenant(track_id: UUID, tenant_id: UUID) -> None:
+    """404 if the electronic_invoices row is not owned by the session tenant.
+
+    Mirrors `facturacion_service.get_document_pdf_url` ownership pattern.
+    Critical: api-facturacion does NOT enforce tenant scoping (no session
+    there). Without this check a user from tenant A could trigger Matias
+    to send tenant B's invoice anywhere they want.
+    """
+    async with get_db_connection(use_transaction=False) as conn:
+        row = await conn.fetchrow(
+            "SELECT id FROM electronic_invoices WHERE id = $1 AND tenant_id = $2",
+            track_id, tenant_id,
+        )
+    if not row:
+        raise HTTPException(status_code=404, detail="Invoice not found")
+
+
+class SendEmailToBody(BaseModel):
+    email: EmailStr = Field(..., description="Recipient email address")
+    name: Optional[str] = Field(None, description="Recipient display name (optional)")
 
 
 @router.get("", dependencies=[Depends(require_module(Module.FACTURACION))])
@@ -32,12 +57,7 @@ async def list_documents(
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
 ) -> Dict[str, Any]:
-    """
-    List electronic invoices for the authenticated tenant.
-
-    Optional filters: prefix, invoice number, status, date range.
-    Returns paginated list with total count.
-    """
+    """List electronic invoices for the authenticated tenant."""
     session = require_valid_session(request)
     return await facturacion_service.get_documents_list(
         tenant_id=str(session.tenant_id),
@@ -56,13 +76,29 @@ async def resend_document_email(
     request: Request,
     track_id: UUID,
 ) -> Dict[str, Any]:
-    """
-    Resend the invoice email for an electronic document.
+    """Resend the invoice email to the customer address registered on Matias."""
+    session = require_valid_session(request)
+    await _assert_invoice_belongs_to_tenant(track_id, session.tenant_id)
+    return await facturacion_service.proxy_to_facturacion(
+        method='POST',
+        path=f'/documents/{track_id}/resend-email',
+    )
 
-    Stub — returns 503 until api-facturacion /document/resend-email is implemented.
-    """
-    require_valid_session(request)
-    raise HTTPException(status_code=503, detail=_STUB_DETAIL)
+
+@router.post("/{track_id}/send-email-to", dependencies=[Depends(require_module(Module.FACTURACION))])
+async def send_document_email_to(
+    request: Request,
+    track_id: UUID,
+    body: SendEmailToBody,
+) -> Dict[str, Any]:
+    """Send the invoice email to a custom recipient (e.g. an accountant)."""
+    session = require_valid_session(request)
+    await _assert_invoice_belongs_to_tenant(track_id, session.tenant_id)
+    return await facturacion_service.proxy_to_facturacion(
+        method='POST',
+        path=f'/documents/{track_id}/send-email-to',
+        payload={'email': body.email, 'name': body.name or ''},
+    )
 
 
 @router.get("/{track_id}/pdf", dependencies=[Depends(require_module(Module.FACTURACION))])
@@ -70,12 +106,7 @@ async def get_document_pdf(
     request: Request,
     track_id: UUID,
 ) -> Dict[str, Any]:
-    """
-    Get a fresh presigned URL for the PDF of an electronic invoice.
-
-    track_id is the electronic_invoices.id (UUID).
-    URL expires in 1 hour.
-    """
+    """Get a fresh presigned URL for the PDF of an electronic invoice."""
     session = require_valid_session(request)
     pdf_url = await facturacion_service.get_document_pdf_url(
         track_id=str(track_id),
@@ -91,12 +122,7 @@ async def get_document_xml(
     request: Request,
     track_id: UUID,
 ) -> Dict[str, Any]:
-    """
-    Get a fresh presigned URL for the XML (AttachedDocument) of an electronic invoice.
-
-    track_id is the electronic_invoices.id (UUID).
-    URL expires in 1 hour.
-    """
+    """Get a fresh presigned URL for the XML (AttachedDocument) of an electronic invoice."""
     session = require_valid_session(request)
     xml_url = await facturacion_service.get_document_xml_url(
         track_id=str(track_id),

--- a/app/services/facturacion_service.py
+++ b/app/services/facturacion_service.py
@@ -405,6 +405,7 @@ async def get_order_invoice(
             logger.warning(f"Could not generate presigned URL for invoice {row['id']}: {exc}")
 
     return {
+        'id': str(row['id']),
         'order_id': order_id,
         'invoice_number': row['invoice_number'],
         'prefix': row['prefix'],

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -331,6 +331,7 @@ async def get_order_by_id(
                     p.id as customer_id,
                     p.name as customer_name,
                     p.phone_number as customer_phone,
+                    p.email as customer_email,
                     -- Hydrated delivery address (NULL if not a delivery, or address was soft-deleted)
                     ap.address_line1   AS addr_line1,
                     ap.address_line2   AS addr_line2,
@@ -448,7 +449,8 @@ async def get_order_by_id(
                     "customer": {
                         "id": str(order_row['customer_id']) if order_row['customer_id'] else None,
                         "name": order_row['customer_name'],
-                        "phone": order_row['customer_phone']
+                        "phone": order_row['customer_phone'],
+                        "email": order_row['customer_email'],
                     },
                     "items_count": order_row['items_count'],
                     "split_payments": split_payments,

--- a/tests/test_document_email.py
+++ b/tests/test_document_email.py
@@ -1,0 +1,190 @@
+"""
+Tests for invoice-email endpoints in app.routers.documents (warocol.com#598).
+
+Both endpoints:
+  1. Require Module.FACTURACION (already-gated, not tested here — covered by
+     existing module-gating tests).
+  2. Pull tenant_id from the validated session.
+  3. Verify the electronic_invoices.id belongs to that tenant — 404 otherwise.
+  4. Proxy to api-facturacion via facturacion_service.proxy_to_facturacion.
+
+Patches:
+  - app.routers.documents.require_valid_session → fake session w/ tenant_id
+  - app.routers.documents.get_db_connection     → controlled fetchrow result
+  - app.services.facturacion_service.httpx.AsyncClient → captures proxy call
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.routers import documents as documents_router
+
+
+_TENANT_ID = UUID('93b3e582-34fa-44a6-8d0f-bf82a3608727')
+_TRACK_ID = uuid4()
+
+
+class _ConnCtx:
+    """Minimal async context manager wrapping a single row response."""
+
+    def __init__(self, row):
+        self._row = row
+
+    async def __aenter__(self):
+        conn = MagicMock()
+        conn.fetchrow = AsyncMock(return_value=self._row)
+        return conn
+
+    async def __aexit__(self, *_):
+        return False
+
+
+def _patch_db_returns(row):
+    return patch(
+        'app.routers.documents.get_db_connection',
+        lambda *args, **kwargs: _ConnCtx(row),
+    )
+
+
+def _patch_session():
+    fake_session = MagicMock()
+    fake_session.tenant_id = _TENANT_ID
+    return patch(
+        'app.routers.documents.require_valid_session',
+        return_value=fake_session,
+    )
+
+
+def _patch_httpx(status_code: int = 200, body: dict = None):
+    """Patch httpx.AsyncClient where the proxy helper imports it."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.is_success = 200 <= status_code < 300
+    resp.json = MagicMock(return_value=body or {'status': 'sent'})
+    resp.text = '{"status":"sent"}'
+
+    client = MagicMock()
+    client.post = AsyncMock(return_value=resp)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+
+    return patch(
+        'app.services.facturacion_service.httpx.AsyncClient',
+        return_value=client,
+    ), client
+
+
+# ── resend-email ─────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_resend_email_proxies_to_facturacion():
+    """Owned invoice → proxy fires with the right URL, response bubbles."""
+    request = MagicMock()
+    httpx_patch, fake_client = _patch_httpx(
+        body={'status': 'sent', 'matias_response': {'ok': True}}
+    )
+
+    with _patch_session(), _patch_db_returns({'id': _TRACK_ID}), httpx_patch:
+        result = await documents_router.resend_document_email(request, _TRACK_ID)
+
+    assert result == {'status': 'sent', 'matias_response': {'ok': True}}
+    fake_client.post.assert_awaited_once()
+    posted_url = fake_client.post.await_args.args[0]
+    assert posted_url.endswith(f'/documents/{_TRACK_ID}/resend-email')
+
+
+@pytest.mark.asyncio
+async def test_resend_email_blocks_cross_tenant():
+    """Invoice not owned by session tenant → 404, no proxy call."""
+    request = MagicMock()
+    httpx_patch, fake_client = _patch_httpx()
+
+    with _patch_session(), _patch_db_returns(None), httpx_patch:
+        with pytest.raises(HTTPException) as exc_info:
+            await documents_router.resend_document_email(request, _TRACK_ID)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == 'Invoice not found'
+    fake_client.post.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resend_email_facturacion_503_bubbles():
+    """Proxy returns 503 → api-warolabs returns 503 with detail propagated."""
+    request = MagicMock()
+    httpx_patch, _ = _patch_httpx(
+        status_code=503, body={'detail': 'upstream down'},
+    )
+
+    with _patch_session(), _patch_db_returns({'id': _TRACK_ID}), httpx_patch:
+        with pytest.raises(HTTPException) as exc_info:
+            await documents_router.resend_document_email(request, _TRACK_ID)
+
+    assert exc_info.value.status_code == 503
+
+
+# ── send-email-to ────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_send_email_to_proxies_with_body():
+    """Owned invoice + valid email → forwards body {email, name} to facturacion."""
+    request = MagicMock()
+    httpx_patch, fake_client = _patch_httpx(
+        body={'status': 'sent', 'email': 'contador@empresa.com'}
+    )
+    body = documents_router.SendEmailToBody(
+        email='contador@empresa.com', name='Contador'
+    )
+
+    with _patch_session(), _patch_db_returns({'id': _TRACK_ID}), httpx_patch:
+        result = await documents_router.send_document_email_to(request, _TRACK_ID, body)
+
+    assert result['status'] == 'sent'
+    fake_client.post.assert_awaited_once()
+    posted_url = fake_client.post.await_args.args[0]
+    assert posted_url.endswith(f'/documents/{_TRACK_ID}/send-email-to')
+
+    sent_body = fake_client.post.await_args.kwargs['json']
+    assert sent_body == {'email': 'contador@empresa.com', 'name': 'Contador'}
+
+
+@pytest.mark.asyncio
+async def test_send_email_to_blocks_cross_tenant():
+    """Invoice not owned by session tenant → 404, no proxy call."""
+    request = MagicMock()
+    httpx_patch, fake_client = _patch_httpx()
+    body = documents_router.SendEmailToBody(email='x@y.com', name=None)
+
+    with _patch_session(), _patch_db_returns(None), httpx_patch:
+        with pytest.raises(HTTPException) as exc_info:
+            await documents_router.send_document_email_to(request, _TRACK_ID, body)
+
+    assert exc_info.value.status_code == 404
+    fake_client.post.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_email_to_validates_email_format():
+    """Invalid email → pydantic raises before we even enter the handler."""
+    # Pydantic v2 raises ValidationError, but FastAPI converts it to a 422
+    # on the request boundary. At unit-test level we test the model directly.
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        documents_router.SendEmailToBody(email='not-an-email', name=None)
+
+
+@pytest.mark.asyncio
+async def test_send_email_to_empty_name_defaults_to_empty_string():
+    """Optional `name` field absent → forwarded as empty string to facturacion."""
+    request = MagicMock()
+    httpx_patch, fake_client = _patch_httpx()
+    body = documents_router.SendEmailToBody(email='x@y.com', name=None)
+
+    with _patch_session(), _patch_db_returns({'id': _TRACK_ID}), httpx_patch:
+        await documents_router.send_document_email_to(request, _TRACK_ID, body)
+
+    sent_body = fake_client.post.await_args.kwargs['json']
+    assert sent_body == {'email': 'x@y.com', 'name': ''}


### PR DESCRIPTION
## Summary

Backend half of warocol.com#598. Replaces the 503 stub on `POST /api/documents/{track_id}/resend-email` with a real proxy to api-facturacion, and adds a sibling `POST /api/documents/{track_id}/send-email-to` that forwards a custom recipient. Both enforce tenant ownership before proxying — api-facturacion has no session context, so the gate has to live here.

`get_order_by_id` now includes `customer.email` so the frontend modal can prefill without an extra roundtrip.

## Stack
🔵 FastAPI + 🟣 Postgres + 🐍 Python 3.9

## Changes

### `app/routers/documents.py`
- `resend_document_email`: 503 stub → real proxy to `/documents/{id}/resend-email`. Adds the `_assert_invoice_belongs_to_tenant` ownership check up front.
- New `send_document_email_to` with `SendEmailToBody(email: EmailStr, name?: str)` body. Same ownership pattern, forwards `{email, name or ''}` to `/documents/{id}/send-email-to`.
- Both gated by the existing `Depends(require_module(Module.FACTURACION))`.

### `app/services/orders_service.py`
- `get_order_by_id`: add `p.email as customer_email` to the SELECT + `"email"` to the `customer` dict. Pure addition.

### `tests/test_document_email.py` (new)
7 cases:
1. `resend_email_proxies_to_facturacion` — happy path: owned invoice → proxy fires at the expected URL.
2. `resend_email_blocks_cross_tenant` — `SELECT` returns nothing → 404, no proxy call.
3. `resend_email_facturacion_503_bubbles` — proxy 503 propagates as 503.
4. `send_email_to_proxies_with_body` — body `{email, name}` forwarded as-is.
5. `send_email_to_blocks_cross_tenant` — 404 on cross-tenant.
6. `send_email_to_validates_email_format` — pydantic `EmailStr` rejects `not-an-email`.
7. `send_email_to_empty_name_defaults_to_empty_string` — optional `name` → `''` in the forwarded body.

## Test Plan

- [x] `python3 -m py_compile` on all touched files.
- [x] `pytest tests/test_document_email.py tests/test_emit_short_circuit.py tests/test_invoicing_readiness.py -v` — **26/26 pass** (7 new + 19 regression).
- [ ] After deploy + warocol.com PR merge: open `/ventas/{id}` with an accepted invoice, click "Enviar por correo", verify Matias delivers to both the customer email and a custom one.

## Pairs with
warocol.com#598 → frontend modal PR.

## Closes
warocol.com#598 (backend half).