### PR TITLE
fix(tenant-profile): default accepts_online_orders to True for new tenants (warocol.com#626)

### DIFF
--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -236,7 +236,12 @@ async def update_public_profile(
                     data_dict.get('neighborhood'),
                     json.dumps(data_dict['business_hours']) if data_dict.get('business_hours') is not None else None,
                     json.dumps(data_dict['social_media']) if data_dict.get('social_media') is not None else None,
-                    data_dict.get('accepts_online_orders', False),
+                    # Default True so new tenants are immediately able to
+                    # receive online orders — the platform's core value
+                    # prop (warocol.com#626). Operators can still toggle
+                    # off from /negocio at any time. Existing rows are
+                    # untouched by this change.
+                    data_dict.get('accepts_online_orders', True),
                     data_dict.get('min_order_amount', 0),
                     data_dict.get('estimated_preparation_time', 30),
                     data_dict.get('is_manually_open', True),


### PR DESCRIPTION
## Summary

One-line backend half of warocol.com#626. New tenants get `accepts_online_orders = true` by default on profile INSERT, so customers reaching the tenant via the directory aren't silently rejected at checkout.

## Stack

FastAPI + Python 3.9 (no syntax changes).

## Changes

- `app/services/tenant_config_service.py:239` — `data_dict.get('accepts_online_orders', False)` → `True`

## Behavior

- New profiles: come up with online orders enabled.
- Existing profiles: untouched (this change only affects the INSERT path's default; the field stays whatever it was for already-created rows).
- Operators can still toggle off from /negocio at any time.

## Test plan

- [ ] Sign up a fresh tenant via the existing onboarding flow → verify DB row has `accepts_online_orders = true`
- [ ] Existing tenants (sandwichito-monroy, rebel-rebel, etc.) keep their current value
- [ ] PATCH `/public-profile` with `{ accepts_online_orders: false }` still persists correctly

## Out of scope

- Backfill of 3 existing tenants in `is_active=true && accepts_online_orders=false` → tracked in warocol.com#628.

Closes warocol.com#626 (backend half)