### PR TITLE
[#744] Unify costo_calculado (real) across list, save, analytics recalc

### DIFF
--- a/app/services/analytics_service.py
+++ b/app/services/analytics_service.py
@@ -6,6 +6,7 @@ from typing import Optional, List, Dict, Any
 from uuid import UUID
 from fastapi import Request
 from app.database import get_db_connection
+from app.services import cost_resolution_service
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError
 from datetime import datetime, date, timedelta
@@ -1384,32 +1385,12 @@ async def resolve_data_quality_alert(
                     effective_quantity * corrected_value,
                 )
 
-                # 5. Recalculate costo_calculado for all products using this ingredient
-                await conn.execute("""
-                    UPDATE product
-                    SET costo_calculado = (
-                        SELECT COALESCE(SUM(
-                            pr.quantity * COALESCE(
-                                (SELECT pi.unit_cost
-                                 FROM tenant_purchase_items pi
-                                 JOIN tenant_purchases tp ON pi.purchase_id = tp.id
-                                 WHERE pi.ingredient_id = pr.ingredient_id
-                                   AND tp.tenant_id = $2
-                                   AND pi.unit_cost IS NOT NULL AND pi.unit_cost > 0
-                                 ORDER BY tp.purchase_date DESC LIMIT 1),
-                                i.costo_unitario, 0
-                            )
-                        ), 0)
-                        FROM product_recipes pr
-                        JOIN ingredients i ON pr.ingredient_id = i.id
-                        WHERE pr.product_id = product.id
-                    )
-                    WHERE id IN (
-                        SELECT DISTINCT pr.product_id
-                        FROM product_recipes pr
-                        WHERE pr.ingredient_id = $1
-                    )
-                """, ingredient_id, tenant_id)
+                # 5. Recalculate costo_calculado (unified resolver, incl. base recipes)
+                await cost_resolution_service.recalculate_products_for_ingredient(
+                    ingredient_id,
+                    tenant_id,
+                    conn,
+                )
 
                 # 6. Mark alert resolved with full audit trail
                 await conn.execute("""

--- a/app/services/cost_resolution_service.py
+++ b/app/services/cost_resolution_service.py
@@ -1,0 +1,189 @@
+"""
+Unified real-cost resolution for menu products (costo_calculado).
+
+Priority for each ingredient unit cost:
+  1. Latest tenant_purchase_items.unit_cost (tenant-scoped, purchase_date DESC)
+  2. ingredients.costo_unitario
+  3. 0
+
+Product total = sum(direct product_recipes) + sum(product_base_recipes × base_recipe_templates).
+"""
+from decimal import Decimal
+from typing import Optional
+from uuid import UUID
+
+# Shared CTE for list queries — $1 must be tenant_id
+LIST_COST_CTE_PREFIX = """
+    WITH latest_purchase_costs AS (
+        SELECT DISTINCT ON (pi.ingredient_id)
+            pi.ingredient_id,
+            pi.unit_cost
+        FROM tenant_purchase_items pi
+        JOIN tenant_purchases tp ON pi.purchase_id = tp.id
+        WHERE tp.tenant_id = $1
+          AND pi.unit_cost IS NOT NULL
+          AND pi.unit_cost > 0
+        ORDER BY pi.ingredient_id, tp.purchase_date DESC
+    ),
+    direct_costs AS (
+        SELECT
+            pr.product_id,
+            SUM(
+                pr.quantity * COALESCE(lpc.unit_cost, i.costo_unitario, 0)
+            ) AS direct_cost
+        FROM product_recipes pr
+        JOIN ingredients i ON pr.ingredient_id = i.id
+        LEFT JOIN latest_purchase_costs lpc ON pr.ingredient_id = lpc.ingredient_id
+        GROUP BY pr.product_id
+    ),
+    base_costs AS (
+        SELECT
+            pbr.product_id,
+            SUM(
+                pbr.quantity * brt.base_quantity * COALESCE(lpc.unit_cost, i.costo_unitario, 0)
+            ) AS base_cost
+        FROM product_base_recipes pbr
+        JOIN base_recipe_templates brt ON pbr.product_base_type_id = brt.product_base_type_id
+        JOIN ingredients i ON brt.ingredient_id = i.id
+        LEFT JOIN latest_purchase_costs lpc ON brt.ingredient_id = lpc.ingredient_id
+        GROUP BY pbr.product_id
+    )
+"""
+
+_CALCULATE_PRODUCT_COST_SQL = """
+    WITH latest_purchase_costs AS (
+        SELECT DISTINCT ON (pi.ingredient_id)
+            pi.ingredient_id,
+            pi.unit_cost
+        FROM tenant_purchase_items pi
+        JOIN tenant_purchases tp ON pi.purchase_id = tp.id
+        WHERE tp.tenant_id = $2
+          AND pi.unit_cost IS NOT NULL
+          AND pi.unit_cost > 0
+        ORDER BY pi.ingredient_id, tp.purchase_date DESC
+    ),
+    direct_cost AS (
+        SELECT COALESCE(SUM(
+            pr.quantity * COALESCE(lpc.unit_cost, i.costo_unitario, 0)
+        ), 0) AS amount
+        FROM product_recipes pr
+        JOIN ingredients i ON pr.ingredient_id = i.id
+        LEFT JOIN latest_purchase_costs lpc ON pr.ingredient_id = lpc.ingredient_id
+        WHERE pr.product_id = $1
+    ),
+    base_cost AS (
+        SELECT COALESCE(SUM(
+            pbr.quantity * brt.base_quantity * COALESCE(lpc.unit_cost, i.costo_unitario, 0)
+        ), 0) AS amount
+        FROM product_base_recipes pbr
+        JOIN base_recipe_templates brt ON pbr.product_base_type_id = brt.product_base_type_id
+        JOIN ingredients i ON brt.ingredient_id = i.id
+        LEFT JOIN latest_purchase_costs lpc ON brt.ingredient_id = lpc.ingredient_id
+        WHERE pbr.product_id = $1
+    )
+    SELECT (SELECT amount FROM direct_cost) + (SELECT amount FROM base_cost) AS total_cost
+"""
+
+
+async def calculated_product_cost_real(
+    product_id: UUID,
+    tenant_id: UUID,
+    conn,
+) -> Decimal:
+    """Return real calculated cost for a product (direct recipes + base recipes)."""
+    row = await conn.fetchrow(
+        _CALCULATE_PRODUCT_COST_SQL,
+        product_id,
+        tenant_id,
+    )
+    if not row or row["total_cost"] is None:
+        return Decimal("0")
+    return Decimal(str(row["total_cost"]))
+
+
+async def product_has_any_recipe(product_id: UUID, conn) -> bool:
+    return await conn.fetchval(
+        """
+        SELECT EXISTS (
+            SELECT 1 FROM product_recipes WHERE product_id = $1
+            UNION ALL
+            SELECT 1 FROM product_base_recipes WHERE product_id = $1
+        )
+        """,
+        product_id,
+    )
+
+
+async def persist_product_costo_calculado(
+    product_id: UUID,
+    tenant_id: UUID,
+    conn,
+    *,
+    tracks_inventory: bool,
+) -> None:
+    """
+    Write product.costo_calculado using the unified resolver.
+    NULL when the product does not track inventory / has no recipe.
+    """
+    if not tracks_inventory:
+        await conn.execute(
+            "UPDATE product SET costo_calculado = NULL WHERE id = $1",
+            product_id,
+        )
+        return
+
+    has_recipe = await product_has_any_recipe(product_id, conn)
+    if not has_recipe:
+        await conn.execute(
+            "UPDATE product SET costo_calculado = NULL WHERE id = $1",
+            product_id,
+        )
+        return
+
+    total = await calculated_product_cost_real(product_id, tenant_id, conn)
+    await conn.execute(
+        "UPDATE product SET costo_calculado = $2 WHERE id = $1",
+        product_id,
+        total,
+    )
+
+
+async def recalculate_products_for_ingredient(
+    ingredient_id: UUID,
+    tenant_id: UUID,
+    conn,
+) -> None:
+    """Recalculate costo_calculado for all products that use an ingredient."""
+    product_ids = await conn.fetch(
+        """
+        SELECT DISTINCT product_id FROM (
+            SELECT pr.product_id
+            FROM product_recipes pr
+            WHERE pr.ingredient_id = $1
+            UNION
+            SELECT pbr.product_id
+            FROM product_base_recipes pbr
+            JOIN base_recipe_templates brt ON pbr.product_base_type_id = brt.product_base_type_id
+            WHERE brt.ingredient_id = $1
+        ) affected
+        """,
+        ingredient_id,
+    )
+    for row in product_ids:
+        pid = row["product_id"]
+        await persist_product_costo_calculado(
+            pid,
+            tenant_id,
+            conn,
+            tracks_inventory=True,
+        )
+
+
+def apply_analytics_cost_fallback(calc_cost: Decimal, price: Decimal) -> Decimal:
+    """
+    Analytics-only: when real cost is missing or exceeds price, use 40% of price.
+    Menu product list/detail do not apply this rule.
+    """
+    if calc_cost <= 0 or calc_cost > price:
+        return price * Decimal("0.40")
+    return calc_cost

--- a/app/services/products_service.py
+++ b/app/services/products_service.py
@@ -10,6 +10,7 @@ from app.models.product import (
     ProductResponse, ProductStats, RecipeBaseLink
 )
 from app.services import menu_history_service
+from app.services import cost_resolution_service
 from app.services.aws_s3_service import AWSS3Service
 from app.services.ingredient_purchase_units_service import resolve_to_base_unit
 import asyncpg
@@ -154,38 +155,13 @@ async def create_product_with_recipe(
                             tenant_id
                         )
 
-                # 4. Calculate and update product cost (last purchase price).
-                # Products without recipe persist costo_calculado=NULL — semantically
-                # "not applicable" rather than "$0", which avoids polluting margin
-                # reports and lets the frontend render "—".
-                if tracks_inventory:
-                    cost_query = """
-                        UPDATE product
-                        SET costo_calculado = (
-                            SELECT COALESCE(SUM(
-                                pr.quantity * COALESCE(
-                                    (SELECT pi.unit_cost
-                                     FROM tenant_purchase_items pi
-                                     JOIN tenant_purchases tp ON pi.purchase_id = tp.id
-                                     WHERE pi.ingredient_id = pr.ingredient_id
-                                       AND tp.tenant_id = $2
-                                       AND pi.unit_cost IS NOT NULL AND pi.unit_cost > 0
-                                     ORDER BY tp.purchase_date DESC LIMIT 1),
-                                    i.costo_unitario, 0
-                                )
-                            ), 0)
-                            FROM product_recipes pr
-                            JOIN ingredients i ON pr.ingredient_id = i.id
-                            WHERE pr.product_id = $1
-                        )
-                        WHERE id = $1
-                    """
-                    await conn.execute(cost_query, product_id, tenant_id)
-                else:
-                    await conn.execute(
-                        "UPDATE product SET costo_calculado = NULL WHERE id = $1",
-                        product_id,
-                    )
+                # 4. Unified real cost (direct recipes + base recipes)
+                await cost_resolution_service.persist_product_costo_calculado(
+                    product_id,
+                    tenant_id,
+                    conn,
+                    tracks_inventory=tracks_inventory,
+                )
 
                 # 5. Registrar en historial
                 user_id = session_context.user_id if hasattr(session_context, 'user_id') else None
@@ -442,36 +418,7 @@ async def get_products_list(
         async with get_db_connection() as conn:
             # CTE: pre-compute latest purchase cost per ingredient once (O(1) index scan)
             # Replaces nested correlated subqueries that ran O(products × base_recipe_rows) times
-            cte_prefix = """
-                WITH latest_purchase_costs AS (
-                    SELECT DISTINCT ON (pi.ingredient_id)
-                        pi.ingredient_id,
-                        pi.unit_cost
-                    FROM tenant_purchase_items pi
-                    JOIN tenant_purchases tp ON pi.purchase_id = tp.id
-                    WHERE tp.tenant_id = $1
-                      AND pi.unit_cost IS NOT NULL
-                      AND pi.unit_cost > 0
-                    ORDER BY pi.ingredient_id, tp.purchase_date DESC
-                ),
-                direct_costs AS (
-                    SELECT
-                        pr.product_id,
-                        SUM(pr.quantity * COALESCE(lpc.unit_cost, 0)) as direct_cost
-                    FROM product_recipes pr
-                    LEFT JOIN latest_purchase_costs lpc ON pr.ingredient_id = lpc.ingredient_id
-                    GROUP BY pr.product_id
-                ),
-                base_costs AS (
-                    SELECT
-                        pbr.product_id,
-                        SUM(pbr.quantity * brt.base_quantity * COALESCE(lpc.unit_cost, 0)) as base_cost
-                    FROM product_base_recipes pbr
-                    JOIN base_recipe_templates brt ON pbr.product_base_type_id = brt.product_base_type_id
-                    LEFT JOIN latest_purchase_costs lpc ON brt.ingredient_id = lpc.ingredient_id
-                    GROUP BY pbr.product_id
-                )
-            """
+            cte_prefix = cost_resolution_service.LIST_COST_CTE_PREFIX
 
             # Base query uses CTE JOINs instead of correlated subqueries
             base_query = """
@@ -894,44 +841,15 @@ async def update_product_with_recipe(
                     # 4. Recalculate product cost (last purchase price).
                     # Without recipe → NULL (semantically "no aplica") so the
                     # margin/cost UI renders "—" instead of $0.
-                    has_any_recipe = await conn.fetchval(
-                        """
-                        SELECT EXISTS (
-                            SELECT 1 FROM product_recipes WHERE product_id = $1
-                            UNION ALL
-                            SELECT 1 FROM product_base_recipes WHERE product_id = $1
-                        )
-                        """,
-                        product_id,
+                    has_any_recipe = await cost_resolution_service.product_has_any_recipe(
+                        product_id, conn
                     )
-                    if has_any_recipe:
-                        cost_query = """
-                            UPDATE product
-                            SET costo_calculado = (
-                                SELECT COALESCE(SUM(
-                                    pr.quantity * COALESCE(
-                                        (SELECT pi.unit_cost
-                                         FROM tenant_purchase_items pi
-                                         JOIN tenant_purchases tp ON pi.purchase_id = tp.id
-                                         WHERE pi.ingredient_id = pr.ingredient_id
-                                           AND tp.tenant_id = $2
-                                           AND pi.unit_cost IS NOT NULL AND pi.unit_cost > 0
-                                         ORDER BY tp.purchase_date DESC LIMIT 1),
-                                        i.costo_unitario, 0
-                                    )
-                                ), 0)
-                                FROM product_recipes pr
-                                JOIN ingredients i ON pr.ingredient_id = i.id
-                                WHERE pr.product_id = $1
-                            )
-                            WHERE id = $1
-                        """
-                        await conn.execute(cost_query, product_id, tenant_id)
-                    else:
-                        await conn.execute(
-                            "UPDATE product SET costo_calculado = NULL WHERE id = $1",
-                            product_id,
-                        )
+                    await cost_resolution_service.persist_product_costo_calculado(
+                        product_id,
+                        tenant_id,
+                        conn,
+                        tracks_inventory=has_any_recipe,
+                    )
 
                 # 5. Registrar cambios en historial
                 if old_snapshot:

--- a/tests/test_recipe_base_costs.py
+++ b/tests/test_recipe_base_costs.py
@@ -239,3 +239,44 @@ class TestRecipeTotalCostCalculation:
         costo_total = self.calculate_recipe_cost(ingredients)
 
         assert costo_total == Decimal("0")
+
+
+class TestUnifiedProductCostResolution:
+    """Tests for cost_resolution_service (#744)."""
+
+    def test_list_cte_includes_costo_unitario_fallback(self):
+        from app.services.cost_resolution_service import LIST_COST_CTE_PREFIX
+
+        assert "i.costo_unitario" in LIST_COST_CTE_PREFIX
+        assert "COALESCE(lpc.unit_cost, i.costo_unitario, 0)" in LIST_COST_CTE_PREFIX
+
+    def test_direct_plus_base_recipe_total(self):
+        """Product cost = direct ingredients + base template ingredients."""
+        direct = Decimal("10") * Decimal("100")  # 1000
+        base = Decimal("2") * Decimal("500") * Decimal("3")  # qty × base_qty × unit
+        assert direct + base == Decimal("4000")
+
+    def test_purchase_wins_over_costo_unitario_for_line(self):
+        purchase = Decimal("500")
+        configured = Decimal("100")
+        effective = purchase if purchase > 0 else configured
+        assert effective == Decimal("500")
+
+    def test_analytics_fallback_when_zero_real_cost(self):
+        from app.services.cost_resolution_service import apply_analytics_cost_fallback
+
+        price = Decimal("10000")
+        assert apply_analytics_cost_fallback(Decimal("0"), price) == Decimal("4000")
+
+    def test_analytics_fallback_when_cost_exceeds_price(self):
+        from app.services.cost_resolution_service import apply_analytics_cost_fallback
+
+        price = Decimal("5000")
+        assert apply_analytics_cost_fallback(Decimal("8000"), price) == Decimal("2000")
+
+    def test_analytics_no_fallback_when_valid_cost(self):
+        from app.services.cost_resolution_service import apply_analytics_cost_fallback
+
+        price = Decimal("10000")
+        real = Decimal("3500")
+        assert apply_analytics_cost_fallback(real, price) == real


### PR DESCRIPTION
## Summary
- Add `cost_resolution_service` as single source for real product cost (purchase → `costo_unitario` → 0)
- Include direct recipes **and** `product_base_recipes` on save/update
- Fix list CTE to use same `costo_unitario` fallback as persistence
- Purchase-correction recalc uses unified resolver (incl. base recipes)

## Stack
Python 3.9 / FastAPI / asyncpg

## Changes
- `app/services/cost_resolution_service.py` (new)
- `app/services/products_service.py`
- `app/services/analytics_service.py`
- `tests/test_recipe_base_costs.py`

## Testing
- `pytest tests/test_recipe_base_costs.py -v` (19 passed)

Closes uno0uno/warocol.com#744

Made with [Cursor](https://cursor.com)