### PR TITLE
feat(categories): PUT, DELETE, and delete-impact endpoints (warocol.com#600)

### DIFF
--- a/app/models/category.py
+++ b/app/models/category.py
@@ -31,6 +31,14 @@ class CategoryCreate(BaseModel):
     description: Optional[str] = Field(None, max_length=500, description="Optional descriptive text")
 
 
+class CategoryUpdate(BaseModel):
+    """Payload for PUT /menu/categories/{id}. Fields are optional —
+    only the provided ones are updated. tenant_id is immutable and
+    taken from the session."""
+    name: Optional[str] = Field(None, min_length=1, max_length=100, description="New display name")
+    description: Optional[str] = Field(None, max_length=500, description="New description")
+
+
 class CategoriesListResponse(BaseModel):
     """List of categories response"""
     success: bool = True

--- a/app/routers/categories.py
+++ b/app/routers/categories.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 import asyncpg
 
@@ -10,6 +11,7 @@ from app.models.category import (
     Category,
     CategoryCreate,
     CategoryResponse,
+    CategoryUpdate,
 )
 
 router = APIRouter()
@@ -96,3 +98,178 @@ async def create_category_endpoint(request: Request, payload: CategoryCreate):
         )
 
     return CategoryResponse(success=True, data=Category(**dict(row)))
+
+
+async def _load_owned_category(conn, category_id: UUID, tenant_id: UUID):
+    """Fetch a category and reject globals / cross-tenant access.
+
+    Returns the row when it belongs to the caller's tenant; raises 404
+    otherwise (we don't leak existence of globals or other tenants' rows).
+    """
+    row = await conn.fetchrow(
+        "SELECT id, tenant_id FROM categories WHERE id = $1",
+        category_id,
+    )
+    if row is None or row["tenant_id"] is None or row["tenant_id"] != tenant_id:
+        raise HTTPException(status_code=404, detail="Category not found")
+    return row
+
+
+@router.put(
+    "/{category_id}",
+    response_model=CategoryResponse,
+    dependencies=[Depends(require_module(Module.MENU))],
+)
+async def update_category_endpoint(
+    request: Request,
+    category_id: UUID,
+    payload: CategoryUpdate,
+):
+    """
+    Update a tenant-owned category. Globals (tenant_id IS NULL) are
+    rejected with 404. Returns 409 on duplicate name, mirroring POST.
+    """
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+
+    if not tenant_id:
+        raise HTTPException(status_code=400, detail="Tenant context is required")
+
+    updates = {}
+    if payload.name is not None:
+        updates["name"] = payload.name.strip()
+    if payload.description is not None:
+        updates["description"] = payload.description.strip() or None
+
+    if not updates:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    set_clauses = []
+    params = []
+    for idx, (field, value) in enumerate(updates.items(), start=1):
+        set_clauses.append(f"{field} = ${idx}")
+        params.append(value)
+    set_clauses.append("updated_at = NOW()")
+    params.append(category_id)
+
+    update_query = f"""
+        UPDATE categories
+        SET {", ".join(set_clauses)}
+        WHERE id = ${len(params)}
+        RETURNING id, name, description, tenant_id, created_at, updated_at
+    """
+
+    try:
+        async with get_db_connection() as conn:
+            await _load_owned_category(conn, category_id, tenant_id)
+            row = await conn.fetchrow(update_query, *params)
+    except asyncpg.UniqueViolationError:
+        raise HTTPException(
+            status_code=409,
+            detail="Ya existe una categoría con ese nombre",
+        )
+
+    return CategoryResponse(success=True, data=Category(**dict(row)))
+
+
+@router.get(
+    "/{category_id}/delete-impact",
+    dependencies=[Depends(require_module(Module.MENU))],
+)
+async def category_delete_impact_endpoint(request: Request, category_id: UUID):
+    """
+    Return dependent counts a delete would affect, without side effects.
+
+    `products` is RESTRICT — non-zero count blocks deletion.
+    `station_mappings` is ON DELETE CASCADE — will be silently removed.
+    The frontend uses both to warn the user before they confirm.
+    """
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+
+    if not tenant_id:
+        raise HTTPException(status_code=400, detail="Tenant context is required")
+
+    async with get_db_connection() as conn:
+        await _load_owned_category(conn, category_id, tenant_id)
+        deps = await conn.fetchrow(
+            """
+            SELECT
+                COALESCE((SELECT COUNT(*) FROM product WHERE category_id = $1), 0) AS products,
+                COALESCE((SELECT COUNT(*) FROM tenant_category_stations WHERE category_id = $1), 0) AS station_mappings
+            """,
+            category_id,
+        )
+
+    return {
+        "success": True,
+        "data": {
+            "products": int(deps["products"]),
+            "station_mappings": int(deps["station_mappings"]),
+        },
+    }
+
+
+@router.delete(
+    "/{category_id}",
+    dependencies=[Depends(require_module(Module.MENU))],
+)
+async def delete_category_endpoint(request: Request, category_id: UUID):
+    """
+    Delete a tenant-owned category.
+
+    Blocks deletion (409) when `product.category_id` references exist
+    (RESTRICT FK). Station-mapping rows cascade-delete automatically and
+    are NOT a blocker — the count is returned so the caller can refresh
+    the routing UI on success.
+    """
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+
+    if not tenant_id:
+        raise HTTPException(status_code=400, detail="Tenant context is required")
+
+    async with get_db_connection() as conn:
+        await _load_owned_category(conn, category_id, tenant_id)
+
+        deps = await conn.fetchrow(
+            """
+            SELECT
+                COALESCE((SELECT COUNT(*) FROM product WHERE category_id = $1), 0) AS products,
+                COALESCE((SELECT COUNT(*) FROM tenant_category_stations WHERE category_id = $1), 0) AS station_mappings
+            """,
+            category_id,
+        )
+
+        if deps["products"] > 0:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "category_has_dependents",
+                    "counts": {"products": int(deps["products"])},
+                    "message": "La categoría tiene productos asociados que impiden su eliminación.",
+                },
+            )
+
+        try:
+            await conn.execute(
+                "DELETE FROM categories WHERE id = $1 AND tenant_id = $2",
+                category_id,
+                tenant_id,
+            )
+        except asyncpg.exceptions.ForeignKeyViolationError:
+            # Defense-in-depth: a future RESTRICT FK we didn't pre-count would
+            # land here instead of leaking a generic 500.
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "category_has_dependents_unknown",
+                    "message": "La categoría tiene registros asociados que impiden su eliminación.",
+                },
+            )
+
+    return {
+        "success": True,
+        "message": "Category deleted successfully",
+        "cascaded": {"station_mappings": int(deps["station_mappings"])},
+    }

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -113,3 +113,100 @@ class TestCategoryCreateModel:
         # not surface in the model
         cat = CategoryCreate(name="ok", tenant_id=str(uuid4()))  # type: ignore[call-arg]
         assert not hasattr(cat, "tenant_id")
+
+
+class TestCategoryUpdateAndDelete:
+    """Test PUT, DELETE, and delete-impact endpoints (issue warocol.com#600)."""
+
+    @pytest.mark.asyncio
+    async def test_update_category_not_found(self, client: AsyncClient):
+        """PUT on non-existent / global / cross-tenant id returns 404 (or auth error)."""
+        fake_id = str(uuid4())
+        response = await client.put(
+            f"/menu/categories/{fake_id}",
+            json={"name": "Renombrada"},
+        )
+        assert response.status_code in [404, 401, 403, 500]
+
+    @pytest.mark.asyncio
+    async def test_update_category_rejects_empty_payload(self, client: AsyncClient):
+        """PUT with no fields returns 400 (or auth error if not authenticated)."""
+        fake_id = str(uuid4())
+        response = await client.put(
+            f"/menu/categories/{fake_id}",
+            json={},
+        )
+        assert response.status_code in [400, 404, 401, 403, 500]
+
+    @pytest.mark.asyncio
+    async def test_delete_category_not_found(self, client: AsyncClient):
+        """DELETE on non-existent id returns 404 (or auth error)."""
+        fake_id = str(uuid4())
+        response = await client.delete(f"/menu/categories/{fake_id}")
+        assert response.status_code in [404, 401, 403, 500]
+
+    @pytest.mark.asyncio
+    async def test_delete_impact_not_found(self, client: AsyncClient):
+        """delete-impact for non-existent / global id returns 404 (or auth error)."""
+        fake_id = str(uuid4())
+        response = await client.get(f"/menu/categories/{fake_id}/delete-impact")
+        assert response.status_code in [404, 401, 403, 500]
+
+    @pytest.mark.asyncio
+    async def test_delete_impact_response_shape(self, client: AsyncClient):
+        """When a category exists and is queryable, delete-impact returns counts."""
+        list_response = await client.get("/menu/categories?limit=50")
+        if list_response.status_code != 200:
+            pytest.skip("list endpoint unauthenticated in this run")
+
+        data = list_response.json()
+        for cat in data.get("data", []):
+            response = await client.get(f"/menu/categories/{cat['id']}/delete-impact")
+            if response.status_code == 200:
+                body = response.json()
+                assert body.get("success") is True
+                assert "data" in body
+                counts = body["data"]
+                assert isinstance(counts.get("products"), int)
+                assert isinstance(counts.get("station_mappings"), int)
+                return
+        pytest.skip("no tenant-owned category accessible in this run")
+
+    @pytest.mark.asyncio
+    async def test_delete_category_409_response_shape(self, client: AsyncClient):
+        """Validate the 409 response body when a category has product dependents."""
+        list_response = await client.get("/menu/categories?limit=50")
+        if list_response.status_code != 200:
+            pytest.skip("list endpoint unauthenticated in this run")
+
+        data = list_response.json()
+        for cat in data.get("data", []):
+            response = await client.delete(f"/menu/categories/{cat['id']}")
+            if response.status_code == 409:
+                body = response.json()
+                assert "detail" in body
+                detail = body["detail"]
+                assert isinstance(detail, dict)
+                assert detail.get("code") in (
+                    "category_has_dependents",
+                    "category_has_dependents_unknown",
+                )
+                assert "message" in detail
+                if detail["code"] == "category_has_dependents":
+                    assert "counts" in detail
+                    counts = detail["counts"]
+                    assert isinstance(counts.get("products"), int)
+                    assert counts["products"] > 0
+                return
+        pytest.skip("no category with product dependents in this run")
+
+    def test_category_update_accepts_partial(self):
+        from app.models.category import CategoryUpdate
+        payload = CategoryUpdate(name="Renombrada")
+        assert payload.name == "Renombrada"
+        assert payload.description is None
+
+    def test_category_update_rejects_empty_name(self):
+        from app.models.category import CategoryUpdate
+        with pytest.raises(ValidationError):
+            CategoryUpdate(name="")


### PR DESCRIPTION
## Summary
Adds the missing edit + delete endpoints for `/menu/categories`, gated under `Module.MENU`. Backend half of warocol.com#600.

- `PUT /menu/categories/{id}` — rename or change description. Tenant-owned only (globals return 404). Duplicate name returns 409 via the existing unique constraint.
- `DELETE /menu/categories/{id}` — pre-counts dependents to return a structured 409 only when `product.category_id` rows reference the category (RESTRICT FK). `tenant_category_stations` is `ON DELETE CASCADE` and is NOT a blocker — its count is returned in the success response so the frontend can refresh the kitchen-routing UI.
- `GET /menu/categories/{id}/delete-impact` — same counts without side effects, lets the frontend warn about the cascade before the user confirms.
- `asyncpg.exceptions.ForeignKeyViolationError` caught explicitly as defense-in-depth against future schema drift.

All three new endpoints share `_load_owned_category()` to reject globals / cross-tenant access with 404 (no existence leak).

## Stack
FastAPI + Python 3.9 (`Optional`, `Dict` from `typing` — no PEP 604/585)

## Changes
- `app/models/category.py`: `CategoryUpdate(BaseModel)`.
- `app/routers/categories.py`: PUT, DELETE, GET delete-impact + shared owner guard.
- `tests/test_categories.py`: 6 shape tests (skip gracefully when no seed data).

## Pairs with
uno0uno/warocol.com#600 — must deploy backend first or together with the frontend modal PR.

## Test plan
- [x] `python3 -m py_compile` on both files
- [ ] PUT on tenant-owned id → 200, name updated
- [ ] PUT on global id → 404
- [ ] PUT with duplicate name → 409
- [ ] DELETE on tenant-owned with 0 products → 200 (station mapping cascades silently)
- [ ] DELETE on tenant-owned with 1+ products → 409 with `detail.counts.products > 0`
- [ ] GET delete-impact → returns `{ products, station_mappings }` without DB change

Refs uno0uno/warocol.com#600