### PR TITLE
feat(api): CRUD /operaciones/shifts for shift templates

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, tenant_config, online_cart, online_verification, address_profile, analytics, online_orders, notifications, customer_portal, leads, waros, billing, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
+from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, tenant_config, online_cart, online_verification, address_profile, analytics, online_orders, notifications, customer_portal, leads, waros, billing, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
 from app.config import settings
 from app.core.logging import setup_logging
 from app.core.exceptions import api_exception_handler, general_exception_handler, APIError
@@ -171,6 +171,7 @@ app.include_router(customers.router, prefix="/customers", tags=["customers"])
 app.include_router(pos_cart.router)
 app.include_router(pos_context.router)  # POS-scoped aggregator (BFF for /pos/restaurant-context)
 app.include_router(operaciones_context.router)  # OPERACIONES-scoped aggregator + 5 toggle PATCH endpoints
+app.include_router(operaciones_shifts.router)  # OPERACIONES shift templates CRUD (#682)
 app.include_router(online_cart.router)  # Public online ordering cart
 app.include_router(online_orders.router)  # Authenticated online orders management
 app.include_router(notifications.router)  # Authenticated notifications management

--- a/app/models/shift_template.py
+++ b/app/models/shift_template.py
@@ -1,0 +1,43 @@
+"""Pydantic models for tenant shift templates (warocol.com#682)."""
+from datetime import time
+from typing import Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+def _validate_shift_window(
+    *,
+    start_time: time,
+    end_time: time,
+    crosses_midnight: bool,
+) -> None:
+    if not crosses_midnight and end_time <= start_time:
+        raise ValueError(
+            "end_time must be after start_time when crosses_midnight is false"
+        )
+
+
+class ShiftTemplateCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=80)
+    start_time: time
+    end_time: time
+    crosses_midnight: bool = False
+    sort_order: int = Field(0, ge=0, le=32767)
+
+    @model_validator(mode="after")
+    def _validate_window(self):
+        _validate_shift_window(
+            start_time=self.start_time,
+            end_time=self.end_time,
+            crosses_midnight=self.crosses_midnight,
+        )
+        return self
+
+
+class ShiftTemplatePatch(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=80)
+    start_time: Optional[time] = None
+    end_time: Optional[time] = None
+    crosses_midnight: Optional[bool] = None
+    sort_order: Optional[int] = Field(None, ge=0, le=32767)
+    is_active: Optional[bool] = None

--- a/app/routers/operaciones_shifts.py
+++ b/app/routers/operaciones_shifts.py
@@ -1,0 +1,55 @@
+"""Shift template CRUD for Operaciones (warocol.com#682)."""
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query, Request
+
+from app.core.permissions import Module, require_module
+from app.models.shift_template import ShiftTemplateCreate, ShiftTemplatePatch
+from app.services import shift_templates_service
+
+router = APIRouter(prefix="/operaciones", tags=["Operaciones Shifts"])
+
+
+@router.get(
+    "/shifts",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def list_shift_templates_endpoint(
+    request: Request,
+    include_inactive: bool = Query(
+        False,
+        description="When true, include deactivated templates (admin settings UI).",
+    ),
+):
+    """List shift templates for the tenant (active only by default)."""
+    return await shift_templates_service.list_shift_templates(
+        request,
+        include_inactive=include_inactive,
+    )
+
+
+@router.post(
+    "/shifts",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def create_shift_template_endpoint(
+    request: Request,
+    body: ShiftTemplateCreate,
+):
+    """Create a reusable shift template."""
+    return await shift_templates_service.create_shift_template(request, body)
+
+
+@router.patch(
+    "/shifts/{template_id}",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def patch_shift_template_endpoint(
+    request: Request,
+    template_id: UUID,
+    body: ShiftTemplatePatch,
+):
+    """Update fields or soft-deactivate (is_active=false)."""
+    return await shift_templates_service.patch_shift_template(
+        request, template_id, body
+    )

--- a/app/services/shift_templates_service.py
+++ b/app/services/shift_templates_service.py
@@ -1,0 +1,166 @@
+"""CRUD for tenant_shift_templates under Operaciones (warocol.com#682)."""
+from datetime import time
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+import asyncpg
+from fastapi import HTTPException, Request
+
+from app.core.exceptions import AuthenticationError
+from app.core.middleware import require_valid_session
+from app.database import get_db_connection
+from app.models.shift_template import ShiftTemplateCreate, ShiftTemplatePatch, _validate_shift_window
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _row_to_dict(row: asyncpg.Record) -> Dict[str, Any]:
+    data = dict(row)
+    data["id"] = str(data["id"])
+    data["tenant_id"] = str(data["tenant_id"])
+    for key in ("start_time", "end_time"):
+        if data[key] is not None:
+            data[key] = data[key].isoformat()
+    for key in ("created_at", "updated_at"):
+        if data[key] is not None:
+            data[key] = data[key].isoformat()
+    return data
+
+
+async def list_shift_templates(
+    request: Request,
+    *,
+    include_inactive: bool = False,
+) -> dict:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    query = """
+        SELECT *
+        FROM tenant_shift_templates
+        WHERE tenant_id = $1
+    """
+    if not include_inactive:
+        query += " AND is_active = true"
+    query += " ORDER BY sort_order, name"
+
+    async with get_db_connection(use_transaction=False) as conn:
+        rows = await conn.fetch(query, tenant_id)
+
+    return {"success": True, "data": [_row_to_dict(r) for r in rows]}
+
+
+async def create_shift_template(request: Request, body: ShiftTemplateCreate) -> dict:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    try:
+        async with get_db_connection() as conn:
+            row = await conn.fetchrow(
+                """
+                INSERT INTO tenant_shift_templates (
+                    tenant_id, name, start_time, end_time,
+                    crosses_midnight, sort_order
+                )
+                VALUES ($1, $2, $3, $4, $5, $6)
+                RETURNING *
+                """,
+                tenant_id,
+                body.name.strip(),
+                body.start_time,
+                body.end_time,
+                body.crosses_midnight,
+                body.sort_order,
+            )
+    except asyncpg.UniqueViolationError:
+        raise HTTPException(
+            status_code=409,
+            detail="Ya existe un turno con ese nombre",
+        ) from None
+
+    logger.info("Created shift template %r for tenant %s", body.name, tenant_id)
+    return {"success": True, "data": _row_to_dict(row)}
+
+
+async def patch_shift_template(
+    request: Request,
+    template_id: UUID,
+    body: ShiftTemplatePatch,
+) -> dict:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    data_dict = body.model_dump(exclude_unset=True)
+    if not data_dict:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    if "name" in data_dict and data_dict["name"] is not None:
+        data_dict["name"] = data_dict["name"].strip()
+
+    async with get_db_connection() as conn:
+        existing = await conn.fetchrow(
+            """
+            SELECT start_time, end_time, crosses_midnight
+            FROM tenant_shift_templates
+            WHERE id = $1 AND tenant_id = $2
+            """,
+            template_id,
+            tenant_id,
+        )
+        if not existing:
+            raise HTTPException(status_code=404, detail="Shift template not found")
+
+        merged_start: time = data_dict.get("start_time", existing["start_time"])
+        merged_end: time = data_dict.get("end_time", existing["end_time"])
+        merged_crosses: bool = data_dict.get(
+            "crosses_midnight", existing["crosses_midnight"]
+        )
+        try:
+            _validate_shift_window(
+                start_time=merged_start,
+                end_time=merged_end,
+                crosses_midnight=merged_crosses,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+        update_fields = []
+        params = []
+        param_counter = 1
+
+        for field, value in data_dict.items():
+            update_fields.append(f"{field} = ${param_counter}")
+            params.append(value)
+            param_counter += 1
+
+        update_fields.append("updated_at = now()")
+        params.extend([tenant_id, template_id])
+
+        try:
+            row = await conn.fetchrow(
+                f"""
+                UPDATE tenant_shift_templates
+                SET {', '.join(update_fields)}
+                WHERE tenant_id = ${param_counter} AND id = ${param_counter + 1}
+                RETURNING *
+                """,
+                *params,
+            )
+        except asyncpg.UniqueViolationError:
+            raise HTTPException(
+                status_code=409,
+                detail="Ya existe un turno con ese nombre",
+            ) from None
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Shift template not found")
+
+    return {"success": True, "data": _row_to_dict(row)}

--- a/tests/test_operaciones_shifts.py
+++ b/tests/test_operaciones_shifts.py
@@ -1,0 +1,155 @@
+"""Tests for /operaciones/shifts shift template CRUD (warocol.com#682)."""
+from contextlib import asynccontextmanager
+from datetime import time
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.core.permissions import Module
+from app.models.shift_template import ShiftTemplateCreate, ShiftTemplatePatch
+from app.routers.operaciones_shifts import router as operaciones_shifts_router
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_session(role: str):
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": role,
+    })
+
+
+def _enforce_db_ctx():
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+
+    return _ctx
+
+
+def test_shift_template_create_rejects_invalid_same_day_window():
+  with pytest.raises(ValidationError):
+    ShiftTemplateCreate(
+      name="Mañana",
+      start_time=time(14, 0),
+      end_time=time(6, 0),
+      crosses_midnight=False,
+    )
+
+
+def test_shift_template_create_allows_overnight_window():
+  body = ShiftTemplateCreate(
+    name="Noche",
+    start_time=time(22, 0),
+    end_time=time(6, 0),
+    crosses_midnight=True,
+  )
+  assert body.crosses_midnight is True
+
+
+def test_supervisor_passes_list_shifts_under_enforce():
+    session = _build_session(role="supervisor")
+    app = FastAPI()
+    app.include_router(operaciones_shifts_router)
+
+    supervisor_modules = frozenset({
+        Module.POS, Module.VENTAS, Module.DESPACHO, Module.MENU,
+        Module.OPERACIONES, Module.ABASTECIMIENTO, Module.ANALITICA,
+    })
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.services.shift_templates_service.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=supervisor_modules),
+         ), \
+         patch(
+             "app.services.shift_templates_service.list_shift_templates",
+             new=AsyncMock(return_value={"success": True, "data": []}),
+         ):
+        client = TestClient(app)
+        response = client.get("/operaciones/shifts")
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+
+def test_kitchen_denied_list_shifts_under_enforce():
+    session = _build_session(role="kitchen")
+    app = FastAPI()
+    app.include_router(operaciones_shifts_router)
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.services.shift_templates_service.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=frozenset({Module.DESPACHO})),
+         ):
+        client = TestClient(app)
+        response = client.get("/operaciones/shifts")
+
+    assert response.status_code == 403
+    assert "operaciones" in response.json()["detail"].lower()
+
+
+def test_create_endpoint_passes_body_to_service():
+    session = _build_session(role="owner")
+    app = FastAPI()
+    app.include_router(operaciones_shifts_router)
+    create_mock = AsyncMock(return_value={"success": True, "data": {"id": str(uuid4())}})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.services.shift_templates_service.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=frozenset(Module)),
+         ), \
+         patch(
+             "app.services.shift_templates_service.create_shift_template",
+             create_mock,
+         ):
+        client = TestClient(app)
+        response = client.post(
+            "/operaciones/shifts",
+            json={
+                "name": "Mañana",
+                "start_time": "06:00:00",
+                "end_time": "14:00:00",
+                "crosses_midnight": False,
+                "sort_order": 0,
+            },
+        )
+
+    assert response.status_code == 200
+    create_mock.assert_awaited_once()
+    body_arg = create_mock.await_args.args[1]
+    assert body_arg.name == "Mañana"
+
+
+def test_patch_model_accepts_deactivate_only():
+    body = ShiftTemplatePatch(is_active=False)
+    assert body.is_active is False


### PR DESCRIPTION
## Summary

Implements warocol.com#682: CRUD API for `tenant_shift_templates` under Operaciones.

- `GET /operaciones/shifts` — active templates by default; `?include_inactive=true` for admin UI (#683)
- `POST /operaciones/shifts` — create with time-window validation
- `PATCH /operaciones/shifts/{id}` — partial update / soft deactivate (`is_active=false`)

Gated with `Module.OPERACIONES` (owner, admin, supervisor).

**Stacked on** `gh-681-accounting-period-shift-template` (needs #680/#681 migrations in DB).

## Changes

| File | Purpose |
|------|---------|
| `app/routers/operaciones_shifts.py` | Routes |
| `app/services/shift_templates_service.py` | SQL + tenant isolation + 409 on duplicate name |
| `app/models/shift_template.py` | Pydantic create/patch + window validator |
| `app/main.py` | Register router |
| `tests/test_operaciones_shifts.py` | Permissions + validation smoke tests |

## Testing

- [x] `pytest tests/test_operaciones_shifts.py` (6 passed)

## API notes

- Response fields: **snake_case** (parity with `/api/stations`)
- `crosses_midnight=false` → requires `end_time > start_time`
- `crosses_midnight=true` → allows overnight (e.g. 22:00–06:00)
- No hard DELETE; use PATCH `is_active: false`

Refs uno0uno/warocol.com#682

Made with [Cursor](https://cursor.com)