### PR TITLE
feat(tips): optional taxable tips (gravada / no gravada) #740

### DIFF
--- a/app/models/tenant_public_profile.py
+++ b/app/models/tenant_public_profile.py
@@ -133,6 +133,11 @@ class TenantPublicProfileBase(BaseModel):
                     "surfaces the tip selector at POS/online checkout and the "
                     "/ventas/propinas history view.",
     )
+    tip_taxable_default: bool = Field(
+        False,
+        description="warocol.com#740 — default: apply consumption tax to tips "
+                    "at checkout (gravada). Cashier may override per sale.",
+    )
     tip_default_percentages: list[Decimal] = Field(
         default_factory=lambda: [Decimal('10')],
         description="Suggested tip presets shown as chips at checkout "
@@ -229,6 +234,7 @@ class TenantPublicProfileUpdate(BaseModel):
 
     # Tipping configuration (warocol.com#635)
     tip_enabled: Optional[bool] = None
+    tip_taxable_default: Optional[bool] = None
     tip_default_percentages: Optional[list[Decimal]] = None
     tip_preselect_index: Optional[int] = None
 

--- a/app/routers/operaciones_context.py
+++ b/app/routers/operaciones_context.py
@@ -182,6 +182,20 @@ async def toggle_tip_enabled(request: Request, body: ToggleRequest):
 
 
 @router.patch(
+    "/toggles/tip-taxable-default",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def toggle_tip_taxable_default(request: Request, body: ToggleRequest):
+    """Toggle default taxable tip (gravada) at checkout (warocol.com#740).
+
+    When true, new checkouts pre-select applying IVA/INC to the tip amount.
+    Cashiers can still override per sale at checkout.
+    """
+    session = require_valid_session(request)
+    return await update_toggle(session.tenant_id, "tip_taxable_default", body.enabled)
+
+
+@router.patch(
     "/tip/config",
     dependencies=[Depends(require_module(Module.OPERACIONES))],
 )

--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -161,6 +161,7 @@ class CompleteOrderRequest(BaseModel):
     served_by_member_id: Optional[UUID] = Field(None, description="Issue warocol.com#575/#663 — waiter at checkout. Validated against active tenant members; persisted even when waiter_attribution_enabled is OFF.")
     tip_amount: float = Field(0, ge=0, description="Issue warocol.com#637 — tip amount in COP. Strictly separate from total_amount. Rejected when tip_enabled=false for the tenant. Allowed with split_mode (settlement is total + tip). For cash payments, cash_received must cover total + tip on single-pay close.")
     tip_source: Literal['preset', 'custom', 'none'] = Field('none', description="Issue warocol.com#637 — how the customer chose the tip. Must agree with tip_amount: (0,'none') or (>0,'preset'|'custom').")
+    tip_taxable: bool = Field(False, description="warocol.com#740 — when true, standard consumption tax is applied to tip_amount (gravada).")
 
 
 @router.post("/{cart_id}/complete", dependencies=[Depends(require_module(Module.POS))])
@@ -198,6 +199,7 @@ async def complete_order(
         served_by_member_id=order_data.served_by_member_id,
         tip_amount=order_data.tip_amount,
         tip_source=order_data.tip_source,
+        tip_taxable=order_data.tip_taxable,
     )
 
 

--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -141,6 +141,7 @@ class CloseSessionRequest(BaseModel):
     cash_received: Optional[float] = Field(None, description="Issue #524 — cash handed over for a single (non-split) cash close. Must be >= total session amount.")
     tip_amount: float = Field(0, ge=0, description="warocol.com#639 — total tip for the mesa session. Applied to the first completed order in the session (like cash_received). Rejected when tip_enabled=false. Allowed with split_mode.")
     tip_source: Literal['preset', 'custom', 'none'] = Field('none', description="warocol.com#639 — how the tip was chosen. Must agree with tip_amount.")
+    tip_taxable: bool = Field(False, description="warocol.com#740 — apply consumption tax to tip_amount when true (gravada).")
     served_by_member_id: Optional[UUID] = Field(None, description="warocol.com#663 — waiter assigned at checkout. Applied to all completed orders in the session.")
 
 
@@ -176,6 +177,7 @@ async def close_session(request: Request, table_id: UUID, body: CloseSessionRequ
         cash_received=body.cash_received,
         tip_amount=body.tip_amount,
         tip_source=body.tip_source,
+        tip_taxable=body.tip_taxable,
         served_by_member_id=body.served_by_member_id,
     )
 

--- a/app/services/operaciones_context_service.py
+++ b/app/services/operaciones_context_service.py
@@ -31,6 +31,7 @@ ALLOWED_TOGGLES = frozenset({
     "auto_select_generic_enabled",
     "waiter_attribution_enabled",  # warocol.com#573
     "tip_enabled",                  # warocol.com#638
+    "tip_taxable_default",          # warocol.com#740
 })
 
 

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -16,17 +16,17 @@ from app.core.exceptions import AuthenticationError, APIError
 from app.services.waros_service import evaluate_and_award
 from app.services.email_helpers import send_pos_receipt_email
 from app.services.cierre_service import _get_tenant_tax_config, _post_order_gl_entry, _post_order_cogs_gl_entry
+from app.services.tip_tax_service import (
+    compute_tip_tax_amount,
+    split_settlement_amount_due,
+    tip_settlement_total,
+)
 from app.services.accounting_service import void_order_journal_entry_in_txn
 from app.services.ingredient_purchase_units_service import resolve_recipe_quantity_to_base_unit
 from app.services.comandas_service import fire_comandas, finalize_open_comandas
 import logging
 
 logger = logging.getLogger(__name__)
-
-
-def _split_settlement_amount_due(order_total: float, tip_amount: float) -> float:
-    """warocol.com#737 — partial payments settle order total + tip (tip not in total_amount)."""
-    return float(order_total) + float(tip_amount or 0)
 
 
 def _distribute_discount(items: List[dict], discount_amount: float) -> List[dict]:
@@ -775,7 +775,7 @@ async def add_order_payment(
                 # 2. Fetch + lock the order linked to this cart via pos_cart_id
                 order_row = await conn.fetchrow(
                     """
-                    SELECT id, total_amount, tip_amount, status, payment_status
+                    SELECT id, total_amount, tip_amount, tip_tax_amount, status, payment_status
                     FROM orders
                     WHERE pos_cart_id = $1 AND tenant_id = $2
                     ORDER BY created_at DESC
@@ -800,7 +800,11 @@ async def add_order_payment(
                     raise APIError("Order is already fully paid", status_code=409)
 
                 total_amount = float(order_row["total_amount"])
-                amount_due = _split_settlement_amount_due(total_amount, float(order_row["tip_amount"] or 0))
+                amount_due = split_settlement_amount_due(
+                    total_amount,
+                    float(order_row["tip_amount"] or 0),
+                    float(order_row["tip_tax_amount"] or 0),
+                )
 
                 # 3. Insert payment record
                 user_id = session_context.user_id if hasattr(session_context, 'user_id') else None
@@ -919,8 +923,8 @@ async def void_order_payment(
                     """
                     SELECT op.id, op.order_id, op.amount, op.payment_method,
                            op.cash_received, op.created_by_user_id, op.voided_at,
-                           o.pos_cart_id, o.total_amount, o.tip_amount, o.payment_status,
-                           o.status AS order_status
+                           o.pos_cart_id, o.total_amount, o.tip_amount, o.tip_tax_amount,
+                           o.payment_status, o.status AS order_status
                     FROM order_payments op
                     JOIN orders o ON o.id = op.order_id
                     WHERE op.id = $1::uuid AND op.tenant_id = $2
@@ -970,8 +974,10 @@ async def void_order_payment(
                 )
                 paid_total = float(paid_row["paid"])
                 total_amount = float(payment_row["total_amount"])
-                amount_due = _split_settlement_amount_due(
-                    total_amount, float(payment_row["tip_amount"] or 0),
+                amount_due = split_settlement_amount_due(
+                    total_amount,
+                    float(payment_row["tip_amount"] or 0),
+                    float(payment_row["tip_tax_amount"] or 0),
                 )
                 remaining = max(0.0, amount_due - paid_total)
                 is_complete = remaining <= 0.01
@@ -1035,6 +1041,7 @@ async def complete_pos_order(
     served_by_member_id: Optional[UUID] = None,
     tip_amount: float = 0,
     tip_source: str = 'none',
+    tip_taxable: bool = False,
 ) -> dict:
     """
     Complete a POS order:
@@ -1160,6 +1167,12 @@ async def complete_pos_order(
                 if not items:
                     raise APIError("Cannot complete order with empty cart", status_code=400)
 
+                tax_config = await _get_tenant_tax_config(conn, tenant_id)
+                _tip_taxable = bool(tip_taxable) if tip_amount > 0 else False
+                _tip_tax_amount = compute_tip_tax_amount(
+                    float(tip_amount), _tip_taxable, tax_config,
+                )
+
                 # 3. Create order record (use customer_id from parameter)
                 # Compute payment_status
                 if split_mode:
@@ -1196,11 +1209,14 @@ async def complete_pos_order(
                 if not split_mode and cash_received is not None:
                     if payment_method != 'cash':
                         raise APIError("cash_received solo aplica a pagos en efectivo", status_code=400)
-                    _required_cash = float(_discounted_total) + float(tip_amount)
+                    _required_cash = float(_discounted_total) + tip_settlement_total(
+                        float(tip_amount), _tip_tax_amount,
+                    )
                     if cash_received < _required_cash:
                         if tip_amount > 0:
                             raise APIError(
-                                f"Efectivo recibido ({cash_received}) debe ser mayor o igual al total + propina ({_required_cash})",
+                                f"Efectivo recibido ({cash_received}) debe ser mayor o igual al total + propina"
+                                f" (+ IVA propina si aplica) ({_required_cash})",
                                 status_code=400,
                             )
                         raise APIError(
@@ -1218,9 +1234,10 @@ async def complete_pos_order(
                         delivery_address_id, scheduled_time, delivery_instructions,
                         cash_received,
                         served_by_member_id,
-                        tip_amount, tip_source
+                        tip_amount, tip_source,
+                        tip_taxable, tip_tax_amount
                     )
-                    VALUES ($1, $2, $3, $4, $5, NOW(), $6, 'completed', $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
+                    VALUES ($1, $2, $3, $4, $5, NOW(), $6, 'completed', $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
                     RETURNING id, order_number, created_at
                 """
                 order_row = await conn.fetchrow(
@@ -1245,6 +1262,8 @@ async def complete_pos_order(
                     resolved_served_by,
                     float(tip_amount),
                     tip_source,
+                    _tip_taxable,
+                    float(_tip_tax_amount),
                 )
                 order_id = order_row['id']
                 order_number = order_row['order_number']
@@ -1612,7 +1631,9 @@ async def complete_pos_order(
                     )
                     _split_first_payment_id = str(_split_first_payment_row["id"])
                     _split_paid_total = split_first_amount
-                    _amount_due = _split_settlement_amount_due(float(_discounted_total), float(tip_amount))
+                    _amount_due = split_settlement_amount_due(
+                        float(_discounted_total), float(tip_amount), _tip_tax_amount,
+                    )
                     _split_remaining = max(0.0, _amount_due - split_first_amount)
                     _split_is_complete = _split_remaining <= 0.01
 
@@ -1723,7 +1744,11 @@ async def complete_pos_order(
                         "total_amount": float(_discounted_total),
                         "tip_amount": float(tip_amount),
                         "tip_source": tip_source,
-                        "charged_amount": float(_discounted_total) + float(tip_amount),
+                        "tip_taxable": _tip_taxable,
+                        "tip_tax_amount": float(_tip_tax_amount),
+                        "charged_amount": float(_discounted_total) + tip_settlement_total(
+                            float(tip_amount), _tip_tax_amount,
+                        ),
                         "payment_method": payment_method,
                         "payment_status": payment_status,
                         "credit_due_date": str(credit_due_date) if credit_due_date is not None else None,

--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -29,6 +29,7 @@ SELECT
     tpp.tables_label_singular,
     tpp.tables_label_plural,
     tpp.tip_enabled,
+    tpp.tip_taxable_default,
     tpp.tip_default_percentages,
     tpp.tip_preselect_index,
     fd.nit,
@@ -42,8 +43,10 @@ SELECT
     fd.phone           AS fiscal_phone,
     fd.email           AS fiscal_email,
     ttc.inc_applicable,
+    ttc.inc_rate,
     ttc.inc_included_in_price,
     ttc.iva_applicable,
+    ttc.iva_rate,
     ttc.iva_included_in_price,
     ttc.liquor_tax_applicable
 FROM tenants t
@@ -100,6 +103,7 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
         'tables_label_singular': row['tables_label_singular'],
         'tables_label_plural': row['tables_label_plural'],
         'tip_enabled': bool(row['tip_enabled']) if row['tip_enabled'] is not None else False,
+        'tip_taxable_default': bool(row['tip_taxable_default']) if row['tip_taxable_default'] is not None else False,
         'tip_default_percentages': (
             [float(p) for p in row['tip_default_percentages']]
             if row['tip_default_percentages'] else [10.0]
@@ -119,8 +123,10 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
         },
         'tax_config': {
             'inc_applicable': bool(row['inc_applicable']) if row['inc_applicable'] is not None else False,
+            'inc_rate': float(row['inc_rate']) if row['inc_rate'] is not None else 0.08,
             'inc_included_in_price': bool(row['inc_included_in_price']) if row['inc_included_in_price'] is not None else False,
             'iva_applicable': bool(row['iva_applicable']) if row['iva_applicable'] is not None else False,
+            'iva_rate': float(row['iva_rate']) if row['iva_rate'] is not None else 0.19,
             'iva_included_in_price': bool(row['iva_included_in_price']) if row['iva_included_in_price'] is not None else False,
             'liquor_tax_applicable': bool(row['liquor_tax_applicable']) if row['liquor_tax_applicable'] is not None else False,
         },

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -20,7 +20,11 @@ from app.services.accounting_service import void_order_journal_entry_in_txn
 from app.services.pos_cart_service import (
     _capture_order_item_ingredients,
     _PAYMENT_VOID_ROLES,
-    _split_settlement_amount_due,
+)
+from app.services.tip_tax_service import (
+    compute_tip_tax_amount,
+    split_settlement_amount_due,
+    tip_settlement_total,
 )
 from app.services.orders_service import _compute_tax_breakdown
 from app.services.ingredient_purchase_units_service import resolve_recipe_quantity_to_base_unit
@@ -686,7 +690,7 @@ async def open_session(
         raise APIError(f"Error opening session: {e}", status_code=500)
 
 
-async def close_session(request: Request, table_id: UUID, payment_method: Optional[str] = None, customer_id: Optional[str] = None, credit_due_date: Optional[date] = None, payment_method_id: Optional[UUID] = None, discount_type: Optional[str] = None, discount_value: Optional[float] = None, split_mode: bool = False, split_first_amount: float = 0.0, *, split_first_cash_received: Optional[float] = None, cash_received: Optional[float] = None, tip_amount: float = 0, tip_source: str = 'none', served_by_member_id: Optional[UUID] = None) -> dict:
+async def close_session(request: Request, table_id: UUID, payment_method: Optional[str] = None, customer_id: Optional[str] = None, credit_due_date: Optional[date] = None, payment_method_id: Optional[UUID] = None, discount_type: Optional[str] = None, discount_value: Optional[float] = None, split_mode: bool = False, split_first_amount: float = 0.0, *, split_first_cash_received: Optional[float] = None, cash_received: Optional[float] = None, tip_amount: float = 0, tip_source: str = 'none', tip_taxable: bool = False, served_by_member_id: Optional[UUID] = None) -> dict:
     """
     Close the active session for a table.
     If payment_method is provided, marks all pending orders as completed with that payment method.
@@ -765,6 +769,8 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                         resolved_served_by = session_row["effective_waiter_member_id"]
 
                 is_bar_table = bool(table_row["is_bar"])
+                _mesa_tip_taxable = bool(tip_taxable) if tip_amount > 0 else False
+                _mesa_tip_tax_amount = 0.0
 
                 # Mark pending orders as completed if payment_method provided
                 if payment_method:
@@ -922,25 +928,35 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                     # `orders` row so the /ventas/propinas aggregator sees a single entry
                     # per mesa close instead of N inflated percentages.
                     if tip_amount > 0:
+                        _mesa_tip_taxable = bool(tip_taxable)
                         tenant_tip_enabled = await conn.fetchval(
                             "SELECT tip_enabled FROM tenant_public_profiles WHERE tenant_id = $1",
                             tenant_id,
                         )
                         if not bool(tenant_tip_enabled):
                             raise APIError("Tipping is not enabled for this tenant", status_code=400)
+                        tax_config = await _get_tenant_tax_config(conn, tenant_id)
+                        _mesa_tip_tax_amount = compute_tip_tax_amount(
+                            float(tip_amount), _mesa_tip_taxable, tax_config,
+                        )
                         if not split_mode and payment_method == 'cash' and cash_received is not None:
                             session_total_with_tip = await conn.fetchval(
                                 "SELECT COALESCE(SUM(total_amount), 0) FROM orders WHERE table_session_id = $1 AND status = 'completed'",
                                 session_row["id"],
                             )
-                            if cash_received < (float(session_total_with_tip or 0) + float(tip_amount)):
+                            _required_cash = float(session_total_with_tip or 0) + tip_settlement_total(
+                                float(tip_amount), _mesa_tip_tax_amount,
+                            )
+                            if cash_received < _required_cash:
                                 raise APIError(
-                                    f"Efectivo recibido ({cash_received}) debe cubrir total + propina ({float(session_total_with_tip or 0) + float(tip_amount)})",
+                                    f"Efectivo recibido ({cash_received}) debe cubrir total + propina"
+                                    f" (+ IVA propina si aplica) ({_required_cash})",
                                     status_code=400,
                                 )
                         await conn.execute(
                             """
-                            UPDATE orders SET tip_amount = $1, tip_source = $2
+                            UPDATE orders SET tip_amount = $1, tip_source = $2,
+                                              tip_taxable = $4, tip_tax_amount = $5
                              WHERE id = (
                                SELECT id FROM orders
                                 WHERE table_session_id = $3 AND status = 'completed'
@@ -950,6 +966,8 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                             float(tip_amount),
                             tip_source,
                             session_row["id"],
+                            _mesa_tip_taxable,
+                            float(_mesa_tip_tax_amount),
                         )
 
                     # GL journal entries — one per order, atomic with session close
@@ -1117,15 +1135,21 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                 )
                 paid_total = float(paid_row["paid"])
                 
-                session_tip = await conn2.fetchval(
+                session_tip_row = await conn2.fetchrow(
                     """
-                    SELECT COALESCE(tip_amount, 0) FROM orders
+                    SELECT COALESCE(tip_amount, 0) AS tip_amount,
+                           COALESCE(tip_tax_amount, 0) AS tip_tax_amount
+                    FROM orders
                     WHERE table_session_id = $1 AND status = 'completed'
                     ORDER BY created_at LIMIT 1
                     """,
                     session_row["id"],
                 )
-                amount_due = _split_settlement_amount_due(session_total, float(session_tip or 0))
+                amount_due = split_settlement_amount_due(
+                    session_total,
+                    float(session_tip_row["tip_amount"] or 0) if session_tip_row else 0.0,
+                    float(session_tip_row["tip_tax_amount"] or 0) if session_tip_row else 0.0,
+                )
                 remaining = max(0.0, amount_due - paid_total)
                 is_complete = remaining <= 0.01
             logger.info(f"Split payment recorded for session {session_row['id']}: paid={paid_total}, remaining={remaining}")
@@ -1202,7 +1226,12 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                 "standard_tax_label": _tax_label,
                 "tip_amount": float(tip_amount) if tip_amount > 0 else 0,
                 "tip_source": tip_source,
-                "charged_amount": float(sum(float(r.get("total_amount", 0)) for r in order_rows) + float(tip_amount)) if tip_amount > 0 else None,
+                "tip_taxable": _mesa_tip_taxable if tip_amount > 0 else False,
+                "tip_tax_amount": float(_mesa_tip_tax_amount) if tip_amount > 0 else 0,
+                "charged_amount": (
+                    float(sum(float(r.get("total_amount", 0)) for r in order_rows))
+                    + tip_settlement_total(float(tip_amount), _mesa_tip_tax_amount)
+                ) if tip_amount > 0 else None,
             },
         }
 
@@ -1303,15 +1332,21 @@ async def add_session_payment(
                 )
                 paid_total = float(paid_row["paid"])
                 
-                session_tip = await conn.fetchval(
+                session_tip_row = await conn.fetchrow(
                     """
-                    SELECT COALESCE(tip_amount, 0) FROM orders
+                    SELECT COALESCE(tip_amount, 0) AS tip_amount,
+                           COALESCE(tip_tax_amount, 0) AS tip_tax_amount
+                    FROM orders
                     WHERE table_session_id = $1 AND status = 'completed'
                     ORDER BY created_at LIMIT 1
                     """,
                     session_row["id"],
                 )
-                amount_due = _split_settlement_amount_due(session_total, float(session_tip or 0))
+                amount_due = split_settlement_amount_due(
+                    session_total,
+                    float(session_tip_row["tip_amount"] or 0) if session_tip_row else 0.0,
+                    float(session_tip_row["tip_tax_amount"] or 0) if session_tip_row else 0.0,
+                )
                 remaining = max(0.0, amount_due - paid_total)
                 is_complete = remaining <= 0.01
 
@@ -2746,15 +2781,21 @@ async def void_table_payment(
                 )
                 paid_total = float(paid_row["paid"])
                 
-                session_tip = await conn.fetchval(
+                session_tip_row = await conn.fetchrow(
                     """
-                    SELECT COALESCE(tip_amount, 0) FROM orders
+                    SELECT COALESCE(tip_amount, 0) AS tip_amount,
+                           COALESCE(tip_tax_amount, 0) AS tip_tax_amount
+                    FROM orders
                     WHERE table_session_id = $1 AND status = 'completed'
                     ORDER BY created_at LIMIT 1
                     """,
                     session_row["id"],
                 )
-                amount_due = _split_settlement_amount_due(session_total, float(session_tip or 0))
+                amount_due = split_settlement_amount_due(
+                    session_total,
+                    float(session_tip_row["tip_amount"] or 0) if session_tip_row else 0.0,
+                    float(session_tip_row["tip_tax_amount"] or 0) if session_tip_row else 0.0,
+                )
                 remaining = max(0.0, amount_due - paid_total)
                 is_complete = remaining <= 0.01
 

--- a/app/services/tip_tax_service.py
+++ b/app/services/tip_tax_service.py
@@ -1,0 +1,43 @@
+"""
+Tip tax helpers — warocol.com#740
+
+Compute consumption tax on voluntary tips when the tenant/cashier opts in
+(tip gravada). Mirrors POS receipt tax breakdown logic in pos_cart_service.
+"""
+from typing import Any, Dict
+
+
+def compute_tip_tax_amount(
+    tip_amount: float,
+    tip_taxable: bool,
+    tax_config: Dict[str, Any],
+) -> float:
+    """Return tax on tip in COP (whole pesos). Zero when not taxable or no tip."""
+    if not tip_taxable or float(tip_amount or 0) <= 0:
+        return 0.0
+    amount = float(tip_amount)
+    if tax_config.get("inc_applicable"):
+        rate = float(tax_config["inc_rate"])
+        if tax_config.get("inc_included_in_price"):
+            return float(round(amount * rate / (1 + rate)))
+        return float(round(amount * rate))
+    if tax_config.get("iva_applicable"):
+        rate = float(tax_config["iva_rate"])
+        if tax_config.get("iva_included_in_price"):
+            return float(round(amount * rate / (1 + rate)))
+        return float(round(amount * rate))
+    return 0.0
+
+
+def tip_settlement_total(tip_amount: float, tip_tax_amount: float) -> float:
+    """Tip + tax on tip for settlement / charged_amount."""
+    return float(tip_amount or 0) + float(tip_tax_amount or 0)
+
+
+def split_settlement_amount_due(
+    order_total: float,
+    tip_amount: float,
+    tip_tax_amount: float = 0,
+) -> float:
+    """warocol.com#737 + #740 — order total + tip + tip tax."""
+    return float(order_total) + tip_settlement_total(tip_amount, tip_tax_amount)

--- a/tests/test_split_tip_settlement.py
+++ b/tests/test_split_tip_settlement.py
@@ -1,14 +1,14 @@
-"""Settlement math for split payments + tips (warocol.com#737)."""
-from app.services.pos_cart_service import _split_settlement_amount_due
+"""Settlement math for split payments + tips (warocol.com#737, #740)."""
+from app.services.tip_tax_service import split_settlement_amount_due
 
 
 def test_split_settlement_amount_due_includes_tip():
-    assert _split_settlement_amount_due(100_000, 10_000) == 110_000
+    assert split_settlement_amount_due(100_000, 10_000) == 110_000
 
 
 def test_split_settlement_amount_due_zero_tip():
-    assert _split_settlement_amount_due(50_000, 0) == 50_000
+    assert split_settlement_amount_due(50_000, 0) == 50_000
 
 
-def test_split_settlement_amount_due_none_tip_treated_as_zero():
-    assert _split_settlement_amount_due(50_000, None) == 50_000
+def test_split_settlement_amount_due_with_tip_tax():
+    assert split_settlement_amount_due(100_000, 10_000, 1_900) == 111_900

--- a/tests/test_tip_tax_service.py
+++ b/tests/test_tip_tax_service.py
@@ -1,0 +1,35 @@
+"""Tip tax helpers — warocol.com#740."""
+from app.services.tip_tax_service import (
+    compute_tip_tax_amount,
+    split_settlement_amount_due,
+    tip_settlement_total,
+)
+
+
+def _iva_config(*, included: bool = False, rate: float = 0.19):
+    return {
+        "inc_applicable": False,
+        "iva_applicable": True,
+        "iva_rate": rate,
+        "iva_included_in_price": included,
+    }
+
+
+def test_compute_tip_tax_zero_when_not_taxable():
+    assert compute_tip_tax_amount(10_000, False, _iva_config()) == 0.0
+
+
+def test_compute_tip_tax_iva_excluded():
+    assert compute_tip_tax_amount(10_000, True, _iva_config(included=False)) == 1900.0
+
+
+def test_compute_tip_tax_iva_included():
+    assert compute_tip_tax_amount(11_900, True, _iva_config(included=True)) == 1900.0
+
+
+def test_split_settlement_includes_tip_tax():
+    assert split_settlement_amount_due(100_000, 10_000, 1_900) == 111_900
+
+
+def test_tip_settlement_total():
+    assert tip_settlement_total(5_000, 950) == 5_950


### PR DESCRIPTION
## Summary
- Tenant default `tip_taxable_default` + per-sale `tip_taxable` on orders
- Server-side tip tax via `tip_tax_service` (IVA/INC)
- Settlement includes `tip_amount + tip_tax_amount`
- Operaciones toggle `PATCH /operaciones/toggles/tip-taxable-default`

## Migration
Run on DB before/with deploy (not in git — `migrations/` is ignored):
`migrations/080_tip_taxable.sql`

## Testing
- `python3 -m pytest tests/test_tip_tax_service.py tests/test_split_tip_settlement.py`

Closes #740

Made with [Cursor](https://cursor.com)