### PR TITLE
feat(operaciones): tenant-global custom mesa label (warocol.com#614)

### DIFF
--- a/app/models/tenant_public_profile.py
+++ b/app/models/tenant_public_profile.py
@@ -101,6 +101,22 @@ class TenantPublicProfileBase(BaseModel):
                     "of tables_enabled — bar/counter modes work without tables."
     )
 
+    # Custom mesa label (warocol.com#614) — tenant-global override for the noun
+    # used across the UI. NULL means the frontend falls back to defaults
+    # ("Mesa" / "Mesas"). Empty/whitespace input on the API normalizes to NULL.
+    tables_label_singular: Optional[str] = Field(
+        None,
+        min_length=1,
+        max_length=40,
+        description="Custom singular noun for 'Mesa' (e.g. 'Habitación' for hotels). NULL = use default.",
+    )
+    tables_label_plural: Optional[str] = Field(
+        None,
+        min_length=1,
+        max_length=40,
+        description="Custom plural noun for 'Mesas' (e.g. 'Habitaciones'). NULL = use default.",
+    )
+
 class TenantPublicProfileCreate(TenantPublicProfileBase):
     """Create tenant public profile"""
     tenant_id: UUID = Field(..., description="Tenant ID")
@@ -142,6 +158,10 @@ class TenantPublicProfileUpdate(BaseModel):
     auto_select_generic_enabled: Optional[bool] = None
     expediter_enabled: Optional[bool] = None
     waiter_attribution_enabled: Optional[bool] = None
+
+    # Custom mesa label (warocol.com#614)
+    tables_label_singular: Optional[str] = Field(None, min_length=1, max_length=40)
+    tables_label_plural: Optional[str] = Field(None, min_length=1, max_length=40)
 
 class TenantPublicProfile(TenantPublicProfileBase):
     """Complete tenant public profile with all fields"""

--- a/app/routers/operaciones_context.py
+++ b/app/routers/operaciones_context.py
@@ -11,8 +11,10 @@ column whitelist guards against SQL injection.
 """
 from uuid import UUID
 
+from typing import Optional
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.core.middleware import require_valid_session
 from app.core.permissions import Module, require_module
@@ -20,6 +22,7 @@ from app.models.table_member_assignment import AssignMemberRequest
 from app.services import table_assignments_service
 from app.services.operaciones_context_service import (
     get_operaciones_context,
+    update_tables_label,
     update_toggle,
 )
 
@@ -28,6 +31,17 @@ router = APIRouter(prefix="/operaciones", tags=["Operaciones Context"])
 
 class ToggleRequest(BaseModel):
     enabled: bool
+
+
+class TablesLabelRequest(BaseModel):
+    """Payload for PATCH /operaciones/labels/tables (warocol.com#614).
+
+    Both fields optional and accept empty strings — the service normalizes
+    empty/whitespace input to NULL so users can reset to defaults by
+    clearing both inputs.
+    """
+    singular: Optional[str] = Field(None, max_length=40)
+    plural: Optional[str] = Field(None, max_length=40)
 
 
 @router.get(
@@ -115,6 +129,24 @@ async def toggle_waiter_attribution_enabled(request: Request, body: ToggleReques
     session = require_valid_session(request)
     return await update_toggle(
         session.tenant_id, "waiter_attribution_enabled", body.enabled
+    )
+
+
+# ── Custom mesa label (warocol.com#614) ─────────────────────────────────
+
+@router.patch(
+    "/labels/tables",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def patch_tables_label(request: Request, body: TablesLabelRequest):
+    """Persist tenant-global custom labels for the 'Mesa' noun.
+
+    Empty / whitespace input on either field is normalized server-side to
+    NULL — the frontend interprets that as "use default" (Mesa / Mesas).
+    """
+    session = require_valid_session(request)
+    return await update_tables_label(
+        session.tenant_id, body.singular, body.plural,
     )
 
 

--- a/app/services/operaciones_context_service.py
+++ b/app/services/operaciones_context_service.py
@@ -86,6 +86,57 @@ async def update_toggle(
     return {"success": True, "data": {column_name: enabled}}
 
 
+async def update_tables_label(
+    tenant_id: UUID,
+    singular: Optional[str],
+    plural: Optional[str],
+) -> Dict[str, Any]:
+    """Persist tenant-global custom labels for the mesa noun (warocol.com#614).
+
+    Empty / whitespace inputs are normalized to NULL — the frontend
+    interprets that as "use defaults" (Mesa / Mesas).
+
+    Mirrors the UPSERT pattern from `update_toggle()` so fresh tenants
+    without a tenant_public_profiles row still work; `slug` and
+    `display_name` are seeded from the `tenants` table (both NOT NULL
+    with no DB defaults).
+
+    String-valued sibling to `update_toggle()`; deliberately NOT entered
+    into the `ALLOWED_TOGGLES` whitelist since that frozenset is for
+    boolean toggles only.
+    """
+    # Normalize: empty / whitespace-only -> NULL (resets to default)
+    sin = singular.strip() if singular and singular.strip() else None
+    plu = plural.strip() if plural and plural.strip() else None
+
+    query = """
+        INSERT INTO tenant_public_profiles
+            (tenant_id, slug, display_name, tables_label_singular, tables_label_plural)
+        SELECT t.id, t.slug, t.name, $2, $3
+        FROM tenants t
+        WHERE t.id = $1
+        ON CONFLICT (tenant_id) DO UPDATE
+            SET tables_label_singular = EXCLUDED.tables_label_singular,
+                tables_label_plural   = EXCLUDED.tables_label_plural,
+                updated_at = now()
+        RETURNING tables_label_singular, tables_label_plural
+    """
+
+    async with get_db_connection() as conn:
+        row = await conn.fetchrow(query, tenant_id, sin, plu)
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+
+    return {
+        "success": True,
+        "data": {
+            "tables_label_singular": row["tables_label_singular"],
+            "tables_label_plural": row["tables_label_plural"],
+        },
+    }
+
+
 async def assert_waiter_attribution_enabled(tenant_id: UUID) -> None:
     """Raise 409 if `waiter_attribution_enabled` is False for this tenant.
 

--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -25,6 +25,8 @@ SELECT
     tpp.accepts_online_orders,
     tpp.auto_select_generic_enabled,
     tpp.waiter_attribution_enabled,
+    tpp.tables_label_singular,
+    tpp.tables_label_plural,
     fd.nit,
     fd.business_name,
     fd.type_organization_id,
@@ -90,6 +92,8 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
         'accepts_online_orders': bool(row['accepts_online_orders']) if row['accepts_online_orders'] is not None else False,
         'auto_select_generic_enabled': bool(row['auto_select_generic_enabled']) if row['auto_select_generic_enabled'] is not None else False,
         'waiter_attribution_enabled': bool(row['waiter_attribution_enabled']) if row['waiter_attribution_enabled'] is not None else False,
+        'tables_label_singular': row['tables_label_singular'],
+        'tables_label_plural': row['tables_label_plural'],
         'fiscal_data': {
             'nit': row['nit'],
             'business_name': row['business_name'],

--- a/migrations/076_add_tables_label_columns_to_tenant_public_profiles.sql
+++ b/migrations/076_add_tables_label_columns_to_tenant_public_profiles.sql
@@ -1,0 +1,15 @@
+-- 076_add_tables_label_columns_to_tenant_public_profiles.sql
+-- Issue warocol.com#614 — tenant-global persistence of the custom mesa label
+-- (follow-up to warocol.com#612 which shipped the v1 as per-device localStorage).
+--
+-- Both columns NULLable; NULL means "use the frontend default (Mesa / Mesas)".
+-- Empty/whitespace input on the API is normalized to NULL so users can reset.
+
+ALTER TABLE tenant_public_profiles
+    ADD COLUMN IF NOT EXISTS tables_label_singular VARCHAR(40),
+    ADD COLUMN IF NOT EXISTS tables_label_plural   VARCHAR(40);
+
+COMMENT ON COLUMN tenant_public_profiles.tables_label_singular IS
+    'Custom singular noun for "Mesa" (warocol.com#614). E.g. "Habitación" for hotels. NULL → frontend uses "Mesa".';
+COMMENT ON COLUMN tenant_public_profiles.tables_label_plural IS
+    'Custom plural noun for "Mesas" (warocol.com#614). E.g. "Habitaciones". NULL → frontend uses "Mesas".';

--- a/tests/test_operaciones_context_permissions.py
+++ b/tests/test_operaciones_context_permissions.py
@@ -190,3 +190,101 @@ async def test_update_toggle_rejects_unknown_column():
 
     assert excinfo.value.status_code == 422
     assert "Unknown toggle" in excinfo.value.detail
+
+
+# ─── Custom mesa label (warocol.com#614) ────────────────────────────────
+
+
+def test_supervisor_passes_tables_label_under_enforce():
+    """Supervisor PATCHes /operaciones/labels/tables with new noun pair."""
+    session = _build_session(role="supervisor")
+    app = FastAPI()
+    app.include_router(operaciones_context_router)
+
+    supervisor_modules = frozenset({
+        Module.POS, Module.VENTAS, Module.OPERACIONES,
+    })
+    label_stub = AsyncMock(return_value={
+        "success": True,
+        "data": {
+            "tables_label_singular": "Habitación",
+            "tables_label_plural": "Habitaciones",
+        },
+    })
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.operaciones_context.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=supervisor_modules),
+         ), \
+         patch(
+             "app.routers.operaciones_context.update_tables_label",
+             new=label_stub,
+         ):
+        client = TestClient(app)
+        response = client.patch(
+            "/operaciones/labels/tables",
+            json={"singular": "Habitación", "plural": "Habitaciones"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["tables_label_singular"] == "Habitación"
+    assert data["tables_label_plural"] == "Habitaciones"
+    # Service receives (tenant_id, singular, plural)
+    args, _ = label_stub.call_args
+    assert args[1] == "Habitación"
+    assert args[2] == "Habitaciones"
+
+
+def test_cashier_denied_tables_label_under_enforce():
+    """Cashier without OPERACIONES cannot PATCH the labels."""
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(operaciones_context_router)
+
+    cashier_modules = frozenset({Module.POS, Module.VENTAS, Module.MENU})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.operaciones_context.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ):
+        client = TestClient(app)
+        response = client.patch(
+            "/operaciones/labels/tables",
+            json={"singular": "Habitación", "plural": "Habitaciones"},
+        )
+
+    assert response.status_code == 403
+    assert "operaciones" in response.json()["detail"].lower()
+
+
+def test_tables_label_rejects_oversized_strings():
+    """Pydantic max_length=40 enforced before any service code runs."""
+    session = _build_session(role="supervisor")
+    app = FastAPI()
+    app.include_router(operaciones_context_router)
+
+    supervisor_modules = frozenset({
+        Module.POS, Module.VENTAS, Module.OPERACIONES,
+    })
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.operaciones_context.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=supervisor_modules),
+         ):
+        client = TestClient(app)
+        response = client.patch(
+            "/operaciones/labels/tables",
+            json={"singular": "x" * 41, "plural": "y" * 41},
+        )
+
+    assert response.status_code == 422


### PR DESCRIPTION
Migration 076 adds tables_label_singular + tables_label_plural to tenant_public_profiles (nullable VARCHAR(40)). Pos aggregator passes them through. New PATCH /api/operaciones/labels/tables endpoint + update_tables_label service function (UPSERT with slug+display_name seeding). MI_NEGOCIO PUT also accepts the fields via TenantPublicProfileUpdate. Empty/whitespace → NULL server-side. 3 shape tests. Python 3.9-safe. Refs uno0uno/warocol.com#614