### PR TITLE
POS: partial fire via item_ids on table fire endpoint (#753)

### DIFF
--- a/app/models/comanda.py
+++ b/app/models/comanda.py
@@ -52,6 +52,14 @@ class Comanda(BaseModel):
         from_attributes = True
 
 
+class FireTableItemsRequest(BaseModel):
+    """Optional body for POST /tables/{table_id}/fire (#753)."""
+    item_ids: Optional[List[UUID]] = Field(
+        None,
+        description="If set, only fire these order_item UUIDs (must be fulfillment_status=new).",
+    )
+
+
 class FireComandasResult(BaseModel):
     success: bool = True
     comandas: List[Comanda] = []

--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -11,6 +11,7 @@ from datetime import date
 from pydantic import BaseModel, Field
 from app.core.permissions import Module, require_module
 from app.models.table_member_assignment import OpenTableRequest
+from app.models.comanda import FireTableItemsRequest
 from app.services import tables_service
 
 router = APIRouter(tags=["Tables"])
@@ -280,12 +281,18 @@ async def request_bill(request: Request, table_id: UUID):
 
 
 @router.post("/{table_id}/fire", dependencies=[Depends(require_module(Module.POS))])
-async def fire_table_items(request: Request, table_id: UUID):
+async def fire_table_items(
+    request: Request,
+    table_id: UUID,
+    body: Optional[FireTableItemsRequest] = None,
+):
     """
-    Explicitly fire all 'new' items in the table session to the kitchen.
+    Explicitly fire 'new' items in the table session to the kitchen.
+    Optional item_ids: fire only selected order_items (#753).
     Returns comanda summaries and fired item count.
     """
-    return await tables_service.fire_table_items(request, table_id)
+    item_ids = body.item_ids if body else None
+    return await tables_service.fire_table_items(request, table_id, item_ids=item_ids)
 
 
 @router.delete("/{table_id}/session", dependencies=[Depends(require_module(Module.POS))])

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -2588,9 +2588,14 @@ async def clear_tab(request: Request, table_id: UUID) -> dict:
         raise APIError(f"Error clearing tab: {e}", status_code=500)
 
 
-async def fire_table_items(request: Request, table_id: UUID) -> dict:
+async def fire_table_items(
+    request: Request,
+    table_id: UUID,
+    item_ids: Optional[List[UUID]] = None,
+) -> dict:
     """
-    Explicitly fire all 'new' items in the current table session to the KDS.
+    Explicitly fire 'new' items in the current table session to the KDS.
+    When item_ids is set, only those order_items are fired (#753).
     """
     try:
         session_context = require_valid_session(request)
@@ -2640,7 +2645,8 @@ async def fire_table_items(request: Request, table_id: UUID) -> dict:
                         tenant_id=tenant_id,
                         source_type='table',
                         table_display_name=table_row["name"],
-                        conn=conn
+                        item_ids=item_ids,
+                        conn=conn,
                     )
                     all_comandas.extend(res)
                     total_fired += sum(len(c.get('items', [])) for c in res)

--- a/tests/test_fire_table_item_ids.py
+++ b/tests/test_fire_table_item_ids.py
@@ -1,0 +1,59 @@
+"""POST /tables/{id}/fire with optional item_ids (#753)."""
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.services import tables_service
+
+
+@pytest.mark.asyncio
+async def test_fire_table_items_passes_item_ids_to_fire_comandas():
+    tenant_id = uuid4()
+    table_id = uuid4()
+    order_id = uuid4()
+    item_a = uuid4()
+    item_b = uuid4()
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(side_effect=[
+        {"comandas_enabled": True},
+        {"id": table_id, "name": "Mesa 1"},
+        {"id": uuid4()},
+    ])
+    mock_conn.fetch = AsyncMock(return_value=[{"id": order_id}])
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    captured_item_ids = []
+
+    async def capture_fire(*args, **kwargs):
+        captured_item_ids.append(kwargs.get("item_ids"))
+        return [{"items": [{"id": str(item_a)}]}]
+
+    mock_request = MagicMock()
+    with patch("app.services.tables_service.require_valid_session") as mock_sess, \
+         patch("app.services.tables_service.get_db_connection", return_value=mock_cm), \
+         patch("app.services.tables_service.fire_comandas", side_effect=capture_fire):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id)
+
+        result = await tables_service.fire_table_items(
+            mock_request,
+            table_id,
+            item_ids=[item_a, item_b],
+        )
+
+    assert result["success"] is True
+    assert captured_item_ids == [[item_a, item_b]]


### PR DESCRIPTION
## Summary
- `POST /tables/{table_id}/fire` accepts optional `{ item_ids: UUID[] }` for partial kitchen fire.
- `fire_table_items` passes `item_ids` to `fire_comandas` for each order in the session.
- Unit test verifies `item_ids` propagation.

## Stack
FastAPI / PostgreSQL

## Changes
- `app/models/comanda.py`: `FireTableItemsRequest`
- `app/routers/tables.py`: optional request body on fire route
- `app/services/tables_service.py`: `item_ids` parameter
- `tests/test_fire_table_item_ids.py`: regression test

## Testing
- `python3 -m pytest tests/test_fire_table_item_ids.py`
- POS mesa: fire all vs selected tab items (requires front PR)

Closes #753

Made with [Cursor](https://cursor.com)