### PR TITLE
feat(propinas): expose tip config in operaciones aggregator + endpoints

### DIFF
--- a/app/routers/operaciones_context.py
+++ b/app/routers/operaciones_context.py
@@ -9,12 +9,13 @@ Five dedicated PATCH endpoints (one per toggle) — REST-friendly and easier
 to gate / observe than a single combined endpoint. The service layer's
 column whitelist guards against SQL injection.
 """
+from decimal import Decimal
 from uuid import UUID
 
-from typing import Optional
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.core.middleware import require_valid_session
 from app.core.permissions import Module, require_module
@@ -23,6 +24,7 @@ from app.services import table_assignments_service
 from app.services.operaciones_context_service import (
     get_operaciones_context,
     update_tables_label,
+    update_tip_config,
     update_toggle,
 )
 
@@ -42,6 +44,43 @@ class TablesLabelRequest(BaseModel):
     """
     singular: Optional[str] = Field(None, max_length=40)
     plural: Optional[str] = Field(None, max_length=40)
+
+
+class TipConfigRequest(BaseModel):
+    """Payload for PATCH /operaciones/tip/config (warocol.com#638).
+
+    Non-boolean part of the tipping configuration. The boolean toggle
+    (tip_enabled) flows through PATCH /operaciones/toggles/tip via the
+    generic update_toggle() helper.
+
+    Mirrors the validation rules baked into the DB CHECK constraints from
+    migration 078 + the @field_validator on TenantPublicProfileBase:
+        - 1 to 5 percentage entries, each in [0, 100]
+        - preselect_index is NULL or a valid index into percentages
+    """
+    percentages: List[Decimal] = Field(..., min_length=1, max_length=5)
+    preselect_index: Optional[int] = None
+
+    @field_validator('percentages')
+    @classmethod
+    def _validate_percentages(cls, v):
+        for p in v:
+            if p < 0 or p > 100:
+                raise ValueError(f"tip preset {p} must be between 0 and 100")
+        return v
+
+    @model_validator(mode='after')
+    def _validate_preselect(self):
+        if self.preselect_index is None:
+            return self
+        if self.preselect_index < 0:
+            raise ValueError("preselect_index must be non-negative")
+        if self.preselect_index >= len(self.percentages):
+            raise ValueError(
+                f"preselect_index {self.preselect_index} is out of bounds for "
+                f"percentages of length {len(self.percentages)}"
+            )
+        return self
 
 
 @router.get(
@@ -110,6 +149,43 @@ async def toggle_auto_select_generic(request: Request, body: ToggleRequest):
     session = require_valid_session(request)
     return await update_toggle(
         session.tenant_id, "auto_select_generic_enabled", body.enabled
+    )
+
+
+# ── Tipping family (warocol.com#638) ────────────────────────────────────
+
+@router.patch(
+    "/toggles/tip",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def toggle_tip_enabled(request: Request, body: ToggleRequest):
+    """Toggle `tip_enabled` on the tenant profile.
+
+    Master switch for the tipping feature (warocol.com#638). When false,
+    the checkout selector (POS + online) is hidden and the API rejects
+    tip_amount > 0. Reads/writes of the existing tip presets remain
+    accessible — operators can keep their preset list ready without
+    surfacing tipping to customers.
+    """
+    session = require_valid_session(request)
+    return await update_toggle(session.tenant_id, "tip_enabled", body.enabled)
+
+
+@router.patch(
+    "/tip/config",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def patch_tip_config(request: Request, body: TipConfigRequest):
+    """Persist tip presets + preselected index (warocol.com#638).
+
+    Non-boolean sibling of /operaciones/toggles/tip. Validates that the
+    presets array is non-empty + <= 5 entries each in [0, 100], and that
+    preselect_index (when set) is in bounds. App-level validation mirrors
+    the DB CHECK constraints from migration 078.
+    """
+    session = require_valid_session(request)
+    return await update_tip_config(
+        session.tenant_id, body.percentages, body.preselect_index,
     )
 
 

--- a/app/services/operaciones_context_service.py
+++ b/app/services/operaciones_context_service.py
@@ -29,6 +29,7 @@ ALLOWED_TOGGLES = frozenset({
     "tables_enabled",
     "auto_select_generic_enabled",
     "waiter_attribution_enabled",  # warocol.com#573
+    "tip_enabled",                  # warocol.com#638
 })
 
 
@@ -133,6 +134,52 @@ async def update_tables_label(
         "data": {
             "tables_label_singular": row["tables_label_singular"],
             "tables_label_plural": row["tables_label_plural"],
+        },
+    }
+
+
+async def update_tip_config(
+    tenant_id: UUID,
+    percentages: list,
+    preselect_index: Optional[int],
+) -> Dict[str, Any]:
+    """Persist tip presets + preselected index (warocol.com#638).
+
+    Sibling to update_tables_label — handles the non-boolean part of the
+    tipping configuration. The boolean toggle (tip_enabled) flows through
+    the generic update_toggle() helper.
+
+    Mirrors the UPSERT pattern so fresh tenants without a
+    tenant_public_profiles row still work; slug and display_name are
+    seeded from the tenants table (both NOT NULL with no DB defaults).
+
+    Pydantic validators on TipConfigRequest enforce array bounds; DB
+    CHECKs from migration 078 / 079 are the defensive net.
+    """
+    query = """
+        INSERT INTO tenant_public_profiles
+            (tenant_id, slug, display_name, tip_default_percentages, tip_preselect_index)
+        SELECT t.id, t.slug, t.name, $2::numeric(5,2)[], $3
+        FROM tenants t
+        WHERE t.id = $1
+        ON CONFLICT (tenant_id) DO UPDATE
+            SET tip_default_percentages = EXCLUDED.tip_default_percentages,
+                tip_preselect_index     = EXCLUDED.tip_preselect_index,
+                updated_at              = now()
+        RETURNING tip_default_percentages, tip_preselect_index
+    """
+
+    async with get_db_connection() as conn:
+        row = await conn.fetchrow(query, tenant_id, percentages, preselect_index)
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+
+    return {
+        "success": True,
+        "data": {
+            "tip_default_percentages": [float(p) for p in row["tip_default_percentages"] or []],
+            "tip_preselect_index": row["tip_preselect_index"],
         },
     }
 

--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -27,6 +27,9 @@ SELECT
     tpp.waiter_attribution_enabled,
     tpp.tables_label_singular,
     tpp.tables_label_plural,
+    tpp.tip_enabled,
+    tpp.tip_default_percentages,
+    tpp.tip_preselect_index,
     fd.nit,
     fd.business_name,
     fd.type_organization_id,
@@ -94,6 +97,12 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
         'waiter_attribution_enabled': bool(row['waiter_attribution_enabled']) if row['waiter_attribution_enabled'] is not None else False,
         'tables_label_singular': row['tables_label_singular'],
         'tables_label_plural': row['tables_label_plural'],
+        'tip_enabled': bool(row['tip_enabled']) if row['tip_enabled'] is not None else False,
+        'tip_default_percentages': (
+            [float(p) for p in row['tip_default_percentages']]
+            if row['tip_default_percentages'] else [10.0]
+        ),
+        'tip_preselect_index': row['tip_preselect_index'],
         'fiscal_data': {
             'nit': row['nit'],
             'business_name': row['business_name'],


### PR DESCRIPTION
## Summary

Backend support for the tipping configuration page (warocol.com#638). Three small additions, no migrations, no new modules.

Closes nothing on its own — paired with the frontend PR in uno0uno/warocol.com that creates `/ventas/propinas`.

## Changes

| File | Change |
|---|---|
| `app/services/operaciones_context_service.py` | Add `'tip_enabled'` to `ALLOWED_TOGGLES` + new `update_tip_config()` service function (mirrors `update_tables_label`) |
| `app/services/pos_context_service.py` | Extend aggregator SELECT + response dict with 3 `tip_*` fields |
| `app/routers/operaciones_context.py` | Two new endpoints + `TipConfigRequest` model |

## New API surface

- `PATCH /operaciones/toggles/tip` — body `{ "enabled": bool }`. Toggles `tip_enabled`.
- `PATCH /operaciones/tip/config` — body `{ "percentages": [10, 15, 20], "preselect_index": 0|null }`. Persists presets + preselected index.

Both gated under `Module.OPERACIONES` (supervisor + admin), same as the other 6 toggle endpoints. The generic `PATCH /v1/tenant/config/public-profile` is owner-only (`MI_NEGOCIO`); we deliberately avoid it so supervisors can tune tipping.

## Validation baked in

- `TipConfigRequest.percentages`: 1-5 entries, each in `[0, 100]`.
- `TipConfigRequest.preselect_index`: NULL or in-bounds.
- App-level validation mirrors the DB CHECK constraints from migration 078 and the `@field_validator` on `TenantPublicProfileBase` from warocol.com#637 (api-warolabs#245).

## Test plan

After deploy:

- [ ] `GET /operaciones/restaurant-context` returns `tip_enabled` (bool), `tip_default_percentages` (list[float], defaults to `[10.0]`), `tip_preselect_index` (int | null).
- [ ] `PATCH /operaciones/toggles/tip` with `{enabled: true}` succeeds; `GET` reflects.
- [ ] `PATCH /operaciones/tip/config` with `{percentages: [12.5, 15, 20], preselect_index: 0}` succeeds; `GET` reflects.
- [ ] Same with `percentages: []` returns 422.
- [ ] Same with `percentages: [1,2,3,4,5,6]` returns 422.
- [ ] Same with `percentages: [-5]` returns 422.
- [ ] Same with `preselect_index: 99` returns 422.
- [ ] Supervisor role (no `MI_NEGOCIO`) can call both endpoints.

## Lint

`ruff check` on the 3 touched files: **All checks passed!** No new warnings introduced.