### PR TITLE
Copy effective session waiter to orders on mesa close

### DIFF
--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -158,7 +158,7 @@ class CompleteOrderRequest(BaseModel):
     delivery_address_id: Optional[UUID] = Field(None, description="UUID of an addresses_profile row owned by customer_id. When set, this order is treated as a delivery and the comanda fires with source_type='delivery'.")
     scheduled_time: Optional[datetime] = Field(None, description="ISO datetime for scheduled delivery. NULL = ASAP. Forward-compatible: v1 UI sends NULL only.")
     delivery_instructions: Optional[str] = Field(None, description="Free-text notes for the courier (e.g. 'Tocar el timbre 2 veces').")
-    served_by_member_id: Optional[UUID] = Field(None, description="Issue warocol.com#575 — per-order waiter attribution. Pre-validated when set: must belong to tenant + be active. Silently ignored when waiter_attribution_enabled is OFF for the tenant.")
+    served_by_member_id: Optional[UUID] = Field(None, description="Issue warocol.com#575/#663 — waiter at checkout. Validated against active tenant members; persisted even when waiter_attribution_enabled is OFF.")
     tip_amount: float = Field(0, ge=0, description="Issue warocol.com#637 — tip amount in COP. Strictly separate from total_amount. Rejected when tip_enabled=false for the tenant. Rejected when split_mode=true. For cash payments, cash_received must cover total + tip.")
     tip_source: Literal['preset', 'custom', 'none'] = Field('none', description="Issue warocol.com#637 — how the customer chose the tip. Must agree with tip_amount: (0,'none') or (>0,'preset'|'custom').")
 

--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -141,6 +141,7 @@ class CloseSessionRequest(BaseModel):
     cash_received: Optional[float] = Field(None, description="Issue #524 — cash handed over for a single (non-split) cash close. Must be >= total session amount.")
     tip_amount: float = Field(0, ge=0, description="warocol.com#639 — total tip for the mesa session. Applied to the first completed order in the session (like cash_received). Rejected when tip_enabled=false or split_mode=true.")
     tip_source: Literal['preset', 'custom', 'none'] = Field('none', description="warocol.com#639 — how the tip was chosen. Must agree with tip_amount.")
+    served_by_member_id: Optional[UUID] = Field(None, description="warocol.com#663 — waiter assigned at checkout. Applied to all completed orders in the session.")
 
 
 class AddSessionPaymentRequest(BaseModel):
@@ -175,6 +176,7 @@ async def close_session(request: Request, table_id: UUID, body: CloseSessionRequ
         cash_received=body.cash_received,
         tip_amount=body.tip_amount,
         tip_source=body.tip_source,
+        served_by_member_id=body.served_by_member_id,
     )
 
 

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -518,6 +518,8 @@ async def get_order_by_id(
                     o.scheduled_time,
                     o.delivery_instructions,
                     t_meta2.is_bar as is_bar,
+                    o.served_by_member_id,
+                    p_served.name as served_by_member_name,
                     p.id as customer_id,
                     p.name as customer_name,
                     p.phone_number as customer_phone,
@@ -539,6 +541,8 @@ async def get_order_by_id(
                         WHERE oi.order_id = o.id
                     ) as items_count
                 FROM orders o
+                LEFT JOIN tenant_members tm_served ON tm_served.id = o.served_by_member_id
+                LEFT JOIN profile p_served ON p_served.id = tm_served.user_id
                 LEFT JOIN profile p ON o.customer_id = p.id
                 LEFT JOIN table_sessions ts_meta2 ON ts_meta2.id = o.table_session_id
                 LEFT JOIN tables t_meta2 ON t_meta2.id = ts_meta2.table_id
@@ -642,6 +646,8 @@ async def get_order_by_id(
                         "phone": order_row['customer_phone'],
                         "email": order_row['customer_email'],
                     },
+                    "served_by_member_id": str(order_row['served_by_member_id']) if order_row['served_by_member_id'] else None,
+                    "served_by_member_name": order_row['served_by_member_name'],
                     "items_count": order_row['items_count'],
                     "split_payments": split_payments,
                     "standard_tax": _std_tax,

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -1059,7 +1059,8 @@ async def complete_pos_order(
                 if flags:
                     waiter_attribution_enabled = bool(flags['waiter_attribution_enabled'])
                     tip_enabled = bool(flags['tip_enabled'])
-                if served_by_member_id is not None and waiter_attribution_enabled:
+                # warocol.com#663 — persist checkout attribution even when per-table toggle is off
+                if served_by_member_id is not None:
                     member_check = await _conn.fetchval(
                         """
                         SELECT id FROM tenant_members
@@ -1071,7 +1072,6 @@ async def complete_pos_order(
                     if member_check is None:
                         raise NotFoundError("Member not found")
                     resolved_served_by = served_by_member_id
-                # waiter toggle OFF → leave resolved_served_by as None (silent ignore)
 
         # warocol.com#637 — tip validation (fail fast, before the transaction).
         # Coerce (0, anything) → (0, 'none') for idempotency. Reject inconsistent

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -597,7 +597,7 @@ async def open_session(
         raise APIError(f"Error opening session: {e}", status_code=500)
 
 
-async def close_session(request: Request, table_id: UUID, payment_method: Optional[str] = None, customer_id: Optional[str] = None, credit_due_date: Optional[date] = None, payment_method_id: Optional[UUID] = None, discount_type: Optional[str] = None, discount_value: Optional[float] = None, split_mode: bool = False, split_first_amount: float = 0.0, *, split_first_cash_received: Optional[float] = None, cash_received: Optional[float] = None, tip_amount: float = 0, tip_source: str = 'none') -> dict:
+async def close_session(request: Request, table_id: UUID, payment_method: Optional[str] = None, customer_id: Optional[str] = None, credit_due_date: Optional[date] = None, payment_method_id: Optional[UUID] = None, discount_type: Optional[str] = None, discount_value: Optional[float] = None, split_mode: bool = False, split_first_amount: float = 0.0, *, split_first_cash_received: Optional[float] = None, cash_received: Optional[float] = None, tip_amount: float = 0, tip_source: str = 'none', served_by_member_id: Optional[UUID] = None) -> dict:
     """
     Close the active session for a table.
     If payment_method is provided, marks all pending orders as completed with that payment method.
@@ -613,6 +613,26 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
         raise APIError("tip_source cannot be 'none' when tip_amount > 0", status_code=400)
     if tip_amount > 0 and split_mode:
         raise APIError("Tip is not supported in split-payment mode in this phase", status_code=400)
+
+    resolved_served_by: Optional[UUID] = None
+    if served_by_member_id is not None:
+        session_context_pre = require_valid_session(request)
+        tenant_id_pre = session_context_pre.tenant_id
+        if not tenant_id_pre:
+            raise AuthenticationError("Tenant ID is required")
+        async with get_db_connection(use_transaction=False) as _conn:
+            member_check = await _conn.fetchval(
+                """
+                SELECT id FROM tenant_members
+                WHERE id = $1 AND tenant_id = $2 AND is_active = true AND terminated_at IS NULL
+                """,
+                served_by_member_id,
+                tenant_id_pre,
+            )
+            if member_check is None:
+                raise NotFoundError("Member not found")
+            resolved_served_by = served_by_member_id
+
     try:
         session_context = require_valid_session(request)
         tenant_id = session_context.tenant_id
@@ -749,6 +769,18 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                         f"(payment_method={payment_method}, payment_status={payment_status}, "
                         f"discount_amount={_discount_amount}) for session {session_row['id']}"
                     )
+
+                    # warocol.com#663 — checkout waiter attribution on all completed session orders
+                    if resolved_served_by is not None:
+                        await conn.execute(
+                            """
+                            UPDATE orders
+                            SET served_by_member_id = $1, updated_at = now()
+                            WHERE table_session_id = $2 AND status = 'completed'
+                            """,
+                            resolved_served_by,
+                            session_row["id"],
+                        )
 
                     # Issue #524 — single-payment (non-split) cash close: attach cash_received
                     # to the FIRST completed order in the session (others stay NULL). Cierre

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -650,12 +650,33 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                     raise NotFoundError("Table not found")
 
                 session_row = await conn.fetchrow(
-                    "SELECT id FROM table_sessions WHERE table_id = $1 AND tenant_id = $2 AND closed_at IS NULL",
+                    """
+                    SELECT
+                        ts.id,
+                        COALESCE(ts.attended_by_member_id, t.assigned_member_id) AS effective_waiter_member_id
+                    FROM table_sessions ts
+                    JOIN tables t ON t.id = ts.table_id
+                    WHERE ts.table_id = $1 AND ts.tenant_id = $2 AND ts.closed_at IS NULL
+                    """,
                     table_id,
                     tenant_id,
                 )
                 if not session_row:
                     raise NotFoundError("No open session found for this table")
+
+                # warocol.com#665 — when checkout omits served_by (session already has a waiter),
+                # copy the effective waiter onto completed orders for propinas / member reports.
+                if resolved_served_by is None and session_row.get("effective_waiter_member_id"):
+                    member_ok = await conn.fetchval(
+                        """
+                        SELECT id FROM tenant_members
+                        WHERE id = $1 AND tenant_id = $2 AND is_active = true AND terminated_at IS NULL
+                        """,
+                        session_row["effective_waiter_member_id"],
+                        tenant_id,
+                    )
+                    if member_ok:
+                        resolved_served_by = session_row["effective_waiter_member_id"]
 
                 is_bar_table = bool(table_row["is_bar"])
 


### PR DESCRIPTION
## Summary

Fixes warocol.com#665: mesa orders with an assigned table waiter showed **Sin asignar** in `/ventas/propinas` because checkout (#663) hides the waiter picker when `effectiveWaiterMemberId` is set, so `served_by_member_id` was never written on close.

## Changes

- `app/services/tables_service.py` — `close_session` loads `COALESCE(attended_by, assigned_member)` for the open session; when the request omits `served_by_member_id`, validates and applies it to all completed session orders.

## Testing

- [ ] Mesa with assigned waiter → close with tip → propinas shows mesero name
- [ ] Mesa without waiter → checkout picker still works (#663)
- [ ] Explicit `served_by_member_id` in close body still wins

Related: uno0uno/warocol.com#665

Made with [Cursor](https://cursor.com)