### PR TITLE
[#745] costo_percibido: migration, models, products_service, history

### DIFF
--- a/app/models/product.py
+++ b/app/models/product.py
@@ -100,6 +100,11 @@ class ProductCreate(ProductBase):
         description="Recipe bases with per-product quantity multiplier. Preferred over recipe_base_ids."
     )
     tenant_id: UUID = Field(..., description="Tenant ID")
+    costo_percibido: Optional[Decimal] = Field(
+        None,
+        ge=0,
+        description="Operational/perceived unit cost set by the tenant",
+    )
 
 class ProductUpdate(BaseModel):
     """Update product fields"""
@@ -124,12 +129,21 @@ class ProductUpdate(BaseModel):
     station_id: Optional[UUID] = None
     kitchen_name: Optional[str] = Field(None, max_length=100)
     image_url: Optional[str] = Field(None, max_length=500, description="Public URL of the product hero image (null clears it)")
+    costo_percibido: Optional[Decimal] = Field(
+        None,
+        ge=0,
+        description="Operational/perceived unit cost (null clears)",
+    )
 
 class Product(ProductBase):
     """Complete product with calculated fields"""
     id: UUID
     tenant_id: Optional[UUID]
     costo_calculado: Optional[Decimal] = Field(None, description="Calculated cost from recipe")
+    costo_percibido: Optional[Decimal] = Field(
+        None,
+        description="Operational/perceived cost set by tenant",
+    )
     precio_sugerido: Optional[Decimal] = Field(None, description="Suggested price")
     margen_objetivo: Optional[Decimal] = Field(None, description="Target margin")
     created_at: datetime
@@ -145,9 +159,13 @@ class Product(ProductBase):
     recipe_bases: List[RecipeBaseLink] = Field(default=[], description="Recipe bases with per-product quantity multiplier (Issue #517).")
     modifier_groups: List[ModifierGroup] = Field(default=[], description="Modifier groups for this product")
 
-    # Calculated fields
-    margen_porcentaje: Optional[float] = None  # (price - cost) / cost * 100
-    margen_valor: Optional[Decimal] = None  # price - cost
+    # Calculated fields (real = costo_calculado, operativo = costo_percibido)
+    margen_real_pct: Optional[float] = None
+    margen_real_valor: Optional[Decimal] = None
+    margen_operativo_pct: Optional[float] = None
+    margen_operativo_valor: Optional[Decimal] = None
+    margen_porcentaje: Optional[float] = None  # alias margen_real_pct (backward compat)
+    margen_valor: Optional[Decimal] = None  # alias margen_real_valor
 
     class Config:
         from_attributes = True

--- a/app/services/menu_history_service.py
+++ b/app/services/menu_history_service.py
@@ -546,7 +546,7 @@ async def get_product_snapshot(conn, product_id: UUID, tenant_id: UUID) -> Optio
         product = await conn.fetchrow("""
             SELECT id, name, description, price, category_id, is_available,
                    allow_modifiers, preparation_time, product_base_type_id,
-                   costo_calculado, controla_stock, is_combo
+                   costo_calculado, costo_percibido, controla_stock, is_combo
             FROM product WHERE id = $1 AND tenant_id = $2
         """, product_id, tenant_id)
 

--- a/app/services/products_service.py
+++ b/app/services/products_service.py
@@ -20,6 +20,40 @@ logger = logging.getLogger(__name__)
 
 _DUPLICATE_PRODUCT_NAME_DETAIL = "Ya existe un producto con ese nombre en tu menú"
 
+# Dual margins: real (costo_calculado) + operativo (costo_percibido). Outer SELECT only.
+_PRODUCT_MARGIN_OUTER_SQL = """
+    CASE
+        WHEN costo_calculado > 0 AND costo_calculado IS NOT NULL
+        THEN ((price - costo_calculado) / costo_calculado * 100)
+        ELSE NULL
+    END as margen_real_pct,
+    CASE
+        WHEN costo_calculado IS NOT NULL
+        THEN (price - costo_calculado)
+        ELSE NULL
+    END as margen_real_valor,
+    CASE
+        WHEN costo_percibido > 0 AND costo_percibido IS NOT NULL
+        THEN ((price - costo_percibido) / costo_percibido * 100)
+        ELSE NULL
+    END as margen_operativo_pct,
+    CASE
+        WHEN costo_percibido IS NOT NULL
+        THEN (price - costo_percibido)
+        ELSE NULL
+    END as margen_operativo_valor,
+    CASE
+        WHEN costo_calculado > 0 AND costo_calculado IS NOT NULL
+        THEN ((price - costo_calculado) / costo_calculado * 100)
+        ELSE NULL
+    END as margen_porcentaje,
+    CASE
+        WHEN costo_calculado IS NOT NULL
+        THEN (price - costo_calculado)
+        ELSE NULL
+    END as margen_valor
+"""
+
 
 def _normalize_recipe_bases(
     recipe_bases: Optional[List[RecipeBaseLink]],
@@ -84,9 +118,9 @@ async def create_product_with_recipe(
                         name, description, price, category_id, product_base_type_id, preparation_time,
                         controla_stock, is_available, is_available_online, is_available_table_qr,
                         is_combo, is_resale, allow_modifiers,
-                        tax_category, tenant_id, station_id, kitchen_name, image_url
+                        tax_category, tenant_id, station_id, kitchen_name, image_url, costo_percibido
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
                     RETURNING id, created_at, updated_at
                 """
                 product_result = await conn.fetchrow(
@@ -109,6 +143,7 @@ async def create_product_with_recipe(
                     product_data.station_id,
                     product_data.kitchen_name,
                     product_data.image_url,
+                    product_data.costo_percibido,
                 )
 
                 product_id = product_result['id']
@@ -220,6 +255,7 @@ async def get_product_by_id(
                     p.allow_modifiers,
                     p.tax_category,
                     p.costo_calculado,
+                    p.costo_percibido,
                     p.precio_sugerido,
                     p.margen_objetivo,
                     p.tenant_id,
@@ -231,13 +267,36 @@ async def get_product_by_id(
                     ks.id as ks_id,
                     ks.name as station_name,
                     ks.color as station_color,
-                    -- Calculated fields
+                    CASE
+                        WHEN p.costo_calculado > 0
+                        THEN ((p.price - p.costo_calculado) / p.costo_calculado * 100)
+                        ELSE NULL
+                    END as margen_real_pct,
+                    CASE
+                        WHEN p.costo_calculado IS NOT NULL
+                        THEN (p.price - p.costo_calculado)
+                        ELSE NULL
+                    END as margen_real_valor,
+                    CASE
+                        WHEN p.costo_percibido > 0
+                        THEN ((p.price - p.costo_percibido) / p.costo_percibido * 100)
+                        ELSE NULL
+                    END as margen_operativo_pct,
+                    CASE
+                        WHEN p.costo_percibido IS NOT NULL
+                        THEN (p.price - p.costo_percibido)
+                        ELSE NULL
+                    END as margen_operativo_valor,
                     CASE
                         WHEN p.costo_calculado > 0
                         THEN ((p.price - p.costo_calculado) / p.costo_calculado * 100)
                         ELSE NULL
                     END as margen_porcentaje,
-                    (p.price - COALESCE(p.costo_calculado, 0)) as margen_valor
+                    CASE
+                        WHEN p.costo_calculado IS NOT NULL
+                        THEN (p.price - p.costo_calculado)
+                        ELSE NULL
+                    END as margen_valor
                 FROM product p
                 LEFT JOIN categories c ON p.category_id = c.id
                 LEFT JOIN tenant_category_stations tcs ON tcs.category_id = p.category_id AND tcs.tenant_id = p.tenant_id
@@ -439,6 +498,7 @@ async def get_products_list(
                     p.allow_modifiers,
                     p.tax_category,
                     COALESCE(dc.direct_cost, 0) + COALESCE(bc.base_cost, 0) as costo_calculado,
+                    p.costo_percibido,
                     p.precio_sugerido,
                     p.margen_objetivo,
                     p.tenant_id,
@@ -463,16 +523,7 @@ async def get_products_list(
             base_query = cte_prefix + """
                 SELECT
                     *,
-                    CASE
-                        WHEN costo_calculado > 0 AND costo_calculado IS NOT NULL
-                        THEN ((price - costo_calculado) / costo_calculado * 100)
-                        ELSE NULL
-                    END as margen_porcentaje,
-                    CASE
-                        WHEN costo_calculado IS NOT NULL
-                        THEN (price - costo_calculado)
-                        ELSE NULL
-                    END as margen_valor
+            """ + _PRODUCT_MARGIN_OUTER_SQL + """
                 FROM (
             """ + base_query + """
                 ) subquery
@@ -751,7 +802,7 @@ async def update_product_with_recipe(
                 # Fields where None is a valid "clear this value" intent (#465).
                 # Without this, the loop below silently drops attempts to remove
                 # an image when the user clicks "Eliminar imagen" in the form.
-                NULLABLE_FIELDS = {'image_url'}
+                NULLABLE_FIELDS = {'image_url', 'costo_percibido'}
                 for field, value in product_data.dict(exclude={'ingredients', 'recipe_base_ids', 'recipe_bases', 'controla_stock'}, exclude_unset=True).items():
                     if value is None and field not in NULLABLE_FIELDS:
                         continue
@@ -838,18 +889,16 @@ async def update_product_with_recipe(
                                 tenant_id
                             )
 
-                    # 4. Recalculate product cost (last purchase price).
-                    # Without recipe → NULL (semantically "no aplica") so the
-                    # margin/cost UI renders "—" instead of $0.
-                    has_any_recipe = await cost_resolution_service.product_has_any_recipe(
-                        product_id, conn
-                    )
-                    await cost_resolution_service.persist_product_costo_calculado(
-                        product_id,
-                        tenant_id,
-                        conn,
-                        tracks_inventory=has_any_recipe,
-                    )
+                # 4. Recalculate real cost only (never touches costo_percibido).
+                has_any_recipe = await cost_resolution_service.product_has_any_recipe(
+                    product_id, conn
+                )
+                await cost_resolution_service.persist_product_costo_calculado(
+                    product_id,
+                    tenant_id,
+                    conn,
+                    tracks_inventory=has_any_recipe,
+                )
 
                 # 5. Registrar cambios en historial
                 if old_snapshot:

--- a/dbdoc/public.product.md
+++ b/dbdoc/public.product.md
@@ -18,6 +18,7 @@
 | is_available | boolean | true | true |  |  |  |
 | is_combo | boolean | false | true |  |  | true si es un combo/bundle de productos |
 | costo_calculado | numeric(10,2) |  | true |  |  | Costo automático calculado desde recetas (se actualiza cuando cambian precios de ingredientes) |
+| costo_percibido | numeric(10,2) |  | true |  |  | Costo operativo/percibido definido por el tenant; independiente de costo_calculado |
 | precio_sugerido | numeric(10,2) |  | true |  |  |  |
 | margen_objetivo | numeric(5,2) |  | true |  |  | Margen de ganancia objetivo en porcentaje (ej: 150 = 150%) |
 | allow_modifiers | boolean | true | true |  |  |  |

--- a/dbdoc/schema.json
+++ b/dbdoc/schema.json
@@ -9825,6 +9825,12 @@
           "comment": "Costo automático calculado desde recetas (se actualiza cuando cambian precios de ingredientes)"
         },
         {
+          "name": "costo_percibido",
+          "type": "numeric(10,2)",
+          "nullable": true,
+          "comment": "Costo operativo/percibido definido por el tenant; independiente de costo_calculado"
+        },
+        {
           "name": "precio_sugerido",
           "type": "numeric(10,2)",
           "nullable": true

--- a/sql/20260520_add_product_costo_percibido.sql
+++ b/sql/20260520_add_product_costo_percibido.sql
@@ -1,0 +1,6 @@
+-- #745: operational (perceived) cost — tenant-set, independent of costo_calculado
+ALTER TABLE product
+    ADD COLUMN IF NOT EXISTS costo_percibido NUMERIC(10, 2) NULL;
+
+COMMENT ON COLUMN product.costo_percibido IS
+    'Costo operativo/percibido definido por el tenant; no se recalcula con compras ni recetas.';

--- a/tests/test_product_create_bind.py
+++ b/tests/test_product_create_bind.py
@@ -1,4 +1,4 @@
-"""Regression: create_product INSERT must pass 18 bind args (#279)."""
+"""Regression: create_product INSERT must pass 19 bind args (#279, #745)."""
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -24,7 +24,7 @@ def _session():
 
 
 @pytest.mark.asyncio
-async def test_create_product_insert_passes_18_bind_args_in_order():
+async def test_create_product_insert_passes_19_bind_args_in_order():
     """INSERT lists is_available_table_qr as $10 — bind must not shift is_combo."""
     request = MagicMock(spec=Request)
     session = _session()
@@ -74,7 +74,7 @@ async def test_create_product_insert_passes_18_bind_args_in_order():
         result = await create_product_with_recipe(request, product_data)
 
     assert result is mock_response
-    assert len(insert_args) == 18
+    assert len(insert_args) == 19
     # $7 controla_stock=True, $8 is_available, $9 is_available_online,
     # $10 is_available_table_qr, $11 is_combo
     assert insert_args[6] is True  # controla_stock

--- a/tests/test_product_perceived_cost.py
+++ b/tests/test_product_perceived_cost.py
@@ -1,0 +1,145 @@
+"""Tests for costo_percibido (#745) — independent of costo_calculado."""
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import Request
+
+from app.core.middleware import SessionContext
+from app.models.product import ProductCreate, ProductUpdate
+from app.services.products_service import create_product_with_recipe, update_product_with_recipe
+
+
+def _session():
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@warocol.com",
+        "name": "Test",
+        "expires_at": None,
+        "is_active": True,
+    })
+
+
+@pytest.mark.asyncio
+async def test_create_product_with_perceived_only_no_recipe():
+    """Perceived cost without recipe: costo_calculado stays NULL after persist."""
+    request = MagicMock(spec=Request)
+    session = _session()
+    product_id = uuid4()
+    persist_calls = []
+
+    async def _fetchrow(query, *args):
+        if "INSERT INTO product" in query:
+            assert args[-1] == Decimal("8500")
+            return {
+                "id": product_id,
+                "created_at": datetime.now(timezone.utc),
+                "updated_at": datetime.now(timezone.utc),
+            }
+        return None
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=_fetchrow)
+    conn.execute = AsyncMock()
+
+    async def _persist(pid, tid, c, *, tracks_inventory):
+        persist_calls.append(tracks_inventory)
+
+    @asynccontextmanager
+    async def _txn():
+        yield
+
+    conn.transaction.return_value = _txn()
+
+    @asynccontextmanager
+    async def _db_ctx():
+        yield conn
+
+    product_data = ProductCreate(
+        name="Servicio envío",
+        price=Decimal("25000"),
+        category_id=uuid4(),
+        tenant_id=session.tenant_id,
+        costo_percibido=Decimal("8500"),
+        ingredients=[],
+    )
+
+    mock_response = MagicMock()
+
+    with patch("app.services.products_service.require_valid_session", return_value=session), \
+         patch("app.services.products_service.get_db_connection", side_effect=_db_ctx), \
+         patch("app.services.products_service.cost_resolution_service.persist_product_costo_calculado", AsyncMock(side_effect=_persist)), \
+         patch("app.services.products_service.menu_history_service.get_product_snapshot", AsyncMock(return_value=None)), \
+         patch("app.services.products_service.get_product_by_id", AsyncMock(return_value=mock_response)):
+        result = await create_product_with_recipe(request, product_data)
+
+    assert result is mock_response
+    assert persist_calls == [False]
+
+
+@pytest.mark.asyncio
+async def test_update_perceived_still_recalcs_real_not_perceived():
+    """PATCH costo_percibido updates column; real cost recalc stays separate."""
+    request = MagicMock(spec=Request)
+    session = _session()
+    product_id = uuid4()
+    update_sql = []
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={"id": product_id, "name": "Test"})
+    conn.execute = AsyncMock(side_effect=lambda q, *a: update_sql.append(q))
+    @asynccontextmanager
+    async def _txn():
+        yield
+
+    conn.transaction.return_value = _txn()
+
+    @asynccontextmanager
+    async def _db_ctx():
+        yield conn
+
+    product_data = ProductUpdate(costo_percibido=Decimal("9000"))
+
+    mock_response = MagicMock()
+
+    with patch("app.services.products_service.require_valid_session", return_value=session), \
+         patch("app.services.products_service.get_db_connection", side_effect=_db_ctx), \
+         patch("app.services.products_service.menu_history_service.get_product_snapshot", AsyncMock(return_value=None)), \
+         patch("app.services.products_service.cost_resolution_service.product_has_any_recipe", AsyncMock(return_value=False)), \
+         patch("app.services.products_service.cost_resolution_service.persist_product_costo_calculado", AsyncMock()) as mock_persist, \
+         patch("app.services.products_service.get_product_by_id", AsyncMock(return_value=mock_response)):
+        await update_product_with_recipe(request, product_id, product_data)
+
+    assert any("costo_percibido" in q for q in update_sql)
+    mock_persist.assert_called_once()
+    assert mock_persist.call_args.kwargs["tracks_inventory"] is False
+
+
+@pytest.mark.asyncio
+async def test_recalculate_ingredient_only_updates_real_cost():
+    """Purchase recalc path must not UPDATE costo_percibido."""
+    from app.services import cost_resolution_service
+
+    ingredient_id = uuid4()
+    tenant_id = uuid4()
+    product_id = uuid4()
+
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[{"product_id": product_id}])
+    persist = AsyncMock()
+
+    with patch(
+        "app.services.cost_resolution_service.persist_product_costo_calculado",
+        persist,
+    ):
+        await cost_resolution_service.recalculate_products_for_ingredient(
+            ingredient_id, tenant_id, conn
+        )
+
+    persist.assert_called_once()
+    assert persist.call_args[0][0] == product_id
+    assert "costo_percibido" not in str(persist.call_args)


### PR DESCRIPTION
## Summary
- Add `product.costo_percibido` (nullable, tenant-set operational cost)
- CRUD + list/detail expose perceived cost and dual margins (`margen_real_*`, `margen_operativo_*`)
- `margen_porcentaje` / `margen_valor` remain aliases for real margin (backward compat)
- History snapshots include `costo_percibido`
- Real-cost recalc (`cost_resolution_service`) never writes perceived; fix update to always recalc real after PATCH

## Depends on
- #744 / `gh-744-unify-costo-calculado` (base branch)

## Migration (run before deploy)
```bash
psql ... -f sql/20260520_add_product_costo_percibido.sql
```

## Testing
- `pytest tests/test_product_perceived_cost.py tests/test_product_create_bind.py -v` (4 passed)

## Notes
- No backfill: tenants set perceived per product via UI (#746)
- Does not change analytics or public API

Closes uno0uno/warocol.com#745

Made with [Cursor](https://cursor.com)