### PR TITLE
feat(tables): public Table QR menu and pending request submit

### DIFF
--- a/app/routers/public_table_qr.py
+++ b/app/routers/public_table_qr.py
@@ -1,14 +1,91 @@
-"""Public Table QR resolve endpoint (api-warolabs#266).
+"""Public Table QR endpoints (api-warolabs#266, #267).
 
-No authentication — used by warocol.com/{slug}/mesa/{token} before checkout.
+No authentication — used by warocol.com/{slug}/mesa/{token}.
 """
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
+from uuid import UUID
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel, Field
 
 from app.services import public_table_qr_service
 
 router = APIRouter()
+
+
+class TableQrRequestModifier(BaseModel):
+    id: UUID
+
+
+class TableQrRequestItem(BaseModel):
+    product_id: UUID
+    quantity: int = Field(..., gt=0)
+    modifiers: Optional[List[TableQrRequestModifier]] = None
+    notes: Optional[str] = None
+
+
+class SubmitTableQrRequest(BaseModel):
+    items: List[TableQrRequestItem] = Field(..., min_length=1)
+    payment_method: Optional[str] = None
+    payment_method_id: Optional[UUID] = None
+    customer_notes: Optional[str] = None
+
+
+@router.get("/{token}/menu")
+async def get_table_qr_menu(
+    token: str,
+    category_id: Optional[UUID] = Query(default=None),
+) -> Dict[str, Any]:
+    """Products available for Table QR ordering (`is_available_table_qr`)."""
+    menu = await public_table_qr_service.get_menu_for_token(token, category_id=category_id)
+    return {"success": True, "data": menu}
+
+
+@router.get("/{token}/product/{product_id}")
+async def get_table_qr_product(
+    token: str,
+    product_id: UUID,
+) -> Dict[str, Any]:
+    """Product detail with modifier groups for Table QR checkout."""
+    product = await public_table_qr_service.get_product_detail_for_token(token, product_id)
+    return {"success": True, "data": product}
+
+
+@router.get("/{token}/payment-methods")
+async def get_table_qr_payment_methods(token: str) -> Dict[str, Any]:
+    """Active payment groups for this table's tenant (no cartera groups)."""
+    return await public_table_qr_service.get_payment_methods_for_token(token)
+
+
+@router.post("/{token}/requests")
+async def submit_table_qr_request(
+    request: Request,
+    token: str,
+    body: SubmitTableQrRequest,
+) -> Dict[str, Any]:
+    """
+    Submit a pending order for staff confirmation.
+
+    Does not create orders, comandas, or POS tab items (#267).
+    """
+    items = [
+        {
+            "product_id": str(item.product_id),
+            "quantity": item.quantity,
+            "modifiers": [{"id": str(m.id)} for m in item.modifiers] if item.modifiers else [],
+            "notes": item.notes,
+        }
+        for item in body.items
+    ]
+    result = await public_table_qr_service.submit_table_qr_request(
+        request,
+        token,
+        items=items,
+        payment_method=body.payment_method,
+        payment_method_id=body.payment_method_id,
+        customer_notes=body.customer_notes,
+    )
+    return {"success": True, "data": result}
 
 
 @router.get("/{token}")

--- a/app/services/notifications_service.py
+++ b/app/services/notifications_service.py
@@ -28,6 +28,21 @@ async def create_order_notification(conn, tenant_id, order_id, payload: dict):
     await conn.execute("SELECT pg_notify($1, $2)", channel, json.dumps(payload))
 
 
+async def create_table_qr_notification(
+    conn, tenant_id: UUID, request_id: UUID, payload: dict
+) -> None:
+    """Notify staff of a pending Table QR request (api-warolabs#267). order_id is NULL."""
+    await conn.execute(
+        """INSERT INTO notifications (tenant_id, order_id, type, payload)
+           VALUES ($1, NULL, 'table_qr_request', $2::jsonb)""",
+        tenant_id,
+        json.dumps(payload),
+    )
+    channel = "tenant_" + str(tenant_id).replace("-", "")
+    notify_payload = {**payload, "request_id": str(request_id)}
+    await conn.execute("SELECT pg_notify($1, $2)", channel, json.dumps(notify_payload))
+
+
 async def get_unread_notifications(request: Request) -> dict:
     """GET /notifications — returns last 50 unread for the tenant."""
     try:

--- a/app/services/public_table_qr_service.py
+++ b/app/services/public_table_qr_service.py
@@ -1,49 +1,497 @@
-"""Public Table QR token resolution (warocol.com#710 / api-warolabs#266).
+"""Public Table QR — resolve, menu, submit (warocol.com#710).
 
-Resolves an opaque `qr_public_token` to tenant/table metadata for the
-customer-facing menu route. No session required.
+api-warolabs#266: token resolve
+api-warolabs#267: menu + pending request submit
 """
-from typing import Any, Dict, Optional
+import json
+import logging
+import time
+from collections import defaultdict
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+from uuid import UUID
 
+from fastapi import HTTPException, Request
+
+from app.core.exceptions import NotFoundError
 from app.database import get_db_connection
+from app.services import notifications_service, payment_method_service
+from app.services.online_cart_service import (
+    validate_modifiers_for_item,
+    validate_products_belong_to_tenant,
+)
+from app.services.public_restaurant_service import is_currently_open
+
+logger = logging.getLogger(__name__)
+
+_CONTEXT_SQL = """
+    SELECT
+        t.id AS table_id,
+        t.tenant_id,
+        t.name AS table_name,
+        t.qr_enabled,
+        t.is_active AS table_active,
+        tpp.slug AS tenant_slug,
+        tpp.display_name,
+        tpp.table_qr_module_enabled,
+        tpp.is_active AS profile_active,
+        tpp.business_hours,
+        tpp.is_manually_open
+    FROM tables t
+    JOIN tenant_public_profiles tpp ON tpp.tenant_id = t.tenant_id
+    WHERE t.qr_public_token = $1
+      AND t.deleted_at IS NULL
+"""
+
+_SUBMIT_LIMIT_PER_TOKEN = 10
+_SUBMIT_LIMIT_PER_IP = 30
+_SUBMIT_WINDOW_SECONDS = 300
+_submit_rate_buckets: Dict[str, List[float]] = defaultdict(list)
 
 
-async def resolve_table_qr_token(token: str) -> Optional[Dict[str, Any]]:
-    """Return public metadata for an active QR link, or None if inactive/unknown."""
+def _parse_business_hours(raw: Any) -> Optional[Dict[str, Any]]:
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return None
+    if isinstance(raw, dict):
+        return raw
+    return None
+
+
+def _is_context_active(row: dict, is_open: bool) -> bool:
+    return bool(
+        row["table_qr_module_enabled"]
+        and row["qr_enabled"]
+        and row["profile_active"]
+        and row["table_active"]
+        and is_open
+    )
+
+
+async def _load_context_row(token: str) -> Optional[dict]:
     async with get_db_connection(use_transaction=False) as conn:
-        row = await conn.fetchrow(
-            """
-            SELECT
-                t.name AS table_name,
-                t.qr_enabled,
-                t.is_active AS table_active,
-                tpp.slug AS tenant_slug,
-                tpp.display_name,
-                tpp.table_qr_module_enabled,
-                tpp.is_active AS profile_active
-            FROM tables t
-            JOIN tenant_public_profiles tpp ON tpp.tenant_id = t.tenant_id
-            WHERE t.qr_public_token = $1
-              AND t.deleted_at IS NULL
-            """,
-            token,
-        )
+        return await conn.fetchrow(_CONTEXT_SQL, token)
 
+
+async def resolve_table_qr_context(token: str) -> Optional[Dict[str, Any]]:
+    """Internal context for menu/submit; None if token unknown or inactive."""
+    row = await _load_context_row(token)
     if not row:
         return None
 
-    if (
-        not row["table_qr_module_enabled"]
-        or not row["qr_enabled"]
-        or not row["profile_active"]
-        or not row["table_active"]
-    ):
+    business_hours = _parse_business_hours(row["business_hours"])
+    is_open = is_currently_open(business_hours, bool(row["is_manually_open"]))
+    if not _is_context_active(row, is_open):
         return None
 
     return {
+        "tenant_id": row["tenant_id"],
+        "table_id": row["table_id"],
         "tenant_slug": row["tenant_slug"],
         "display_name": row["display_name"],
         "table_name": row["table_name"],
-        "table_qr_module_enabled": bool(row["table_qr_module_enabled"]),
-        "qr_enabled": bool(row["qr_enabled"]),
+        "is_currently_open": is_open,
+    }
+
+
+async def resolve_table_qr_token(token: str) -> Optional[Dict[str, Any]]:
+    """Public metadata for GET /public/table-qr/{token} (#266)."""
+    ctx = await resolve_table_qr_context(token)
+    if not ctx:
+        return None
+    return {
+        "tenant_slug": ctx["tenant_slug"],
+        "display_name": ctx["display_name"],
+        "table_name": ctx["table_name"],
+        "table_qr_module_enabled": True,
+        "qr_enabled": True,
+        "is_currently_open": ctx["is_currently_open"],
+    }
+
+
+def _check_submit_rate_limit(*, token: str, client_ip: Optional[str]) -> None:
+    now = time.time()
+    window_start = now - _SUBMIT_WINDOW_SECONDS
+
+    for key in (f"token:{token}", f"ip:{client_ip or 'unknown'}"):
+        limit = _SUBMIT_LIMIT_PER_TOKEN if key.startswith("token:") else _SUBMIT_LIMIT_PER_IP
+        bucket = _submit_rate_buckets[key]
+        bucket[:] = [ts for ts in bucket if ts > window_start]
+        if len(bucket) >= limit:
+            raise HTTPException(
+                status_code=429,
+                detail="Demasiadas solicitudes. Intenta de nuevo en unos minutos.",
+            )
+        bucket.append(now)
+
+
+async def get_menu_for_token(
+    token: str,
+    category_id: Optional[UUID] = None,
+) -> Dict[str, Any]:
+    ctx = await resolve_table_qr_context(token)
+    if not ctx:
+        raise HTTPException(status_code=404, detail="QR link not found or inactive")
+
+    tenant_id = ctx["tenant_id"]
+    async with get_db_connection(use_transaction=False) as conn:
+        categories_query = """
+            SELECT DISTINCT c.id, c.name, c.description
+            FROM categories c
+            JOIN product p ON p.category_id = c.id
+            WHERE p.tenant_id = $1
+              AND p.is_available = true
+              AND p.is_available_table_qr = true
+            ORDER BY c.name
+        """
+        categories = [dict(r) for r in await conn.fetch(categories_query, tenant_id)]
+
+        products_query = """
+            SELECT
+                p.id, p.name, p.description, p.price, p.image_url,
+                p.category_id, c.name AS category_name,
+                p.is_available, p.preparation_time,
+                p.allow_modifiers,
+                EXISTS(
+                    SELECT 1 FROM product_modifier_groups pmg
+                    WHERE pmg.product_id = p.id
+                ) AS has_modifiers
+            FROM product p
+            JOIN categories c ON p.category_id = c.id
+            WHERE p.tenant_id = $1
+              AND p.is_available = true
+              AND p.is_available_table_qr = true
+        """
+        params: List[Any] = [tenant_id]
+        if category_id:
+            products_query += " AND p.category_id = $2"
+            params.append(category_id)
+        products_query += " ORDER BY c.name, p.name"
+
+        products = [dict(r) for r in await conn.fetch(products_query, *params)]
+        for p in products:
+            p["price"] = float(p["price"])
+
+    return {
+        "restaurant_name": ctx["display_name"],
+        "table_name": ctx["table_name"],
+        "is_currently_open": ctx["is_currently_open"],
+        "categories": categories,
+        "products": products,
+    }
+
+
+async def get_product_detail_for_token(token: str, product_id: UUID) -> Dict[str, Any]:
+    ctx = await resolve_table_qr_context(token)
+    if not ctx:
+        raise HTTPException(status_code=404, detail="QR link not found or inactive")
+
+    tenant_id = ctx["tenant_id"]
+    async with get_db_connection(use_transaction=False) as conn:
+        product_row = await conn.fetchrow(
+            """
+            SELECT
+                p.id, p.name, p.description, p.price, p.image_url,
+                c.name AS category_name,
+                p.is_available, p.is_available_table_qr, p.preparation_time
+            FROM product p
+            JOIN categories c ON p.category_id = c.id
+            WHERE p.id = $1
+              AND p.tenant_id = $2
+              AND p.is_available = true
+              AND p.is_available_table_qr = true
+            """,
+            product_id,
+            tenant_id,
+        )
+        if not product_row:
+            raise HTTPException(status_code=404, detail="Product not found")
+
+        product = dict(product_row)
+        product["price"] = float(product["price"])
+
+        modifiers_rows = await conn.fetch(
+            """
+            SELECT
+                mg.id AS group_id,
+                mg.name AS group_name,
+                mg.is_required,
+                mg.min_qty,
+                mg.max_qty,
+                mg.sort_order AS group_sort_order,
+                m.id AS modifier_id,
+                m.name AS modifier_name,
+                m.price AS modifier_price,
+                m.is_available AS modifier_is_available,
+                m.is_default AS modifier_is_default,
+                m.max_limit AS modifier_max_limit,
+                m.sort_order AS modifier_sort_order
+            FROM product_modifier_groups pmg
+            JOIN modifier_groups mg ON mg.id = pmg.modifier_group_id
+            LEFT JOIN modifiers m ON m.modifier_group_id = mg.id
+            WHERE pmg.product_id = $1
+            ORDER BY mg.sort_order, m.sort_order
+            """,
+            product_id,
+        )
+
+    modifier_groups: Dict[str, dict] = {}
+    for row in modifiers_rows:
+        group_id = str(row["group_id"])
+        if group_id not in modifier_groups:
+            modifier_groups[group_id] = {
+                "id": row["group_id"],
+                "name": row["group_name"],
+                "is_required": row["is_required"],
+                "min_qty": row["min_qty"],
+                "max_qty": row["max_qty"],
+                "modifiers": [],
+            }
+        if row["modifier_id"] and row["modifier_is_available"]:
+            modifier_groups[group_id]["modifiers"].append({
+                "id": row["modifier_id"],
+                "name": row["modifier_name"],
+                "price": float(row["modifier_price"]),
+                "is_available": row["modifier_is_available"],
+                "is_default": row["modifier_is_default"],
+                "max_limit": row["modifier_max_limit"],
+            })
+
+    product["modifier_groups"] = list(modifier_groups.values())
+    return product
+
+
+async def get_payment_methods_for_token(token: str) -> dict:
+    ctx = await resolve_table_qr_context(token)
+    if not ctx:
+        raise HTTPException(status_code=404, detail="QR link not found or inactive")
+    try:
+        return await payment_method_service.list_public_methods_by_tenant_slug(ctx["tenant_slug"])
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail="QR link not found or inactive") from None
+
+
+async def _validate_payment_selection(
+    conn,
+    tenant_id: UUID,
+    payment_method: Optional[str],
+    payment_method_id: Optional[UUID],
+) -> None:
+    if not payment_method:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "payment_method_required",
+                "message": "Selecciona un método de pago.",
+            },
+        )
+
+    group_row = await conn.fetchrow(
+        """
+        SELECT id, triggers_cartera FROM payment_method_groups
+        WHERE slug = $1
+          AND is_active = true
+          AND (tenant_id IS NULL OR tenant_id = $2)
+        """,
+        payment_method,
+        tenant_id,
+    )
+    if not group_row:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "payment_method_invalid",
+                "message": f"Método de pago '{payment_method}' no es válido para este restaurante.",
+            },
+        )
+    if group_row["triggers_cartera"]:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "payment_method_not_allowed",
+                "message": "Este método de pago no está disponible para pedidos por QR.",
+            },
+        )
+
+    if payment_method_id:
+        method_row = await conn.fetchrow(
+            """
+            SELECT id FROM payment_methods
+            WHERE id = $1
+              AND tenant_id = $2
+              AND group_id = $3
+              AND is_active = true
+            """,
+            payment_method_id,
+            tenant_id,
+            group_row["id"],
+        )
+        if not method_row:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "payment_method_id_invalid",
+                    "message": "El método seleccionado no pertenece al grupo elegido.",
+                },
+            )
+
+
+async def _build_item_snapshots(
+    conn,
+    tenant_id: UUID,
+    items: List[dict],
+) -> tuple[List[dict], Decimal]:
+    if not items:
+        raise HTTPException(status_code=400, detail="El pedido debe incluir al menos un producto.")
+
+    product_ids = [UUID(str(item["product_id"])) for item in items]
+    await validate_products_belong_to_tenant(conn, product_ids, tenant_id)
+
+    product_rows = await conn.fetch(
+        """
+        SELECT id, name, price
+        FROM product
+        WHERE id = ANY($1::uuid[])
+          AND tenant_id = $2
+          AND is_available = true
+          AND is_available_table_qr = true
+        """,
+        product_ids,
+        tenant_id,
+    )
+    if len(product_rows) != len(set(product_ids)):
+        raise HTTPException(
+            status_code=409,
+            detail="Uno o más productos ya no están disponibles para pedido por QR.",
+        )
+
+    prices = {row["id"]: Decimal(str(row["price"])) for row in product_rows}
+    snapshots: List[dict] = []
+    total = Decimal("0")
+
+    for item in items:
+        product_id = UUID(str(item["product_id"]))
+        quantity = int(item["quantity"])
+        if quantity < 1:
+            raise HTTPException(status_code=400, detail="La cantidad debe ser al menos 1.")
+
+        modifiers_in = item.get("modifiers") or []
+        if modifiers_in:
+            await validate_modifiers_for_item(conn, product_id, modifiers_in)
+
+        unit_price = prices[product_id]
+        resolved_modifiers: List[dict] = []
+        modifier_total = Decimal("0")
+
+        if modifiers_in:
+            modifier_ids = [UUID(str(m["id"])) for m in modifiers_in]
+            mod_rows = await conn.fetch(
+                "SELECT id, name, price FROM modifiers WHERE id = ANY($1::uuid[])",
+                modifier_ids,
+            )
+            mod_map = {row["id"]: row for row in mod_rows}
+            for mod in modifiers_in:
+                mod_id = UUID(str(mod["id"]))
+                db_mod = mod_map.get(mod_id)
+                if not db_mod:
+                    raise HTTPException(
+                        status_code=422,
+                        detail=f"Modifier '{mod_id}' does not exist or is not available",
+                    )
+                price = Decimal(str(db_mod["price"]))
+                modifier_total += price
+                resolved_modifiers.append({
+                    "id": str(mod_id),
+                    "name": db_mod["name"],
+                    "price": float(price),
+                })
+
+        line_total = (unit_price + modifier_total) * quantity
+        total += line_total
+
+        snapshots.append({
+            "product_id": str(product_id),
+            "quantity": quantity,
+            "unit_price": float(unit_price),
+            "modifiers": resolved_modifiers,
+            "notes": item.get("notes"),
+            "line_total": float(line_total),
+        })
+
+    return snapshots, total
+
+
+async def submit_table_qr_request(
+    request: Request,
+    token: str,
+    items: List[dict],
+    payment_method: Optional[str],
+    payment_method_id: Optional[UUID],
+    customer_notes: Optional[str],
+) -> Dict[str, Any]:
+    """Create a pending table_qr_requests row — no orders, tab, or comandas (#267)."""
+    ctx = await resolve_table_qr_context(token)
+    if not ctx:
+        raise HTTPException(status_code=404, detail="QR link not found or inactive")
+
+    if not ctx["is_currently_open"]:
+        raise HTTPException(
+            status_code=409,
+            detail="El restaurante está cerrado en este momento. No se pueden enviar pedidos.",
+        )
+
+    client_ip = request.client.host if request.client else None
+    _check_submit_rate_limit(token=token, client_ip=client_ip)
+
+    tenant_id = ctx["tenant_id"]
+    table_id = ctx["table_id"]
+
+    async with get_db_connection() as conn:
+        async with conn.transaction():
+            item_snapshots, total_amount = await _build_item_snapshots(conn, tenant_id, items)
+            await _validate_payment_selection(conn, tenant_id, payment_method, payment_method_id)
+
+            row = await conn.fetchrow(
+                """
+                INSERT INTO table_qr_requests (
+                    tenant_id, table_id, status, items,
+                    payment_method, payment_method_id, customer_notes
+                )
+                VALUES ($1, $2, 'pending', $3::jsonb, $4, $5, $6)
+                RETURNING id, created_at
+                """,
+                tenant_id,
+                table_id,
+                json.dumps(item_snapshots),
+                payment_method,
+                payment_method_id,
+                customer_notes,
+            )
+
+            request_id = row["id"]
+            payload = {
+                "type": "table_qr_request",
+                "request_id": str(request_id),
+                "table_id": str(table_id),
+                "table_name": ctx["table_name"],
+                "item_count": len(item_snapshots),
+                "total_amount": float(total_amount),
+            }
+            try:
+                await notifications_service.create_table_qr_notification(
+                    conn, tenant_id, request_id, payload
+                )
+            except Exception as err:
+                logger.warning("Table QR notification failed for %s: %s", request_id, err)
+
+    return {
+        "request_id": str(request_id),
+        "status": "pending",
+        "table_name": ctx["table_name"],
+        "total_amount": float(total_amount),
+        "message": "Pedido recibido — el restaurante lo confirmará.",
     }

--- a/tests/test_table_qr_public.py
+++ b/tests/test_table_qr_public.py
@@ -1,0 +1,146 @@
+"""Tests for public Table QR menu and submit (api-warolabs#267)."""
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from app.routers import public_table_qr as public_table_qr_router
+from app.services import public_table_qr_service
+
+
+def _active_ctx():
+    return {
+        "tenant_id": uuid4(),
+        "table_id": uuid4(),
+        "tenant_slug": "cafe-demo",
+        "display_name": "Café Demo",
+        "table_name": "Mesa 1",
+        "is_currently_open": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_menu_for_token_returns_table_qr_products():
+    ctx = _active_ctx()
+    conn = MagicMock()
+    conn.fetch = AsyncMock(side_effect=[
+        [{"id": uuid4(), "name": "Bebidas", "description": None}],
+        [{
+            "id": uuid4(),
+            "name": "Café",
+            "description": None,
+            "price": 5000,
+            "image_url": None,
+            "category_id": uuid4(),
+            "category_name": "Bebidas",
+            "is_available": True,
+            "preparation_time": 5,
+            "allow_modifiers": False,
+            "has_modifiers": False,
+        }],
+    ])
+
+    with patch(
+        "app.services.public_table_qr_service.resolve_table_qr_context",
+        new_callable=AsyncMock,
+        return_value=ctx,
+    ), patch("app.services.public_table_qr_service.get_db_connection") as mock_conn:
+        mock_conn.return_value.__aenter__ = AsyncMock(return_value=conn)
+        mock_conn.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await public_table_qr_service.get_menu_for_token("tok-abc")
+        assert result["restaurant_name"] == "Café Demo"
+        assert result["table_name"] == "Mesa 1"
+        assert result["is_currently_open"] is True
+        assert len(result["products"]) == 1
+        assert result["products"][0]["price"] == 5000.0
+
+
+@pytest.mark.asyncio
+async def test_get_menu_inactive_token_404():
+    with patch(
+        "app.services.public_table_qr_service.resolve_table_qr_context",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await public_table_qr_service.get_menu_for_token("bad")
+        assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_submit_requires_open_restaurant():
+    ctx = _active_ctx()
+    ctx["is_currently_open"] = False
+
+    with patch(
+        "app.services.public_table_qr_service.resolve_table_qr_context",
+        new_callable=AsyncMock,
+        return_value=ctx,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await public_table_qr_service.submit_table_qr_request(
+                MagicMock(client=MagicMock(host="127.0.0.1")),
+                "tok",
+                items=[{"product_id": str(uuid4()), "quantity": 1, "modifiers": []}],
+                payment_method="cash",
+                payment_method_id=None,
+                customer_notes=None,
+            )
+        assert exc.value.status_code == 409
+
+
+def test_menu_endpoint_success():
+    app = FastAPI()
+    app.include_router(public_table_qr_router.router, prefix="/public/table-qr")
+
+    menu_payload = {
+        "restaurant_name": "Café",
+        "table_name": "Mesa 1",
+        "is_currently_open": True,
+        "categories": [],
+        "products": [],
+    }
+
+    with patch(
+        "app.routers.public_table_qr.public_table_qr_service.get_menu_for_token",
+        new_callable=AsyncMock,
+        return_value=menu_payload,
+    ):
+        client = TestClient(app)
+        res = client.get("/public/table-qr/tok-abc/menu")
+        assert res.status_code == 200
+        assert res.json()["success"] is True
+        assert res.json()["data"]["table_name"] == "Mesa 1"
+
+
+def test_submit_endpoint_delegates_to_service():
+    app = FastAPI()
+    app.include_router(public_table_qr_router.router, prefix="/public/table-qr")
+
+    submit_result = {
+        "request_id": str(uuid4()),
+        "status": "pending",
+        "table_name": "Mesa 1",
+        "total_amount": 10000.0,
+        "message": "Pedido recibido — el restaurante lo confirmará.",
+    }
+
+    with patch(
+        "app.routers.public_table_qr.public_table_qr_service.submit_table_qr_request",
+        new_callable=AsyncMock,
+        return_value=submit_result,
+    ):
+        client = TestClient(app)
+        product_id = str(uuid4())
+        res = client.post(
+            f"/public/table-qr/tok-abc/requests",
+            json={
+                "items": [{"product_id": product_id, "quantity": 1}],
+                "payment_method": "cash",
+            },
+        )
+        assert res.status_code == 200
+        assert res.json()["data"]["status"] == "pending"

--- a/tests/test_table_qr_tokens.py
+++ b/tests/test_table_qr_tokens.py
@@ -27,6 +27,8 @@ def _session():
 @pytest.mark.asyncio
 async def test_resolve_table_qr_token_active():
     row = {
+        "tenant_id": uuid4(),
+        "table_id": uuid4(),
         "table_name": "Mesa 1",
         "qr_enabled": True,
         "table_active": True,
@@ -38,7 +40,11 @@ async def test_resolve_table_qr_token_active():
     conn = MagicMock()
     conn.fetchrow = AsyncMock(return_value=row)
 
-    with patch("app.services.public_table_qr_service.get_db_connection") as mock_get_conn:
+    row["business_hours"] = None
+    row["is_manually_open"] = True
+
+    with patch("app.services.public_table_qr_service.get_db_connection") as mock_get_conn, \
+         patch("app.services.public_table_qr_service.is_currently_open", return_value=True):
         mock_get_conn.return_value.__aenter__ = AsyncMock(return_value=conn)
         mock_get_conn.return_value.__aexit__ = AsyncMock(return_value=False)
         result = await public_table_qr_service.resolve_table_qr_token("tok-abc")
@@ -60,7 +66,11 @@ async def test_resolve_table_qr_token_disabled_module_returns_none():
     conn = MagicMock()
     conn.fetchrow = AsyncMock(return_value=row)
 
-    with patch("app.services.public_table_qr_service.get_db_connection") as mock_get_conn:
+    row["business_hours"] = None
+    row["is_manually_open"] = True
+
+    with patch("app.services.public_table_qr_service.get_db_connection") as mock_get_conn, \
+         patch("app.services.public_table_qr_service.is_currently_open", return_value=True):
         mock_get_conn.return_value.__aenter__ = AsyncMock(return_value=conn)
         mock_get_conn.return_value.__aexit__ = AsyncMock(return_value=False)
         assert await public_table_qr_service.resolve_table_qr_token("tok-abc") is None


### PR DESCRIPTION
## Summary
Public endpoints for Table QR customers to browse the menu and submit pending orders for staff confirmation (warocol.com#710 / api-warolabs#267).

## Changes
- `app/services/public_table_qr_service.py`: menu, product detail, payment methods, submit with DB price validation, rate limiting, payment validation
- `app/routers/public_table_qr.py`: `GET .../menu`, `GET .../product/{id}`, `GET .../payment-methods`, `POST .../requests`
- `app/services/notifications_service.py`: `create_table_qr_notification()` with `type=table_qr_request`
- `tests/test_table_qr_public.py`: unit tests for menu/submit
- `tests/test_table_qr_tokens.py`: updated resolve mocks

## Testing
- `python3 -m pytest tests/test_table_qr_tokens.py tests/test_table_qr_public.py` — 10 passed
- No orders, comandas, or POS tab writes on submit

Closes #267

Made with [Cursor](https://cursor.com)