### PR TITLE
fix(cierre): filter cash expenses and open tables by timestamp for shift windows

### DIFF
--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -673,6 +673,52 @@ def _build_order_date_filter(
     return sql, [period_start, period_end]
 
 
+def _build_expense_filter(
+    period_start: date,
+    period_end: date,
+    period_start_time: Optional[datetime],
+    period_end_time: Optional[datetime],
+    param_offset: int = 2,
+):
+    """
+    Cash expenses: date-only arqueos use transaction_date (business day).
+    Shift windows use created_at (transaction_date has no time component).
+    """
+    p2 = f"${param_offset}"
+    p3 = f"${param_offset + 1}"
+    if period_start_time and period_end_time:
+        sql = f"AND created_at >= {p2} AND created_at <= {p3}"
+        return sql, [period_start_time, period_end_time]
+    sql = f"AND transaction_date >= {p2} AND transaction_date <= {p3}"
+    return sql, [period_start, period_end]
+
+
+def _build_open_tables_filter(
+    period_start: date,
+    period_end: date,
+    period_start_time: Optional[datetime],
+    period_end_time: Optional[datetime],
+    param_offset: int = 2,
+):
+    """
+    Open tables (closed_at IS NULL applied by caller).
+
+    Date-only: opened on a calendar day in [period_start, period_end].
+    Shift window: session started on or before shift end (still-open tables
+    that began before the shift still block the close).
+    """
+    if period_start_time and period_end_time:
+        p_end = f"${param_offset}"
+        return f"AND ts.opened_at <= {p_end}", [period_end_time]
+    p2 = f"${param_offset}"
+    p3 = f"${param_offset + 1}"
+    sql = (
+        f"AND ts.opened_at::date >= {p2} "
+        f"AND ts.opened_at::date <= {p3}"
+    )
+    return sql, [period_start, period_end]
+
+
 async def _compute_preview(
     conn,
     tenant_id: UUID,
@@ -690,11 +736,17 @@ async def _compute_preview(
     completed_only=False → 'completed' + 'pending' (used for Cierre X preview so
                            open-table orders are visible)
 
-    When period_start_time / period_end_time are supplied the order filter uses
-    exact TIMESTAMPTZ comparison, enabling cross-midnight shift closing.
+    When period_start_time / period_end_time are supplied the order, expense,
+    and open-table filters use exact TIMESTAMPTZ comparison (shift windows).
     """
     status_filter = "AND status = 'completed'" if completed_only else "AND status IN ('completed', 'pending')"
     date_filter, date_params = _build_order_date_filter(
+        period_start, period_end, period_start_time, period_end_time
+    )
+    expense_filter, expense_params = _build_expense_filter(
+        period_start, period_end, period_start_time, period_end_time
+    )
+    open_tables_filter, open_tables_params = _build_open_tables_filter(
         period_start, period_end, period_start_time, period_end_time
     )
     sales_row = await conn.fetchrow(
@@ -749,30 +801,28 @@ async def _compute_preview(
             method_totals[m] = method_totals.get(m, 0.0) + float(row["total"])
 
     gastos_row = await conn.fetchrow(
-        """
+        f"""
         SELECT COALESCE(SUM(amount), 0) AS gastos_efectivo
         FROM tenant_expenses
         WHERE tenant_id = $1
           AND payment_method = 'cash'
-          AND transaction_date >= $2
-          AND transaction_date <= $3
+          {expense_filter}
         """,
-        tenant_id, period_start, period_end,
+        tenant_id, *expense_params,
     )
 
     open_tables_row = await conn.fetchrow(
-        """
+        f"""
         SELECT COUNT(*) AS open_tables_count
         FROM table_sessions ts
         JOIN tables t ON t.id = ts.table_id
         WHERE ts.tenant_id = $1
           AND ts.closed_at IS NULL
           AND ts.is_discarded = FALSE
-          AND ts.opened_at::date >= $2
-          AND ts.opened_at::date <= $3
+          {open_tables_filter}
           AND t.is_bar IS FALSE
         """,
-        tenant_id, period_start, period_end,
+        tenant_id, *open_tables_params,
     )
 
     total_cash = method_totals.get("cash", 0.0)

--- a/tests/test_cierre_shift_filters.py
+++ b/tests/test_cierre_shift_filters.py
@@ -1,0 +1,68 @@
+"""Unit tests for cierre shift-window filter builders (issue #685)."""
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+from app.services.cierre_service import (
+    _build_expense_filter,
+    _build_open_tables_filter,
+    _build_order_date_filter,
+)
+
+BOG = ZoneInfo("America/Bogota")
+
+
+def test_order_filter_date_only_uses_bogota_dates():
+    sql, params = _build_order_date_filter(
+        date(2026, 5, 18), date(2026, 5, 18), None, None
+    )
+    assert "AT TIME ZONE 'America/Bogota'" in sql
+    assert params == [date(2026, 5, 18), date(2026, 5, 18)]
+
+
+def test_order_filter_shift_uses_timestamps():
+    start = datetime(2026, 5, 18, 14, 0, tzinfo=BOG)
+    end = datetime(2026, 5, 18, 22, 0, tzinfo=BOG)
+    sql, params = _build_order_date_filter(
+        date(2026, 5, 18), date(2026, 5, 18), start, end
+    )
+    assert "order_date >=" in sql
+    assert "AT TIME ZONE" not in sql
+    assert params == [start, end]
+
+
+def test_expense_filter_date_only_uses_transaction_date():
+    sql, params = _build_expense_filter(
+        date(2026, 5, 18), date(2026, 5, 18), None, None
+    )
+    assert "transaction_date" in sql
+    assert "created_at" not in sql
+    assert params == [date(2026, 5, 18), date(2026, 5, 18)]
+
+
+def test_expense_filter_shift_uses_created_at():
+    start = datetime(2026, 5, 18, 14, 0, tzinfo=BOG)
+    end = datetime(2026, 5, 18, 22, 0, tzinfo=BOG)
+    sql, params = _build_expense_filter(
+        date(2026, 5, 18), date(2026, 5, 18), start, end
+    )
+    assert "created_at >=" in sql
+    assert "transaction_date" not in sql
+    assert params == [start, end]
+
+
+def test_open_tables_filter_date_only_uses_opened_at_date():
+    sql, params = _build_open_tables_filter(
+        date(2026, 5, 18), date(2026, 5, 18), None, None
+    )
+    assert "opened_at::date" in sql
+    assert params == [date(2026, 5, 18), date(2026, 5, 18)]
+
+
+def test_open_tables_filter_shift_uses_opened_at_before_end():
+    end = datetime(2026, 5, 18, 22, 0, tzinfo=BOG)
+    sql, params = _build_open_tables_filter(
+        date(2026, 5, 18), date(2026, 5, 18), datetime(2026, 5, 18, 14, 0, tzinfo=BOG), end
+    )
+    assert "ts.opened_at <=" in sql
+    assert "opened_at::date" not in sql
+    assert params == [end]


### PR DESCRIPTION
## Summary

When a cash count uses `period_start_time` / `period_end_time`, sales were already filtered by timestamp but cash expenses and open-table counts still used calendar dates only. This aligns all three aggregations with the shift window.

## Changes

- `cierre_service.py`: `_build_expense_filter` (shift → `created_at`; full day → `transaction_date`) and `_build_open_tables_filter` (shift → `opened_at <= period_end`; full day unchanged)
- `tests/test_cierre_shift_filters.py`: unit tests for filter builders

## Testing

- [x] `python3 -m pytest tests/test_cierre_shift_filters.py`
- [ ] Manual: preview arqueo 14:00–22:00 — morning cash expense excluded from `gastosEfectivo`
- [ ] Manual: full-day arqueo unchanged

Closes uno0uno/warocol.com#685

Made with [Cursor](https://cursor.com)