### PR TITLE
fix(menu): return 409 on duplicate product name (PUT/POST)

### DIFF
--- a/app/services/products_service.py
+++ b/app/services/products_service.py
@@ -12,9 +12,12 @@ from app.models.product import (
 from app.services import menu_history_service
 from app.services.aws_s3_service import AWSS3Service
 from app.services.ingredient_purchase_units_service import resolve_to_base_unit
+import asyncpg
 import logging
 
 logger = logging.getLogger(__name__)
+
+_DUPLICATE_PRODUCT_NAME_DETAIL = "Ya existe un producto con ese nombre en tu menú"
 
 
 def _normalize_recipe_bases(
@@ -194,8 +197,12 @@ async def create_product_with_recipe(
                 # 6. Get complete product with recipe
                 return await get_product_by_id(request, product_id, conn)
 
+    except HTTPException:
+        raise
     except AuthenticationError as e:
         raise e
+    except asyncpg.UniqueViolationError:
+        raise HTTPException(status_code=409, detail=_DUPLICATE_PRODUCT_NAME_DETAIL)
     except Exception as e:
         logger.error(f"Error creating product: {str(e)}")
         raise APIError(f"Error creating product: {str(e)}", status_code=500)
@@ -938,6 +945,8 @@ async def update_product_with_recipe(
         raise
     except AuthenticationError as e:
         raise e
+    except asyncpg.UniqueViolationError:
+        raise HTTPException(status_code=409, detail=_DUPLICATE_PRODUCT_NAME_DETAIL)
     except Exception as e:
         logger.error(f"Error updating product: {str(e)}")
         raise APIError(f"Error updating product: {str(e)}", status_code=500)

--- a/tests/test_product_duplicate_name.py
+++ b/tests/test_product_duplicate_name.py
@@ -1,0 +1,99 @@
+"""Tests for duplicate product name → 409 (warocol.com#707)."""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import asyncpg
+import pytest
+from fastapi import HTTPException, Request
+
+from app.core.middleware import SessionContext
+from app.models.product import ProductCreate, ProductUpdate
+from app.services.products_service import create_product_with_recipe, update_product_with_recipe
+
+
+def _session():
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@warocol.com",
+        "name": "Test",
+        "expires_at": None,
+        "is_active": True,
+    })
+
+
+def _mock_conn_unique_violation():
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=asyncpg.UniqueViolationError("duplicate key"))
+    conn.fetchval = AsyncMock(return_value=False)
+    conn.execute = AsyncMock()
+    conn.transaction = MagicMock()
+
+    @asynccontextmanager
+    async def _txn():
+        yield
+
+    conn.transaction.return_value = _txn()
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_create_product_duplicate_name_returns_409():
+    request = MagicMock(spec=Request)
+    session = _session()
+    conn = _mock_conn_unique_violation()
+
+    @asynccontextmanager
+    async def _db_ctx():
+        yield conn
+
+    product_data = ProductCreate(
+        name="Producción de Hamburguesa de Pollo",
+        price=10000,
+        category_id=uuid4(),
+        tenant_id=session.tenant_id,
+    )
+
+    with patch("app.services.products_service.require_valid_session", return_value=session), \
+         patch("app.services.products_service.get_db_connection", side_effect=_db_ctx):
+        with pytest.raises(HTTPException) as exc:
+            await create_product_with_recipe(request, product_data)
+
+    assert exc.value.status_code == 409
+    assert "producto" in exc.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_update_product_duplicate_name_returns_409():
+    request = MagicMock(spec=Request)
+    product_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={"id": product_id, "name": "Old Name"})
+    conn.fetchval = AsyncMock(return_value=False)
+    conn.execute = AsyncMock(side_effect=asyncpg.UniqueViolationError("duplicate key"))
+    conn.transaction = MagicMock()
+
+    @asynccontextmanager
+    async def _txn():
+        yield
+
+    conn.transaction.return_value = _txn()
+
+    @asynccontextmanager
+    async def _db_ctx():
+        yield conn
+
+    product_data = ProductUpdate(name="Producción de Hamburguesa de Pollo")
+
+    with patch("app.services.products_service.require_valid_session", return_value=_session()), \
+         patch("app.services.products_service.get_db_connection", side_effect=_db_ctx), \
+         patch(
+             "app.services.products_service.menu_history_service.get_product_snapshot",
+             new=AsyncMock(return_value={"name": "Old Name"}),
+         ):
+        with pytest.raises(HTTPException) as exc:
+            await update_product_with_recipe(request, product_id, product_data)
+
+    assert exc.value.status_code == 409
+    assert "producto" in exc.value.detail.lower()


### PR DESCRIPTION
## Summary
- Catch `asyncpg.UniqueViolationError` in `create_product_with_recipe` and `update_product_with_recipe`.
- Return **409** with `Ya existe un producto con ese nombre en tu menú` instead of 500.
- Unit tests for create and update paths.

## Testing
- `python3 -m pytest tests/test_product_duplicate_name.py -q`

## Front
Edit form (`productos/[id].vue`) already surfaces `error.data.detail` — no front change required.

Closes uno0uno/warocol.com#707

Made with [Cursor](https://cursor.com)