### PR TITLE
feat(orders): POST /orders/{id}/invoice/send-email — WARO-branded SES dispatch (warocol.com#603)

### DIFF
--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -5,7 +5,7 @@ Endpoints for listing and managing orders
 from fastapi import APIRouter, Depends, HTTPException, Request, Query
 from typing import Optional, List
 from uuid import UUID
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field
 from app.core.dependencies import require_invoicing_ready
 from app.core.middleware import require_valid_session
 from app.core.permissions import Module, require_module
@@ -424,3 +424,21 @@ async def get_order_invoice_dian_status(
     if result is None:
         raise HTTPException(status_code=404, detail="No invoice found for this order")
     return result
+
+
+class SendInvoiceEmailBody(BaseModel):
+    email: EmailStr = Field(..., description="Recipient email address")
+
+
+@router.post(
+    "/{order_id}/invoice/send-email",
+    tags=["Invoices"],
+    dependencies=[Depends(require_module(Module.VENTAS))],
+)
+async def send_order_invoice_email(
+    request: Request,
+    order_id: UUID,
+    body: SendInvoiceEmailBody,
+):
+    """Send the WARO-branded receipt email for this order's accepted invoice (warocol.com#603)."""
+    return await orders_service.send_invoice_email(request, order_id, body.email)

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -12,6 +12,8 @@ from app.core.exceptions import AuthenticationError, APIError
 from app.services.aws_ses_service import ses_service
 from app.services.waros_service import evaluate_and_award
 from app.services.cierre_service import assert_order_not_in_closed_monthly_period, _get_tenant_tax_config
+from app.services.email_helpers import send_pos_receipt_email
+from fastapi import HTTPException
 from datetime import datetime, date
 import csv
 
@@ -2788,3 +2790,149 @@ async def get_products_sold(
     except Exception as e:
         logger.error(f"Error getting products sold: {str(e)}")
         raise APIError(f"Error getting products sold: {str(e)}", status_code=500)
+
+
+async def send_invoice_email(
+    request: Request,
+    order_id: UUID,
+    recipient_email: str,
+) -> Dict[str, Any]:
+    """
+    Send the WARO-branded receipt email for an order's accepted invoice (warocol.com#603).
+
+    Loads the order header + items + invoice + tenant business profile from DB
+    (single connection, sequential reads), validates the invoice is accepted and
+    has a PDF available in R2, then dispatches the existing `send_pos_receipt_email`
+    helper which handles SES + template + PDF/XML attachment.
+
+    Raises:
+        HTTPException 404 — order not found for the session tenant
+        HTTPException 422 — no invoice / invoice not accepted / PDF not available
+        HTTPException 502 — SES rejected the send
+    """
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    async with get_db_connection() as conn:
+        # 1. Order header (also enforces tenant ownership).
+        order_row = await conn.fetchrow(
+            """SELECT id, order_number, order_date, total_amount, payment_method,
+                      discount_amount
+               FROM orders
+               WHERE id = $1 AND tenant_id = $2""",
+            order_id, tenant_id,
+        )
+        if not order_row:
+            raise HTTPException(status_code=404, detail="Order not found")
+
+        # 2. Invoice header — must exist, be accepted, and have a PDF available.
+        invoice_row = await conn.fetchrow(
+            """SELECT prefix, invoice_number, cufe, status, r2_pdf_key
+               FROM electronic_invoices
+               WHERE order_id = $1 AND tenant_id = $2
+               ORDER BY created_at DESC
+               LIMIT 1""",
+            order_id, tenant_id,
+        )
+        if not invoice_row:
+            raise HTTPException(
+                status_code=422,
+                detail="Esta orden no tiene factura electrónica. Emitila antes de enviarla.",
+            )
+        if invoice_row['status'] != 'accepted':
+            raise HTTPException(
+                status_code=422,
+                detail="La factura debe estar aceptada por DIAN para poder enviarla por correo.",
+            )
+        if not invoice_row['r2_pdf_key']:
+            raise HTTPException(
+                status_code=422,
+                detail="El PDF de la factura aún no está disponible. Reintentá en unos segundos.",
+            )
+
+        # 3. Tax breakdown — same helpers get_order_by_id uses.
+        tax_config = await _get_tenant_tax_config(conn, tenant_id)
+        items_for_tax = await conn.fetch(
+            """SELECT COALESCE(p.tax_category, 'standard') AS tax_category,
+                      COALESCE(oi.subtotal, 0) AS subtotal
+               FROM order_items oi
+               JOIN product p ON p.id = oi.product_id
+               WHERE oi.order_id = $1""",
+            order_id,
+        )
+        std_tax, liq_tax, tax_label = _compute_tax_breakdown(items_for_tax, tax_config)
+
+        # 4. Items in the shape `pos_receipt_template` expects.
+        item_rows = await conn.fetch(
+            """SELECT oi.id, oi.quantity, oi.subtotal,
+                      p.name as product_name
+               FROM order_items oi
+               LEFT JOIN product p ON p.id = oi.product_id
+               WHERE oi.order_id = $1
+               ORDER BY oi.created_at""",
+            order_id,
+        )
+        items = []
+        for it in item_rows:
+            modifiers_rows = await conn.fetch(
+                """SELECT modifier_name, price_at_purchase
+                   FROM order_item_modifiers WHERE order_item_id = $1""",
+                it['id'],
+            )
+            items.append({
+                'quantity': it['quantity'],
+                'subtotal': float(it['subtotal']),
+                'product': {'name': it['product_name'] or 'Producto'},
+                'modifiers': [
+                    {'name': m['modifier_name'], 'price': float(m['price_at_purchase'])}
+                    for m in modifiers_rows
+                ],
+            })
+
+        # 5. Business profile for the email header.
+        profile_row = await conn.fetchrow(
+            """SELECT COALESCE(p.display_name, t.name) AS display_name,
+                      p.address, p.city, p.phone_number
+               FROM tenants t
+               LEFT JOIN tenant_public_profiles p ON p.tenant_id = t.id
+               WHERE t.id = $1""",
+            tenant_id,
+        )
+
+    discount_amount = float(order_row['discount_amount']) if order_row['discount_amount'] is not None else 0.0
+    # Subtotal: only carried into the template when there's a discount (the
+    # template falls back to total_amount when no discount). Matches the POS
+    # cart caller convention at pos_cart_service.py:1577.
+    subtotal_for_email = sum(float(it['subtotal']) for it in item_rows) if discount_amount > 0 else 0.0
+
+    success = await send_pos_receipt_email(
+        customer_email=recipient_email,
+        order_number=int(order_row['order_number']),
+        total_amount=float(order_row['total_amount']),
+        payment_method=order_row['payment_method'] or '',
+        items=items,
+        order_date=order_row['order_date'],
+        tenant_id=str(tenant_id),
+        business_name=profile_row['display_name'] if profile_row else None,
+        business_address=profile_row['address'] if profile_row else None,
+        business_city=profile_row['city'] if profile_row else None,
+        business_phone=profile_row['phone_number'] if profile_row else None,
+        discount_amount=discount_amount,
+        subtotal=subtotal_for_email,
+        standard_tax=std_tax,
+        liquor_tax=liq_tax,
+        standard_tax_label=tax_label,
+        invoice_prefix=invoice_row['prefix'],
+        invoice_number=int(invoice_row['invoice_number']),
+        invoice_cufe=invoice_row['cufe'],
+    )
+
+    if not success:
+        raise HTTPException(
+            status_code=502,
+            detail="No se pudo enviar el correo. Intentá nuevamente en unos segundos.",
+        )
+
+    return {'success': True, 'sent_to': recipient_email}

--- a/tests/test_invoice_send_email.py
+++ b/tests/test_invoice_send_email.py
@@ -1,0 +1,254 @@
+"""
+Tests for POST /api/orders/{order_id}/invoice/send-email (warocol.com#603).
+
+The endpoint orchestrates: validate session → load order + invoice + items +
+tax + profile from DB → call send_pos_receipt_email (existing SES helper).
+
+We patch:
+  - app.services.orders_service.require_valid_session → fake session
+  - app.services.orders_service.get_db_connection → controlled fetch responses
+  - app.services.orders_service._get_tenant_tax_config → minimal config
+  - app.services.orders_service.send_pos_receipt_email → AsyncMock (True/False)
+"""
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.services import orders_service
+
+
+_TENANT_ID = UUID('93b3e582-34fa-44a6-8d0f-bf82a3608727')
+_ORDER_ID = uuid4()
+_RECIPIENT = 'anderson.electronico@gmail.com'
+
+
+class _SeqConnCtx:
+    """Async context manager that hands a conn whose fetchrow/fetch are
+    pre-loaded with sequenced responses."""
+
+    def __init__(self, fetchrow_responses, fetch_responses):
+        self._frows = iter(fetchrow_responses)
+        self._fetch = iter(fetch_responses)
+
+    async def __aenter__(self):
+        conn = MagicMock()
+        conn.fetchrow = AsyncMock(side_effect=lambda *a, **k: next(self._frows))
+        conn.fetch = AsyncMock(side_effect=lambda *a, **k: next(self._fetch))
+        return conn
+
+    async def __aexit__(self, *_):
+        return False
+
+
+def _order_row(discount: float = 0.0):
+    return {
+        'id': _ORDER_ID,
+        'order_number': 5462,
+        'order_date': datetime(2026, 5, 13, 20, 43, tzinfo=timezone.utc),
+        'total_amount': 200.0,
+        'payment_method': 'cash',
+        'discount_amount': discount,
+    }
+
+
+def _invoice_row(status: str = 'accepted', r2_pdf_key: str = 'lzt/5462/test.pdf'):
+    return {
+        'prefix': 'LZT',
+        'invoice_number': 5462,
+        'cufe': 'TEST_CUFE',
+        'status': status,
+        'r2_pdf_key': r2_pdf_key,
+    }
+
+
+def _profile_row():
+    return {
+        'display_name': 'Waro Colombia',
+        'address': 'Calle 123 #45-67',
+        'city': 'Bogotá',
+        'phone_number': '+57 320 1234567',
+    }
+
+
+def _patch_session():
+    fake = MagicMock()
+    fake.tenant_id = _TENANT_ID
+    return patch(
+        'app.services.orders_service.require_valid_session',
+        return_value=fake,
+    )
+
+
+def _patch_db(*, fetchrow, fetch):
+    ctx = _SeqConnCtx(fetchrow, fetch)
+    return patch(
+        'app.services.orders_service.get_db_connection',
+        lambda *args, **kwargs: ctx,
+    )
+
+
+def _patch_tax():
+    return patch(
+        'app.services.orders_service._get_tenant_tax_config',
+        new=AsyncMock(return_value={
+            'inc_applicable': False, 'iva_applicable': False,
+            'liquor_tax_applicable': False,
+            'inc_included_in_price': True, 'iva_included_in_price': True,
+        }),
+    )
+
+
+# ── Happy path ───────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_send_invoice_email_happy_path():
+    """Owned order + accepted invoice + PDF → 200, helper called with full payload."""
+    request = MagicMock()
+
+    fetchrow = [_order_row(), _invoice_row(), _profile_row()]
+    fetch = [
+        [],  # tax items (empty → no tax)
+        [{'id': uuid4(), 'quantity': 1, 'subtotal': 200.0, 'product_name': 'tomate barranca'}],
+        [],  # modifiers for item
+    ]
+    helper_mock = AsyncMock(return_value=True)
+
+    with _patch_session(), _patch_db(fetchrow=fetchrow, fetch=fetch), _patch_tax(), patch(
+        'app.services.orders_service.send_pos_receipt_email',
+        new=helper_mock,
+    ):
+        result = await orders_service.send_invoice_email(request, _ORDER_ID, _RECIPIENT)
+
+    assert result == {'success': True, 'sent_to': _RECIPIENT}
+    helper_mock.assert_awaited_once()
+    kwargs = helper_mock.await_args.kwargs
+    assert kwargs['customer_email'] == _RECIPIENT
+    assert kwargs['order_number'] == 5462
+    assert kwargs['invoice_prefix'] == 'LZT'
+    assert kwargs['invoice_number'] == 5462
+    assert kwargs['invoice_cufe'] == 'TEST_CUFE'
+    assert kwargs['tenant_id'] == str(_TENANT_ID)
+    assert kwargs['business_name'] == 'Waro Colombia'
+    # items shape: list of dicts with product.name + quantity + subtotal + modifiers
+    assert len(kwargs['items']) == 1
+    assert kwargs['items'][0]['product']['name'] == 'tomate barranca'
+    assert kwargs['items'][0]['quantity'] == 1
+    assert kwargs['items'][0]['modifiers'] == []
+    # order_date from the row, NOT datetime.utcnow()
+    assert kwargs['order_date'].year == 2026
+    assert kwargs['order_date'].month == 5
+    assert kwargs['order_date'].day == 13
+
+
+# ── Cross-tenant guard ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_send_invoice_email_blocks_cross_tenant():
+    """SELECT order returns nothing → 404, no helper call."""
+    request = MagicMock()
+    helper_mock = AsyncMock(return_value=True)
+
+    with _patch_session(), _patch_db(fetchrow=[None], fetch=[]), patch(
+        'app.services.orders_service.send_pos_receipt_email',
+        new=helper_mock,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await orders_service.send_invoice_email(request, _ORDER_ID, _RECIPIENT)
+
+    assert exc_info.value.status_code == 404
+    assert 'Order not found' in exc_info.value.detail
+    helper_mock.assert_not_awaited()
+
+
+# ── No invoice on the order ──────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_send_invoice_email_rejects_when_no_invoice():
+    """Order exists but has no electronic_invoices row → 422, no helper call."""
+    request = MagicMock()
+    helper_mock = AsyncMock(return_value=True)
+
+    with _patch_session(), _patch_db(fetchrow=[_order_row(), None], fetch=[]), patch(
+        'app.services.orders_service.send_pos_receipt_email',
+        new=helper_mock,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await orders_service.send_invoice_email(request, _ORDER_ID, _RECIPIENT)
+
+    assert exc_info.value.status_code == 422
+    assert 'no tiene factura' in exc_info.value.detail.lower()
+    helper_mock.assert_not_awaited()
+
+
+# ── Invoice not accepted ─────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_send_invoice_email_rejects_non_accepted():
+    """Invoice exists but status != 'accepted' → 422."""
+    request = MagicMock()
+    helper_mock = AsyncMock(return_value=True)
+
+    with _patch_session(), _patch_db(
+        fetchrow=[_order_row(), _invoice_row(status='rejected')],
+        fetch=[],
+    ), patch(
+        'app.services.orders_service.send_pos_receipt_email',
+        new=helper_mock,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await orders_service.send_invoice_email(request, _ORDER_ID, _RECIPIENT)
+
+    assert exc_info.value.status_code == 422
+    assert 'aceptada' in exc_info.value.detail.lower()
+    helper_mock.assert_not_awaited()
+
+
+# ── Missing PDF (r2_pdf_key is null) ─────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_send_invoice_email_rejects_missing_pdf():
+    """Invoice accepted but r2_pdf_key is NULL → 422, no email sent."""
+    request = MagicMock()
+    helper_mock = AsyncMock(return_value=True)
+
+    with _patch_session(), _patch_db(
+        fetchrow=[_order_row(), _invoice_row(r2_pdf_key=None)],
+        fetch=[],
+    ), patch(
+        'app.services.orders_service.send_pos_receipt_email',
+        new=helper_mock,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await orders_service.send_invoice_email(request, _ORDER_ID, _RECIPIENT)
+
+    assert exc_info.value.status_code == 422
+    assert 'pdf' in exc_info.value.detail.lower()
+    helper_mock.assert_not_awaited()
+
+
+# ── SES failure ──────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_send_invoice_email_ses_failure_502():
+    """send_pos_receipt_email returns False → 502."""
+    request = MagicMock()
+
+    fetchrow = [_order_row(), _invoice_row(), _profile_row()]
+    fetch = [
+        [],
+        [{'id': uuid4(), 'quantity': 1, 'subtotal': 200.0, 'product_name': 'tomate barranca'}],
+        [],
+    ]
+
+    with _patch_session(), _patch_db(fetchrow=fetchrow, fetch=fetch), _patch_tax(), patch(
+        'app.services.orders_service.send_pos_receipt_email',
+        new=AsyncMock(return_value=False),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await orders_service.send_invoice_email(request, _ORDER_ID, _RECIPIENT)
+
+    assert exc_info.value.status_code == 502
+    assert 'no se pudo' in exc_info.value.detail.lower()


### PR DESCRIPTION
## Summary

Replaces the Matias-based email path (shipped in warocol.com#598, reverted in warocol.com#604) with a new endpoint that uses the same SES + branded template as the POS checkout receipt.

## Stack
🔵 FastAPI + 🟣 Postgres + 🐍 Python 3.9

## Changes

### `app/services/orders_service.py`
- `send_invoice_email(request, order_id, recipient_email)` (~140 LOC). Single connection, sequential reads for order header + invoice + tax items + items + modifiers + business profile. Calls `send_pos_receipt_email` (existing, branded, attaches PDF/XML from R2).
- Gates: 404 cross-tenant, 422 no-invoice / not-accepted / missing-PDF, 502 SES failure.
- `order_date` from the loaded row (not `utcnow`) so the email reflects the real sale time.

### `app/routers/orders.py`
- `SendInvoiceEmailBody(email: EmailStr)` Pydantic model.
- `POST /api/orders/{order_id}/invoice/send-email` gated by `Module.VENTAS` (consistent with every other endpoint on the orders router).

### `tests/test_invoice_send_email.py` (new)
6 cases: happy path + cross-tenant + no-invoice + non-accepted + missing-PDF + SES-failure. Patches `send_pos_receipt_email` so no real SES call fires.

## Test Plan

- [x] `python3 -m py_compile` clean on all touched files.
- [x] `pytest tests/test_invoice_send_email.py tests/test_emit_short_circuit.py tests/test_document_email.py tests/test_invoicing_readiness.py -v` — **32/32 pass** (6 new + 26 regression).
- [ ] After deploy + frontend re-modal: `/ventas/{id}` → "Enviar por correo" → email arrives from `hola@warolabs.com` with branded WARO template + PDF + XML attached.

## Pairs with

- warocol.com#604 — revert of the Matias-broken button (must merge first).
- warocol.com#603 frontend PR — re-creates the modal pointing at the new endpoint here.

## Closes
warocol.com#603 (backend half).