### PR TITLE
feat(propinas): expose tip config in public restaurant endpoint

### DIFF
--- a/app/services/public_restaurant_service.py
+++ b/app/services/public_restaurant_service.py
@@ -44,6 +44,7 @@ async def get_profile_by_slug(slug: str) -> Optional[Dict[str, Any]]:
                     tpp.seo_title, tpp.seo_description,
                     tpp.accepts_online_orders, tpp.min_order_amount, tpp.estimated_preparation_time,
                     tpp.is_manually_open,
+                    tpp.tip_enabled, tpp.tip_default_percentages, tpp.tip_preselect_index,
                     tpp.created_at, tpp.updated_at
                 FROM tenant_public_profiles tpp
                 JOIN tenant_subscriptions ts ON ts.tenant_id = tpp.tenant_id
@@ -72,6 +73,17 @@ async def get_profile_by_slug(slug: str) -> Optional[Dict[str, Any]]:
                     profile['social_media'] = json.loads(profile['social_media'])
                 except (json.JSONDecodeError, TypeError):
                     profile['social_media'] = {}
+
+            # warocol.com#639 — tip presets surface to the public storefront so the
+            # online checkout can render the tip selector. asyncpg returns
+            # numeric(5,2)[] as list[Decimal]; cast to list[float] for JSON.
+            # Default to [10.0] when missing so the checkout has something to show
+            # if a tenant enables tipping without explicitly setting presets.
+            tip_presets = profile.get('tip_default_percentages')
+            profile['tip_default_percentages'] = (
+                [float(p) for p in tip_presets] if tip_presets else [10.0]
+            )
+            profile['tip_enabled'] = bool(profile.get('tip_enabled'))
 
             # Calculate if currently open — manual toggle takes priority
             profile['is_currently_open'] = is_currently_open(


### PR DESCRIPTION
## Summary

Single backend change for the online tipping selector (warocol.com#639). The public storefront endpoint now returns tip_enabled, tip_default_percentages, and tip_preselect_index alongside the existing storefront-relevant fields.

Closes nothing on its own — paired with the frontend PR in uno0uno/warocol.com that creates the TipSelector component and wires it into both checkouts.

## Why this is needed

The online storefront (\`pages/[tenant]/index.vue\`, \`components/online/checkout/StepConfirm.vue\`) is **unauthenticated**. It cannot call \`/api/operaciones/restaurant-context\` or \`/api/pos/restaurant-context\` (both gated by Module dependencies). Its only source of tenant config is \`GET /api/public/restaurant/{slug}\`. Without exposing the three tip fields there, the online checkout has no way to know whether to render the selector.

## Change

| File | Change |
|---|---|
| \`app/services/public_restaurant_service.py\` | Add 3 columns to the \`get_profile_by_slug\` SELECT + 3 keys to the response dict |

12 insertions, 0 deletions, 0 migrations, 0 new endpoints.

## Cast notes

- \`tpp.tip_default_percentages\` is \`numeric(5,2)[]\` in Postgres; asyncpg returns \`list[Decimal]\`. Cast to \`list[float]\` for JSON serialization (matches what api-warolabs#246 does in \`pos_context_service\`).
- Default to \`[10.0]\` when the column is empty so a tenant who enables tipping without configuring presets still sees a sensible default.

## Security

The fields are public by design — operators broadcast their suggested tip percentages at checkout. No PII, no internal config.

## Test plan

After deploy:

- [ ] \`GET /api/public/restaurant/{any-slug}\` returns the response with three new keys: \`tip_enabled\` (bool), \`tip_default_percentages\` (list[float]), \`tip_preselect_index\` (int | null).
- [ ] When the tenant has \`tip_enabled = false\` (default), the fields still appear (\`false\`, \`[10.0]\`, \`null\`) — frontend uses \`tip_enabled\` to decide whether to render.
- [ ] No regressions on the existing fields (run a smoke through the storefront menu page which consumes the same endpoint).

## Lint

\`ruff check\` clean on the touched file.