### PR TITLE
test(permissions): cierre finanzas vs operaciones shifts gates (#689)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, tenant_config, online_cart, online_verification, address_profile, analytics, online_orders, notifications, customer_portal, leads, waros, billing, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
+from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, tenant_config, online_cart, online_verification, address_profile, analytics, online_orders, notifications, customer_portal, leads, waros, billing, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
 from app.config import settings
 from app.core.logging import setup_logging
 from app.core.exceptions import api_exception_handler, general_exception_handler, APIError
@@ -171,6 +171,7 @@ app.include_router(customers.router, prefix="/customers", tags=["customers"])
 app.include_router(pos_cart.router)
 app.include_router(pos_context.router)  # POS-scoped aggregator (BFF for /pos/restaurant-context)
 app.include_router(operaciones_context.router)  # OPERACIONES-scoped aggregator + 5 toggle PATCH endpoints
+app.include_router(operaciones_shifts.router)  # OPERACIONES shift templates CRUD (#682)
 app.include_router(online_cart.router)  # Public online ordering cart
 app.include_router(online_orders.router)  # Authenticated online orders management
 app.include_router(notifications.router)  # Authenticated notifications management

--- a/app/models/cierre.py
+++ b/app/models/cierre.py
@@ -15,6 +15,7 @@ class CierreCreate(BaseModel):
     # instead of the date-truncated comparison (supports cross-midnight shifts).
     period_start_time: Optional[datetime] = Field(None, alias='periodStartTime')
     period_end_time: Optional[datetime] = Field(None, alias='periodEndTime')
+    shift_template_id: Optional[UUID] = Field(None, alias='shiftTemplateId')
     cash_counted: float = Field(alias='cashCounted')
     notes: Optional[str] = None
 

--- a/app/models/shift_template.py
+++ b/app/models/shift_template.py
@@ -1,0 +1,43 @@
+"""Pydantic models for tenant shift templates (warocol.com#682)."""
+from datetime import time
+from typing import Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+def _validate_shift_window(
+    *,
+    start_time: time,
+    end_time: time,
+    crosses_midnight: bool,
+) -> None:
+    if not crosses_midnight and end_time <= start_time:
+        raise ValueError(
+            "end_time must be after start_time when crosses_midnight is false"
+        )
+
+
+class ShiftTemplateCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=80)
+    start_time: time
+    end_time: time
+    crosses_midnight: bool = False
+    sort_order: int = Field(0, ge=0, le=32767)
+
+    @model_validator(mode="after")
+    def _validate_window(self):
+        _validate_shift_window(
+            start_time=self.start_time,
+            end_time=self.end_time,
+            crosses_midnight=self.crosses_midnight,
+        )
+        return self
+
+
+class ShiftTemplatePatch(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=80)
+    start_time: Optional[time] = None
+    end_time: Optional[time] = None
+    crosses_midnight: Optional[bool] = None
+    sort_order: Optional[int] = Field(None, ge=0, le=32767)
+    is_active: Optional[bool] = None

--- a/app/routers/cierre.py
+++ b/app/routers/cierre.py
@@ -121,6 +121,31 @@ async def get_ultimo_cierre(request: Request):
     return await cierre_service.get_ultimo_cierre(request)
 
 
+@router.get("/suggested-window", dependencies=[Depends(require_module(Module.FINANZAS))])
+async def get_suggested_cierre_window(
+    request: Request,
+    anchor_date: date = Query(..., alias="date", description="Fallback anchor date if no prior close exists"),
+):
+    """Suggest a custom cash-count window from last arqueo end through now (Bogotá)."""
+    from app.services import shift_window_service
+
+    return await shift_window_service.get_suggested_window(request, anchor_date)
+
+
+@router.get("/shift-window", dependencies=[Depends(require_module(Module.FINANZAS))])
+async def get_cierre_shift_window(
+    request: Request,
+    shift_template_id: UUID = Query(..., alias="shift_template_id"),
+    anchor_date: date = Query(..., alias="date", description="Anchor calendar date (YYYY-MM-DD, Bogotá)"),
+):
+    """Finanzas-facing alias for template window resolution (same payload as operaciones)."""
+    from app.services import shift_window_service
+
+    return await shift_window_service.get_template_window(
+        request, shift_template_id, anchor_date
+    )
+
+
 @router.get("/{cierre_id}", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_cierre(request: Request, cierre_id: UUID):
     """

--- a/app/routers/cierre.py
+++ b/app/routers/cierre.py
@@ -23,6 +23,7 @@ async def cierre_preview(
     completed_only: bool = Query(False, alias="completed_only"),
     period_start_time: Optional[datetime] = Query(None, alias="period_start_time"),
     period_end_time: Optional[datetime] = Query(None, alias="period_end_time"),
+    shift_template_id: Optional[UUID] = Query(None, alias="shift_template_id"),
 ):
     """
     Cierre X — non-destructive daily summary.
@@ -37,6 +38,7 @@ async def cierre_preview(
         request, period_start, period_end, completed_only,
         period_start_time=period_start_time,
         period_end_time=period_end_time,
+        shift_template_id=shift_template_id,
     )
 
 
@@ -130,6 +132,12 @@ async def get_suggested_cierre_window(
     from app.services import shift_window_service
 
     return await shift_window_service.get_suggested_window(request, anchor_date)
+
+
+@router.get("/shift-templates", dependencies=[Depends(require_module(Module.FINANZAS))])
+async def list_cierre_shift_templates(request: Request):
+    """Active shift templates for arqueo template mode (Finanzas-only)."""
+    return await cierre_service.list_active_shift_templates(request)
 
 
 @router.get("/shift-window", dependencies=[Depends(require_module(Module.FINANZAS))])

--- a/app/routers/operaciones_shifts.py
+++ b/app/routers/operaciones_shifts.py
@@ -1,0 +1,55 @@
+"""Shift template CRUD for Operaciones (warocol.com#682)."""
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query, Request
+
+from app.core.permissions import Module, require_module
+from app.models.shift_template import ShiftTemplateCreate, ShiftTemplatePatch
+from app.services import shift_templates_service
+
+router = APIRouter(prefix="/operaciones", tags=["Operaciones Shifts"])
+
+
+@router.get(
+    "/shifts",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def list_shift_templates_endpoint(
+    request: Request,
+    include_inactive: bool = Query(
+        False,
+        description="When true, include deactivated templates (admin settings UI).",
+    ),
+):
+    """List shift templates for the tenant (active only by default)."""
+    return await shift_templates_service.list_shift_templates(
+        request,
+        include_inactive=include_inactive,
+    )
+
+
+@router.post(
+    "/shifts",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def create_shift_template_endpoint(
+    request: Request,
+    body: ShiftTemplateCreate,
+):
+    """Create a reusable shift template."""
+    return await shift_templates_service.create_shift_template(request, body)
+
+
+@router.patch(
+    "/shifts/{template_id}",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def patch_shift_template_endpoint(
+    request: Request,
+    template_id: UUID,
+    body: ShiftTemplatePatch,
+):
+    """Update fields or soft-deactivate (is_active=false)."""
+    return await shift_templates_service.patch_shift_template(
+        request, template_id, body
+    )

--- a/app/routers/operaciones_shifts.py
+++ b/app/routers/operaciones_shifts.py
@@ -1,11 +1,12 @@
-"""Shift template CRUD for Operaciones (warocol.com#682)."""
+"""Shift template CRUD for Operaciones (warocol.com#682, #684)."""
+from datetime import date
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, Request
 
 from app.core.permissions import Module, require_module
 from app.models.shift_template import ShiftTemplateCreate, ShiftTemplatePatch
-from app.services import shift_templates_service
+from app.services import shift_templates_service, shift_window_service
 
 router = APIRouter(prefix="/operaciones", tags=["Operaciones Shifts"])
 
@@ -38,6 +39,21 @@ async def create_shift_template_endpoint(
 ):
     """Create a reusable shift template."""
     return await shift_templates_service.create_shift_template(request, body)
+
+
+@router.get(
+    "/shifts/{template_id}/window",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def get_shift_template_window_endpoint(
+    request: Request,
+    template_id: UUID,
+    anchor_date: date = Query(..., alias="date", description="Anchor calendar date (YYYY-MM-DD, Bogotá)"),
+):
+    """Resolve template clock times to periodStart/End + periodStartTime/EndTime."""
+    return await shift_window_service.get_template_window(
+        request, template_id, anchor_date
+    )
 
 
 @router.patch(

--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -6,6 +6,7 @@ Issue: https://github.com/uno0uno/warocol.com/issues/311
 """
 import logging
 from decimal import Decimal
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 from datetime import date, datetime
@@ -936,6 +937,111 @@ async def _compute_breakdown_rows(
 
 
 # ---------------------------------------------------------------------------
+# Shift template resolution (#686)
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ResolvedCierrePeriod:
+    period_start: date
+    period_end: date
+    period_start_time: Optional[datetime]
+    period_end_time: Optional[datetime]
+    shift_template_id: Optional[UUID]
+
+
+async def resolve_cierre_period_fields(
+    conn,
+    tenant_id: UUID,
+    *,
+    period_start: date,
+    period_end: date,
+    period_start_time: Optional[datetime],
+    period_end_time: Optional[datetime],
+    shift_template_id: Optional[UUID],
+) -> ResolvedCierrePeriod:
+    """Resolve template vs custom vs full-day period fields before preview/create."""
+    if shift_template_id:
+        if period_start_time or period_end_time:
+            raise APIError(
+                "No envíes horas manuales cuando usas una plantilla de turno.",
+                status_code=422,
+            )
+        if period_start != period_end:
+            raise APIError(
+                "La plantilla de turno solo aplica a un solo día.",
+                status_code=422,
+            )
+
+        row = await conn.fetchrow(
+            """
+            SELECT id, name, start_time, end_time, crosses_midnight
+            FROM tenant_shift_templates
+            WHERE id = $1 AND tenant_id = $2 AND is_active = true
+            """,
+            shift_template_id,
+            tenant_id,
+        )
+        if not row:
+            raise APIError("Plantilla de turno no encontrada o inactiva.", status_code=404)
+
+        from app.services.shift_window_service import resolve_shift_template_window
+
+        payload = resolve_shift_template_window(
+            anchor_date=period_start,
+            start_time=row["start_time"],
+            end_time=row["end_time"],
+            crosses_midnight=row["crosses_midnight"],
+            template_id=row["id"],
+            template_name=row["name"],
+        )
+        return ResolvedCierrePeriod(
+            period_start=date.fromisoformat(payload["periodStart"]),
+            period_end=date.fromisoformat(payload["periodEnd"]),
+            period_start_time=datetime.fromisoformat(payload["periodStartTime"]),
+            period_end_time=datetime.fromisoformat(payload["periodEndTime"]),
+            shift_template_id=shift_template_id,
+        )
+
+    return ResolvedCierrePeriod(
+        period_start=period_start,
+        period_end=period_end,
+        period_start_time=period_start_time,
+        period_end_time=period_end_time,
+        shift_template_id=None,
+    )
+
+
+async def list_active_shift_templates(request: Request) -> dict:
+    """Active shift templates for Finanzas arqueo UI (warocol.com#686)."""
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    async with get_db_connection(use_transaction=False) as conn:
+        rows = await conn.fetch(
+            """
+            SELECT id, name, start_time, end_time, crosses_midnight, sort_order
+            FROM tenant_shift_templates
+            WHERE tenant_id = $1 AND is_active = true
+            ORDER BY sort_order, name
+            """,
+            tenant_id,
+        )
+
+    data = []
+    for row in rows:
+        data.append({
+            "id": str(row["id"]),
+            "name": row["name"],
+            "startTime": row["start_time"].strftime("%H:%M"),
+            "endTime": row["end_time"].strftime("%H:%M"),
+            "crossesMidnight": row["crosses_midnight"],
+        })
+    return {"success": True, "data": data}
+
+
+# ---------------------------------------------------------------------------
 # GET /cierre/preview
 # ---------------------------------------------------------------------------
 
@@ -946,6 +1052,7 @@ async def get_cierre_preview(
     completed_only: bool = False,
     period_start_time: Optional[datetime] = None,
     period_end_time: Optional[datetime] = None,
+    shift_template_id: Optional[UUID] = None,
 ) -> dict:
     try:
         session_context = require_valid_session(request)
@@ -954,17 +1061,28 @@ async def get_cierre_preview(
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection(use_transaction=False) as conn:
-            preview = await _compute_preview(
-                conn, tenant_id, period_start, period_end,
-                completed_only=completed_only,
+            resolved = await resolve_cierre_period_fields(
+                conn,
+                tenant_id,
+                period_start=period_start,
+                period_end=period_end,
                 period_start_time=period_start_time,
                 period_end_time=period_end_time,
+                shift_template_id=shift_template_id,
+            )
+            preview = await _compute_preview(
+                conn, tenant_id,
+                resolved.period_start, resolved.period_end,
+                completed_only=completed_only,
+                period_start_time=resolved.period_start_time,
+                period_end_time=resolved.period_end_time,
             )
             breakdown = await _compute_breakdown_rows(
-                conn, tenant_id, period_start, period_end,
+                conn, tenant_id,
+                resolved.period_start, resolved.period_end,
                 completed_only=completed_only,
-                period_start_time=period_start_time,
-                period_end_time=period_end_time,
+                period_start_time=resolved.period_start_time,
+                period_end_time=resolved.period_end_time,
             )
             preview["breakdown"] = breakdown
 
@@ -989,8 +1107,23 @@ async def create_cierre(request: Request, body: CierreCreate) -> dict:
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection(use_transaction=True) as conn:
+            resolved = await resolve_cierre_period_fields(
+                conn,
+                tenant_id,
+                period_start=body.period_start,
+                period_end=body.period_end,
+                period_start_time=body.period_start_time,
+                period_end_time=body.period_end_time,
+                shift_template_id=body.shift_template_id,
+            )
+            period_start = resolved.period_start
+            period_end = resolved.period_end
+            period_start_time = resolved.period_start_time
+            period_end_time = resolved.period_end_time
+            shift_template_id = resolved.shift_template_id
+
             # 0. Validation: multi-day periods require exact timestamps
-            if body.period_start != body.period_end and not (body.period_start_time and body.period_end_time):
+            if period_start != period_end and not (period_start_time and period_end_time):
                 raise APIError(
                     "Para períodos de varios días debes especificar hora de inicio y fin exactas.",
                     status_code=422,
@@ -1002,16 +1135,16 @@ async def create_cierre(request: Request, body: CierreCreate) -> dict:
             #    This allows multiple non-overlapping shifts on the same day.
             from zoneinfo import ZoneInfo
             bog = ZoneInfo("America/Bogota")
-            if body.period_start_time and body.period_end_time:
-                eff_start = body.period_start_time
-                eff_end   = body.period_end_time
+            if period_start_time and period_end_time:
+                eff_start = period_start_time
+                eff_end   = period_end_time
             else:
                 eff_start = datetime(
-                    body.period_start.year, body.period_start.month, body.period_start.day,
+                    period_start.year, period_start.month, period_start.day,
                     0, 0, 0, tzinfo=bog,
                 )
                 eff_end = datetime(
-                    body.period_end.year, body.period_end.month, body.period_end.day,
+                    period_end.year, period_end.month, period_end.day,
                     23, 59, 59, tzinfo=bog,
                 )
 
@@ -1042,17 +1175,17 @@ async def create_cierre(request: Request, body: CierreCreate) -> dict:
 
             # 2. Preview aggregation (completed only — cash already received)
             preview = await _compute_preview(
-                conn, tenant_id, body.period_start, body.period_end,
+                conn, tenant_id, period_start, period_end,
                 completed_only=True,
-                period_start_time=body.period_start_time,
-                period_end_time=body.period_end_time,
+                period_start_time=period_start_time,
+                period_end_time=period_end_time,
             )
 
             # 3. Open tables check — skip for past periods (mesas actuales no pertenecen al período)
             # Use Bogota date so the check is correct even when the server runs in UTC.
             from zoneinfo import ZoneInfo
             today_bogota = datetime.now(ZoneInfo("America/Bogota")).date()
-            is_past_period = body.period_end < today_bogota
+            is_past_period = period_end < today_bogota
             if not is_past_period and preview["openTablesCount"] > 0:
                 raise APIError(
                     f"Hay {preview['openTablesCount']} mesa(s) con cuenta abierta. "
@@ -1064,12 +1197,12 @@ async def create_cierre(request: Request, body: CierreCreate) -> dict:
             period_row = await conn.fetchrow(
                 """
                 INSERT INTO accounting_period
-                    (tenant_id, period_start, period_end, period_start_time, period_end_time)
-                VALUES ($1, $2, $3, $4, $5)
+                    (tenant_id, period_start, period_end, period_start_time, period_end_time, shift_template_id)
+                VALUES ($1, $2, $3, $4, $5, $6)
                 RETURNING id, closed_at
                 """,
-                tenant_id, body.period_start, body.period_end,
-                body.period_start_time, body.period_end_time,
+                tenant_id, period_start, period_end,
+                period_start_time, period_end_time, shift_template_id,
             )
             period_id = period_row["id"]
             closed_at = period_row["closed_at"]
@@ -1104,10 +1237,10 @@ async def create_cierre(request: Request, body: CierreCreate) -> dict:
 
             # 6. Compute and persist payment breakdown
             breakdown_rows = await _compute_breakdown_rows(
-                conn, tenant_id, body.period_start, body.period_end,
+                conn, tenant_id, period_start, period_end,
                 completed_only=True,
-                period_start_time=body.period_start_time,
-                period_end_time=body.period_end_time,
+                period_start_time=period_start_time,
+                period_end_time=period_end_time,
             )
             if breakdown_rows:
                 await conn.execute(
@@ -1134,10 +1267,11 @@ async def create_cierre(request: Request, body: CierreCreate) -> dict:
                 "id":                   str(summary_row["id"]),
                 "accountingPeriodId":   str(period_id),
                 "tenantId":             str(tenant_id),
-                "periodStart":          body.period_start.isoformat(),
-                "periodEnd":            body.period_end.isoformat(),
-                "periodStartTime":      body.period_start_time.isoformat() if body.period_start_time else None,
-                "periodEndTime":        body.period_end_time.isoformat()   if body.period_end_time   else None,
+                "periodStart":          period_start.isoformat(),
+                "periodEnd":            period_end.isoformat(),
+                "periodStartTime":      period_start_time.isoformat() if period_start_time else None,
+                "periodEndTime":        period_end_time.isoformat()   if period_end_time   else None,
+                "shiftTemplateId":      str(shift_template_id) if shift_template_id else None,
                 "totalSales":           preview["totalSales"],
                 "itemsSold":            preview["itemsSold"],
                 "totalCash":            preview["totalCash"],

--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -673,6 +673,52 @@ def _build_order_date_filter(
     return sql, [period_start, period_end]
 
 
+def _build_expense_filter(
+    period_start: date,
+    period_end: date,
+    period_start_time: Optional[datetime],
+    period_end_time: Optional[datetime],
+    param_offset: int = 2,
+):
+    """
+    Cash expenses: date-only arqueos use transaction_date (business day).
+    Shift windows use created_at (transaction_date has no time component).
+    """
+    p2 = f"${param_offset}"
+    p3 = f"${param_offset + 1}"
+    if period_start_time and period_end_time:
+        sql = f"AND created_at >= {p2} AND created_at <= {p3}"
+        return sql, [period_start_time, period_end_time]
+    sql = f"AND transaction_date >= {p2} AND transaction_date <= {p3}"
+    return sql, [period_start, period_end]
+
+
+def _build_open_tables_filter(
+    period_start: date,
+    period_end: date,
+    period_start_time: Optional[datetime],
+    period_end_time: Optional[datetime],
+    param_offset: int = 2,
+):
+    """
+    Open tables (closed_at IS NULL applied by caller).
+
+    Date-only: opened on a calendar day in [period_start, period_end].
+    Shift window: session started on or before shift end (still-open tables
+    that began before the shift still block the close).
+    """
+    if period_start_time and period_end_time:
+        p_end = f"${param_offset}"
+        return f"AND ts.opened_at <= {p_end}", [period_end_time]
+    p2 = f"${param_offset}"
+    p3 = f"${param_offset + 1}"
+    sql = (
+        f"AND ts.opened_at::date >= {p2} "
+        f"AND ts.opened_at::date <= {p3}"
+    )
+    return sql, [period_start, period_end]
+
+
 async def _compute_preview(
     conn,
     tenant_id: UUID,
@@ -690,11 +736,17 @@ async def _compute_preview(
     completed_only=False → 'completed' + 'pending' (used for Cierre X preview so
                            open-table orders are visible)
 
-    When period_start_time / period_end_time are supplied the order filter uses
-    exact TIMESTAMPTZ comparison, enabling cross-midnight shift closing.
+    When period_start_time / period_end_time are supplied the order, expense,
+    and open-table filters use exact TIMESTAMPTZ comparison (shift windows).
     """
     status_filter = "AND status = 'completed'" if completed_only else "AND status IN ('completed', 'pending')"
     date_filter, date_params = _build_order_date_filter(
+        period_start, period_end, period_start_time, period_end_time
+    )
+    expense_filter, expense_params = _build_expense_filter(
+        period_start, period_end, period_start_time, period_end_time
+    )
+    open_tables_filter, open_tables_params = _build_open_tables_filter(
         period_start, period_end, period_start_time, period_end_time
     )
     sales_row = await conn.fetchrow(
@@ -749,30 +801,28 @@ async def _compute_preview(
             method_totals[m] = method_totals.get(m, 0.0) + float(row["total"])
 
     gastos_row = await conn.fetchrow(
-        """
+        f"""
         SELECT COALESCE(SUM(amount), 0) AS gastos_efectivo
         FROM tenant_expenses
         WHERE tenant_id = $1
           AND payment_method = 'cash'
-          AND transaction_date >= $2
-          AND transaction_date <= $3
+          {expense_filter}
         """,
-        tenant_id, period_start, period_end,
+        tenant_id, *expense_params,
     )
 
     open_tables_row = await conn.fetchrow(
-        """
+        f"""
         SELECT COUNT(*) AS open_tables_count
         FROM table_sessions ts
         JOIN tables t ON t.id = ts.table_id
         WHERE ts.tenant_id = $1
           AND ts.closed_at IS NULL
           AND ts.is_discarded = FALSE
-          AND ts.opened_at::date >= $2
-          AND ts.opened_at::date <= $3
+          {open_tables_filter}
           AND t.is_bar IS FALSE
         """,
-        tenant_id, period_start, period_end,
+        tenant_id, *open_tables_params,
     )
 
     total_cash = method_totals.get("cash", 0.0)

--- a/app/services/shift_templates_service.py
+++ b/app/services/shift_templates_service.py
@@ -1,0 +1,166 @@
+"""CRUD for tenant_shift_templates under Operaciones (warocol.com#682)."""
+from datetime import time
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+import asyncpg
+from fastapi import HTTPException, Request
+
+from app.core.exceptions import AuthenticationError
+from app.core.middleware import require_valid_session
+from app.database import get_db_connection
+from app.models.shift_template import ShiftTemplateCreate, ShiftTemplatePatch, _validate_shift_window
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _row_to_dict(row: asyncpg.Record) -> Dict[str, Any]:
+    data = dict(row)
+    data["id"] = str(data["id"])
+    data["tenant_id"] = str(data["tenant_id"])
+    for key in ("start_time", "end_time"):
+        if data[key] is not None:
+            data[key] = data[key].isoformat()
+    for key in ("created_at", "updated_at"):
+        if data[key] is not None:
+            data[key] = data[key].isoformat()
+    return data
+
+
+async def list_shift_templates(
+    request: Request,
+    *,
+    include_inactive: bool = False,
+) -> dict:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    query = """
+        SELECT *
+        FROM tenant_shift_templates
+        WHERE tenant_id = $1
+    """
+    if not include_inactive:
+        query += " AND is_active = true"
+    query += " ORDER BY sort_order, name"
+
+    async with get_db_connection(use_transaction=False) as conn:
+        rows = await conn.fetch(query, tenant_id)
+
+    return {"success": True, "data": [_row_to_dict(r) for r in rows]}
+
+
+async def create_shift_template(request: Request, body: ShiftTemplateCreate) -> dict:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    try:
+        async with get_db_connection() as conn:
+            row = await conn.fetchrow(
+                """
+                INSERT INTO tenant_shift_templates (
+                    tenant_id, name, start_time, end_time,
+                    crosses_midnight, sort_order
+                )
+                VALUES ($1, $2, $3, $4, $5, $6)
+                RETURNING *
+                """,
+                tenant_id,
+                body.name.strip(),
+                body.start_time,
+                body.end_time,
+                body.crosses_midnight,
+                body.sort_order,
+            )
+    except asyncpg.UniqueViolationError:
+        raise HTTPException(
+            status_code=409,
+            detail="Ya existe un turno con ese nombre",
+        ) from None
+
+    logger.info("Created shift template %r for tenant %s", body.name, tenant_id)
+    return {"success": True, "data": _row_to_dict(row)}
+
+
+async def patch_shift_template(
+    request: Request,
+    template_id: UUID,
+    body: ShiftTemplatePatch,
+) -> dict:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    data_dict = body.model_dump(exclude_unset=True)
+    if not data_dict:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    if "name" in data_dict and data_dict["name"] is not None:
+        data_dict["name"] = data_dict["name"].strip()
+
+    async with get_db_connection() as conn:
+        existing = await conn.fetchrow(
+            """
+            SELECT start_time, end_time, crosses_midnight
+            FROM tenant_shift_templates
+            WHERE id = $1 AND tenant_id = $2
+            """,
+            template_id,
+            tenant_id,
+        )
+        if not existing:
+            raise HTTPException(status_code=404, detail="Shift template not found")
+
+        merged_start: time = data_dict.get("start_time", existing["start_time"])
+        merged_end: time = data_dict.get("end_time", existing["end_time"])
+        merged_crosses: bool = data_dict.get(
+            "crosses_midnight", existing["crosses_midnight"]
+        )
+        try:
+            _validate_shift_window(
+                start_time=merged_start,
+                end_time=merged_end,
+                crosses_midnight=merged_crosses,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+        update_fields = []
+        params = []
+        param_counter = 1
+
+        for field, value in data_dict.items():
+            update_fields.append(f"{field} = ${param_counter}")
+            params.append(value)
+            param_counter += 1
+
+        update_fields.append("updated_at = now()")
+        params.extend([tenant_id, template_id])
+
+        try:
+            row = await conn.fetchrow(
+                f"""
+                UPDATE tenant_shift_templates
+                SET {', '.join(update_fields)}
+                WHERE tenant_id = ${param_counter} AND id = ${param_counter + 1}
+                RETURNING *
+                """,
+                *params,
+            )
+        except asyncpg.UniqueViolationError:
+            raise HTTPException(
+                status_code=409,
+                detail="Ya existe un turno con ese nombre",
+            ) from None
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Shift template not found")
+
+    return {"success": True, "data": _row_to_dict(row)}

--- a/app/services/shift_window_service.py
+++ b/app/services/shift_window_service.py
@@ -1,0 +1,143 @@
+"""Resolve shift template + calendar date to cierre period fields (warocol.com#684)."""
+from datetime import date, datetime, time, timedelta
+from typing import Any, Dict, Optional
+from uuid import UUID
+from zoneinfo import ZoneInfo
+
+from fastapi import HTTPException, Request
+
+from app.core.exceptions import AuthenticationError
+from app.core.middleware import require_valid_session
+from app.database import get_db_connection
+
+BOGOTA = ZoneInfo("America/Bogota")
+
+
+def resolve_shift_template_window(
+    *,
+    anchor_date: date,
+    start_time: time,
+    end_time: time,
+    crosses_midnight: bool,
+    template_id: Optional[UUID] = None,
+    template_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Pure resolver: template clock times + anchor date → cierre period fields (Bogotá)."""
+    period_start = anchor_date
+    period_end = anchor_date + timedelta(days=1) if crosses_midnight else anchor_date
+
+    period_start_time = datetime.combine(anchor_date, start_time, tzinfo=BOGOTA)
+    period_end_time = datetime.combine(period_end, end_time, tzinfo=BOGOTA)
+
+    payload: Dict[str, Any] = {
+        "periodStart": period_start.isoformat(),
+        "periodEnd": period_end.isoformat(),
+        "periodStartTime": period_start_time.isoformat(),
+        "periodEndTime": period_end_time.isoformat(),
+        "crossesMidnight": crosses_midnight,
+    }
+    if template_id is not None:
+        payload["templateId"] = str(template_id)
+    if template_name is not None:
+        payload["templateName"] = template_name
+    return payload
+
+
+async def get_template_window(
+    request: Request,
+    template_id: UUID,
+    anchor_date: date,
+) -> dict:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    async with get_db_connection(use_transaction=False) as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT id, name, start_time, end_time, crosses_midnight
+            FROM tenant_shift_templates
+            WHERE id = $1 AND tenant_id = $2 AND is_active = true
+            """,
+            template_id,
+            tenant_id,
+        )
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Shift template not found")
+
+    data = resolve_shift_template_window(
+        anchor_date=anchor_date,
+        start_time=row["start_time"],
+        end_time=row["end_time"],
+        crosses_midnight=row["crosses_midnight"],
+        template_id=row["id"],
+        template_name=row["name"],
+    )
+    return {"success": True, "data": data}
+
+
+async def get_suggested_window(
+    request: Request,
+    anchor_date: date,
+) -> dict:
+    """Suggest a custom arqueo window from last close end through now (Bogotá)."""
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    now_bogota = datetime.now(BOGOTA)
+
+    async with get_db_connection(use_transaction=False) as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT
+                ap.period_start,
+                ap.period_end,
+                ap.period_start_time,
+                ap.period_end_time
+            FROM accounting_period ap
+            WHERE ap.tenant_id = $1
+              AND ap.deleted_at IS NULL
+            ORDER BY
+                COALESCE(
+                    ap.period_end_time,
+                    (ap.period_end::timestamp + INTERVAL '23:59:59')
+                        AT TIME ZONE 'America/Bogota'
+                ) DESC
+            LIMIT 1
+            """,
+            tenant_id,
+        )
+
+    if row and row["period_end_time"]:
+        period_start_time = row["period_end_time"]
+        period_start = period_start_time.astimezone(BOGOTA).date()
+    elif row:
+        period_start = row["period_end"]
+        period_start_time = datetime.combine(period_start, time(0, 0, 0), tzinfo=BOGOTA)
+    else:
+        period_start = anchor_date
+        period_start_time = datetime.combine(anchor_date, time(0, 0, 0), tzinfo=BOGOTA)
+
+    period_end = now_bogota.date()
+    period_end_time = now_bogota
+
+    if period_start_time >= period_end_time:
+        raise HTTPException(
+            status_code=422,
+            detail="No hay ventana sugerida: el último cierre es posterior a ahora",
+        )
+
+    return {
+        "success": True,
+        "data": {
+            "periodStart": period_start.isoformat(),
+            "periodEnd": period_end.isoformat(),
+            "periodStartTime": period_start_time.isoformat(),
+            "periodEndTime": period_end_time.isoformat(),
+            "suggested": True,
+        },
+    }

--- a/migrations/080_tenant_shift_templates.sql
+++ b/migrations/080_tenant_shift_templates.sql
@@ -1,0 +1,31 @@
+-- 080_tenant_shift_templates.sql
+-- Issue warocol.com#680 — Reusable shift template catalog per tenant (epic #678)
+--
+-- ADD-only: new table only. No changes to accounting_period / closing_summary.
+-- #681 adds shift_template_id FK on accounting_period after this lands.
+
+CREATE TABLE IF NOT EXISTS tenant_shift_templates (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id        UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    name             VARCHAR(80) NOT NULL,
+    start_time       TIME NOT NULL,
+    end_time         TIME NOT NULL,
+    crosses_midnight BOOLEAN NOT NULL DEFAULT false,
+    sort_order       SMALLINT NOT NULL DEFAULT 0,
+    is_active        BOOLEAN NOT NULL DEFAULT true,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (tenant_id, name)
+);
+
+COMMENT ON TABLE tenant_shift_templates IS
+    'Reusable operating-shift schedules per tenant (warocol.com#680). '
+    'Configured under Operaciones → Turnos; resolved to TIMESTAMPTZ windows '
+    'per calendar date in #684.';
+
+COMMENT ON COLUMN tenant_shift_templates.crosses_midnight IS
+    'When true, end_time is on the day after start_time (e.g. 22:00–06:00).';
+
+CREATE INDEX IF NOT EXISTS idx_shift_templates_tenant
+    ON tenant_shift_templates(tenant_id)
+    WHERE is_active = true;

--- a/migrations/081_accounting_period_shift_template_id.sql
+++ b/migrations/081_accounting_period_shift_template_id.sql
@@ -1,0 +1,17 @@
+-- 081_accounting_period_shift_template_id.sql
+-- Issue warocol.com#681 — Optional link from arqueo to shift template (epic #678)
+--
+-- ADD-only: nullable column + partial index. Depends on 080_tenant_shift_templates.sql (#680).
+-- API/UI persistence lands in later issues (#683+).
+
+ALTER TABLE accounting_period
+    ADD COLUMN IF NOT EXISTS shift_template_id UUID NULL
+    REFERENCES tenant_shift_templates(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN accounting_period.shift_template_id IS
+    'Optional FK to tenant_shift_templates (warocol.com#681). '
+    'NULL = custom time window or legacy full-day arqueo.';
+
+CREATE INDEX IF NOT EXISTS idx_accounting_period_shift
+    ON accounting_period(shift_template_id)
+    WHERE shift_template_id IS NOT NULL;

--- a/tests/test_cierre_permissions.py
+++ b/tests/test_cierre_permissions.py
@@ -1,0 +1,121 @@
+"""Permission tests for /cierre vs /operaciones/shifts split (warocol.com#689).
+
+Arqueo execution (including shift-template read for wizards) requires FINANZAS.
+Template CRUD requires OPERACIONES. Default matrix: owner/admin have finanzas;
+supervisor/cashier do not unless tenant override.
+"""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.core.permissions import Module
+from app.routers.cierre import router as cierre_router
+from app.routers.operaciones_shifts import router as operaciones_shifts_router
+
+ADMIN_MODULES = frozenset({
+    Module.POS, Module.VENTAS, Module.DESPACHO, Module.MENU,
+    Module.OPERACIONES, Module.ABASTECIMIENTO, Module.ANALITICA,
+    Module.FINANZAS, Module.FACTURACION, Module.INTEGRACIONES, Module.MI_PLAN,
+})
+SUPERVISOR_MODULES = frozenset({
+    Module.POS, Module.VENTAS, Module.DESPACHO, Module.MENU,
+    Module.OPERACIONES, Module.ABASTECIMIENTO, Module.ANALITICA,
+})
+CASHIER_MODULES = frozenset({Module.POS, Module.VENTAS, Module.MENU})
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_session(role: str):
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": role,
+    })
+
+
+def _enforce_db_ctx():
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+
+    return _ctx
+
+
+def test_admin_passes_cierre_and_shifts_under_enforce():
+    session = _build_session(role="admin")
+    app = FastAPI()
+    app.include_router(cierre_router)
+    app.include_router(operaciones_shifts_router)
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.services.cierre_service.require_valid_session", return_value=session), \
+         patch("app.services.shift_templates_service.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.core.permissions.get_role_modules", new=AsyncMock(return_value=ADMIN_MODULES)), \
+         patch("app.services.cierre_service.get_ultimo_cierre", new=AsyncMock(return_value={"success": True, "data": None})), \
+         patch("app.services.shift_templates_service.list_shift_templates", new=AsyncMock(return_value={"success": True, "data": []})):
+        client = TestClient(app)
+        assert client.get("/cierre/ultimo").status_code == 200
+        assert client.get("/cierre/shift-templates").status_code == 200
+        assert client.get("/operaciones/shifts").status_code == 200
+
+
+def test_supervisor_denied_cierre_allowed_shifts_under_enforce():
+    session = _build_session(role="supervisor")
+    app = FastAPI()
+    app.include_router(cierre_router)
+    app.include_router(operaciones_shifts_router)
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.services.shift_templates_service.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.core.permissions.get_role_modules", new=AsyncMock(return_value=SUPERVISOR_MODULES)), \
+         patch("app.services.shift_templates_service.list_shift_templates", new=AsyncMock(return_value={"success": True, "data": []})):
+        client = TestClient(app)
+        denied = client.get("/cierre/ultimo")
+        assert denied.status_code == 403
+        assert "finanzas" in denied.json()["detail"].lower()
+        assert client.get("/operaciones/shifts").status_code == 200
+
+
+def test_cashier_denied_cierre_and_shifts_under_enforce():
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(cierre_router)
+    app.include_router(operaciones_shifts_router)
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.services.shift_templates_service.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.core.permissions.get_role_modules", new=AsyncMock(return_value=CASHIER_MODULES)):
+        client = TestClient(app)
+        cierre_resp = client.get("/cierre/ultimo")
+        assert cierre_resp.status_code == 403
+        assert "finanzas" in cierre_resp.json()["detail"].lower()
+        shifts_resp = client.get("/operaciones/shifts")
+        assert shifts_resp.status_code == 403
+        assert "operaciones" in shifts_resp.json()["detail"].lower()

--- a/tests/test_cierre_shift_filters.py
+++ b/tests/test_cierre_shift_filters.py
@@ -1,0 +1,68 @@
+"""Unit tests for cierre shift-window filter builders (issue #685)."""
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+from app.services.cierre_service import (
+    _build_expense_filter,
+    _build_open_tables_filter,
+    _build_order_date_filter,
+)
+
+BOG = ZoneInfo("America/Bogota")
+
+
+def test_order_filter_date_only_uses_bogota_dates():
+    sql, params = _build_order_date_filter(
+        date(2026, 5, 18), date(2026, 5, 18), None, None
+    )
+    assert "AT TIME ZONE 'America/Bogota'" in sql
+    assert params == [date(2026, 5, 18), date(2026, 5, 18)]
+
+
+def test_order_filter_shift_uses_timestamps():
+    start = datetime(2026, 5, 18, 14, 0, tzinfo=BOG)
+    end = datetime(2026, 5, 18, 22, 0, tzinfo=BOG)
+    sql, params = _build_order_date_filter(
+        date(2026, 5, 18), date(2026, 5, 18), start, end
+    )
+    assert "order_date >=" in sql
+    assert "AT TIME ZONE" not in sql
+    assert params == [start, end]
+
+
+def test_expense_filter_date_only_uses_transaction_date():
+    sql, params = _build_expense_filter(
+        date(2026, 5, 18), date(2026, 5, 18), None, None
+    )
+    assert "transaction_date" in sql
+    assert "created_at" not in sql
+    assert params == [date(2026, 5, 18), date(2026, 5, 18)]
+
+
+def test_expense_filter_shift_uses_created_at():
+    start = datetime(2026, 5, 18, 14, 0, tzinfo=BOG)
+    end = datetime(2026, 5, 18, 22, 0, tzinfo=BOG)
+    sql, params = _build_expense_filter(
+        date(2026, 5, 18), date(2026, 5, 18), start, end
+    )
+    assert "created_at >=" in sql
+    assert "transaction_date" not in sql
+    assert params == [start, end]
+
+
+def test_open_tables_filter_date_only_uses_opened_at_date():
+    sql, params = _build_open_tables_filter(
+        date(2026, 5, 18), date(2026, 5, 18), None, None
+    )
+    assert "opened_at::date" in sql
+    assert params == [date(2026, 5, 18), date(2026, 5, 18)]
+
+
+def test_open_tables_filter_shift_uses_opened_at_before_end():
+    end = datetime(2026, 5, 18, 22, 0, tzinfo=BOG)
+    sql, params = _build_open_tables_filter(
+        date(2026, 5, 18), date(2026, 5, 18), datetime(2026, 5, 18, 14, 0, tzinfo=BOG), end
+    )
+    assert "ts.opened_at <=" in sql
+    assert "opened_at::date" not in sql
+    assert params == [end]

--- a/tests/test_cierre_shift_template_create.py
+++ b/tests/test_cierre_shift_template_create.py
@@ -1,0 +1,113 @@
+"""Unit tests for cierre shift-template resolution (warocol.com#686)."""
+from datetime import date, datetime, time
+from unittest.mock import AsyncMock
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.core.exceptions import APIError
+from app.services.cierre_service import resolve_cierre_period_fields
+
+BOG = ZoneInfo("America/Bogota")
+
+
+@pytest.mark.asyncio
+async def test_template_mode_resolves_window():
+    template_id = uuid4()
+    tenant_id = uuid4()
+    conn = AsyncMock()
+    conn.fetchrow.return_value = {
+        "id": template_id,
+        "name": "Mañana",
+        "start_time": time(6, 0),
+        "end_time": time(14, 0),
+        "crosses_midnight": False,
+    }
+
+    resolved = await resolve_cierre_period_fields(
+        conn,
+        tenant_id,
+        period_start=date(2026, 5, 18),
+        period_end=date(2026, 5, 18),
+        period_start_time=None,
+        period_end_time=None,
+        shift_template_id=template_id,
+    )
+
+    assert resolved.shift_template_id == template_id
+    assert resolved.period_start == date(2026, 5, 18)
+    assert resolved.period_end == date(2026, 5, 18)
+    assert resolved.period_start_time == datetime(2026, 5, 18, 6, 0, tzinfo=BOG)
+    assert resolved.period_end_time == datetime(2026, 5, 18, 14, 0, tzinfo=BOG)
+
+
+@pytest.mark.asyncio
+async def test_template_mode_rejects_manual_times():
+    conn = AsyncMock()
+    with pytest.raises(APIError) as exc:
+        await resolve_cierre_period_fields(
+            conn,
+            uuid4(),
+            period_start=date(2026, 5, 18),
+            period_end=date(2026, 5, 18),
+            period_start_time=datetime(2026, 5, 18, 15, 0, tzinfo=BOG),
+            period_end_time=datetime(2026, 5, 18, 18, 0, tzinfo=BOG),
+            shift_template_id=uuid4(),
+        )
+    assert exc.value.status_code == 422
+    conn.fetchrow.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_template_mode_rejects_multi_day():
+    conn = AsyncMock()
+    with pytest.raises(APIError) as exc:
+        await resolve_cierre_period_fields(
+            conn,
+            uuid4(),
+            period_start=date(2026, 5, 17),
+            period_end=date(2026, 5, 18),
+            period_start_time=None,
+            period_end_time=None,
+            shift_template_id=uuid4(),
+        )
+    assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_custom_mode_passes_through_times():
+    tenant_id = uuid4()
+    start = datetime(2026, 5, 18, 15, 0, tzinfo=BOG)
+    end = datetime(2026, 5, 18, 18, 0, tzinfo=BOG)
+    conn = AsyncMock()
+
+    resolved = await resolve_cierre_period_fields(
+        conn,
+        tenant_id,
+        period_start=date(2026, 5, 18),
+        period_end=date(2026, 5, 18),
+        period_start_time=start,
+        period_end_time=end,
+        shift_template_id=None,
+    )
+
+    assert resolved.shift_template_id is None
+    assert resolved.period_start_time == start
+    assert resolved.period_end_time == end
+    conn.fetchrow.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_full_day_mode_no_times():
+    resolved = await resolve_cierre_period_fields(
+        AsyncMock(),
+        uuid4(),
+        period_start=date(2026, 5, 18),
+        period_end=date(2026, 5, 18),
+        period_start_time=None,
+        period_end_time=None,
+        shift_template_id=None,
+    )
+    assert resolved.period_start_time is None
+    assert resolved.period_end_time is None

--- a/tests/test_operaciones_shifts.py
+++ b/tests/test_operaciones_shifts.py
@@ -1,0 +1,155 @@
+"""Tests for /operaciones/shifts shift template CRUD (warocol.com#682)."""
+from contextlib import asynccontextmanager
+from datetime import time
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.core.permissions import Module
+from app.models.shift_template import ShiftTemplateCreate, ShiftTemplatePatch
+from app.routers.operaciones_shifts import router as operaciones_shifts_router
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_session(role: str):
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": role,
+    })
+
+
+def _enforce_db_ctx():
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+
+    return _ctx
+
+
+def test_shift_template_create_rejects_invalid_same_day_window():
+  with pytest.raises(ValidationError):
+    ShiftTemplateCreate(
+      name="Mañana",
+      start_time=time(14, 0),
+      end_time=time(6, 0),
+      crosses_midnight=False,
+    )
+
+
+def test_shift_template_create_allows_overnight_window():
+  body = ShiftTemplateCreate(
+    name="Noche",
+    start_time=time(22, 0),
+    end_time=time(6, 0),
+    crosses_midnight=True,
+  )
+  assert body.crosses_midnight is True
+
+
+def test_supervisor_passes_list_shifts_under_enforce():
+    session = _build_session(role="supervisor")
+    app = FastAPI()
+    app.include_router(operaciones_shifts_router)
+
+    supervisor_modules = frozenset({
+        Module.POS, Module.VENTAS, Module.DESPACHO, Module.MENU,
+        Module.OPERACIONES, Module.ABASTECIMIENTO, Module.ANALITICA,
+    })
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.services.shift_templates_service.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=supervisor_modules),
+         ), \
+         patch(
+             "app.services.shift_templates_service.list_shift_templates",
+             new=AsyncMock(return_value={"success": True, "data": []}),
+         ):
+        client = TestClient(app)
+        response = client.get("/operaciones/shifts")
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+
+def test_kitchen_denied_list_shifts_under_enforce():
+    session = _build_session(role="kitchen")
+    app = FastAPI()
+    app.include_router(operaciones_shifts_router)
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.services.shift_templates_service.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=frozenset({Module.DESPACHO})),
+         ):
+        client = TestClient(app)
+        response = client.get("/operaciones/shifts")
+
+    assert response.status_code == 403
+    assert "operaciones" in response.json()["detail"].lower()
+
+
+def test_create_endpoint_passes_body_to_service():
+    session = _build_session(role="owner")
+    app = FastAPI()
+    app.include_router(operaciones_shifts_router)
+    create_mock = AsyncMock(return_value={"success": True, "data": {"id": str(uuid4())}})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.services.shift_templates_service.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=frozenset(Module)),
+         ), \
+         patch(
+             "app.services.shift_templates_service.create_shift_template",
+             create_mock,
+         ):
+        client = TestClient(app)
+        response = client.post(
+            "/operaciones/shifts",
+            json={
+                "name": "Mañana",
+                "start_time": "06:00:00",
+                "end_time": "14:00:00",
+                "crosses_midnight": False,
+                "sort_order": 0,
+            },
+        )
+
+    assert response.status_code == 200
+    create_mock.assert_awaited_once()
+    body_arg = create_mock.await_args.args[1]
+    assert body_arg.name == "Mañana"
+
+
+def test_patch_model_accepts_deactivate_only():
+    body = ShiftTemplatePatch(is_active=False)
+    assert body.is_active is False

--- a/tests/test_operaciones_shifts.py
+++ b/tests/test_operaciones_shifts.py
@@ -96,6 +96,27 @@ def test_supervisor_passes_list_shifts_under_enforce():
     assert response.json()["success"] is True
 
 
+def test_cashier_denied_list_shifts_under_enforce():
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(operaciones_shifts_router)
+
+    cashier_modules = frozenset({Module.POS, Module.VENTAS, Module.MENU})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.services.shift_templates_service.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ):
+        client = TestClient(app)
+        response = client.get("/operaciones/shifts")
+
+    assert response.status_code == 403
+    assert "operaciones" in response.json()["detail"].lower()
+
+
 def test_kitchen_denied_list_shifts_under_enforce():
     session = _build_session(role="kitchen")
     app = FastAPI()

--- a/tests/test_shift_window_resolver.py
+++ b/tests/test_shift_window_resolver.py
@@ -1,0 +1,48 @@
+"""Unit tests for shift template window resolution (warocol.com#684)."""
+from datetime import date, time
+from uuid import uuid4
+
+from app.services.shift_window_service import resolve_shift_template_window
+
+
+def test_overnight_template_may_18_bogota():
+    """AC: 22:00–06:00 on May 18 → start May 18 22:00, end May 19 06:00."""
+    data = resolve_shift_template_window(
+        anchor_date=date(2026, 5, 18),
+        start_time=time(22, 0),
+        end_time=time(6, 0),
+        crosses_midnight=True,
+    )
+    assert data["periodStart"] == "2026-05-18"
+    assert data["periodEnd"] == "2026-05-19"
+    assert data["periodStartTime"] == "2026-05-18T22:00:00-05:00"
+    assert data["periodEndTime"] == "2026-05-19T06:00:00-05:00"
+    assert data["crossesMidnight"] is True
+
+
+def test_same_day_template():
+    data = resolve_shift_template_window(
+        anchor_date=date(2026, 5, 18),
+        start_time=time(6, 0),
+        end_time=time(14, 0),
+        crosses_midnight=False,
+    )
+    assert data["periodStart"] == "2026-05-18"
+    assert data["periodEnd"] == "2026-05-18"
+    assert data["periodStartTime"] == "2026-05-18T06:00:00-05:00"
+    assert data["periodEndTime"] == "2026-05-18T14:00:00-05:00"
+    assert data["crossesMidnight"] is False
+
+
+def test_includes_template_metadata_when_provided():
+    tid = uuid4()
+    data = resolve_shift_template_window(
+        anchor_date=date(2026, 5, 18),
+        start_time=time(6, 0),
+        end_time=time(14, 0),
+        crosses_midnight=False,
+        template_id=tid,
+        template_name="Mañana",
+    )
+    assert data["templateId"] == str(tid)
+    assert data["templateName"] == "Mañana"


### PR DESCRIPTION
## What this issue is about (warocol.com#689)

Epic #678 needs **separate permissions for configuration vs execution**:

| Concern | API | Module |
|---------|-----|--------|
| **Run cash counts (arqueo)** | `/cierre*` (incl. `shift-templates` read for template mode) | `finanzas` |
| **Configure shift templates** | `/operaciones/shifts*` | `operaciones` |

**Product decision (confirmed):** Arqueo uses the **full `finanzas` module** — no special “arqueo-only” permission. Default roles with Finanzas: **owner**, **admin**. Cashier/supervisor do **not** get Finanzas unless the tenant owner grants it in Equipo.

Router `require_module()` wiring was already correct; this PR **locks the behavior in tests**.

## Changes
- `tests/test_cierre_permissions.py` — admin: cierre + shifts OK; supervisor: 403 cierre, 200 shifts; cashier: 403 both
- `tests/test_operaciones_shifts.py` — cashier denied on `GET /operaciones/shifts`

## Testing
```bash
python3 -m pytest tests/test_cierre_permissions.py tests/test_operaciones_shifts.py -q
```

Part of warocol.com#689 — merge with front PR.

Made with [Cursor](https://cursor.com)