### PR TITLE
feat(api): accept table QR requests — open session, tab/add, bulk

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, tenant_config, online_cart, online_verification, address_profile, analytics, online_orders, notifications, customer_portal, leads, waros, billing, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
+from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, online_cart, online_verification, address_profile, analytics, online_orders, notifications, customer_portal, leads, waros, billing, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
 from app.config import settings
 from app.core.logging import setup_logging
 from app.core.exceptions import api_exception_handler, general_exception_handler, APIError
@@ -196,6 +196,7 @@ app.include_router(v1_ordering.customer_router_v1)  # V1 customer validate — A
 app.include_router(v1_ordering.product_router_v1)   # V1 product detail + modifiers — API key auth
 app.include_router(public_restaurant.router, prefix="/public/restaurant", tags=["public-restaurant"])
 app.include_router(public_table_qr.router, prefix="/public/table-qr", tags=["public-table-qr"])
+app.include_router(table_qr_requests.router, prefix="/table-qr-requests", tags=["table-qr-requests"])
 app.include_router(tenant_config.router, prefix="/api/tenant", tags=["tenant-config"])
 app.include_router(stations.router, prefix="/api/stations", tags=["stations"])
 app.include_router(tables.router, prefix="/tables", tags=["tables"])

--- a/app/routers/table_qr_requests.py
+++ b/app/routers/table_qr_requests.py
@@ -1,0 +1,49 @@
+"""Staff endpoints for Table QR pending requests (api-warolabs#268)."""
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query, Request
+from pydantic import BaseModel
+
+from app.core.exceptions import APIError
+from app.core.permissions import Module, require_module
+from app.services import table_qr_requests_service
+
+router = APIRouter(tags=["Table QR Requests"])
+
+
+class BulkAcceptRequest(BaseModel):
+    request_ids: Optional[List[UUID]] = None
+    table_id: Optional[UUID] = None
+    all_pending: bool = False
+
+
+@router.get("", dependencies=[Depends(require_module(Module.DESPACHO))])
+async def list_table_qr_requests(
+    request: Request,
+    status: str = Query(default="pending", pattern="^(pending|accepted|rejected)$"),
+):
+    """List pending Table QR requests grouped by table (Despacho UI)."""
+    if status != "pending":
+        raise APIError("Only status=pending is supported", status_code=400)
+    return await table_qr_requests_service.list_pending_grouped(request)
+
+
+@router.patch("/{request_id}/reject", dependencies=[Depends(require_module(Module.DESPACHO))])
+async def reject_table_qr_request(request: Request, request_id: UUID):
+    return await table_qr_requests_service.reject_request(request, request_id)
+
+
+@router.patch("/{request_id}/accept", dependencies=[Depends(require_module(Module.DESPACHO))])
+async def accept_table_qr_request(request: Request, request_id: UUID):
+    return await table_qr_requests_service.accept_requests(request, [request_id])
+
+
+@router.post("/bulk-accept", dependencies=[Depends(require_module(Module.DESPACHO))])
+async def bulk_accept_table_qr_requests(request: Request, body: BulkAcceptRequest):
+    return await table_qr_requests_service.bulk_accept(
+        request,
+        request_ids=body.request_ids,
+        table_id=body.table_id,
+        all_pending=body.all_pending,
+    )

--- a/app/services/table_qr_requests_service.py
+++ b/app/services/table_qr_requests_service.py
@@ -1,0 +1,346 @@
+"""Table QR request accept/reject for staff (api-warolabs#268, warocol.com#710)."""
+import json
+import logging
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from fastapi import Request
+
+from app.core.exceptions import APIError, AuthenticationError, NotFoundError
+from app.core.middleware import require_valid_session
+from app.database import get_db_connection
+from app.services.tables_service import _add_tab_items_core, fire_table_items
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_items_json(raw: Any) -> List[dict]:
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return json.loads(raw)
+    return list(raw)
+
+
+def _format_request_row(row: dict) -> dict:
+    items = _parse_items_json(row["items"])
+    return {
+        "id": str(row["id"]),
+        "table_id": str(row["table_id"]),
+        "table_name": row.get("table_name"),
+        "status": row["status"],
+        "items": items,
+        "item_count": len(items),
+        "payment_method": row["payment_method"],
+        "payment_method_id": str(row["payment_method_id"]) if row.get("payment_method_id") else None,
+        "customer_notes": row.get("customer_notes"),
+        "created_at": row["created_at"].isoformat(),
+    }
+
+
+async def _resolve_tenant_member_id(conn, tenant_id: UUID, user_id: UUID) -> Optional[UUID]:
+    return await conn.fetchval(
+        """
+        SELECT id FROM tenant_members
+        WHERE tenant_id = $1 AND user_id = $2
+          AND is_active = true AND terminated_at IS NULL
+        """,
+        tenant_id,
+        user_id,
+    )
+
+
+async def _ensure_open_session_in_tx(
+    conn, table_id: UUID, tenant_id: UUID, user_id: UUID
+) -> UUID:
+    """Open a table session if none exists (same tx as accept)."""
+    existing = await conn.fetchrow(
+        """
+        SELECT id FROM table_sessions
+        WHERE table_id = $1 AND tenant_id = $2 AND closed_at IS NULL
+        """,
+        table_id,
+        tenant_id,
+    )
+    if existing:
+        return existing["id"]
+
+    table_row = await conn.fetchrow(
+        """
+        SELECT id, status FROM tables
+        WHERE id = $1 AND tenant_id = $2 AND is_active = true
+        FOR UPDATE
+        """,
+        table_id,
+        tenant_id,
+    )
+    if not table_row:
+        raise NotFoundError("Table not found")
+
+    session_row = await conn.fetchrow(
+        """
+        INSERT INTO table_sessions (table_id, tenant_id, opened_by_user_id)
+        VALUES ($1, $2, $3)
+        RETURNING id
+        """,
+        table_id,
+        tenant_id,
+        user_id,
+    )
+    await conn.execute(
+        "UPDATE tables SET status = 'open' WHERE id = $1 AND tenant_id = $2",
+        table_id,
+        tenant_id,
+    )
+    return session_row["id"]
+
+
+async def list_pending_grouped(request: Request) -> dict:
+    """GET /table-qr-requests?status=pending — grouped by table for Despacho."""
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    async with get_db_connection(use_transaction=False) as conn:
+        rows = await conn.fetch(
+            """
+            SELECT
+                r.id, r.table_id, r.status, r.items,
+                r.payment_method, r.payment_method_id, r.customer_notes, r.created_at,
+                t.name AS table_name
+            FROM table_qr_requests r
+            JOIN tables t ON t.id = r.table_id
+            WHERE r.tenant_id = $1 AND r.status = 'pending'
+            ORDER BY t.name, r.created_at ASC
+            """,
+            tenant_id,
+        )
+
+    tables_map: Dict[str, dict] = {}
+    for row in rows:
+        table_id = str(row["table_id"])
+        if table_id not in tables_map:
+            tables_map[table_id] = {
+                "table_id": table_id,
+                "table_name": row["table_name"],
+                "requests": [],
+            }
+        tables_map[table_id]["requests"].append(_format_request_row(dict(row)))
+
+    return {
+        "success": True,
+        "data": {
+            "tables": list(tables_map.values()),
+            "total_pending": len(rows),
+        },
+    }
+
+
+async def reject_request(request: Request, request_id: UUID) -> dict:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    async with get_db_connection() as conn:
+        row = await conn.fetchrow(
+            """
+            UPDATE table_qr_requests
+            SET status = 'rejected', rejected_at = now()
+            WHERE id = $1 AND tenant_id = $2 AND status = 'pending'
+            RETURNING id, table_id
+            """,
+            request_id,
+            tenant_id,
+        )
+        if not row:
+            raise APIError(
+                "Request not found or not pending",
+                status_code=404,
+            )
+
+    return {
+        "success": True,
+        "data": {
+            "request_id": str(row["id"]),
+            "status": "rejected",
+        },
+    }
+
+
+async def _load_pending_for_accept(
+    conn,
+    tenant_id: UUID,
+    request_ids: List[UUID],
+) -> List[dict]:
+    rows = await conn.fetch(
+        """
+        SELECT
+            id, table_id, status, items,
+            payment_method, payment_method_id, customer_notes, created_at
+        FROM table_qr_requests
+        WHERE tenant_id = $1 AND id = ANY($2::uuid[]) AND status = 'pending'
+        ORDER BY created_at ASC
+        FOR UPDATE
+        """,
+        tenant_id,
+        request_ids,
+    )
+    if len(rows) != len(set(request_ids)):
+        raise APIError(
+            "One or more requests are missing or not pending",
+            status_code=409,
+        )
+    return [dict(r) for r in rows]
+
+
+async def accept_requests(
+    request: Request,
+    request_ids: List[UUID],
+) -> dict:
+    """
+    Accept pending Table QR requests: open session, one tab add, mark accepted.
+    All request_ids must belong to the same table.
+    """
+    if not request_ids:
+        raise APIError("No request IDs provided", status_code=400)
+
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    user_id = session.user_id
+    if not tenant_id or not user_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    table_id: Optional[UUID] = None
+    tab_result: dict = {}
+    accepted_ids: List[UUID] = []
+    payment_method: Optional[str] = None
+    payment_method_id: Optional[UUID] = None
+
+    async with get_db_connection() as conn:
+        async with conn.transaction():
+            pending_rows = await _load_pending_for_accept(conn, tenant_id, request_ids)
+
+            table_ids = {row["table_id"] for row in pending_rows}
+            if len(table_ids) != 1:
+                raise APIError(
+                    "All requests must belong to the same table",
+                    status_code=409,
+                )
+            table_id = pending_rows[0]["table_id"]
+
+            payment_methods = {row["payment_method"] for row in pending_rows if row["payment_method"]}
+            if len(payment_methods) > 1:
+                raise APIError(
+                    "Conflicting payment methods across selected requests",
+                    status_code=409,
+                )
+            payment_method = pending_rows[0]["payment_method"]
+            payment_method_id = pending_rows[0]["payment_method_id"]
+
+            member_id = await _resolve_tenant_member_id(conn, tenant_id, user_id)
+            session_id = await _ensure_open_session_in_tx(conn, table_id, tenant_id, user_id)
+
+            merged_items: List[dict] = []
+            for row in pending_rows:
+                merged_items.extend(_parse_items_json(row["items"]))
+
+            if not merged_items:
+                raise APIError("No items to accept", status_code=400)
+
+            tab_result = await _add_tab_items_core(
+                conn, tenant_id, user_id, table_id, merged_items
+            )
+
+            if payment_method:
+                await conn.execute(
+                    """
+                    UPDATE orders
+                    SET payment_method = $1, payment_method_id = $2
+                    WHERE table_session_id = $3 AND status = 'pending'
+                    """,
+                    payment_method,
+                    payment_method_id,
+                    tab_result["session_id"],
+                )
+
+            updated = await conn.fetch(
+                """
+                UPDATE table_qr_requests
+                SET status = 'accepted',
+                    session_id = $1,
+                    accepted_by = $2,
+                    accepted_at = now()
+                WHERE tenant_id = $3
+                  AND id = ANY($4::uuid[])
+                  AND status = 'pending'
+                RETURNING id
+                """,
+                session_id,
+                member_id,
+                tenant_id,
+                request_ids,
+            )
+            accepted_ids = [r["id"] for r in updated]
+            if len(accepted_ids) != len(request_ids):
+                raise APIError("Failed to mark all requests as accepted", status_code=500)
+
+    try:
+        await fire_table_items(request, table_id)
+    except Exception as err:
+        logger.error("Table QR accept auto-fire failed for table %s: %s", table_id, err)
+
+    return {
+        "success": True,
+        "data": {
+            "accepted_request_ids": [str(rid) for rid in accepted_ids],
+            "table_id": str(table_id),
+            "session_id": str(tab_result["session_id"]),
+            "order_id": str(tab_result["order_id"]),
+            "order_number": tab_result["order_number"],
+            "items_count": tab_result["items_count"],
+            "total_amount": tab_result["total_amount"],
+            "payment_method": payment_method,
+            "payment_method_id": str(payment_method_id) if payment_method_id else None,
+        },
+    }
+
+
+async def bulk_accept(
+    request: Request,
+    request_ids: Optional[List[UUID]] = None,
+    table_id: Optional[UUID] = None,
+    all_pending: bool = False,
+) -> dict:
+    """Resolve request IDs then delegate to accept_requests."""
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    resolved_ids: List[UUID] = []
+
+    if request_ids:
+        resolved_ids = list(request_ids)
+    elif table_id and all_pending:
+        async with get_db_connection(use_transaction=False) as conn:
+            rows = await conn.fetch(
+                """
+                SELECT id FROM table_qr_requests
+                WHERE tenant_id = $1 AND table_id = $2 AND status = 'pending'
+                ORDER BY created_at ASC
+                """,
+                tenant_id,
+                table_id,
+            )
+        resolved_ids = [r["id"] for r in rows]
+        if not resolved_ids:
+            raise APIError("No pending requests for this table", status_code=404)
+    else:
+        raise APIError(
+            "Provide request_ids or table_id with all_pending=true",
+            status_code=400,
+        )
+
+    return await accept_requests(request, resolved_ids)

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -1704,6 +1704,208 @@ async def update_tab_item_quantity(
         raise APIError(f"Error updating item: {e}", status_code=500)
 
 
+async def _add_tab_items_core(
+    conn,
+    tenant_id: UUID,
+    user_id: UUID,
+    table_id: UUID,
+    items: List[dict],
+) -> dict:
+    """
+    Add tab items using an existing connection (caller owns transaction).
+    Used by add_tab_items and table QR accept (#268).
+    """
+    session_row = await conn.fetchrow(
+        """
+        SELECT ts.id AS session_id
+        FROM table_sessions ts
+        JOIN tables t ON t.id = ts.table_id
+        WHERE ts.table_id = $1
+          AND ts.tenant_id = $2
+          AND ts.closed_at IS NULL
+          AND t.is_active = true
+        """,
+        table_id,
+        tenant_id,
+    )
+    if not session_row:
+        raise NotFoundError("No open session found for this table")
+
+    session_id = session_row["session_id"]
+
+    for item in items:
+        mod_sum = sum(float(m.get("price", 0)) for m in (item.get("modifiers") or []))
+        logger.info(
+            f"[add_tab_items] item product_id={item['product_id']} "
+            f"qty={item['quantity']} unit_price={item['unit_price']} "
+            f"modifier_sum={mod_sum} "
+            f"line_total={item['quantity'] * (item['unit_price'] + mod_sum)}"
+        )
+    batch_amount = sum(
+        item["quantity"] * (
+            item["unit_price"]
+            + sum(float(m.get("price", 0)) for m in (item.get("modifiers") or []))
+        )
+        for item in items
+    )
+    logger.info(f"[add_tab_items] batch_amount={batch_amount} items_count={len(items)}")
+
+    existing_order = await conn.fetchrow(
+        """
+        SELECT id FROM orders
+        WHERE table_session_id = $1 AND status = 'pending'
+        ORDER BY order_date ASC
+        LIMIT 1
+        """,
+        session_id,
+    )
+    order_number: int
+    order_total: float
+    if existing_order:
+        order_id = existing_order["id"]
+        updated = await conn.fetchrow(
+            """
+            UPDATE orders
+            SET total_amount = total_amount + $1
+            WHERE id = $2
+            RETURNING order_number, total_amount
+            """,
+            batch_amount,
+            order_id,
+        )
+        order_number = updated["order_number"]
+        order_total = float(updated["total_amount"])
+        logger.info(f"[add_tab_items] reusing existing order {order_id}, adding {batch_amount}")
+    else:
+        order_row = await conn.fetchrow(
+            """
+            INSERT INTO orders (
+                user_id, tenant_id, table_session_id,
+                order_date, total_amount, status
+            )
+            VALUES ($1, $2, $3, NOW(), $4, 'pending')
+            RETURNING id, order_number, total_amount
+            """,
+            user_id,
+            tenant_id,
+            session_id,
+            batch_amount,
+        )
+        order_id = order_row["id"]
+        order_number = order_row["order_number"]
+        order_total = float(order_row["total_amount"])
+        logger.info(f"[add_tab_items] created new order {order_id}")
+
+    for item in items:
+        modifier_unit_total = sum(float(m.get("price", 0)) for m in (item.get("modifiers") or []))
+        subtotal = item["quantity"] * (item["unit_price"] + modifier_unit_total)
+        order_item_row = await conn.fetchrow(
+            """
+            INSERT INTO order_items (
+                order_id, product_id, quantity,
+                price_at_purchase, subtotal
+            )
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING id
+            """,
+            order_id,
+            item["product_id"],
+            item["quantity"],
+            item["unit_price"],
+            subtotal,
+        )
+        order_item_id = order_item_row["id"]
+
+        for mod in item.get("modifiers") or []:
+            await conn.execute(
+                """
+                INSERT INTO order_item_modifiers (
+                    order_item_id, modifier_id, modifier_name,
+                    price_at_purchase, quantity
+                )
+                VALUES ($1, $2, $3, $4, $5)
+                """,
+                order_item_id,
+                mod.get("id"),
+                mod.get("name"),
+                mod.get("price", 0),
+                1,
+            )
+
+        try:
+            await _capture_order_item_ingredients(
+                conn, order_item_id, item["product_id"],
+                float(item["quantity"]), str(tenant_id)
+            )
+        except Exception as _snap_exc:
+            logger.error(f"[tab] ingredient snapshot failed for item {order_item_id}: {_snap_exc}")
+
+        try:
+            ingredients = await conn.fetch(
+                """
+                SELECT pr.ingredient_id, pr.quantity, pr.unit, i.name as ingredient_name
+                FROM product_recipes pr
+                JOIN ingredients i ON i.id = pr.ingredient_id
+                WHERE pr.product_id = $1
+                UNION ALL
+                SELECT brt.ingredient_id, brt.base_quantity * pbr.quantity AS quantity, brt.unit, i.name as ingredient_name
+                FROM product_base_recipes pbr
+                JOIN base_recipe_templates brt ON pbr.product_base_type_id = brt.product_base_type_id
+                JOIN ingredients i ON i.id = brt.ingredient_id
+                WHERE pbr.product_id = $1
+                """,
+                item["product_id"],
+            )
+            for ing in ingredients:
+                resolved_qty = await resolve_recipe_quantity_to_base_unit(
+                    conn, ing["ingredient_id"],
+                    float(ing["quantity"]), ing["unit"] or "",
+                )
+                qty_to_deduct = float(item["quantity"]) * resolved_qty
+                stock_row = await conn.fetchrow(
+                    "SELECT current_stock FROM tenant_inventory WHERE ingredient_id = $1 AND tenant_id = $2",
+                    ing["ingredient_id"], tenant_id,
+                )
+                if stock_row:
+                    prev = float(stock_row["current_stock"] or 0)
+                    new_stock = prev - qty_to_deduct
+                    await conn.execute(
+                        "UPDATE tenant_inventory SET current_stock = $1, last_updated = NOW() WHERE ingredient_id = $2 AND tenant_id = $3",
+                        new_stock, ing["ingredient_id"], tenant_id,
+                    )
+                else:
+                    new_stock = -qty_to_deduct
+                    await conn.execute(
+                        "INSERT INTO tenant_inventory (tenant_id, ingredient_id, current_stock, minimum_stock, last_updated) VALUES ($1, $2, $3, 0, NOW())",
+                        tenant_id, ing["ingredient_id"], new_stock,
+                    )
+                await conn.execute(
+                    """
+                    INSERT INTO tenant_ingredient_movements (
+                        tenant_id, ingredient_id, movement_type, quantity_change,
+                        unit, previous_stock, new_stock, reference_table, reference_id,
+                        reason, created_by, created_at
+                    ) VALUES ($1, $2, 'consumption', $3, $4, $5, $6, 'orders', $7, $8, $9, NOW())
+                    """,
+                    tenant_id, ing["ingredient_id"], -qty_to_deduct,
+                    ing["unit"] or "und",
+                    float(stock_row["current_stock"] or 0) if stock_row else 0.0,
+                    new_stock, order_id,
+                    f"Venta de {item['quantity']}x (mesa {table_id}) - Orden #{order_number}",
+                    user_id,
+                )
+        except Exception as _inv_exc:
+            logger.error(f"[tab] inventory deduction failed for item {order_item_id}: {_inv_exc}")
+
+    return {
+        "order_id": order_id,
+        "order_number": order_number,
+        "total_amount": order_total,
+        "session_id": session_id,
+        "items_count": len(items),
+    }
+
+
 async def add_tab_items(
     request: Request,
     table_id: UUID,
@@ -1722,197 +1924,14 @@ async def add_tab_items(
         if not items:
             raise APIError("No items provided", status_code=400)
 
+        tab_result: dict = {}
         async with get_db_connection() as conn:
             async with conn.transaction():
-                # Verify the table has an open session owned by this tenant
-                session_row = await conn.fetchrow(
-                    """
-                    SELECT ts.id AS session_id
-                    FROM table_sessions ts
-                    JOIN tables t ON t.id = ts.table_id
-                    WHERE ts.table_id = $1
-                      AND ts.tenant_id = $2
-                      AND ts.closed_at IS NULL
-                      AND t.is_active = true
-                    """,
-                    table_id,
-                    tenant_id,
-                )
-                if not session_row:
-                    raise NotFoundError("No open session found for this table")
+                tab_result = await _add_tab_items_core(conn, tenant_id, user_id, table_id, items)
 
-                session_id = session_row["session_id"]
-
-                # Compute total including modifier prices (no DB price lookup — POS already verified)
-                for item in items:
-                    mod_sum = sum(float(m.get("price", 0)) for m in (item.get("modifiers") or []))
-                    logger.info(
-                        f"[add_tab_items] item product_id={item['product_id']} "
-                        f"qty={item['quantity']} unit_price={item['unit_price']} "
-                        f"modifier_sum={mod_sum} "
-                        f"line_total={item['quantity'] * (item['unit_price'] + mod_sum)}"
-                    )
-                batch_amount = sum(
-                    item["quantity"] * (
-                        item["unit_price"]
-                        + sum(float(m.get("price", 0)) for m in (item.get("modifiers") or []))
-                    )
-                    for item in items
-                )
-                logger.info(f"[add_tab_items] batch_amount={batch_amount} items_count={len(items)}")
-
-                # Reuse the existing pending order for this session, or create one if none exists
-                existing_order = await conn.fetchrow(
-                    """
-                    SELECT id FROM orders
-                    WHERE table_session_id = $1 AND status = 'pending'
-                    ORDER BY order_date ASC
-                    LIMIT 1
-                    """,
-                    session_id,
-                )
-                order_number: int
-                order_total: float
-                if existing_order:
-                    order_id = existing_order["id"]
-                    updated = await conn.fetchrow(
-                        """
-                        UPDATE orders
-                        SET total_amount = total_amount + $1
-                        WHERE id = $2
-                        RETURNING order_number, total_amount
-                        """,
-                        batch_amount,
-                        order_id,
-                    )
-                    order_number = updated["order_number"]
-                    order_total = float(updated["total_amount"])
-                    logger.info(f"[add_tab_items] reusing existing order {order_id}, adding {batch_amount}")
-                else:
-                    order_row = await conn.fetchrow(
-                        """
-                        INSERT INTO orders (
-                            user_id, tenant_id, table_session_id,
-                            order_date, total_amount, status
-                        )
-                        VALUES ($1, $2, $3, NOW(), $4, 'pending')
-                        RETURNING id, order_number, total_amount
-                        """,
-                        user_id,
-                        tenant_id,
-                        session_id,
-                        batch_amount,
-                    )
-                    order_id = order_row["id"]
-                    order_number = order_row["order_number"]
-                    order_total = float(order_row["total_amount"])
-                    logger.info(f"[add_tab_items] created new order {order_id}")
-
-                # Insert order_items
-                for item in items:
-                    modifier_unit_total = sum(float(m.get("price", 0)) for m in (item.get("modifiers") or []))
-                    subtotal = item["quantity"] * (item["unit_price"] + modifier_unit_total)
-                    order_item_row = await conn.fetchrow(
-                        """
-                        INSERT INTO order_items (
-                            order_id, product_id, quantity,
-                            price_at_purchase, subtotal
-                        )
-                        VALUES ($1, $2, $3, $4, $5)
-                        RETURNING id
-                        """,
-                        order_id,
-                        item["product_id"],
-                        item["quantity"],
-                        item["unit_price"],
-                        subtotal,
-                    )
-                    order_item_id = order_item_row["id"]
-
-                    # Insert modifiers if any
-                    for mod in item.get("modifiers") or []:
-                        await conn.execute(
-                            """
-                            INSERT INTO order_item_modifiers (
-                                order_item_id, modifier_id, modifier_name,
-                                price_at_purchase, quantity
-                            )
-                            VALUES ($1, $2, $3, $4, $5)
-                            """,
-                            order_item_id,
-                            mod.get("id"),
-                            mod.get("name"),
-                            mod.get("price", 0),
-                            1,
-                        )
-
-                    # Capture ingredient cost snapshot (needed for COGS GL at close)
-                    try:
-                        await _capture_order_item_ingredients(
-                            conn, order_item_id, item["product_id"],
-                            float(item["quantity"]), str(tenant_id)
-                        )
-                    except Exception as _snap_exc:
-                        logger.error(f"[tab] ingredient snapshot failed for item {order_item_id}: {_snap_exc}")
-
-                    # Deduct inventory for each ingredient in the product recipe
-                    try:
-                        ingredients = await conn.fetch(
-                            """
-                            SELECT pr.ingredient_id, pr.quantity, pr.unit, i.name as ingredient_name
-                            FROM product_recipes pr
-                            JOIN ingredients i ON i.id = pr.ingredient_id
-                            WHERE pr.product_id = $1
-                            UNION ALL
-                            -- Issue #517: multiply by pbr.quantity
-                            SELECT brt.ingredient_id, brt.base_quantity * pbr.quantity AS quantity, brt.unit, i.name as ingredient_name
-                            FROM product_base_recipes pbr
-                            JOIN base_recipe_templates brt ON pbr.product_base_type_id = brt.product_base_type_id
-                            JOIN ingredients i ON i.id = brt.ingredient_id
-                            WHERE pbr.product_id = $1
-                            """,
-                            item["product_id"],
-                        )
-                        for ing in ingredients:
-                            resolved_qty = await resolve_recipe_quantity_to_base_unit(
-                                conn, ing["ingredient_id"],
-                                float(ing["quantity"]), ing["unit"] or "",
-                            )
-                            qty_to_deduct = float(item["quantity"]) * resolved_qty
-                            stock_row = await conn.fetchrow(
-                                "SELECT current_stock FROM tenant_inventory WHERE ingredient_id = $1 AND tenant_id = $2",
-                                ing["ingredient_id"], tenant_id,
-                            )
-                            if stock_row:
-                                prev = float(stock_row["current_stock"] or 0)
-                                new_stock = prev - qty_to_deduct
-                                await conn.execute(
-                                    "UPDATE tenant_inventory SET current_stock = $1, last_updated = NOW() WHERE ingredient_id = $2 AND tenant_id = $3",
-                                    new_stock, ing["ingredient_id"], tenant_id,
-                                )
-                            else:
-                                new_stock = -qty_to_deduct
-                                await conn.execute(
-                                    "INSERT INTO tenant_inventory (tenant_id, ingredient_id, current_stock, minimum_stock, last_updated) VALUES ($1, $2, $3, 0, NOW())",
-                                    tenant_id, ing["ingredient_id"], new_stock,
-                                )
-                            await conn.execute(
-                                """
-                                INSERT INTO tenant_ingredient_movements (
-                                    tenant_id, ingredient_id, movement_type, quantity_change,
-                                    unit, previous_stock, new_stock, reference_table, reference_id,
-                                    reason, created_by, created_at
-                                ) VALUES ($1, $2, 'consumption', $3, $4, $5, $6, 'orders', $7, $8, $9, NOW())
-                                """,
-                                tenant_id, ing["ingredient_id"], -qty_to_deduct,
-                                ing["unit"] or "und",
-                                float(stock_row["current_stock"] or 0) if stock_row else 0.0,
-                                new_stock, order_id,
-                                f"Venta de {item['quantity']}x (mesa {table_id}) - Orden #{order_number}",
-                                user_id,
-                            )
-                    except Exception as _inv_exc:
-                        logger.error(f"[tab] inventory deduction failed for item {order_item_id}: {_inv_exc}")
+        order_id = tab_result["order_id"]
+        order_number = tab_result["order_number"]
+        order_total = tab_result["total_amount"]
 
         # Auto-fire comandas if enabled
         try:

--- a/tests/test_table_qr_requests.py
+++ b/tests/test_table_qr_requests.py
@@ -1,0 +1,152 @@
+"""Tests for Table QR request accept/reject (api-warolabs#268)."""
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.exceptions import APIError
+from app.core.middleware import SessionContext
+from app.routers import table_qr_requests as table_qr_requests_router
+from app.services import table_qr_requests_service
+
+
+def _session():
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "despacho@example.com",
+        "name": "Despacho",
+        "expires_at": None,
+        "is_active": True,
+        "role": "supervisor",
+    })
+
+
+@pytest.mark.asyncio
+async def test_reject_request_marks_rejected():
+    session = _session()
+    request_id = uuid4()
+    table_id = uuid4()
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={"id": request_id, "table_id": table_id})
+
+    with patch("app.services.table_qr_requests_service.require_valid_session", return_value=session), \
+         patch("app.services.table_qr_requests_service.get_db_connection") as mock_conn:
+        mock_conn.return_value.__aenter__ = AsyncMock(return_value=conn)
+        mock_conn.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await table_qr_requests_service.reject_request(MagicMock(), request_id)
+        assert result["data"]["status"] == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_accept_conflicting_tables_409():
+    session = _session()
+    id1, id2 = uuid4(), uuid4()
+    table_a, table_b = uuid4(), uuid4()
+
+    rows = [
+        {
+            "id": id1,
+            "table_id": table_a,
+            "status": "pending",
+            "items": json.dumps([{"product_id": str(uuid4()), "quantity": 1, "unit_price": 10.0}]),
+            "payment_method": "cash",
+            "payment_method_id": None,
+            "customer_notes": None,
+            "created_at": MagicMock(),
+        },
+        {
+            "id": id2,
+            "table_id": table_b,
+            "status": "pending",
+            "items": json.dumps([{"product_id": str(uuid4()), "quantity": 1, "unit_price": 5.0}]),
+            "payment_method": "cash",
+            "payment_method_id": None,
+            "customer_notes": None,
+            "created_at": MagicMock(),
+        },
+    ]
+
+    conn = MagicMock()
+    tx = MagicMock()
+    tx.__aenter__ = AsyncMock(return_value=None)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction.return_value = tx
+    conn.fetch = AsyncMock(return_value=rows)
+
+    with patch("app.services.table_qr_requests_service.require_valid_session", return_value=session), \
+         patch("app.services.table_qr_requests_service.get_db_connection") as mock_conn:
+        mock_conn.return_value.__aenter__ = AsyncMock(return_value=conn)
+        mock_conn.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with pytest.raises(APIError) as exc:
+            await table_qr_requests_service.accept_requests(MagicMock(), [id1, id2])
+        assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_accept_conflicting_payment_methods_409():
+    session = _session()
+    id1, id2 = uuid4(), uuid4()
+    table_id = uuid4()
+
+    rows = [
+        {
+            "id": id1,
+            "table_id": table_id,
+            "status": "pending",
+            "items": "[]",
+            "payment_method": "cash",
+            "payment_method_id": None,
+            "customer_notes": None,
+            "created_at": MagicMock(),
+        },
+        {
+            "id": id2,
+            "table_id": table_id,
+            "status": "pending",
+            "items": "[]",
+            "payment_method": "card",
+            "payment_method_id": None,
+            "customer_notes": None,
+            "created_at": MagicMock(),
+        },
+    ]
+
+    conn = MagicMock()
+    tx = MagicMock()
+    tx.__aenter__ = AsyncMock(return_value=None)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction.return_value = tx
+    conn.fetch = AsyncMock(return_value=rows)
+
+    with patch("app.services.table_qr_requests_service.require_valid_session", return_value=session), \
+         patch("app.services.table_qr_requests_service.get_db_connection") as mock_conn:
+        mock_conn.return_value.__aenter__ = AsyncMock(return_value=conn)
+        mock_conn.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with pytest.raises(APIError) as exc:
+            await table_qr_requests_service.accept_requests(MagicMock(), [id1, id2])
+        assert exc.value.status_code == 409
+
+
+def test_list_endpoint_delegates():
+    app = FastAPI()
+    app.include_router(table_qr_requests_router.router, prefix="/table-qr-requests")
+
+    payload = {"success": True, "data": {"tables": [], "total_pending": 0}}
+
+    with patch(
+        "app.routers.table_qr_requests.table_qr_requests_service.list_pending_grouped",
+        new_callable=AsyncMock,
+        return_value=payload,
+    ):
+        client = TestClient(app)
+        res = client.get("/table-qr-requests?status=pending")
+        assert res.status_code == 200
+        assert res.json()["data"]["total_pending"] == 0


### PR DESCRIPTION
## Summary
Staff endpoints to confirm or reject Table QR customer orders (warocol.com#710 / api-warolabs#268). Accept merges pending items into one mesa tab add with auto-fire; reject has no POS/kitchen side effects.

## Changes
- `app/services/tables_service.py`: extract `_add_tab_items_core(conn, …)` for transactional accept
- `app/services/table_qr_requests_service.py`: list pending (grouped), accept, reject, bulk-accept
- `app/routers/table_qr_requests.py`: DESPACHO-gated routes
- `app/main.py`: register `/table-qr-requests`
- `tests/test_table_qr_requests.py`: unit tests

## Testing
- `python3 -m pytest tests/test_table_qr_requests.py tests/test_table_qr_tokens.py tests/test_table_qr_public.py` — 14 passed

Closes #268

Made with [Cursor](https://cursor.com)