### PR TITLE
fix(menu): archive products with sales instead of hard DELETE

### DIFF
--- a/app/routers/products.py
+++ b/app/routers/products.py
@@ -138,9 +138,10 @@ async def delete_product_endpoint(
     product_id: UUID
 ):
     """
-    Delete a product and its recipe.
+    Delete or archive a product.
 
-    This will permanently delete the product and all associated recipe data.
+    Products with sales history (order_items) are archived (is_available=false) to
+    preserve orders and KDS links. Products never sold are permanently deleted.
 
     Requires valid session with tenant context.
     """

--- a/app/services/products_service.py
+++ b/app/services/products_service.py
@@ -948,8 +948,9 @@ async def delete_product(
     product_id: UUID
 ) -> dict:
     """
-    Deletes a product and its recipe.
-    Returns success status.
+    Deletes a product when it has no sales history, or archives it when order_items exist.
+
+    Hard delete would CASCADE into order_items and fail on comanda_items FK (warocol.com#705).
     """
     try:
         session_context = require_valid_session(request)
@@ -959,38 +960,87 @@ async def delete_product(
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection() as conn:
-            # Verify product exists and belongs to tenant
-            verify_query = "SELECT id, name FROM product WHERE id = $1 AND tenant_id = $2"
-            product_exists = await conn.fetchrow(verify_query, product_id, tenant_id)
+            verify_query = """
+                SELECT id, name, is_available, is_available_online
+                FROM product WHERE id = $1 AND tenant_id = $2
+            """
+            product_row = await conn.fetchrow(verify_query, product_id, tenant_id)
 
-            if not product_exists:
+            if not product_row:
                 raise HTTPException(status_code=404, detail="Product not found")
 
-            # Obtener snapshot ANTES de eliminar (para historial)
             product_snapshot = await menu_history_service.get_product_snapshot(conn, product_id, tenant_id)
-            product_name = product_exists['name']
+            product_name = product_row['name']
             user_id = session_context.user_id if hasattr(session_context, 'user_id') else None
 
-            # Start transaction
             async with conn.transaction():
-                # 1. Registrar eliminación en historial
+                has_sales = await conn.fetchval(
+                    "SELECT EXISTS(SELECT 1 FROM order_items WHERE product_id = $1)",
+                    product_id,
+                )
+
+                if has_sales:
+                    if not product_row['is_available'] and not product_row['is_available_online']:
+                        return {
+                            "success": True,
+                            "archived": True,
+                            "message": "Product is already archived",
+                        }
+
+                    await conn.execute(
+                        """
+                        UPDATE product
+                           SET is_available = false,
+                               is_available_online = false,
+                               updated_at = NOW()
+                         WHERE id = $1 AND tenant_id = $2
+                        """,
+                        product_id,
+                        tenant_id,
+                    )
+
+                    archive_reason = "Archived: product has sales history (order_items)"
+                    if product_row['is_available']:
+                        await menu_history_service.record_product_update(
+                            conn, tenant_id, product_id, product_name,
+                            'is_available', product_row['is_available'], False,
+                            user_id, archive_reason,
+                        )
+                    if product_row['is_available_online']:
+                        await menu_history_service.record_product_update(
+                            conn, tenant_id, product_id, product_name,
+                            'is_available_online', product_row['is_available_online'], False,
+                            user_id, archive_reason,
+                        )
+
+                    return {
+                        "success": True,
+                        "archived": True,
+                        "message": (
+                            "Product archived. It remains in sales history and is hidden "
+                            "from POS and online ordering."
+                        ),
+                    }
+
                 if product_snapshot:
                     await menu_history_service.record_product_delete(
                         conn, tenant_id, product_id, product_name,
                         product_snapshot, user_id
                     )
 
-                # 2. Delete recipe first (foreign key constraint)
-                delete_recipe_query = "DELETE FROM product_recipes WHERE product_id = $1"
-                await conn.execute(delete_recipe_query, product_id)
-
-                # 3. Delete product
-                delete_product_query = "DELETE FROM product WHERE id = $1 AND tenant_id = $2"
-                await conn.execute(delete_product_query, product_id, tenant_id)
+                await conn.execute(
+                    "DELETE FROM product_recipes WHERE product_id = $1",
+                    product_id,
+                )
+                await conn.execute(
+                    "DELETE FROM product WHERE id = $1 AND tenant_id = $2",
+                    product_id, tenant_id,
+                )
 
                 return {
                     "success": True,
-                    "message": "Product deleted successfully"
+                    "archived": False,
+                    "message": "Product deleted successfully",
                 }
 
     except HTTPException:

--- a/tests/test_product_delete_archive.py
+++ b/tests/test_product_delete_archive.py
@@ -1,0 +1,128 @@
+"""Tests for product delete vs archive (warocol.com#705)."""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import Request
+
+from app.core.middleware import SessionContext
+from app.services.products_service import delete_product
+
+
+def _session():
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@warocol.com",
+        "name": "Test",
+        "expires_at": None,
+        "is_active": True,
+    })
+
+
+def _mock_conn(*, has_sales: bool, is_available: bool = True, is_available_online: bool = True):
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "id": uuid4(),
+        "name": "Test Product",
+        "is_available": is_available,
+        "is_available_online": is_available_online,
+    })
+    conn.fetchval = AsyncMock(return_value=has_sales)
+    conn.execute = AsyncMock()
+    conn.transaction = MagicMock()
+
+    @asynccontextmanager
+    async def _txn():
+        yield
+
+    conn.transaction.return_value = _txn()
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_delete_archives_when_product_has_sales():
+    product_id = uuid4()
+    request = MagicMock(spec=Request)
+    conn = _mock_conn(has_sales=True)
+
+    @asynccontextmanager
+    async def _db_ctx():
+        yield conn
+
+    with patch("app.services.products_service.require_valid_session", return_value=_session()), \
+         patch("app.services.products_service.get_db_connection", side_effect=_db_ctx), \
+         patch(
+             "app.services.products_service.menu_history_service.get_product_snapshot",
+             new=AsyncMock(return_value={"name": "Test Product"}),
+         ), \
+         patch(
+             "app.services.products_service.menu_history_service.record_product_update",
+             new=AsyncMock(),
+         ) as record_update:
+        result = await delete_product(request, product_id)
+
+    assert result["success"] is True
+    assert result["archived"] is True
+    assert "archived" in result["message"].lower()
+    conn.execute.assert_called_once()
+    assert "UPDATE product" in conn.execute.call_args[0][0]
+    assert record_update.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_hard_deletes_when_no_sales():
+    product_id = uuid4()
+    request = MagicMock(spec=Request)
+    conn = _mock_conn(has_sales=False)
+
+    @asynccontextmanager
+    async def _db_ctx():
+        yield conn
+
+    with patch("app.services.products_service.require_valid_session", return_value=_session()), \
+         patch("app.services.products_service.get_db_connection", side_effect=_db_ctx), \
+         patch(
+             "app.services.products_service.menu_history_service.get_product_snapshot",
+             new=AsyncMock(return_value={"name": "Test Product"}),
+         ), \
+         patch(
+             "app.services.products_service.menu_history_service.record_product_delete",
+             new=AsyncMock(),
+         ), \
+         patch(
+             "app.services.products_service.menu_history_service.record_product_update",
+             new=AsyncMock(),
+         ) as record_update:
+        result = await delete_product(request, product_id)
+
+    assert result["success"] is True
+    assert result["archived"] is False
+    assert conn.execute.await_count == 2
+    delete_calls = [str(c[0][0]) for c in conn.execute.await_args_list]
+    assert any("DELETE FROM product_recipes" in q for q in delete_calls)
+    assert any("DELETE FROM product" in q for q in delete_calls)
+    record_update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_idempotent_when_already_archived():
+    product_id = uuid4()
+    request = MagicMock(spec=Request)
+    conn = _mock_conn(has_sales=True, is_available=False, is_available_online=False)
+
+    @asynccontextmanager
+    async def _db_ctx():
+        yield conn
+
+    with patch("app.services.products_service.require_valid_session", return_value=_session()), \
+         patch("app.services.products_service.get_db_connection", side_effect=_db_ctx), \
+         patch(
+             "app.services.products_service.menu_history_service.get_product_snapshot",
+             new=AsyncMock(return_value={}),
+         ):
+        result = await delete_product(request, product_id)
+
+    assert result["archived"] is True
+    conn.execute.assert_not_called()


### PR DESCRIPTION
## Summary
- Archive products that have `order_items` (`is_available` / `is_available_online` false) instead of `DELETE FROM product` (fixes FK 500 with `comanda_items` and preserves sales history).
- Hard delete unchanged when the product was never sold.
- Unit tests in `tests/test_product_delete_archive.py`.

## Testing
- `python3 -m pytest tests/test_product_delete_archive.py -q`

Refs uno0uno/warocol.com#705

Made with [Cursor](https://cursor.com)