### PR TITLE
feat(api): extend GET /products list filters for advanced menu UI

### DIFF
--- a/app/routers/products.py
+++ b/app/routers/products.py
@@ -52,13 +52,38 @@ async def get_products_endpoint(
     response: Response,
     page: int = Query(default=1, ge=1, description="Page number"),
     limit: int = Query(default=50, ge=1, le=250, description="Items per page"),
-    search: Optional[str] = Query(default=None, description="Search by name or description"),
+    search: Optional[str] = Query(default=None, description="Search term (see search_field)"),
+    search_field: Optional[str] = Query(
+        default=None,
+        description="Search in a single field: name, description, or kitchen_name. Omit to search name OR description.",
+    ),
     category_id: Optional[UUID] = Query(default=None, description="Filter by category ID"),
     is_available: Optional[bool] = Query(default=None, description="Filter by availability"),
     is_combo: Optional[bool] = Query(default=None, description="Filter combos only"),
     is_resale: Optional[bool] = Query(default=None, description="Filter resale products only"),
+    station_id: Optional[UUID] = Query(
+        default=None,
+        description="Filter by kitchen station (product.station_id OR category default station)",
+    ),
+    is_available_online: Optional[bool] = Query(default=None, description="Filter by online menu availability"),
+    is_available_table_qr: Optional[bool] = Query(default=None, description="Filter by table QR menu availability"),
+    has_recipe: Optional[bool] = Query(
+        default=None,
+        description="Filter products with/without recipe (ingredients, recipe bases, or base type)",
+    ),
+    margin_negative: Optional[bool] = Query(
+        default=None,
+        description="When true, only products where calculated cost exceeds price",
+    ),
+    sort: Optional[str] = Query(
+        default=None,
+        description=(
+            "Sort order: created_at_desc (default), created_at_asc, name_asc, name_desc, "
+            "price_asc, price_desc, margin_asc, margin_desc"
+        ),
+    ),
     include_ingredients: bool = Query(default=False, description="Include recipe ingredients in response"),
-    include_modifiers: bool = Query(default=False, description="Include modifier groups in response (for POS)")
+    include_modifiers: bool = Query(default=False, description="Include modifier groups in response (for POS)"),
 ):
     """
     Get products list with filters and pagination.
@@ -73,7 +98,24 @@ async def get_products_endpoint(
     Requires valid session with tenant context.
     """
     return await get_products_list(
-        request, response, page, limit, search, category_id, is_available, is_combo, is_resale, include_ingredients, include_modifiers
+        request,
+        response,
+        page,
+        limit,
+        search,
+        search_field,
+        category_id,
+        is_available,
+        is_combo,
+        is_resale,
+        station_id,
+        is_available_online,
+        is_available_table_qr,
+        has_recipe,
+        margin_negative,
+        sort,
+        include_ingredients,
+        include_modifiers,
     )
 
 

--- a/app/services/products_service.py
+++ b/app/services/products_service.py
@@ -54,6 +54,38 @@ _PRODUCT_MARGIN_OUTER_SQL = """
     END as margen_valor
 """
 
+_PRODUCT_SEARCH_FIELDS = frozenset({"name", "description", "kitchen_name"})
+
+_PRODUCT_SORT_SQL = {
+    "created_at_desc": "created_at DESC",
+    "created_at_asc": "created_at ASC",
+    "name_asc": "name ASC",
+    "name_desc": "name DESC",
+    "price_asc": "price ASC",
+    "price_desc": "price DESC",
+    "margin_asc": "margen_valor ASC NULLS LAST",
+    "margin_desc": "margen_valor DESC NULLS LAST",
+}
+
+_HAS_RECIPE_SQL = """
+    (
+        EXISTS (SELECT 1 FROM product_recipes pr WHERE pr.product_id = p.id)
+        OR EXISTS (SELECT 1 FROM product_base_recipes pbr WHERE pbr.product_id = p.id)
+        OR p.product_base_type_id IS NOT NULL
+    )
+"""
+
+
+def _resolve_products_sort(sort: Optional[str]) -> str:
+    key = (sort or "created_at_desc").strip().lower()
+    order = _PRODUCT_SORT_SQL.get(key)
+    if not order:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid sort '{sort}'. Allowed: {', '.join(sorted(_PRODUCT_SORT_SQL))}",
+        )
+    return order
+
 
 def _normalize_recipe_bases(
     recipe_bases: Optional[List[RecipeBaseLink]],
@@ -459,12 +491,19 @@ async def get_products_list(
     page: int = 1,
     limit: int = 50,
     search: Optional[str] = None,
+    search_field: Optional[str] = None,
     category_id: Optional[UUID] = None,
     is_available: Optional[bool] = None,
     is_combo: Optional[bool] = None,
     is_resale: Optional[bool] = None,
+    station_id: Optional[UUID] = None,
+    is_available_online: Optional[bool] = None,
+    is_available_table_qr: Optional[bool] = None,
+    has_recipe: Optional[bool] = None,
+    margin_negative: Optional[bool] = None,
+    sort: Optional[str] = None,
     include_ingredients: bool = False,
-    include_modifiers: bool = False
+    include_modifiers: bool = False,
 ) -> ProductsListResponse:
     """Get list of products with filters"""
     try:
@@ -530,33 +569,78 @@ async def get_products_list(
                 WHERE 1=1
             """
 
-            count_query = "SELECT COUNT(*) FROM product WHERE tenant_id = $1"
-
             params = [tenant_id]
             param_count = 2
+            inner_filters = ""
 
-            # Add filters (now applied to subquery)
-            if search:
-                base_query += f" AND (LOWER(name) LIKE LOWER(${param_count}) OR LOWER(description) LIKE LOWER(${param_count}))"
-                count_query += f" AND (LOWER(name) LIKE LOWER(${param_count}) OR LOWER(description) LIKE LOWER(${param_count}))"
-                params.append(f"%{search}%")
+            # Inner filters (product / join predicates)
+            if station_id is not None:
+                inner_filters += (
+                    f" AND (p.station_id = ${param_count}"
+                    f" OR tcs.station_id = ${param_count})"
+                )
+                params.append(station_id)
                 param_count += 1
+
+            if is_available_online is not None:
+                inner_filters += f" AND p.is_available_online = ${param_count}"
+                params.append(is_available_online)
+                param_count += 1
+
+            if is_available_table_qr is not None:
+                inner_filters += f" AND p.is_available_table_qr = ${param_count}"
+                params.append(is_available_table_qr)
+                param_count += 1
+
+            if has_recipe is not None:
+                if has_recipe:
+                    inner_filters += f" AND {_HAS_RECIPE_SQL}"
+                else:
+                    inner_filters += f" AND NOT {_HAS_RECIPE_SQL}"
+
+            if inner_filters:
+                base_query = base_query.replace(
+                    "WHERE p.tenant_id = $1",
+                    "WHERE p.tenant_id = $1" + inner_filters,
+                    1,
+                )
+
+            # Outer filters (subquery column aliases)
+            if search:
+                term = f"%{search}%"
+                if search_field:
+                    field = search_field.strip().lower()
+                    if field not in _PRODUCT_SEARCH_FIELDS:
+                        raise HTTPException(
+                            status_code=422,
+                            detail=(
+                                f"Invalid search_field '{search_field}'. "
+                                f"Allowed: {', '.join(sorted(_PRODUCT_SEARCH_FIELDS))}"
+                            ),
+                        )
+                    base_query += f" AND LOWER({field}) LIKE LOWER(${param_count})"
+                    params.append(term)
+                    param_count += 1
+                else:
+                    base_query += (
+                        f" AND (LOWER(name) LIKE LOWER(${param_count})"
+                        f" OR LOWER(description) LIKE LOWER(${param_count}))"
+                    )
+                    params.append(term)
+                    param_count += 1
 
             if category_id:
                 base_query += f" AND category_id = ${param_count}"
-                count_query += f" AND category_id = ${param_count}"
                 params.append(category_id)
                 param_count += 1
 
             if is_available is not None:
                 base_query += f" AND is_available = ${param_count}"
-                count_query += f" AND is_available = ${param_count}"
                 params.append(is_available)
                 param_count += 1
 
             if is_combo is not None:
                 base_query += f" AND is_combo = ${param_count}"
-                count_query += f" AND is_combo = ${param_count}"
                 params.append(is_combo)
                 param_count += 1
 
@@ -565,19 +649,30 @@ async def get_products_list(
             # Exception: POS (include_modifiers=true) should show ALL products
             if is_resale is None:
                 if not include_modifiers:
-                    # Default for menu list: exclude resale products
                     base_query += " AND (is_resale = false OR is_resale IS NULL)"
-                    count_query += " AND (is_resale = false OR is_resale IS NULL)"
-                # else: POS context - show all products (no filter)
             else:
                 base_query += f" AND is_resale = ${param_count}"
-                count_query += f" AND is_resale = ${param_count}"
                 params.append(is_resale)
                 param_count += 1
 
-            # Add pagination
+            if margin_negative is not None:
+                if margin_negative:
+                    base_query += (
+                        " AND costo_calculado IS NOT NULL"
+                        " AND costo_calculado > price"
+                    )
+                else:
+                    base_query += (
+                        " AND (costo_calculado IS NULL"
+                        " OR costo_calculado <= price)"
+                    )
+
+            order_clause = _resolve_products_sort(sort)
             offset = (page - 1) * limit
-            base_query += f" ORDER BY created_at DESC LIMIT ${param_count} OFFSET ${param_count + 1}"
+            count_query = f"SELECT COUNT(*) FROM ({base_query}) AS counted"
+            base_query += (
+                f" ORDER BY {order_clause} LIMIT ${param_count} OFFSET ${param_count + 1}"
+            )
 
             # Execute queries
             products_data = await conn.fetch(base_query, *params, limit, offset)

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -108,6 +108,68 @@ class TestProductsListEndpoint:
         response = await client.get("/menu/products?limit=251")
         assert response.status_code in [422, 500]
 
+    @pytest.mark.asyncio
+    async def test_get_products_search_field_kitchen_name(self, client: AsyncClient):
+        """Test targeted search_field=kitchen_name"""
+        response = await client.get("/menu/products?search=test&search_field=kitchen_name")
+        assert response.status_code in [200, 401, 403, 422, 500]
+
+    @pytest.mark.asyncio
+    async def test_get_products_invalid_search_field(self, client: AsyncClient):
+        """Invalid search_field returns 422 when authenticated"""
+        response = await client.get("/menu/products?search=test&search_field=invalid")
+        assert response.status_code in [401, 403, 422, 500]
+
+    @pytest.mark.asyncio
+    async def test_get_products_filter_online(self, client: AsyncClient):
+        """Test is_available_online filter"""
+        response = await client.get("/menu/products?is_available_online=true")
+        assert response.status_code in [200, 401, 403, 500]
+
+        if response.status_code == 200:
+            for product in response.json()["data"]:
+                assert product["is_available_online"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_products_filter_table_qr(self, client: AsyncClient):
+        """Test is_available_table_qr filter"""
+        response = await client.get("/menu/products?is_available_table_qr=true")
+        assert response.status_code in [200, 401, 403, 500]
+
+        if response.status_code == 200:
+            for product in response.json()["data"]:
+                assert product["is_available_table_qr"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_products_sort_name_asc(self, client: AsyncClient):
+        """Test server-side sort=name_asc"""
+        response = await client.get("/menu/products?sort=name_asc&limit=5")
+        assert response.status_code in [200, 401, 403, 422, 500]
+
+    @pytest.mark.asyncio
+    async def test_get_products_invalid_sort(self, client: AsyncClient):
+        """Invalid sort returns 422 when authenticated"""
+        response = await client.get("/menu/products?sort=not_a_sort")
+        assert response.status_code in [401, 403, 422, 500]
+
+    @pytest.mark.asyncio
+    async def test_get_products_margin_negative(self, client: AsyncClient):
+        """Test margin_negative filter (cost > price)"""
+        response = await client.get("/menu/products?margin_negative=true&limit=10")
+        assert response.status_code in [200, 401, 403, 500]
+
+        if response.status_code == 200:
+            for product in response.json()["data"]:
+                cost = product.get("costo_calculado")
+                if cost is not None:
+                    assert float(cost) > float(product["price"])
+
+    @pytest.mark.asyncio
+    async def test_get_products_has_recipe(self, client: AsyncClient):
+        """Test has_recipe=true filter"""
+        response = await client.get("/menu/products?has_recipe=true&limit=10")
+        assert response.status_code in [200, 401, 403, 500]
+
 
 class TestProductsStatsEndpoint:
     """Test products stats endpoint"""


### PR DESCRIPTION
## Summary
- Extend `GET /menu/products` with optional filters: `search_field`, `station_id`, `is_available_online`, `is_available_table_qr`, `has_recipe`, `margin_negative`, `sort`
- Refactor count query to use the filtered subquery (accurate totals when margin filter applied)
- Add smoke tests for new query params

## Stack
FastAPI / asyncpg / Python 3.9

## Changes
- `app/services/products_service.py`: filter logic, sort whitelist, count subquery
- `app/routers/products.py`: Query params + OpenAPI descriptions
- `tests/test_products.py`: new param tests

## Testing
- `python3 -m pytest tests/test_products.py -q` (27 passed)
- Manual: `GET /menu/products?is_available_online=true&sort=price_desc`

Closes #764

Made with [Cursor](https://cursor.com)