### PR TITLE
feat(online-checkout): customer-selectable payment method (warocol.com#610)

### DIFF
--- a/app/routers/online_cart.py
+++ b/app/routers/online_cart.py
@@ -192,8 +192,21 @@ async def verify_cart_with_session(
     )
 
 
+class CheckoutCartRequest(BaseModel):
+    """
+    Optional payment selection sent by the customer at checkout (warocol.com#610).
+
+    Both fields are nullable in the schema but enforced in the service:
+    `payment_method` (group slug) is required; `payment_method_id` is required
+    only when the chosen group exposes nested methods. `triggersCartera`
+    groups are rejected — anonymous customers cannot accrue cartera.
+    """
+    payment_method: Optional[str] = None
+    payment_method_id: Optional[UUID] = None
+
+
 @router.post("/{cart_id}/checkout")
-async def checkout_cart(cart_id: UUID):
+async def checkout_cart(cart_id: UUID, body: Optional[CheckoutCartRequest] = None):
     """
     Finalize cart as a confirmed order (PUBLIC - no auth).
 
@@ -201,6 +214,8 @@ async def checkout_cart(cart_id: UUID):
     - Cart is OTP-verified
     - Cart has items and meets minimum order amount
     - Delivery address is set when order_type is 'delivery'
+    - payment_method (slug) is active for the tenant and not a cartera group
+    - payment_method_id (when provided) belongs to the chosen group
 
     Returns order_number, total_amount, order_type, and pickup_pin (pickup orders only).
 
@@ -208,4 +223,8 @@ async def checkout_cart(cart_id: UUID):
 
     **Public endpoint - no authentication required**
     """
-    return await online_cart_service.checkout_cart(cart_id=cart_id)
+    return await online_cart_service.checkout_cart(
+        cart_id=cart_id,
+        payment_method=body.payment_method if body else None,
+        payment_method_id=body.payment_method_id if body else None,
+    )

--- a/app/routers/public_restaurant.py
+++ b/app/routers/public_restaurant.py
@@ -5,7 +5,8 @@ No authentication required
 from fastapi import APIRouter, HTTPException, Query
 from typing import Optional, Dict, Any
 from uuid import UUID
-from app.services import public_restaurant_service
+from app.core.exceptions import NotFoundError
+from app.services import payment_method_service, public_restaurant_service
 
 import logging
 
@@ -50,6 +51,27 @@ async def list_public_restaurants(
         "success": True,
         "data": restaurants
     }
+
+
+@router.get("/{tenant_slug}/payment-methods")
+async def list_public_payment_methods(tenant_slug: str) -> Dict[str, Any]:
+    """
+    Active payment groups + nested methods that the customer can pick at
+    online checkout. Public — no auth header required (warocol.com#610).
+
+    Mirrors the shape of `/pos/payment-methods` and `/online/orders/payment-methods`
+    but resolves the tenant by `tenant_slug` and excludes `triggersCartera=true`
+    groups (anonymous customers cannot accrue cartera).
+    """
+    try:
+        return await payment_method_service.list_public_methods_by_tenant_slug(
+            tenant_slug
+        )
+    except NotFoundError:
+        raise HTTPException(
+            status_code=404,
+            detail="Restaurant not found or not active",
+        )
 
 
 @router.get("/{tenant_slug}")

--- a/app/services/online_cart_service.py
+++ b/app/services/online_cart_service.py
@@ -584,12 +584,21 @@ async def verify_cart_with_session(cart_id: UUID, customer_id: UUID, email: str)
         raise APIError(f"Error al verificar el carrito: {str(e)}", status_code=500)
 
 
-async def checkout_cart(cart_id: UUID) -> dict:
+async def checkout_cart(
+    cart_id: UUID,
+    payment_method: Optional[str] = None,
+    payment_method_id: Optional[UUID] = None,
+) -> dict:
     """
     Convert a verified online cart into a confirmed order (PUBLIC).
 
     Validates cart state, atomically marks it as checked_out, then inserts
     the order, order_items, and order_item_modifiers in a single transaction.
+
+    When `payment_method` is provided it must be the slug of an active
+    `payment_method_group` for the cart's tenant with `triggers_cartera = false`
+    (anonymous customers cannot accrue cartera, warocol.com#610). When
+    `payment_method_id` is provided it must belong to that same group.
 
     Returns order summary with order_number and optional pickup_pin.
     Returns 409 if the cart was already checked out (double-submit prevention).
@@ -665,6 +674,60 @@ async def checkout_cart(cart_id: UUID) -> dict:
                         detail=f"El monto mínimo del pedido es ${min_order_amount:,.0f} COP. Tu carrito tiene ${cart_total:,.0f} COP."
                     )
 
+                # 5b. Validate payment selection (warocol.com#610).
+                #     Mirrors the despacho-side validation in online_orders_service so
+                #     that the slug + UUID belong to the cart's tenant and the chosen
+                #     group is not a cartera one (anonymous customers cannot accrue
+                #     cartera). The selector is optional in the schema but required
+                #     in practice — the frontend always sends a method.
+                resolved_group_id = None
+                if payment_method:
+                    group_row = await conn.fetchrow(
+                        """
+                        SELECT id, triggers_cartera FROM payment_method_groups
+                        WHERE slug = $1
+                          AND is_active = true
+                          AND (tenant_id IS NULL OR tenant_id = $2)
+                        """,
+                        payment_method, cart['tenant_id'],
+                    )
+                    if not group_row:
+                        raise HTTPException(
+                            status_code=400,
+                            detail={
+                                "code": "payment_method_invalid",
+                                "message": f"Método de pago '{payment_method}' no es válido para este restaurante.",
+                            },
+                        )
+                    if group_row["triggers_cartera"]:
+                        raise HTTPException(
+                            status_code=400,
+                            detail={
+                                "code": "payment_method_not_allowed_online",
+                                "message": "Este método de pago no está disponible para pedidos en línea.",
+                            },
+                        )
+                    resolved_group_id = group_row["id"]
+                    if payment_method_id:
+                        method_row = await conn.fetchrow(
+                            """
+                            SELECT id FROM payment_methods
+                            WHERE id = $1
+                              AND tenant_id = $2
+                              AND group_id = $3
+                              AND is_active = true
+                            """,
+                            payment_method_id, cart['tenant_id'], resolved_group_id,
+                        )
+                        if not method_row:
+                            raise HTTPException(
+                                status_code=400,
+                                detail={
+                                    "code": "payment_method_id_invalid",
+                                    "message": "El método seleccionado no pertenece al grupo elegido.",
+                                },
+                            )
+
                 # 5. Validate all cart products are still available online
                 product_ids = [UUID(item['product_id']) for item in items]
                 offline_rows = await conn.fetch(
@@ -694,9 +757,10 @@ async def checkout_cart(cart_id: UUID) -> dict:
                 order_query = """
                     INSERT INTO orders (
                         tenant_id, customer_id, online_cart_id,
-                        order_date, total_amount, status, scheduled_time
+                        order_date, total_amount, status, scheduled_time,
+                        payment_method, payment_method_id
                     )
-                    VALUES ($1, $2, $3, NOW(), $4, 'pending', $5)
+                    VALUES ($1, $2, $3, NOW(), $4, 'pending', $5, $6, $7)
                     RETURNING id, order_number
                 """
                 order_row = await conn.fetchrow(
@@ -705,7 +769,9 @@ async def checkout_cart(cart_id: UUID) -> dict:
                     cart['customer_id'],
                     cart_id,
                     cart_total,
-                    cart['scheduled_time']
+                    cart['scheduled_time'],
+                    payment_method,
+                    payment_method_id,
                 )
                 order_id = order_row['id']
                 order_number = order_row['order_number']

--- a/app/services/payment_method_service.py
+++ b/app/services/payment_method_service.py
@@ -392,16 +392,21 @@ async def delete_method(request: Request, method_id: UUID) -> dict:
 
 # ── POS read-only ──────────────────────────────────────────────────────────────
 
-async def list_pos_methods(request: Request) -> dict:
+async def _list_payment_methods_by_tenant_id(
+    tenant_id,
+    exclude_cartera: bool = False,
+) -> dict:
     """
-    POS consumption endpoint — returns active groups (global + tenant's custom)
-    with their active methods nested inside. Ordered by sort_order.
-    """
-    session = require_valid_session(request)
-    tenant_id = session.tenant_id
+    Internal helper — returns active groups + nested methods for a given tenant.
 
+    Used by both `list_pos_methods` (POS / despacho — authenticated, all groups)
+    and the public-restaurant endpoint (anonymous customer checkout, where
+    `exclude_cartera=True` filters out credit groups since walk-in customers
+    can't accrue cartera).
+
+    See warocol.com#610.
+    """
     async with get_db_connection(use_transaction=False) as conn:
-        # Fetch active groups visible to tenant
         groups = await conn.fetch(
             """
             SELECT id, name, slug, triggers_cartera
@@ -412,7 +417,6 @@ async def list_pos_methods(request: Request) -> dict:
             tenant_id,
         )
 
-        # Fetch active methods for tenant
         methods = await conn.fetch(
             """
             SELECT id, group_id, name
@@ -423,7 +427,6 @@ async def list_pos_methods(request: Request) -> dict:
             tenant_id,
         )
 
-    # Group methods by group_id
     methods_by_group: dict = {}
     for m in methods:
         gid = str(m["group_id"])
@@ -440,5 +443,45 @@ async def list_pos_methods(request: Request) -> dict:
             "methods": methods_by_group.get(str(g["id"]), []),
         }
         for g in groups
+        if not (exclude_cartera and g["triggers_cartera"])
     ]
     return {"success": True, "data": data}
+
+
+async def list_pos_methods(request: Request) -> dict:
+    """
+    POS / despacho consumption endpoint — returns active groups (global +
+    tenant's custom) with their active methods nested inside. Ordered by
+    sort_order.
+    """
+    session = require_valid_session(request)
+    return await _list_payment_methods_by_tenant_id(
+        session.tenant_id, exclude_cartera=False
+    )
+
+
+async def list_public_methods_by_tenant_slug(tenant_slug: str) -> dict:
+    """
+    Public endpoint helper — resolves `tenant_slug` to a tenant_id via
+    `tenant_public_profiles`, then returns the same shape as `list_pos_methods`
+    but with `exclude_cartera=True` enforced server-side (anonymous customers
+    can't use credit).
+
+    Raises NotFoundError if the slug doesn't match an active profile.
+    warocol.com#610.
+    """
+    async with get_db_connection(use_transaction=False) as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT tenant_id
+            FROM tenant_public_profiles
+            WHERE slug = $1 AND is_active = true
+            """,
+            tenant_slug,
+        )
+    if not row:
+        raise NotFoundError("Restaurant not found or not active")
+
+    return await _list_payment_methods_by_tenant_id(
+        row["tenant_id"], exclude_cartera=True
+    )


### PR DESCRIPTION
## Summary

Backend half of warocol.com#610 — let the customer pick a payment method at online checkout instead of forcing "Efectivo contra entrega".

- New **public** endpoint `GET /public/restaurant/{tenant_slug}/payment-methods` returns the tenant's active payment groups + nested methods, excluding `triggersCartera=true` groups (anonymous customers cannot accrue cartera).
- `POST /online/cart/{cart_id}/checkout` now accepts an optional body `{ payment_method, payment_method_id }`. The slug is validated against the cart's tenant; UUIDs are checked to belong to the chosen group; cartera groups are rejected; the values are persisted to `orders.payment_method` / `orders.payment_method_id`.
- `payment_method_service` was refactored to share a private `_list_payment_methods_by_tenant_id(...)` helper between the authenticated POS listing and the new public one. The POS endpoint behavior is unchanged.

Empty body keeps prior behavior, so the v1 alias in `v1_ordering.py` and any other caller continues to work.

## Changes

- `app/routers/public_restaurant.py` — adds the public payment-methods route (declared before `/{tenant_slug}` to avoid route-matching conflicts).
- `app/routers/online_cart.py` — adds `CheckoutCartRequest` model + threads payment fields into the service call.
- `app/services/online_cart_service.py` — validates the payment selection inside the transaction and includes the columns in the `INSERT INTO orders`.
- `app/services/payment_method_service.py` — extracted tenant-scoped helper + new `list_public_methods_by_tenant_slug`.

## Test plan

- [ ] `GET /public/restaurant/<slug>/payment-methods` returns groups for the active tenant and 404 for unknown slugs
- [ ] Returned groups never include `triggersCartera=true`
- [ ] `POST /online/cart/<id>/checkout` with a valid `{ payment_method }` persists it on `orders`
- [ ] `POST` with a cartera slug is rejected with `payment_method_not_allowed_online`
- [ ] `POST` with a `payment_method_id` that belongs to a different group is rejected
- [ ] `POST` with empty body keeps prior behavior (legacy callers unaffected)

Closes warocol.com#610 (backend half)