### PR TITLE
feat(directory): curated city catalog + public endpoint + slug guard (warocol.com#615)

### DIFF
--- a/app/models/tenant_public_profile.py
+++ b/app/models/tenant_public_profile.py
@@ -33,7 +33,16 @@ class TenantPublicProfileBase(BaseModel):
     address: Optional[str] = Field(None, max_length=500, description="Physical address")
 
     # Location
+    country: Optional[str] = Field(
+        'Colombia', max_length=80,
+        description="Country (warocol.com#615). v1 locks the UI to Colombia.",
+    )
     city: Optional[str] = Field(None, max_length=255)
+    city_slug: Optional[str] = Field(
+        None, max_length=120,
+        description="Normalized slug for the city directory (warocol.com#615). "
+                    "Must match an active public_cities entry.",
+    )
     neighborhood: Optional[str] = Field(None, max_length=255)
     latitude: Optional[Decimal] = Field(None, description="Latitude coordinate")
     longitude: Optional[Decimal] = Field(None, description="Longitude coordinate")
@@ -109,7 +118,9 @@ class TenantPublicProfileUpdate(BaseModel):
     email: Optional[str] = Field(None, max_length=255)
     address: Optional[str] = Field(None, max_length=500)
 
+    country: Optional[str] = Field(None, max_length=80)
     city: Optional[str] = Field(None, max_length=255)
+    city_slug: Optional[str] = Field(None, max_length=120)
     neighborhood: Optional[str] = Field(None, max_length=255)
     latitude: Optional[Decimal] = None
     longitude: Optional[Decimal] = None

--- a/app/routers/public_restaurant.py
+++ b/app/routers/public_restaurant.py
@@ -19,31 +19,35 @@ router = APIRouter()
 async def list_public_restaurants(
     city: Optional[str] = Query(
         default=None,
-        description="Optional: filter by city (e.g., 'Bogotá')"
-    )
+        description="Deprecated: filter by display-name city. Use city_slug instead."
+    ),
+    city_slug: Optional[str] = Query(
+        default=None,
+        description="Preferred: filter by normalized slug (e.g. 'bogota', 'mosquera')."
+    ),
 ) -> Dict[str, Any]:
     """
-    List all active public restaurant profiles
+    List all active public restaurant profiles.
 
     Optional filters:
-    - city: Filter by city name
+    - city_slug: preferred (matches `tenant_public_profiles.city_slug`)
+    - city: deprecated alias kept for one release; logs a warning when used.
 
-    Returns list of restaurants with basic info:
-    - id, tenant_id, slug
-    - display_name, description
-    - logo_url, banner_url
-    - city, address
-    - phone_number, email
-    - is_active
+    Returns list of restaurants with basic info plus `country` and `city_slug`.
 
-    **Public endpoint - no authentication required**
+    **Public endpoint — no authentication required**
 
     Example: GET /api/public/restaurant/list
-    Example with filter: GET /api/public/restaurant/list?city=Bogotá
+    Example: GET /api/public/restaurant/list?city_slug=bogota
     """
-    logger.info(f"🔍 [list_public_restaurants] Request with city filter: {city}")
+    logger.info(
+        "🔍 [list_public_restaurants] Request city=%r city_slug=%r",
+        city, city_slug,
+    )
 
-    restaurants = await public_restaurant_service.list_restaurants(city=city)
+    restaurants = await public_restaurant_service.list_restaurants(
+        city=city, city_slug=city_slug,
+    )
 
     logger.info(f"🔍 [list_public_restaurants] Found {len(restaurants)} restaurants")
 
@@ -51,6 +55,28 @@ async def list_public_restaurants(
         "success": True,
         "data": restaurants
     }
+
+
+@router.get("/cities")
+async def list_public_cities(
+    include_empty: bool = Query(
+        default=False,
+        description="Include catalog entries with zero active tenants. "
+                    "True for the operator selector on /negocio; "
+                    "False (default) for the discovery section on /."
+    ),
+) -> Dict[str, Any]:
+    """
+    Return the curated city catalog (warocol.com#615).
+
+    Public — no auth required. Used by the operator-facing city selector
+    on /negocio and the customer-facing discovery section on the root
+    landing page.
+    """
+    cities = await public_restaurant_service.list_cities(
+        include_empty=include_empty,
+    )
+    return {"success": True, "data": cities}
 
 
 @router.get("/{tenant_slug}/payment-methods")

--- a/app/services/public_restaurant_service.py
+++ b/app/services/public_restaurant_service.py
@@ -593,15 +593,22 @@ async def validate_slug_available(slug: str, exclude_tenant_id: Optional[UUID] =
         return False
 
 
-async def list_restaurants(city: Optional[str] = None) -> List[Dict[str, Any]]:
+async def list_restaurants(
+    city: Optional[str] = None,
+    city_slug: Optional[str] = None,
+) -> List[Dict[str, Any]]:
     """
-    List all active public restaurant profiles
+    List all active public restaurant profiles.
 
     Args:
-        city: Optional city filter (e.g., 'Bogotá')
+        city: Deprecated — exact-match display-name filter (e.g. 'Bogotá').
+              Kept for one release while callers migrate to `city_slug`.
+        city_slug: Preferred filter (warocol.com#615). Matches the
+              normalized slug stored on tenant_public_profiles.city_slug,
+              which mirrors public_cities.city_slug.
 
     Returns:
-        List of restaurant profiles with basic information
+        List of restaurant profiles with basic information.
     """
     try:
         async with get_db_connection() as conn:
@@ -613,7 +620,7 @@ async def list_restaurants(city: Optional[str] = None) -> List[Dict[str, Any]]:
                     tpp.id, tpp.tenant_id, tpp.slug, tpp.is_active,
                     tpp.display_name, tpp.description, tpp.logo_url, tpp.banner_url,
                     tpp.phone_number, tpp.email, tpp.address,
-                    tpp.city, tpp.neighborhood,
+                    tpp.city, tpp.city_slug, tpp.country, tpp.neighborhood,
                     tpp.is_manually_open, tpp.business_hours,
                     tpp.created_at, tpp.updated_at
                 FROM tenant_public_profiles tpp
@@ -621,12 +628,20 @@ async def list_restaurants(city: Optional[str] = None) -> List[Dict[str, Any]]:
                 WHERE tpp.is_active = true
                   AND ts.status IN ('active', 'past_due')
             """
-            params = []
+            params: List[Any] = []
 
-            # Add city filter if provided
-            if city:
-                query += " AND tpp.city = $1"
+            # Prefer city_slug. Fall back to legacy city (display name) for
+            # any caller still on the deprecated alias.
+            if city_slug:
+                params.append(city_slug)
+                query += f" AND tpp.city_slug = ${len(params)}"
+            elif city:
                 params.append(city)
+                query += f" AND tpp.city = ${len(params)}"
+                logger.warning(
+                    "list_restaurants: deprecated 'city' param used "
+                    "(value=%r). Migrate caller to 'city_slug'.", city,
+                )
 
             query += " ORDER BY display_name ASC"
 
@@ -654,7 +669,9 @@ async def list_restaurants(city: Optional[str] = None) -> List[Dict[str, Any]]:
                     "phone_number": row["phone_number"],
                     "email": row["email"],
                     "address": row["address"],
+                    "country": row["country"],
                     "city": row["city"],
+                    "city_slug": row["city_slug"],
                     "neighborhood": row["neighborhood"],
                     "is_currently_open": is_currently_open(business_hours, row["is_manually_open"]),
                     "created_at": row["created_at"].isoformat() if row["created_at"] else None,
@@ -664,8 +681,90 @@ async def list_restaurants(city: Optional[str] = None) -> List[Dict[str, Any]]:
             return restaurants
 
     except Exception as e:
-        logger.error(f"Error listing restaurants (city={city}): {e}")
+        logger.error(
+            "Error listing restaurants (city=%r, city_slug=%r): %s",
+            city, city_slug, e,
+        )
         raise HTTPException(
             status_code=500,
             detail=f"Error listing restaurants: {str(e)}"
         )
+
+
+async def list_cities(include_empty: bool = False) -> List[Dict[str, Any]]:
+    """
+    Return the curated city catalog (warocol.com#615).
+
+    Used by the `/negocio` city selector (include_empty=True so operators
+    see every city even before someone in that city signs up) and by the
+    root `/` discovery section (include_empty=False so only populated
+    cities surface to customers).
+
+    Args:
+        include_empty: When False (default), filter out cities with zero
+            active tenants. When True, return every active catalog entry.
+
+    Returns:
+        List of dicts with country, city, city_slug, tenant_count.
+        Sorted by sort_order then city name.
+    """
+    try:
+        async with get_db_connection() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT
+                    pc.country,
+                    pc.city,
+                    pc.city_slug,
+                    pc.sort_order,
+                    COUNT(tpp.id) FILTER (
+                        WHERE tpp.is_active = true
+                          AND ts.status IN ('active', 'past_due')
+                    ) AS tenant_count
+                FROM public_cities pc
+                LEFT JOIN tenant_public_profiles tpp
+                       ON tpp.city_slug = pc.city_slug
+                LEFT JOIN tenant_subscriptions ts
+                       ON ts.tenant_id = tpp.tenant_id
+                WHERE pc.is_active = true
+                GROUP BY pc.country, pc.city, pc.city_slug, pc.sort_order
+                ORDER BY pc.sort_order ASC, pc.city ASC
+                """,
+            )
+            cities = [
+                {
+                    "country": r["country"],
+                    "city": r["city"],
+                    "city_slug": r["city_slug"],
+                    "tenant_count": int(r["tenant_count"] or 0),
+                }
+                for r in rows
+                if include_empty or (r["tenant_count"] or 0) > 0
+            ]
+            return cities
+    except Exception as e:
+        logger.error("Error listing public cities: %s", e)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Error listing cities: {str(e)}"
+        )
+
+
+async def is_city_slug_known(city_slug: str) -> bool:
+    """
+    Check whether `city_slug` is a recognised active entry in the
+    public_cities catalog (warocol.com#615).
+
+    Used by the profile update endpoint to validate operator input and by
+    the tenant slug generator to avoid collisions.
+    """
+    try:
+        async with get_db_connection() as conn:
+            hit = await conn.fetchval(
+                "SELECT 1 FROM public_cities WHERE city_slug = $1 AND is_active = true",
+                city_slug,
+            )
+            return hit is not None
+    except Exception as e:
+        logger.error("Error checking city slug %r: %s", city_slug, e)
+        return False

--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -191,18 +191,32 @@ async def update_public_profile(
                 data_dict = profile_data.model_dump(exclude_unset=True)
                 display_name = data_dict.get('display_name') or tenant_row['name']
 
+                # Validate city_slug against the curated catalog before INSERT
+                # (warocol.com#615). Same gate as the UPDATE path below.
+                if data_dict.get('city_slug'):
+                    known = await public_restaurant_service.is_city_slug_known(
+                        data_dict['city_slug']
+                    )
+                    if not known:
+                        raise HTTPException(
+                            status_code=400,
+                            detail=f"city_slug '{data_dict['city_slug']}' is not in the catalog. "
+                                   "Pick a city from /public/cities.",
+                        )
+
                 insert_query = """
                     INSERT INTO tenant_public_profiles (
                         tenant_id, slug, display_name, is_active,
                         description, logo_url, banner_url,
-                        phone_number, email, address, city, neighborhood,
+                        phone_number, email, address,
+                        country, city, city_slug, neighborhood,
                         business_hours, social_media,
                         accepts_online_orders, min_order_amount, estimated_preparation_time,
                         is_manually_open,
                         comandas_enabled, kds_enabled,
                         auto_select_generic_enabled,
                         expediter_enabled
-                    ) VALUES ($1, $2, $3, FALSE, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
+                    ) VALUES ($1, $2, $3, FALSE, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)
                     RETURNING *
                 """
                 result = await conn.fetchrow(
@@ -216,7 +230,9 @@ async def update_public_profile(
                     data_dict.get('phone_number'),
                     data_dict.get('email'),
                     data_dict.get('address'),
+                    data_dict.get('country', 'Colombia'),
                     data_dict.get('city'),
+                    data_dict.get('city_slug'),
                     data_dict.get('neighborhood'),
                     json.dumps(data_dict['business_hours']) if data_dict.get('business_hours') is not None else None,
                     json.dumps(data_dict['social_media']) if data_dict.get('social_media') is not None else None,
@@ -284,6 +300,20 @@ async def update_public_profile(
                     raise HTTPException(
                         status_code=400,
                         detail=f"Slug '{data_dict['slug']}' is already taken"
+                    )
+
+            # Validate city_slug against the curated catalog (warocol.com#615).
+            # Operators can only pick from public_cities — free text is rejected
+            # at the API boundary so the directory routing stays consistent.
+            if data_dict.get('city_slug'):
+                known = await public_restaurant_service.is_city_slug_known(
+                    data_dict['city_slug']
+                )
+                if not known:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"city_slug '{data_dict['city_slug']}' is not in the catalog. "
+                               "Pick a city from /public/cities.",
                     )
 
             _jsonb_fields = {'business_hours', 'social_media'}

--- a/app/services/tenants_service.py
+++ b/app/services/tenants_service.py
@@ -362,10 +362,22 @@ async def create_tenant(request: Request, body: TenantCreate) -> TenantCreateRes
         base_slug = _generate_slug(body.name)
 
         async with get_db_connection() as conn:
-            # Ensure slug uniqueness — append counter if taken
+            # Ensure slug uniqueness — append counter if taken. The same
+            # counter logic also runs against the public_cities catalog so
+            # a business named e.g. "Bogotá" never grabs the `bogota`
+            # directory slug (warocol.com#615).
             slug = base_slug
             counter = 1
-            while await conn.fetchval("SELECT 1 FROM tenants WHERE slug = $1", slug):
+            while True:
+                tenant_taken = await conn.fetchval(
+                    "SELECT 1 FROM tenants WHERE slug = $1", slug
+                )
+                city_reserved = await conn.fetchval(
+                    "SELECT 1 FROM public_cities WHERE city_slug = $1 AND is_active = true",
+                    slug,
+                )
+                if not tenant_taken and not city_reserved:
+                    break
                 slug = f"{base_slug}-{counter}"
                 counter += 1
 

--- a/migrations/076_add_city_catalog.sql
+++ b/migrations/076_add_city_catalog.sql
@@ -1,0 +1,89 @@
+-- 076_add_city_catalog.sql
+-- Issue warocol.com#615 — Dynamic country/city directory
+--
+-- Replaces the hardcoded /bogota directory with a curated catalog. Adds a
+-- normalized city_slug + country to tenant_public_profiles and creates a
+-- public_cities table seeded with the Colombian cities WARO operates in.
+--
+-- ADD-only per CLAUDE.md — no DROP / destructive ALTER. Existing city
+-- VARCHAR stays as the canonical display name; city_slug is the routing key.
+--
+-- Pre-deploy safety check (run on prod BEFORE applying — must return 0 rows):
+--   SELECT t.slug FROM tenants t
+--   WHERE t.slug IN ('bogota','medellin','cali','barranquilla','cartagena',
+--                    'bucaramanga','pereira','manizales','mosquera',
+--                    'santa-fe-de-antioquia');
+
+CREATE EXTENSION IF NOT EXISTS unaccent;
+
+ALTER TABLE tenant_public_profiles
+    ADD COLUMN IF NOT EXISTS country VARCHAR(80) DEFAULT 'Colombia';
+
+ALTER TABLE tenant_public_profiles
+    ADD COLUMN IF NOT EXISTS city_slug VARCHAR(120);
+
+COMMENT ON COLUMN tenant_public_profiles.country IS
+    'Country where the business operates (warocol.com#615). v1 locks the '
+    'operator UI to Colombia; the column is plain VARCHAR so future countries '
+    'can be added without a type change.';
+
+COMMENT ON COLUMN tenant_public_profiles.city_slug IS
+    'Normalized slug for the business city (warocol.com#615). References '
+    'public_cities.city_slug; used as the routing key on warocol.com/{slug} '
+    'and as the directory filter. The display name lives in the city column.';
+
+CREATE INDEX IF NOT EXISTS idx_tpp_city_slug_active
+    ON tenant_public_profiles(city_slug)
+    WHERE is_active = true;
+
+CREATE TABLE IF NOT EXISTS public_cities (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    country     VARCHAR(80) NOT NULL DEFAULT 'Colombia',
+    city        VARCHAR(120) NOT NULL,
+    city_slug   VARCHAR(120) NOT NULL UNIQUE,
+    is_active   BOOLEAN NOT NULL DEFAULT true,
+    sort_order  INTEGER NOT NULL DEFAULT 100,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public_cities IS
+    'Curated catalog of cities WARO operates in (warocol.com#615). Used to '
+    'populate the city selector on /negocio, the discovery section on /, and '
+    'the reserved-words check in tenants_service._generate_slug. Adding a '
+    'city here makes warocol.com/{city_slug} reachable; removing it requires '
+    'reassigning any tenants that reference it.';
+
+CREATE INDEX IF NOT EXISTS idx_public_cities_active
+    ON public_cities(is_active, sort_order)
+    WHERE is_active = true;
+
+INSERT INTO public_cities (country, city, city_slug, sort_order)
+VALUES
+    ('Colombia', 'Bogotá',                  'bogota',                  10),
+    ('Colombia', 'Medellín',                'medellin',                20),
+    ('Colombia', 'Cali',                    'cali',                    30),
+    ('Colombia', 'Barranquilla',            'barranquilla',            40),
+    ('Colombia', 'Cartagena',               'cartagena',               50),
+    ('Colombia', 'Bucaramanga',             'bucaramanga',             60),
+    ('Colombia', 'Pereira',                 'pereira',                 70),
+    ('Colombia', 'Manizales',               'manizales',               80),
+    ('Colombia', 'Mosquera',                'mosquera',                90),
+    ('Colombia', 'Santa Fe de Antioquia',   'santa-fe-de-antioquia',  100)
+ON CONFLICT (city_slug) DO NOTHING;
+
+-- Backfill city_slug for existing rows whose city column matches a seeded
+-- entry — case-insensitive + accent-insensitive, since prod has values like
+-- 'MOSQUERA' and 'SANTA FE ANTIOQUIA' (missing 'de', wrong case).
+UPDATE tenant_public_profiles tpp
+SET city_slug = pc.city_slug,
+    city = pc.city
+FROM public_cities pc
+WHERE tpp.city_slug IS NULL
+  AND tpp.city IS NOT NULL
+  AND tpp.city != ''
+  AND (
+        lower(unaccent(tpp.city)) = lower(unaccent(pc.city))
+        OR lower(unaccent(tpp.city)) = pc.city_slug
+        OR lower(unaccent(tpp.city)) LIKE lower(unaccent(pc.city)) || '%'
+        OR lower(unaccent(pc.city)) LIKE lower(unaccent(tpp.city)) || '%'
+      );


### PR DESCRIPTION
## Summary

Backend half of warocol.com#615 — replaces the exact-match free-text city filter with a normalized city_slug, ships a new public `/cities` endpoint to feed the frontend operator selector and the customer discovery section, and prevents tenant slugs from colliding with the curated city catalog so the symmetric `warocol.com/<slug>` URL pattern keeps working for both tenants and cities.

## Stack

FastAPI + Postgres + Python 3.9

## Changes

- `migrations/076_add_city_catalog.sql` — ADD-only migration: `unaccent` extension, `tenant_public_profiles.country` (default `'Colombia'`), `tenant_public_profiles.city_slug` + partial index, new `public_cities` table seeded with 10 Colombian cities, accent-insensitive backfill for the 5 rows that currently have a city value.
- `app/services/tenants_service.py` — `_generate_slug`'s uniqueness loop now also rejects collisions with active `public_cities.city_slug` entries.
- `app/services/public_restaurant_service.py` — `list_restaurants` accepts `city_slug` (preferred) and `city` (deprecated alias). New `list_cities()` + `is_city_slug_known()` helpers.
- `app/routers/public_restaurant.py` — adds `GET /public/cities`.
- `app/services/tenant_config_service.py` — profile create + update reject `city_slug` values not in the active catalog.
- `app/models/tenant_public_profile.py` — `country` + `city_slug` on the Pydantic models.

## Pre-deploy safety check

\`\`\`sql
SELECT t.slug FROM tenants t
WHERE t.slug IN ('bogota','medellin','cali','barranquilla','cartagena',
                 'bucaramanga','pereira','manizales','mosquera',
                 'santa-fe-de-antioquia');
-- Must return 0 rows. Already verified — current production is clean.
\`\`\`

## Test plan

- [ ] Apply migration 076 on dev DB
- [ ] GET /public/cities returns the 3 populated cities; ?include_empty=true returns all 10
- [ ] GET /public/restaurant/list?city_slug=bogota returns the 3 tenants /bogota used to return
- [ ] GET /public/restaurant/list?city_slug=cali returns []
- [ ] Creating a tenant named "Bogotá" produces slug bogota-2 (not bogota)
- [ ] PATCH profile with city_slug='invented' → 400; with city_slug='bogota' → 200

Closes warocol.com#615 (backend half)