### PR TITLE
feat(pos-checkout): expose active partial payments for rehydration (#656)

### DIFF
--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -291,6 +291,30 @@ async def add_cart_payment(
     )
 
 
+class VoidPaymentRequest(BaseModel):
+    reason: str = Field(..., min_length=1, description="Issue warocol.com#649 — motivo de la anulación (auditoría).")
+
+
+@router.delete("/{cart_id}/payments/{payment_id}", dependencies=[Depends(require_module(Module.POS))])
+async def void_cart_payment(
+    cart_id: str,
+    payment_id: str,
+    body: VoidPaymentRequest,
+    request: Request,
+):
+    """
+    Issue warocol.com#649 — soft-delete a partial payment on a cart's order.
+    Recomputes paid_total, reopens the cart if the void cleared the closing
+    payment, and auto-reverses the posted sale journal entry atomically.
+    """
+    return await pos_cart_service.void_order_payment(
+        request=request,
+        cart_id=cart_id,
+        payment_id=payment_id,
+        reason=body.reason,
+    )
+
+
 @router.get("/{cart_id}/tax-preview", dependencies=[Depends(require_module(Module.POS))])
 async def get_cart_tax_preview(
     request: Request,

--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -188,6 +188,27 @@ async def add_session_payment(request: Request, table_id: UUID, body: AddSession
     )
 
 
+class VoidSessionPaymentRequest(BaseModel):
+    reason: str = Field(..., min_length=1, description="Issue warocol.com#649 — motivo de la anulación (auditoría).")
+
+
+@router.delete("/{table_id}/payments/{payment_id}", dependencies=[Depends(require_module(Module.POS))])
+async def void_session_payment(
+    request: Request,
+    table_id: UUID,
+    payment_id: UUID,
+    body: VoidSessionPaymentRequest,
+):
+    """
+    Issue warocol.com#649 — soft-delete a mesa partial payment (with its
+    proportional siblings). Reopens the session if the void cleared the
+    closing payment and auto-reverses the GL entries atomically.
+    """
+    return await tables_service.void_table_payment(
+        request, table_id, payment_id, body.reason,
+    )
+
+
 @router.get("/{table_id}/current", dependencies=[Depends(require_module(Module.POS))])
 async def get_current_session(request: Request, table_id: UUID):
     """

--- a/app/services/accounting_service.py
+++ b/app/services/accounting_service.py
@@ -418,6 +418,94 @@ async def _assert_period_open(conn, tenant_id: UUID, year: int, month: int) -> N
         )
 
 
+async def void_order_journal_entry_in_txn(
+    conn,
+    tenant_id: UUID,
+    order_id: UUID,
+    user_id: Optional[UUID],
+    reason: str,
+) -> Optional[UUID]:
+    """
+    Issue warocol.com#649 — void the posted sale entry for an order and post
+    a balancing reversing entry, all inside the caller's transaction.
+
+    Mirrors `void_journal_entry` semantics but works against an already-open
+    connection so a single transaction covers payment-void + GL-void atomically.
+
+    Returns the id of the reversing entry, or None when no posted entry exists
+    for this order (early-stage partials never created one — nothing to undo).
+    """
+    entry_row = await conn.fetchrow(
+        """SELECT id, entry_date, period_year, period_month, description,
+                  reference, total_debit, total_credit, status
+           FROM tenant_journal_entries
+           WHERE tenant_id = $1 AND source_module = 'orden' AND source_id = $2
+             AND status = 'posted'
+           ORDER BY created_at DESC
+           LIMIT 1
+           FOR UPDATE""",
+        tenant_id, order_id,
+    )
+    if not entry_row:
+        return None
+
+    await _assert_period_open(conn, tenant_id, entry_row['period_year'], entry_row['period_month'])
+
+    original_lines = await conn.fetch(
+        """SELECT account_id, debit, credit, description, line_order
+           FROM tenant_journal_lines WHERE journal_entry_id = $1
+           ORDER BY line_order""",
+        entry_row['id'],
+    )
+
+    await conn.execute(
+        """UPDATE tenant_journal_entries
+           SET status = 'voided', voided_at = NOW()
+           WHERE id = $1""",
+        entry_row['id'],
+    )
+
+    rev_description = f"Reversión: {entry_row['description']} — {reason.strip()}"
+    rev_row = await conn.fetchrow(
+        """INSERT INTO tenant_journal_entries
+               (tenant_id, entry_date, period_year, period_month,
+                description, reference, source_module, source_id,
+                status, total_debit, total_credit, created_by, posted_at)
+           VALUES ($1, $2, $3, $4, $5, $6, 'system', $7,
+                   'posted', $8, $9, $10, NOW())
+           RETURNING id""",
+        tenant_id,
+        entry_row['entry_date'],
+        entry_row['period_year'],
+        entry_row['period_month'],
+        rev_description,
+        entry_row['reference'],
+        entry_row['id'],
+        float(entry_row['total_credit']),
+        float(entry_row['total_debit']),
+        user_id,
+    )
+
+    for line in original_lines:
+        await conn.execute(
+            """INSERT INTO tenant_journal_lines
+                   (journal_entry_id, account_id, debit, credit,
+                    description, line_order)
+               VALUES ($1, $2, $3, $4, $5, $6)""",
+            rev_row['id'],
+            line['account_id'],
+            float(line['credit']),
+            float(line['debit']),
+            line['description'],
+            line['line_order'],
+        )
+
+    logger.info(
+        f"🔄 Order GL entry voided in payment-void txn: order={order_id} entry={entry_row['id']} → reversing {rev_row['id']}"
+    )
+    return rev_row['id']
+
+
 async def create_journal_entry(request: Request, body: JournalEntryCreate) -> JournalEntryResponse:
     """
     Create a draft journal entry with its lines.

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -16,6 +16,7 @@ from app.core.exceptions import AuthenticationError, APIError
 from app.services.waros_service import evaluate_and_award
 from app.services.email_helpers import send_pos_receipt_email
 from app.services.cierre_service import _get_tenant_tax_config, _post_order_gl_entry, _post_order_cogs_gl_entry
+from app.services.accounting_service import void_order_journal_entry_in_txn
 from app.services.ingredient_purchase_units_service import resolve_recipe_quantity_to_base_unit
 from app.services.comandas_service import fire_comandas, finalize_open_comandas
 import logging
@@ -776,9 +777,9 @@ async def add_order_payment(
                 )
                 payment_id = str(payment_row["id"])
 
-                # 4. Compute paid total
+                # 4. Compute paid total (warocol.com#649: ignore voided rows)
                 paid_total_row = await conn.fetchrow(
-                    "SELECT COALESCE(SUM(amount), 0) AS paid_total FROM order_payments WHERE order_id = $1",
+                    "SELECT COALESCE(SUM(amount), 0) AS paid_total FROM order_payments WHERE order_id = $1 AND voided_at IS NULL",
                     order_id
                 )
                 paid_total = float(paid_total_row["paid_total"])
@@ -834,6 +835,128 @@ async def add_order_payment(
     except Exception as e:
         logger.error(f"Error adding order payment: {str(e)}")
         raise APIError(f"Error adding payment: {str(e)}", status_code=500)
+
+
+# Roles allowed to void another cashier's payment. The original creator can
+# always void their own. Issue warocol.com#649.
+_PAYMENT_VOID_ROLES = {'admin', 'superuser'}
+
+
+async def void_order_payment(
+    request: Request,
+    cart_id: str,
+    payment_id: str,
+    reason: str,
+) -> Dict[str, Any]:
+    """
+    Issue warocol.com#649 — soft-delete a partial payment on a POS cart's order.
+
+    - Marks order_payments.voided_at = NOW().
+    - Recomputes paid_total ignoring voided rows.
+    - Reopens the order (payment_status='partial') and the cart
+      (status='active') when the voided row was the one that closed them.
+    - Auto-reverses the posted sale journal entry in the same transaction.
+    """
+    if not reason or not reason.strip():
+        raise APIError("Se requiere un motivo para anular el pago", status_code=400)
+
+    try:
+        session_context = require_valid_session(request)
+        tenant_id = session_context.tenant_id
+        user_id = session_context.user_id if hasattr(session_context, 'user_id') else None
+        role = session_context.role if hasattr(session_context, 'role') else None
+
+        if not tenant_id:
+            raise AuthenticationError("Tenant ID is required")
+
+        async with get_db_connection() as conn:
+            async with conn.transaction():
+                # 1. Lock the payment row and join to its parent cart/order.
+                payment_row = await conn.fetchrow(
+                    """
+                    SELECT op.id, op.order_id, op.amount, op.payment_method,
+                           op.cash_received, op.created_by_user_id, op.voided_at,
+                           o.pos_cart_id, o.total_amount, o.payment_status, o.status AS order_status
+                    FROM order_payments op
+                    JOIN orders o ON o.id = op.order_id
+                    WHERE op.id = $1::uuid AND op.tenant_id = $2
+                    FOR UPDATE OF op
+                    """,
+                    payment_id, tenant_id,
+                )
+                if not payment_row:
+                    raise APIError("Pago no encontrado", status_code=404)
+                if payment_row["voided_at"] is not None:
+                    raise APIError("Este pago ya fue anulado", status_code=409)
+                if str(payment_row["pos_cart_id"]) != str(cart_id):
+                    raise APIError("El pago no pertenece a este carrito", status_code=400)
+
+                order_id = payment_row["order_id"]
+
+                # 2. Authorization: creator or manager-level role.
+                creator_id = payment_row["created_by_user_id"]
+                if creator_id is not None and str(creator_id) != str(user_id) and role not in _PAYMENT_VOID_ROLES:
+                    raise APIError(
+                        "Solo el cajero que registró el pago o un administrador puede anularlo",
+                        status_code=403,
+                    )
+
+                # 3. Lock the parent order to coordinate concurrent voids.
+                await conn.execute("SELECT 1 FROM orders WHERE id = $1 FOR UPDATE", order_id)
+
+                was_paid = payment_row["payment_status"] == "paid"
+
+                # 4. Mark payment as voided (soft delete).
+                await conn.execute(
+                    "UPDATE order_payments SET voided_at = NOW() WHERE id = $1",
+                    payment_row["id"],
+                )
+
+                # 5. Recompute paid total ignoring voided rows.
+                paid_row = await conn.fetchrow(
+                    "SELECT COALESCE(SUM(amount), 0) AS paid FROM order_payments WHERE order_id = $1 AND voided_at IS NULL",
+                    order_id,
+                )
+                paid_total = float(paid_row["paid"])
+                total_amount = float(payment_row["total_amount"])
+                remaining = max(0.0, total_amount - paid_total)
+                is_complete = remaining <= 0.01
+
+                # 6. If voiding flipped the order out of fully-paid, reopen.
+                reopened = was_paid and not is_complete
+                if reopened:
+                    await conn.execute(
+                        "UPDATE orders SET payment_status = 'partial' WHERE id = $1",
+                        order_id,
+                    )
+                    await conn.execute(
+                        "UPDATE pos_carts SET status = 'active', updated_at = NOW() WHERE id = $1",
+                        payment_row["pos_cart_id"],
+                    )
+                    # Reverse the posted GL entry — same transaction, atomic.
+                    await void_order_journal_entry_in_txn(
+                        conn, tenant_id, order_id, user_id, reason.strip(),
+                    )
+
+        logger.info(
+            f"Payment {payment_id} voided (order={order_id}, paid_total={paid_total}, reopened={reopened})"
+        )
+        return {
+            "success": True,
+            "data": {
+                "voided_ids": [str(payment_id)],
+                "paid_total": paid_total,
+                "remaining": remaining,
+                "is_complete": is_complete,
+                "reopened": reopened,
+            },
+        }
+
+    except (AuthenticationError, APIError):
+        raise
+    except Exception as e:
+        logger.error(f"Error voiding payment {payment_id}: {e}")
+        raise APIError(f"Error al anular el pago: {e}", status_code=500)
 
 
 async def complete_pos_order(

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -115,6 +115,30 @@ async def get_or_create_active_cart(
             # Get cart items with modifiers
             items = await get_cart_items(conn, cart_id)
 
+            # Issue warocol.com#656 — active (non-voided) partial payments of the
+            # cart's order, surfaced so checkout can rehydrate "Pagos registrados"
+            # on re-entry (otherwise the cashier may double-charge).
+            # POS payments are not split proportionally — one row per logical
+            # payment. Bar mode filter via order state (only orders still in flight).
+            partial_payments_rows = await conn.fetch(
+                """
+                SELECT op.id, op.amount, op.payment_method, op.payment_method_id,
+                       op.paid_at, pm.name AS payment_method_name
+                FROM order_payments op
+                LEFT JOIN payment_methods pm ON pm.id = op.payment_method_id
+                WHERE op.order_id = (
+                    SELECT id FROM orders
+                    WHERE pos_cart_id = $1
+                      AND (status != 'completed' OR payment_status != 'paid')
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                )
+                  AND op.voided_at IS NULL
+                ORDER BY op.paid_at
+                """,
+                cart_id,
+            )
+
             return {
                 "success": True,
                 "data": {
@@ -122,7 +146,19 @@ async def get_or_create_active_cart(
                     "total_amount": float(cart_row['total_amount']),
                     "items": items,
                     "created_at": cart_row['created_at'].isoformat(),
-                    "updated_at": cart_row['updated_at'].isoformat()
+                    "updated_at": cart_row['updated_at'].isoformat(),
+                    # Issue warocol.com#656 — rehydration source for checkout's Pagos registrados
+                    "partial_payments": [
+                        {
+                            "id": str(r["id"]),
+                            "amount": float(r["amount"]),
+                            "payment_method": r["payment_method"],
+                            "payment_method_id": str(r["payment_method_id"]) if r["payment_method_id"] else None,
+                            "payment_method_name": r["payment_method_name"],
+                            "paid_at": r["paid_at"].isoformat(),
+                        }
+                        for r in partial_payments_rows
+                    ],
                 }
             }
 

--- a/app/services/public_restaurant_service.py
+++ b/app/services/public_restaurant_service.py
@@ -44,6 +44,7 @@ async def get_profile_by_slug(slug: str) -> Optional[Dict[str, Any]]:
                     tpp.seo_title, tpp.seo_description,
                     tpp.accepts_online_orders, tpp.min_order_amount, tpp.estimated_preparation_time,
                     tpp.is_manually_open,
+                    tpp.tip_enabled, tpp.tip_default_percentages, tpp.tip_preselect_index,
                     tpp.created_at, tpp.updated_at
                 FROM tenant_public_profiles tpp
                 JOIN tenant_subscriptions ts ON ts.tenant_id = tpp.tenant_id
@@ -72,6 +73,17 @@ async def get_profile_by_slug(slug: str) -> Optional[Dict[str, Any]]:
                     profile['social_media'] = json.loads(profile['social_media'])
                 except (json.JSONDecodeError, TypeError):
                     profile['social_media'] = {}
+
+            # warocol.com#639 — tip presets surface to the public storefront so the
+            # online checkout can render the tip selector. asyncpg returns
+            # numeric(5,2)[] as list[Decimal]; cast to list[float] for JSON.
+            # Default to [10.0] when missing so the checkout has something to show
+            # if a tenant enables tipping without explicitly setting presets.
+            tip_presets = profile.get('tip_default_percentages')
+            profile['tip_default_percentages'] = (
+                [float(p) for p in tip_presets] if tip_presets else [10.0]
+            )
+            profile['tip_enabled'] = bool(profile.get('tip_enabled'))
 
             # Calculate if currently open — manual toggle takes priority
             profile['is_currently_open'] = is_currently_open(

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -1255,6 +1255,41 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                 session_row["id"],
             )
 
+            # Issue warocol.com#656 — active (non-voided) partial payments of the
+            # session, surfaced so checkout can rehydrate "Pagos registrados" on
+            # re-entry (otherwise the cashier may double-charge).
+            #
+            # DISTINCT ON + group_amount collapses mesa proportional splits (one
+            # logical payment stored as N rows across orders, same paid_at) into
+            # one row per logical payment. The canonical id is the first sibling;
+            # the void endpoint already resolves the rest via the
+            # (table_session_id, payment_method, paid_at) heuristic.
+            #
+            # Bar mode filter: only orders still in flight — closed-and-paid
+            # orders from previous rounds should not surface.
+            partial_payments_rows = await conn.fetch(
+                """
+                SELECT DISTINCT ON (op.payment_method, op.paid_at)
+                    op.id, op.amount, op.payment_method, op.payment_method_id,
+                    op.paid_at, pm.name AS payment_method_name,
+                    (SELECT COALESCE(SUM(op2.amount), 0)
+                       FROM order_payments op2
+                       JOIN orders o2 ON o2.id = op2.order_id
+                       WHERE o2.table_session_id = $1
+                         AND op2.payment_method = op.payment_method
+                         AND op2.paid_at = op.paid_at
+                         AND op2.voided_at IS NULL) AS group_amount
+                FROM order_payments op
+                JOIN orders o ON o.id = op.order_id
+                LEFT JOIN payment_methods pm ON pm.id = op.payment_method_id
+                WHERE o.table_session_id = $1
+                  AND op.voided_at IS NULL
+                  AND (o.status != 'completed' OR o.payment_status != 'paid')
+                ORDER BY op.payment_method, op.paid_at, op.id
+                """,
+                session_row["id"],
+            )
+
         return {
             "success": True,
             "data": {
@@ -1279,6 +1314,18 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                     "effective_waiter_member_id": str(session_row["effective_waiter_member_id"]) if session_row.get("effective_waiter_member_id") else None,
                     "effective_waiter_member_name": session_row.get("effective_waiter_member_name"),
                     "effective_waiter_member_role": session_row.get("effective_waiter_member_role"),
+                    # Issue warocol.com#656 — rehydration source for checkout's Pagos registrados
+                    "partial_payments": [
+                        {
+                            "id": str(r["id"]),
+                            "amount": float(r["group_amount"]),
+                            "payment_method": r["payment_method"],
+                            "payment_method_id": str(r["payment_method_id"]) if r["payment_method_id"] else None,
+                            "payment_method_name": r["payment_method_name"],
+                            "paid_at": r["paid_at"].isoformat(),
+                        }
+                        for r in partial_payments_rows
+                    ],
                 },
                 "orders": [
                     {

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -15,7 +15,8 @@ from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError, NotFoundError
 from app.services.cierre_service import _get_tenant_tax_config, _post_order_gl_entry, _post_order_cogs_gl_entry
-from app.services.pos_cart_service import _capture_order_item_ingredients
+from app.services.accounting_service import void_order_journal_entry_in_txn
+from app.services.pos_cart_service import _capture_order_item_ingredients, _PAYMENT_VOID_ROLES
 from app.services.orders_service import _compute_tax_breakdown
 from app.services.ingredient_purchase_units_service import resolve_recipe_quantity_to_base_unit
 from app.services.comandas_service import fire_comandas
@@ -920,7 +921,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                 session_total = sum(float(r["total_amount"]) for r in order_rows)
                 order_ids = [r["id"] for r in order_rows]
                 paid_row = await conn2.fetchrow(
-                    "SELECT COALESCE(SUM(amount), 0) AS paid FROM order_payments WHERE order_id = ANY($1)",
+                    "SELECT COALESCE(SUM(amount), 0) AS paid FROM order_payments WHERE order_id = ANY($1) AND voided_at IS NULL",
                     order_ids,
                 )
                 paid_total = float(paid_row["paid"])
@@ -1085,7 +1086,7 @@ async def add_session_payment(
 
                 # Recompute paid total
                 paid_row = await conn.fetchrow(
-                    "SELECT COALESCE(SUM(amount), 0) AS paid FROM order_payments WHERE order_id = ANY($1)",
+                    "SELECT COALESCE(SUM(amount), 0) AS paid FROM order_payments WHERE order_id = ANY($1) AND voided_at IS NULL",
                     order_ids,
                 )
                 paid_total = float(paid_row["paid"])
@@ -2260,3 +2261,156 @@ def _format_table_simple(row: dict) -> dict:
         "is_active": row["is_active"],
         "created_at": row["created_at"].isoformat(),
     }
+
+
+async def void_table_payment(
+    request: Request,
+    table_id: UUID,
+    payment_id: UUID,
+    reason: str,
+) -> dict:
+    """
+    Issue warocol.com#649 — soft-delete a mesa partial payment.
+
+    Mesa proportional splits store one logical payment as N rows (one per order
+    in the session) at the same paid_at timestamp. The void targets a single
+    payment_id but voids the entire sibling group identified by
+    (table_session_id, payment_method, paid_at) so the books stay consistent.
+
+    Recomputes the session's paid_total over remaining rows. When voiding flips
+    the session out of fully-paid, reopens it (closed_at=NULL, table.status='open')
+    and auto-reverses the per-order GL entries inside the same transaction.
+    """
+    if not reason or not reason.strip():
+        raise APIError("Se requiere un motivo para anular el pago", status_code=400)
+
+    try:
+        session_context = require_valid_session(request)
+        tenant_id = session_context.tenant_id
+        user_id = session_context.user_id if hasattr(session_context, 'user_id') else None
+        role = session_context.role if hasattr(session_context, 'role') else None
+        if not tenant_id:
+            raise AuthenticationError("Tenant ID is required")
+
+        async with get_db_connection() as conn:
+            async with conn.transaction():
+                # 1. Lock target payment + identify its sibling group.
+                target = await conn.fetchrow(
+                    """
+                    SELECT op.id, op.order_id, op.payment_method, op.paid_at,
+                           op.cash_received, op.created_by_user_id, op.voided_at,
+                           o.table_session_id
+                    FROM order_payments op
+                    JOIN orders o ON o.id = op.order_id
+                    WHERE op.id = $1::uuid AND op.tenant_id = $2
+                    FOR UPDATE OF op
+                    """,
+                    payment_id, tenant_id,
+                )
+                if not target:
+                    raise APIError("Pago no encontrado", status_code=404)
+                if target["voided_at"] is not None:
+                    raise APIError("Este pago ya fue anulado", status_code=409)
+                if target["table_session_id"] is None:
+                    raise APIError("El pago no pertenece a una sesión de mesa", status_code=400)
+
+                # 2. Validate the session belongs to the URL's table.
+                session_row = await conn.fetchrow(
+                    "SELECT id, table_id, closed_at FROM table_sessions WHERE id = $1 AND tenant_id = $2 FOR UPDATE",
+                    target["table_session_id"], tenant_id,
+                )
+                if not session_row or str(session_row["table_id"]) != str(table_id):
+                    raise APIError("La sesión no corresponde a esta mesa", status_code=400)
+
+                # 3. Authorization: creator OR manager-level role.
+                creator_id = target["created_by_user_id"]
+                if creator_id is not None and str(creator_id) != str(user_id) and role not in _PAYMENT_VOID_ROLES:
+                    raise APIError(
+                        "Solo el cajero que registró el pago o un administrador puede anularlo",
+                        status_code=403,
+                    )
+
+                # 4. Find sibling rows (proportional split): same session,
+                # same method, same paid_at, not voided. Lock them all.
+                sibling_rows = await conn.fetch(
+                    """
+                    SELECT op.id, op.order_id, op.amount
+                    FROM order_payments op
+                    JOIN orders o ON o.id = op.order_id
+                    WHERE o.table_session_id = $1
+                      AND op.payment_method = $2
+                      AND op.paid_at = $3
+                      AND op.voided_at IS NULL
+                      AND op.tenant_id = $4
+                    FOR UPDATE OF op
+                    """,
+                    session_row["id"], target["payment_method"], target["paid_at"], tenant_id,
+                )
+                if not sibling_rows:
+                    raise APIError("Pago no encontrado en la sesión", status_code=404)
+
+                voided_ids = [str(r["id"]) for r in sibling_rows]
+                affected_order_ids = list({r["order_id"] for r in sibling_rows})
+
+                # 5. Soft-delete all siblings atomically.
+                await conn.execute(
+                    "UPDATE order_payments SET voided_at = NOW() WHERE id = ANY($1::uuid[])",
+                    [r["id"] for r in sibling_rows],
+                )
+
+                # 6. Recompute session-wide paid_total / remaining.
+                session_orders = await conn.fetch(
+                    "SELECT id, total_amount FROM orders WHERE table_session_id = $1",
+                    session_row["id"],
+                )
+                session_total = sum(float(r["total_amount"]) for r in session_orders)
+                order_ids = [r["id"] for r in session_orders]
+                paid_row = await conn.fetchrow(
+                    "SELECT COALESCE(SUM(amount), 0) AS paid FROM order_payments WHERE order_id = ANY($1) AND voided_at IS NULL",
+                    order_ids,
+                )
+                paid_total = float(paid_row["paid"])
+                remaining = max(0.0, session_total - paid_total)
+                is_complete = remaining <= 0.01
+
+                # 7. Reopen if voiding flipped the session out of fully-paid.
+                was_closed = session_row["closed_at"] is not None
+                reopened = was_closed and not is_complete
+                if reopened:
+                    await conn.execute(
+                        "UPDATE orders SET payment_status = 'partial' WHERE table_session_id = $1 AND status = 'completed' AND payment_status = 'paid'",
+                        session_row["id"],
+                    )
+                    await conn.execute(
+                        "UPDATE table_sessions SET closed_at = NULL WHERE id = $1",
+                        session_row["id"],
+                    )
+                    await conn.execute(
+                        "UPDATE tables SET status = 'open' WHERE id = $1 AND tenant_id = $2",
+                        table_id, tenant_id,
+                    )
+                    # Reverse posted GL entry per affected order.
+                    for affected_order_id in affected_order_ids:
+                        await void_order_journal_entry_in_txn(
+                            conn, tenant_id, affected_order_id, user_id, reason.strip(),
+                        )
+
+        logger.info(
+            f"Mesa payments voided: session={session_row['id']} group_size={len(voided_ids)} paid_total={paid_total} reopened={reopened}"
+        )
+        return {
+            "success": True,
+            "data": {
+                "voided_ids": voided_ids,
+                "paid_total": paid_total,
+                "remaining": remaining,
+                "is_complete": is_complete,
+                "reopened": reopened,
+            },
+        }
+
+    except (AuthenticationError, APIError):
+        raise
+    except Exception as e:
+        logger.error(f"Error voiding mesa payment {payment_id}: {e}")
+        raise APIError(f"Error al anular el pago: {e}", status_code=500)


### PR DESCRIPTION
## Summary

Backend half of warocol.com#656. Surfaces active (non-voided) partial payments on both mesa and POS read endpoints so the frontend can rehydrate the **Pagos registrados** list when the cashier re-enters checkout. Without this, the UI silently resets the list and the cashier can register the remaining amount as if it were a fresh full payment.

Frontend half lives in `uno0uno/warocol.com` PR on branch `gh-656-partial-payments-rehydration`.

## No migration

Uses the `voided_at` column + `idx_order_payments_active` partial index already shipped in warocol.com#649.

## Changes

- `app/services/tables_service.py::get_current_session` — adds `partial_payments[]` to the `session` block of the response. Mesa proportional splits (one logical payment stored as N rows across orders at the same `paid_at`) are collapsed via `DISTINCT ON (payment_method, paid_at)` + a `group_amount` subquery that sums sibling rows. Canonical id = first sibling; void endpoint already resolves the rest via the `(table_session_id, payment_method, paid_at)` heuristic from #649.
- `app/services/pos_cart_service.py::get_or_create_active_cart` — adds `partial_payments[]` to the response. POS payments are not split proportionally (one row per logical payment), so the query is simpler.
- Both queries apply the bar-mode filter `(o.status != 'completed' OR o.payment_status != 'paid')` so closed sales from previous rounds never re-surface in checkout.

## Response shape

```jsonc
// Mesa: GET /api/tables/{table_id}/current
{
  "data": {
    "session": {
      // ...existing fields
      "partial_payments": [
        {
          "id": "<uuid>",
          "amount": 100.00,            // collapsed sibling total
          "payment_method": "cash",
          "payment_method_id": null,    // null for group-level methods
          "payment_method_name": null,  // null for group-level (frontend resolves via getPaymentMethodLabel)
          "paid_at": "2026-05-17T04:28:36.332162+00:00"
        }
      ]
    }
  }
}

// POS: GET /api/pos/cart/{customer_id}
{
  "data": {
    "id": "<cart_uuid>",
    "total_amount": 800.00,
    "items": [...],
    "partial_payments": [/* same shape */]
  }
}
```

## Testing

Backend smoke (with a real session that has partials):

```bash
curl -s "http://localhost:9999/tables/<table_id>/current" | jq '.data.session.partial_payments'
curl -s "http://localhost:9999/pos/cart/<customer_id>" | jq '.data.partial_payments'
```

Live data check on order `5384314f-f971-4f76-bac8-5f24e5837202` (mesa, 3 partials totaling $200 of $800):

- Each `paid_at` distinct → `DISTINCT ON` returns 3 rows.
- `group_amount` for each row = own amount (single-order session, no proportional split).
- Closed order would be filtered out (it's still `payment_status='partial'`, so it shows correctly).

## Risks

| Risk | Mitigation |
|---|---|
| New optional field breaks existing consumers | Field is additive — existing fields untouched. Tax-preview consumer ignores unknown fields. |
| Mesa heuristic collides on sub-second timestamps | `paid_at` is `timestamptz` at microsecond precision; two cashiers + same method + same microsecond is astronomically rare. |
| DB cost | Negligible — partial index covers the active-payments lookup. |

## Related

- warocol.com#649 — void partials (shipped). This PR consumes the schema (`voided_at`) and complements the void flow (voiding a rehydrated row works because the `id` is a real UUID).
- warocol.com#636 — partial calculator (shipped). Same flow.

Closes uno0uno/warocol.com#656