### PR TITLE
feat(db): add optional shift_template_id to accounting_period

### DIFF
--- a/migrations/081_accounting_period_shift_template_id.sql
+++ b/migrations/081_accounting_period_shift_template_id.sql
@@ -1,0 +1,17 @@
+-- 081_accounting_period_shift_template_id.sql
+-- Issue warocol.com#681 — Optional link from arqueo to shift template (epic #678)
+--
+-- ADD-only: nullable column + partial index. Depends on 080_tenant_shift_templates.sql (#680).
+-- API/UI persistence lands in later issues (#683+).
+
+ALTER TABLE accounting_period
+    ADD COLUMN IF NOT EXISTS shift_template_id UUID NULL
+    REFERENCES tenant_shift_templates(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN accounting_period.shift_template_id IS
+    'Optional FK to tenant_shift_templates (warocol.com#681). '
+    'NULL = custom time window or legacy full-day arqueo.';
+
+CREATE INDEX IF NOT EXISTS idx_accounting_period_shift
+    ON accounting_period(shift_template_id)
+    WHERE shift_template_id IS NOT NULL;


### PR DESCRIPTION
## Summary

Adds nullable `shift_template_id` on `accounting_period` with FK to `tenant_shift_templates`, partial index, and column comment. `ON DELETE SET NULL` so deleting/retiring a template does not block historical arqueos.

**Stacked on #257** (`gh-680-tenant-shift-templates`) — merge #680 first, then this.

## Changes

- `migrations/081_accounting_period_shift_template_id.sql` — ADD COLUMN, COMMENT, partial index

## Testing

- [x] Applied locally via `psql -f migrations/081_accounting_period_shift_template_id.sql`
- [x] Verified column nullable (`uuid`) and `idx_accounting_period_shift` exists
- [x] Existing `accounting_period` rows unchanged (`NULL`)

## Deploy note

Apply after `080_tenant_shift_templates.sql` in each environment.

Refs uno0uno/warocol.com#681

Made with [Cursor](https://cursor.com)