### PR TITLE
feat(api): resolve shift template window for a calendar date (Bogotá)

### DIFF
--- a/app/routers/cierre.py
+++ b/app/routers/cierre.py
@@ -121,6 +121,31 @@ async def get_ultimo_cierre(request: Request):
     return await cierre_service.get_ultimo_cierre(request)
 
 
+@router.get("/suggested-window", dependencies=[Depends(require_module(Module.FINANZAS))])
+async def get_suggested_cierre_window(
+    request: Request,
+    anchor_date: date = Query(..., alias="date", description="Fallback anchor date if no prior close exists"),
+):
+    """Suggest a custom cash-count window from last arqueo end through now (Bogotá)."""
+    from app.services import shift_window_service
+
+    return await shift_window_service.get_suggested_window(request, anchor_date)
+
+
+@router.get("/shift-window", dependencies=[Depends(require_module(Module.FINANZAS))])
+async def get_cierre_shift_window(
+    request: Request,
+    shift_template_id: UUID = Query(..., alias="shift_template_id"),
+    anchor_date: date = Query(..., alias="date", description="Anchor calendar date (YYYY-MM-DD, Bogotá)"),
+):
+    """Finanzas-facing alias for template window resolution (same payload as operaciones)."""
+    from app.services import shift_window_service
+
+    return await shift_window_service.get_template_window(
+        request, shift_template_id, anchor_date
+    )
+
+
 @router.get("/{cierre_id}", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_cierre(request: Request, cierre_id: UUID):
     """

--- a/app/routers/operaciones_shifts.py
+++ b/app/routers/operaciones_shifts.py
@@ -1,11 +1,12 @@
-"""Shift template CRUD for Operaciones (warocol.com#682)."""
+"""Shift template CRUD for Operaciones (warocol.com#682, #684)."""
+from datetime import date
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, Request
 
 from app.core.permissions import Module, require_module
 from app.models.shift_template import ShiftTemplateCreate, ShiftTemplatePatch
-from app.services import shift_templates_service
+from app.services import shift_templates_service, shift_window_service
 
 router = APIRouter(prefix="/operaciones", tags=["Operaciones Shifts"])
 
@@ -38,6 +39,21 @@ async def create_shift_template_endpoint(
 ):
     """Create a reusable shift template."""
     return await shift_templates_service.create_shift_template(request, body)
+
+
+@router.get(
+    "/shifts/{template_id}/window",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def get_shift_template_window_endpoint(
+    request: Request,
+    template_id: UUID,
+    anchor_date: date = Query(..., alias="date", description="Anchor calendar date (YYYY-MM-DD, Bogotá)"),
+):
+    """Resolve template clock times to periodStart/End + periodStartTime/EndTime."""
+    return await shift_window_service.get_template_window(
+        request, template_id, anchor_date
+    )
 
 
 @router.patch(

--- a/app/services/shift_window_service.py
+++ b/app/services/shift_window_service.py
@@ -1,0 +1,143 @@
+"""Resolve shift template + calendar date to cierre period fields (warocol.com#684)."""
+from datetime import date, datetime, time, timedelta
+from typing import Any, Dict, Optional
+from uuid import UUID
+from zoneinfo import ZoneInfo
+
+from fastapi import HTTPException, Request
+
+from app.core.exceptions import AuthenticationError
+from app.core.middleware import require_valid_session
+from app.database import get_db_connection
+
+BOGOTA = ZoneInfo("America/Bogota")
+
+
+def resolve_shift_template_window(
+    *,
+    anchor_date: date,
+    start_time: time,
+    end_time: time,
+    crosses_midnight: bool,
+    template_id: Optional[UUID] = None,
+    template_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Pure resolver: template clock times + anchor date → cierre period fields (Bogotá)."""
+    period_start = anchor_date
+    period_end = anchor_date + timedelta(days=1) if crosses_midnight else anchor_date
+
+    period_start_time = datetime.combine(anchor_date, start_time, tzinfo=BOGOTA)
+    period_end_time = datetime.combine(period_end, end_time, tzinfo=BOGOTA)
+
+    payload: Dict[str, Any] = {
+        "periodStart": period_start.isoformat(),
+        "periodEnd": period_end.isoformat(),
+        "periodStartTime": period_start_time.isoformat(),
+        "periodEndTime": period_end_time.isoformat(),
+        "crossesMidnight": crosses_midnight,
+    }
+    if template_id is not None:
+        payload["templateId"] = str(template_id)
+    if template_name is not None:
+        payload["templateName"] = template_name
+    return payload
+
+
+async def get_template_window(
+    request: Request,
+    template_id: UUID,
+    anchor_date: date,
+) -> dict:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    async with get_db_connection(use_transaction=False) as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT id, name, start_time, end_time, crosses_midnight
+            FROM tenant_shift_templates
+            WHERE id = $1 AND tenant_id = $2 AND is_active = true
+            """,
+            template_id,
+            tenant_id,
+        )
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Shift template not found")
+
+    data = resolve_shift_template_window(
+        anchor_date=anchor_date,
+        start_time=row["start_time"],
+        end_time=row["end_time"],
+        crosses_midnight=row["crosses_midnight"],
+        template_id=row["id"],
+        template_name=row["name"],
+    )
+    return {"success": True, "data": data}
+
+
+async def get_suggested_window(
+    request: Request,
+    anchor_date: date,
+) -> dict:
+    """Suggest a custom arqueo window from last close end through now (Bogotá)."""
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    now_bogota = datetime.now(BOGOTA)
+
+    async with get_db_connection(use_transaction=False) as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT
+                ap.period_start,
+                ap.period_end,
+                ap.period_start_time,
+                ap.period_end_time
+            FROM accounting_period ap
+            WHERE ap.tenant_id = $1
+              AND ap.deleted_at IS NULL
+            ORDER BY
+                COALESCE(
+                    ap.period_end_time,
+                    (ap.period_end::timestamp + INTERVAL '23:59:59')
+                        AT TIME ZONE 'America/Bogota'
+                ) DESC
+            LIMIT 1
+            """,
+            tenant_id,
+        )
+
+    if row and row["period_end_time"]:
+        period_start_time = row["period_end_time"]
+        period_start = period_start_time.astimezone(BOGOTA).date()
+    elif row:
+        period_start = row["period_end"]
+        period_start_time = datetime.combine(period_start, time(0, 0, 0), tzinfo=BOGOTA)
+    else:
+        period_start = anchor_date
+        period_start_time = datetime.combine(anchor_date, time(0, 0, 0), tzinfo=BOGOTA)
+
+    period_end = now_bogota.date()
+    period_end_time = now_bogota
+
+    if period_start_time >= period_end_time:
+        raise HTTPException(
+            status_code=422,
+            detail="No hay ventana sugerida: el último cierre es posterior a ahora",
+        )
+
+    return {
+        "success": True,
+        "data": {
+            "periodStart": period_start.isoformat(),
+            "periodEnd": period_end.isoformat(),
+            "periodStartTime": period_start_time.isoformat(),
+            "periodEndTime": period_end_time.isoformat(),
+            "suggested": True,
+        },
+    }

--- a/tests/test_shift_window_resolver.py
+++ b/tests/test_shift_window_resolver.py
@@ -1,0 +1,48 @@
+"""Unit tests for shift template window resolution (warocol.com#684)."""
+from datetime import date, time
+from uuid import uuid4
+
+from app.services.shift_window_service import resolve_shift_template_window
+
+
+def test_overnight_template_may_18_bogota():
+    """AC: 22:00–06:00 on May 18 → start May 18 22:00, end May 19 06:00."""
+    data = resolve_shift_template_window(
+        anchor_date=date(2026, 5, 18),
+        start_time=time(22, 0),
+        end_time=time(6, 0),
+        crosses_midnight=True,
+    )
+    assert data["periodStart"] == "2026-05-18"
+    assert data["periodEnd"] == "2026-05-19"
+    assert data["periodStartTime"] == "2026-05-18T22:00:00-05:00"
+    assert data["periodEndTime"] == "2026-05-19T06:00:00-05:00"
+    assert data["crossesMidnight"] is True
+
+
+def test_same_day_template():
+    data = resolve_shift_template_window(
+        anchor_date=date(2026, 5, 18),
+        start_time=time(6, 0),
+        end_time=time(14, 0),
+        crosses_midnight=False,
+    )
+    assert data["periodStart"] == "2026-05-18"
+    assert data["periodEnd"] == "2026-05-18"
+    assert data["periodStartTime"] == "2026-05-18T06:00:00-05:00"
+    assert data["periodEndTime"] == "2026-05-18T14:00:00-05:00"
+    assert data["crossesMidnight"] is False
+
+
+def test_includes_template_metadata_when_provided():
+    tid = uuid4()
+    data = resolve_shift_template_window(
+        anchor_date=date(2026, 5, 18),
+        start_time=time(6, 0),
+        end_time=time(14, 0),
+        crosses_midnight=False,
+        template_id=tid,
+        template_name="Mañana",
+    )
+    assert data["templateId"] == str(tid)
+    assert data["templateName"] == "Mañana"


### PR DESCRIPTION
## Summary

Resolves shift template + calendar date to cierre period fields in America/Bogota (warocol.com#684).

## Endpoints

| Method | Path | Module |
|--------|------|--------|
| GET | `/operaciones/shifts/{id}/window?date=YYYY-MM-DD` | operaciones |
| GET | `/cierre/shift-window?shift_template_id=&date=` | finanzas (alias for arqueo) |
| GET | `/cierre/suggested-window?date=` | finanzas (last close end → now) |

## Example (AC)

Template 22:00–06:00, `date=2026-05-18`:
- `periodStartTime`: `2026-05-18T22:00:00-05:00`
- `periodEndTime`: `2026-05-19T06:00:00-05:00`

## Testing

- [x] `pytest tests/test_shift_window_resolver.py tests/test_operaciones_shifts.py` (9 passed)

Stacked on #259 (#682).

Refs uno0uno/warocol.com#684

Made with [Cursor](https://cursor.com)