### PR TITLE
feat(despacho): GET /table-qr-requests/{id} for en-mesa detail page

### DIFF
--- a/app/routers/table_qr_requests.py
+++ b/app/routers/table_qr_requests.py
@@ -29,6 +29,12 @@ async def list_table_qr_requests(
     return await table_qr_requests_service.list_pending_grouped(request)
 
 
+@router.get("/{request_id}", dependencies=[Depends(require_module(Module.DESPACHO))])
+async def get_table_qr_request(request: Request, request_id: UUID):
+    """Get a single pending Table QR request (Despacho detail page)."""
+    return await table_qr_requests_service.get_request(request, request_id)
+
+
 @router.patch("/{request_id}/reject", dependencies=[Depends(require_module(Module.DESPACHO))])
 async def reject_table_qr_request(request: Request, request_id: UUID):
     return await table_qr_requests_service.reject_request(request, request_id)

--- a/app/services/table_qr_requests_service.py
+++ b/app/services/table_qr_requests_service.py
@@ -38,6 +38,38 @@ def _format_request_row(row: dict) -> dict:
     }
 
 
+def _request_total_amount(items: List[dict]) -> float:
+    return sum(float(item.get("line_total") or 0) for item in items)
+
+
+async def _enrich_items_with_product_names(
+    conn,
+    tenant_id: UUID,
+    items: List[dict],
+) -> None:
+    product_ids = [
+        UUID(str(item["product_id"]))
+        for item in items
+        if item.get("product_id")
+    ]
+    if not product_ids:
+        return
+
+    product_rows = await conn.fetch(
+        """
+        SELECT id, name FROM product
+        WHERE id = ANY($1::uuid[]) AND tenant_id = $2
+        """,
+        product_ids,
+        tenant_id,
+    )
+    names = {str(row["id"]): row["name"] for row in product_rows}
+    for item in items:
+        product_id = item.get("product_id")
+        if product_id and str(product_id) in names:
+            item["product_name"] = names[str(product_id)]
+
+
 async def _resolve_tenant_member_id(conn, tenant_id: UUID, user_id: UUID) -> Optional[UUID]:
     return await conn.fetchval(
         """
@@ -135,6 +167,40 @@ async def list_pending_grouped(request: Request) -> dict:
             "total_pending": len(rows),
         },
     }
+
+
+async def get_request(request: Request, request_id: UUID) -> dict:
+    """GET /table-qr-requests/{request_id} — single pending request for Despacho detail."""
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    async with get_db_connection(use_transaction=False) as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT
+                r.id, r.table_id, r.status, r.items,
+                r.payment_method, r.payment_method_id, r.customer_notes, r.created_at,
+                t.name AS table_name
+            FROM table_qr_requests r
+            JOIN tables t ON t.id = r.table_id
+            WHERE r.id = $1 AND r.tenant_id = $2 AND r.status = 'pending'
+            """,
+            request_id,
+            tenant_id,
+        )
+        if not row:
+            raise APIError(
+                "Request not found or not pending",
+                status_code=404,
+            )
+
+        data = _format_request_row(dict(row))
+        await _enrich_items_with_product_names(conn, tenant_id, data["items"])
+        data["total_amount"] = _request_total_amount(data["items"])
+
+    return {"success": True, "data": data}
 
 
 async def reject_request(request: Request, request_id: UUID) -> dict:

--- a/tests/test_table_qr_requests.py
+++ b/tests/test_table_qr_requests.py
@@ -1,7 +1,8 @@
-"""Tests for Table QR request accept/reject (api-warolabs#268)."""
+"""Tests for Table QR request accept/reject (api-warolabs#268) and detail GET (#275)."""
 import json
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from fastapi import FastAPI
@@ -11,6 +12,32 @@ from app.core.exceptions import APIError
 from app.core.middleware import SessionContext
 from app.routers import table_qr_requests as table_qr_requests_router
 from app.services import table_qr_requests_service
+
+
+def _pending_request_row(**overrides):
+    product_id = uuid4()
+    base = {
+        "id": uuid4(),
+        "table_id": uuid4(),
+        "status": "pending",
+        "items": json.dumps([
+            {
+                "product_id": str(product_id),
+                "quantity": 2,
+                "unit_price": 10.0,
+                "modifiers": [],
+                "notes": None,
+                "line_total": 20.0,
+            },
+        ]),
+        "payment_method": "cash",
+        "payment_method_id": None,
+        "customer_notes": "Sin cebolla",
+        "created_at": datetime(2026, 5, 20, 12, 0, tzinfo=timezone.utc),
+        "table_name": "Mesa 1",
+    }
+    base.update(overrides)
+    return base
 
 
 def _session():
@@ -150,3 +177,82 @@ def test_list_endpoint_delegates():
         res = client.get("/table-qr-requests?status=pending")
         assert res.status_code == 200
         assert res.json()["data"]["total_pending"] == 0
+
+
+@pytest.mark.asyncio
+async def test_get_request_returns_enriched_pending():
+    session = _session()
+    request_id = uuid4()
+    row = _pending_request_row(id=request_id)
+    product_id = json.loads(row["items"])[0]["product_id"]
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=row)
+    conn.fetch = AsyncMock(return_value=[{"id": UUID(product_id), "name": "Hamburguesa"}])
+
+    with patch("app.services.table_qr_requests_service.require_valid_session", return_value=session), \
+         patch("app.services.table_qr_requests_service.get_db_connection") as mock_conn:
+        mock_conn.return_value.__aenter__ = AsyncMock(return_value=conn)
+        mock_conn.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await table_qr_requests_service.get_request(MagicMock(), request_id)
+
+    assert result["success"] is True
+    data = result["data"]
+    assert data["id"] == str(request_id)
+    assert data["table_name"] == "Mesa 1"
+    assert data["status"] == "pending"
+    assert data["total_amount"] == 20.0
+    assert data["items"][0]["product_name"] == "Hamburguesa"
+    assert data["customer_notes"] == "Sin cebolla"
+
+
+@pytest.mark.asyncio
+async def test_get_request_not_found_404():
+    session = _session()
+    request_id = uuid4()
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+
+    with patch("app.services.table_qr_requests_service.require_valid_session", return_value=session), \
+         patch("app.services.table_qr_requests_service.get_db_connection") as mock_conn:
+        mock_conn.return_value.__aenter__ = AsyncMock(return_value=conn)
+        mock_conn.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with pytest.raises(APIError) as exc:
+            await table_qr_requests_service.get_request(MagicMock(), request_id)
+        assert exc.value.status_code == 404
+
+
+def test_get_endpoint_delegates():
+    app = FastAPI()
+    app.include_router(table_qr_requests_router.router, prefix="/table-qr-requests")
+
+    request_id = uuid4()
+    payload = {
+        "success": True,
+        "data": {
+            "id": str(request_id),
+            "table_id": str(uuid4()),
+            "table_name": "Mesa 2",
+            "status": "pending",
+            "items": [],
+            "item_count": 0,
+            "total_amount": 0.0,
+            "payment_method": None,
+            "payment_method_id": None,
+            "customer_notes": None,
+            "created_at": "2026-05-20T12:00:00+00:00",
+        },
+    }
+
+    with patch(
+        "app.routers.table_qr_requests.table_qr_requests_service.get_request",
+        new_callable=AsyncMock,
+        return_value=payload,
+    ):
+        client = TestClient(app)
+        res = client.get(f"/table-qr-requests/{request_id}")
+        assert res.status_code == 200
+        assert res.json()["data"]["id"] == str(request_id)


### PR DESCRIPTION
## Summary

Adds `GET /table-qr-requests/{request_id}` for the Despacho en-mesa detail page (warocol.com#725). Returns a single pending request with the same core shape as the grouped list, plus `product_name` on each item and `total_amount` at request level.

## Stack

- FastAPI router + asyncpg service

## Changes

- `app/services/table_qr_requests_service.py`: `get_request`, `_enrich_items_with_product_names`, `_request_total_amount`
- `app/routers/table_qr_requests.py`: `GET /{request_id}` (DESPACHO module)
- `tests/test_table_qr_requests.py`: service happy path + 404 + router delegation

## Behaviour

- 200 for pending request owned by current tenant
- 404 if missing, wrong tenant, or not `pending` (same message as accept/reject)
- `?view=flat` deferred — front can flatten grouped list for v1

## Testing

```bash
python3 -m pytest tests/test_table_qr_requests.py -q
```

Closes #275

Made with [Cursor](https://cursor.com)