### PR TITLE
feat(api): log POS mesa tab actions

### DIFF
--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -5,7 +5,7 @@ Business logic for table management and session lifecycle.
 Issue: https://github.com/uno0uno/warocol.com/issues/298
 """
 import secrets
-from typing import Optional, List
+from typing import Optional, List, Any, Dict
 from uuid import UUID
 from datetime import date
 from decimal import Decimal
@@ -29,6 +29,7 @@ from app.services.tip_tax_service import (
 from app.services.orders_service import _compute_tax_breakdown
 from app.services.ingredient_purchase_units_service import resolve_recipe_quantity_to_base_unit
 from app.services.comandas_service import fire_comandas
+from app.services.operation_events_service import DOMAIN_POS, record_operation_event
 import logging
 
 logger = logging.getLogger(__name__)
@@ -1616,21 +1617,166 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
         raise APIError(f"Error fetching session: {e}", status_code=500)
 
 
+async def _fetch_tab_operation_context(
+    conn, tenant_id: UUID, table_id: UUID
+) -> Optional[Dict[str, Any]]:
+    """Channel, session, table label, and effective waiter for bitácora events (#783)."""
+    row = await conn.fetchrow(
+        """
+        SELECT
+            t.name AS table_name,
+            t.is_bar,
+            ts.id AS table_session_id,
+            COALESCE(ts.attended_by_member_id, t.assigned_member_id) AS effective_waiter_member_id
+        FROM tables t
+        JOIN table_sessions ts ON ts.table_id = t.id
+        WHERE t.id = $1
+          AND t.tenant_id = $2
+          AND ts.closed_at IS NULL
+        """,
+        table_id,
+        tenant_id,
+    )
+    if not row:
+        return None
+    return {
+        "channel": "barra" if row["is_bar"] else "mesa",
+        "table_name": row["table_name"],
+        "table_session_id": row["table_session_id"],
+        "effective_waiter_member_id": row["effective_waiter_member_id"],
+    }
+
+
+async def _prefetch_product_names(
+    conn, tenant_id: UUID, product_ids: List[Any]
+) -> Dict[str, str]:
+    if not product_ids:
+        return {}
+    rows = await conn.fetch(
+        """
+        SELECT id, name FROM product
+        WHERE tenant_id = $1 AND id = ANY($2::uuid[])
+        """,
+        tenant_id,
+        list(product_ids),
+    )
+    return {str(r["id"]): r["name"] for r in rows}
+
+
+async def _fetch_order_item_modifiers(conn, order_item_id: UUID) -> List[Dict[str, Any]]:
+    rows = await conn.fetch(
+        """
+        SELECT modifier_id, modifier_name, price_at_purchase, quantity
+        FROM order_item_modifiers
+        WHERE order_item_id = $1
+        """,
+        order_item_id,
+    )
+    return [
+        {
+            "id": str(r["modifier_id"]) if r["modifier_id"] else None,
+            "name": r["modifier_name"],
+            "price": float(r["price_at_purchase"]),
+            "quantity": int(r["quantity"]),
+        }
+        for r in rows
+    ]
+
+
+def _build_tab_item_payload(
+    *,
+    product_id: Any,
+    product_name: Optional[str],
+    quantity: Any,
+    unit_price: Any,
+    subtotal: Any,
+    modifiers: List[Dict[str, Any]],
+    notes: Optional[str],
+    table_id: UUID,
+    table_name: str,
+    order_number: Any,
+) -> Dict[str, Any]:
+    return {
+        "product_id": str(product_id) if product_id else None,
+        "product_name": product_name,
+        "quantity": float(quantity) if quantity is not None else None,
+        "unit_price": float(unit_price),
+        "subtotal": float(subtotal),
+        "modifiers": modifiers,
+        "notes": notes,
+        "table_id": str(table_id),
+        "table_name": table_name,
+        "order_number": int(order_number) if order_number is not None else None,
+    }
+
+
+def _modifiers_from_request_item(item: dict) -> List[Dict[str, Any]]:
+    return [
+        {
+            "id": m.get("id"),
+            "name": m.get("name"),
+            "price": float(m.get("price", 0)),
+        }
+        for m in (item.get("modifiers") or [])
+    ]
+
+
+async def _record_tab_operation_event(
+    conn,
+    tenant_id: UUID,
+    *,
+    user_id: UUID,
+    table_id: UUID,
+    tab_ctx: Dict[str, Any],
+    action: str,
+    order_id: Optional[UUID] = None,
+    order_item_id: Optional[UUID] = None,
+    comanda_item_id: Optional[UUID] = None,
+    payload: Optional[Dict[str, Any]] = None,
+) -> None:
+    await record_operation_event(
+        conn,
+        tenant_id,
+        domain=DOMAIN_POS,
+        channel=tab_ctx["channel"],
+        action=action,
+        actor_user_id=user_id,
+        actor_member_id=tab_ctx.get("effective_waiter_member_id"),
+        table_id=table_id,
+        table_session_id=tab_ctx.get("table_session_id"),
+        order_id=order_id,
+        order_item_id=order_item_id,
+        comanda_item_id=comanda_item_id,
+        payload=payload,
+    )
+
+
 async def remove_tab_item(request: Request, table_id: UUID, order_item_id: UUID) -> dict:
     """Remove an order item from the running tab and update the order total."""
     try:
         session_context = require_valid_session(request)
         tenant_id = session_context.tenant_id
+        user_id = session_context.user_id
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection(use_transaction=True) as conn:
             row = await conn.fetchrow(
                 """
-                SELECT oi.id, oi.subtotal, o.id AS order_id, o.total_amount
+                SELECT
+                    oi.id, oi.product_id, oi.quantity, oi.price_at_purchase,
+                    oi.subtotal, oi.notes,
+                    o.id AS order_id, o.total_amount, o.order_number, o.table_session_id,
+                    p.name AS product_name,
+                    t.name AS table_name,
+                    t.is_bar,
+                    COALESCE(ts.attended_by_member_id, t.assigned_member_id)
+                        AS effective_waiter_member_id
                 FROM order_items oi
                 JOIN orders o ON o.id = oi.order_id
                 JOIN table_sessions ts ON ts.id = o.table_session_id
+                JOIN tables t ON t.id = ts.table_id
+                JOIN product p ON p.id = oi.product_id
                 WHERE oi.id = $1
                   AND ts.table_id = $2
                   AND ts.tenant_id = $3
@@ -1640,6 +1786,14 @@ async def remove_tab_item(request: Request, table_id: UUID, order_item_id: UUID)
             )
             if not row:
                 raise NotFoundError("Order item not found or session already closed")
+
+            tab_ctx = {
+                "channel": "barra" if row["is_bar"] else "mesa",
+                "table_name": row["table_name"],
+                "table_session_id": row["table_session_id"],
+                "effective_waiter_member_id": row["effective_waiter_member_id"],
+            }
+            modifiers = await _fetch_order_item_modifiers(conn, order_item_id)
 
             # Cancel linked comanda_item BEFORE deleting order_item (FK: no cascade).
             # If comandas are disabled no row will be found — no-op, continues as before.
@@ -1691,6 +1845,33 @@ async def remove_tab_item(request: Request, table_id: UUID, order_item_id: UUID)
                     comanda_item_row["id"],
                 )
 
+            comanda_item_id = (
+                comanda_item_row["id"] if comanda_item_row else None
+            )
+            await _record_tab_operation_event(
+                conn,
+                tenant_id,
+                user_id=user_id,
+                table_id=table_id,
+                tab_ctx=tab_ctx,
+                action="tab_item_removed",
+                order_id=row["order_id"],
+                order_item_id=order_item_id,
+                comanda_item_id=comanda_item_id,
+                payload=_build_tab_item_payload(
+                    product_id=row["product_id"],
+                    product_name=row["product_name"],
+                    quantity=row["quantity"],
+                    unit_price=row["price_at_purchase"],
+                    subtotal=row["subtotal"],
+                    modifiers=modifiers,
+                    notes=row["notes"],
+                    table_id=table_id,
+                    table_name=row["table_name"],
+                    order_number=row["order_number"],
+                ),
+            )
+
             await conn.execute("DELETE FROM order_items WHERE id = $1", order_item_id)
             new_total = max(0.0, float(row["total_amount"]) - float(row["subtotal"]))
             await conn.execute(
@@ -1715,16 +1896,28 @@ async def update_tab_item_quantity(
     try:
         session_context = require_valid_session(request)
         tenant_id = session_context.tenant_id
+        user_id = session_context.user_id
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection(use_transaction=True) as conn:
             row = await conn.fetchrow(
                 """
-                SELECT oi.id, oi.price_at_purchase, oi.subtotal, o.id AS order_id, o.total_amount
+                SELECT
+                    oi.id, oi.product_id, oi.quantity, oi.price_at_purchase,
+                    oi.subtotal, oi.notes,
+                    o.id AS order_id, o.total_amount, o.order_number,
+                    p.name AS product_name,
+                    t.name AS table_name,
+                    t.is_bar,
+                    ts.id AS table_session_id,
+                    COALESCE(ts.attended_by_member_id, t.assigned_member_id)
+                        AS effective_waiter_member_id
                 FROM order_items oi
                 JOIN orders o ON o.id = oi.order_id
                 JOIN table_sessions ts ON ts.id = o.table_session_id
+                JOIN tables t ON t.id = ts.table_id
+                JOIN product p ON p.id = oi.product_id
                 WHERE oi.id = $1
                   AND ts.table_id = $2
                   AND ts.tenant_id = $3
@@ -1734,6 +1927,15 @@ async def update_tab_item_quantity(
             )
             if not row:
                 raise NotFoundError("Order item not found or session already closed")
+
+            old_quantity = float(row["quantity"])
+            tab_ctx = {
+                "channel": "barra" if row["is_bar"] else "mesa",
+                "table_name": row["table_name"],
+                "table_session_id": row["table_session_id"],
+                "effective_waiter_member_id": row["effective_waiter_member_id"],
+            }
+            modifiers = await _fetch_order_item_modifiers(conn, order_item_id)
 
             modifier_sum = await conn.fetchval(
                 "SELECT COALESCE(SUM(price_at_purchase), 0) FROM order_item_modifiers WHERE order_item_id = $1",
@@ -1750,6 +1952,33 @@ async def update_tab_item_quantity(
             await conn.execute(
                 "UPDATE orders SET total_amount = $1 WHERE id = $2",
                 new_total, row["order_id"],
+            )
+
+            payload = _build_tab_item_payload(
+                product_id=row["product_id"],
+                product_name=row["product_name"],
+                quantity=quantity,
+                unit_price=row["price_at_purchase"],
+                subtotal=new_subtotal,
+                modifiers=modifiers,
+                notes=row["notes"],
+                table_id=table_id,
+                table_name=row["table_name"],
+                order_number=row["order_number"],
+            )
+            payload["old_quantity"] = old_quantity
+            payload["new_quantity"] = float(quantity)
+
+            await _record_tab_operation_event(
+                conn,
+                tenant_id,
+                user_id=user_id,
+                table_id=table_id,
+                tab_ctx=tab_ctx,
+                action="tab_item_qty_changed",
+                order_id=row["order_id"],
+                order_item_id=order_item_id,
+                payload=payload,
             )
 
         return {"success": True, "data": {"order_item_id": str(order_item_id), "quantity": quantity, "subtotal": new_subtotal}}
@@ -1773,7 +2002,12 @@ async def _add_tab_items_core(
     """
     session_row = await conn.fetchrow(
         """
-        SELECT ts.id AS session_id
+        SELECT
+            ts.id AS session_id,
+            t.name AS table_name,
+            t.is_bar,
+            COALESCE(ts.attended_by_member_id, t.assigned_member_id)
+                AS effective_waiter_member_id
         FROM table_sessions ts
         JOIN tables t ON t.id = ts.table_id
         WHERE ts.table_id = $1
@@ -1788,6 +2022,14 @@ async def _add_tab_items_core(
         raise NotFoundError("No open session found for this table")
 
     session_id = session_row["session_id"]
+    tab_ctx = {
+        "channel": "barra" if session_row["is_bar"] else "mesa",
+        "table_name": session_row["table_name"],
+        "table_session_id": session_id,
+        "effective_waiter_member_id": session_row["effective_waiter_member_id"],
+    }
+    product_ids = list({item["product_id"] for item in items})
+    product_names = await _prefetch_product_names(conn, tenant_id, product_ids)
 
     for item in items:
         mod_sum = sum(float(m.get("price", 0)) for m in (item.get("modifiers") or []))
@@ -1889,6 +2131,29 @@ async def _add_tab_items_core(
                 mod.get("price", 0),
                 1,
             )
+
+        await _record_tab_operation_event(
+            conn,
+            tenant_id,
+            user_id=user_id,
+            table_id=table_id,
+            tab_ctx=tab_ctx,
+            action="tab_item_added",
+            order_id=order_id,
+            order_item_id=order_item_id,
+            payload=_build_tab_item_payload(
+                product_id=item["product_id"],
+                product_name=product_names.get(str(item["product_id"])),
+                quantity=item["quantity"],
+                unit_price=item["unit_price"],
+                subtotal=subtotal,
+                modifiers=_modifiers_from_request_item(item),
+                notes=item_notes,
+                table_id=table_id,
+                table_name=tab_ctx["table_name"],
+                order_number=order_number,
+            ),
+        )
 
         try:
             await _capture_order_item_ingredients(
@@ -2529,6 +2794,7 @@ async def clear_tab(request: Request, table_id: UUID) -> dict:
     try:
         session_context = require_valid_session(request)
         tenant_id = session_context.tenant_id
+        user_id = session_context.user_id
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
 
@@ -2541,6 +2807,54 @@ async def clear_tab(request: Request, table_id: UUID) -> dict:
                 )
                 if not session_row:
                     raise NotFoundError("No open session found for this table")
+
+                tab_ctx = await _fetch_tab_operation_context(conn, tenant_id, table_id)
+                if tab_ctx:
+                    pending_lines = await conn.fetch(
+                        """
+                        SELECT
+                            oi.id AS order_item_id,
+                            oi.product_id,
+                            oi.quantity,
+                            oi.price_at_purchase,
+                            oi.subtotal,
+                            oi.notes,
+                            o.id AS order_id,
+                            o.order_number,
+                            p.name AS product_name
+                        FROM order_items oi
+                        JOIN orders o ON o.id = oi.order_id
+                        JOIN product p ON p.id = oi.product_id
+                        WHERE o.table_session_id = $1 AND o.status = 'pending'
+                        """,
+                        session_row["id"],
+                    )
+                    for line in pending_lines:
+                        line_modifiers = await _fetch_order_item_modifiers(
+                            conn, line["order_item_id"]
+                        )
+                        await _record_tab_operation_event(
+                            conn,
+                            tenant_id,
+                            user_id=user_id,
+                            table_id=table_id,
+                            tab_ctx=tab_ctx,
+                            action="tab_cleared",
+                            order_id=line["order_id"],
+                            order_item_id=line["order_item_id"],
+                            payload=_build_tab_item_payload(
+                                product_id=line["product_id"],
+                                product_name=line["product_name"],
+                                quantity=line["quantity"],
+                                unit_price=line["price_at_purchase"],
+                                subtotal=line["subtotal"],
+                                modifiers=line_modifiers,
+                                notes=line["notes"],
+                                table_id=table_id,
+                                table_name=tab_ctx["table_name"],
+                                order_number=line["order_number"],
+                            ),
+                        )
 
                 # Cancel comanda_items that point at the order_items we're
                 # about to delete. Two reasons:

--- a/tests/test_tables_tab_operation_events.py
+++ b/tests/test_tables_tab_operation_events.py
@@ -1,0 +1,244 @@
+"""Operation audit events for mesa/barra tab flows (warocol.com#783)."""
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services import tables_service
+
+
+@pytest.mark.asyncio
+async def test_add_tab_items_core_records_tab_item_added_per_line():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    session_id = uuid4()
+    order_id = uuid4()
+    product_id = uuid4()
+    order_item_id = uuid4()
+    recorded = []
+
+    async def capture_record(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    session_row = {
+        "session_id": session_id,
+        "table_name": "Mesa 3",
+        "is_bar": False,
+        "effective_waiter_member_id": None,
+    }
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(side_effect=[
+        session_row,
+        None,
+        {"id": order_id, "order_number": 42, "total_amount": 15.0},
+        {"id": order_item_id},
+    ])
+    mock_conn.fetch = AsyncMock(return_value=[])
+    mock_conn.execute = AsyncMock()
+
+    items = [{
+        "product_id": product_id,
+        "quantity": 1,
+        "unit_price": 15.0,
+        "modifiers": [{"id": None, "name": "Extra", "price": 0.0}],
+        "notes": "Sin cebolla",
+    }]
+
+    with patch(
+        "app.services.tables_service._record_tab_operation_event",
+        side_effect=capture_record,
+    ), patch(
+        "app.services.tables_service._prefetch_product_names",
+        new=AsyncMock(return_value={str(product_id): "Hamburguesa"}),
+    ), patch(
+        "app.services.tables_service._capture_order_item_ingredients",
+        new=AsyncMock(),
+    ):
+        result = await tables_service._add_tab_items_core(
+            mock_conn, tenant_id, user_id, table_id, items
+        )
+
+    assert result["session_id"] == session_id
+    assert len(recorded) == 1
+    assert recorded[0]["action"] == "tab_item_added"
+    assert recorded[0]["tab_ctx"]["channel"] == "mesa"
+    assert recorded[0]["tab_ctx"]["table_session_id"] == session_id
+    assert recorded[0]["payload"]["product_name"] == "Hamburguesa"
+    assert recorded[0]["payload"]["order_number"] == 42
+
+
+@pytest.mark.asyncio
+async def test_remove_tab_item_records_before_delete():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    order_item_id = uuid4()
+    order_id = uuid4()
+    session_id = uuid4()
+    product_id = uuid4()
+    recorded = []
+    delete_calls = []
+
+    async def capture_record(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    row = {
+        "id": order_item_id,
+        "product_id": product_id,
+        "quantity": 2,
+        "price_at_purchase": 10.0,
+        "subtotal": 20.0,
+        "notes": None,
+        "order_id": order_id,
+        "total_amount": 20.0,
+        "order_number": 7,
+        "table_session_id": session_id,
+        "product_name": "Pizza",
+        "table_name": "Barra 1",
+        "is_bar": True,
+        "effective_waiter_member_id": None,
+    }
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(side_effect=[row, None])
+    mock_conn.fetch = AsyncMock(return_value=[])
+
+    async def track_execute(sql, *args):
+        if "DELETE FROM order_items" in sql:
+            delete_calls.append(True)
+
+    mock_conn.execute = AsyncMock(side_effect=track_execute)
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    mock_request = MagicMock()
+    with patch("app.services.tables_service.require_valid_session") as mock_sess, \
+         patch("app.services.tables_service.get_db_connection", return_value=mock_cm), \
+         patch(
+             "app.services.tables_service._record_tab_operation_event",
+             side_effect=capture_record,
+         ):
+        mock_sess.return_value = MagicMock(
+            tenant_id=tenant_id, user_id=user_id,
+        )
+        await tables_service.remove_tab_item(
+            mock_request, table_id, order_item_id,
+        )
+
+    assert len(recorded) == 1
+    assert recorded[0]["action"] == "tab_item_removed"
+    assert recorded[0]["tab_ctx"]["channel"] == "barra"
+    assert recorded[0]["comanda_item_id"] is None
+    assert recorded[0]["payload"]["product_name"] == "Pizza"
+    assert len(delete_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_add_then_remove_shares_table_session_id():
+    """Integration-style: two events, same table_session_id (#783)."""
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    session_id = uuid4()
+    recorded = []
+
+    async def capture_record(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    # --- add (core only) ---
+    order_id = uuid4()
+    product_id = uuid4()
+    order_item_id = uuid4()
+    mock_conn_add = AsyncMock()
+    mock_conn_add.fetchrow = AsyncMock(side_effect=[
+        {
+            "session_id": session_id,
+            "table_name": "Mesa 1",
+            "is_bar": False,
+            "effective_waiter_member_id": None,
+        },
+        None,
+        {"id": order_id, "order_number": 1, "total_amount": 5.0},
+        {"id": order_item_id},
+    ])
+    mock_conn_add.fetch = AsyncMock(return_value=[])
+    mock_conn_add.execute = AsyncMock()
+
+    with patch(
+        "app.services.tables_service._record_tab_operation_event",
+        side_effect=capture_record,
+    ), patch(
+        "app.services.tables_service._prefetch_product_names",
+        new=AsyncMock(return_value={str(product_id): "Agua"}),
+    ), patch(
+        "app.services.tables_service._capture_order_item_ingredients",
+        new=AsyncMock(),
+    ):
+        await tables_service._add_tab_items_core(
+            mock_conn_add, tenant_id, user_id, table_id,
+            [{"product_id": product_id, "quantity": 1, "unit_price": 5.0, "modifiers": []}],
+        )
+
+    # --- remove ---
+    row = {
+        "id": order_item_id,
+        "product_id": product_id,
+        "quantity": 1,
+        "price_at_purchase": 5.0,
+        "subtotal": 5.0,
+        "notes": None,
+        "order_id": order_id,
+        "total_amount": 5.0,
+        "order_number": 1,
+        "table_session_id": session_id,
+        "product_name": "Agua",
+        "table_name": "Mesa 1",
+        "is_bar": False,
+        "effective_waiter_member_id": None,
+    }
+    mock_conn_rm = AsyncMock()
+    mock_conn_rm.fetchrow = AsyncMock(side_effect=[row, None])
+    mock_conn_rm.fetch = AsyncMock(return_value=[])
+    mock_conn_rm.execute = AsyncMock()
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn_rm.transaction = MagicMock(return_value=_Txn())
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn_rm)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("app.services.tables_service.require_valid_session") as mock_sess, \
+         patch("app.services.tables_service.get_db_connection", return_value=mock_cm), \
+         patch(
+             "app.services.tables_service._record_tab_operation_event",
+             side_effect=capture_record,
+         ):
+        mock_sess.return_value = MagicMock(
+            tenant_id=tenant_id, user_id=user_id,
+        )
+        await tables_service.remove_tab_item(
+            MagicMock(), table_id, order_item_id,
+        )
+
+    assert len(recorded) == 2
+    assert recorded[0]["action"] == "tab_item_added"
+    assert recorded[1]["action"] == "tab_item_removed"
+    assert recorded[0]["tab_ctx"]["table_session_id"] == session_id
+    assert recorded[1]["tab_ctx"]["table_session_id"] == session_id


### PR DESCRIPTION
## Summary
Instruments mesa/barra table tab flows to append `tenant_operation_events` via `record_operation_event` inside existing transactions.

## Stack
Python 3.9 / FastAPI / asyncpg

## Changes
- `tables_service.py`: helpers + `tab_item_added`, `tab_item_removed`, `tab_item_qty_changed`, `tab_cleared` (one event per line on clear)
- `tests/test_tables_tab_operation_events.py`: add → remove same `table_session_id`, barra channel, payload keys

## Design choices
- **`comanda_item_id`** embedded on `tab_item_removed` when KDS line was cancelled — no separate `comanda_line_cancelled` for the same action
- **`tab_cleared`**: one event per pending line (timeline parity with add/remove)
- **`actor_member_id`**: effective waiter (`COALESCE(attended, assigned)`), not cashier member
- QR accept path (`_add_tab_items_core` from table QR) unchanged — out of #783 AC

## Testing
```bash
python3 -m pytest tests/test_tables_tab_operation_events.py tests/test_operation_events.py -q
```
9 passed

## Depends on
- #291 (`gh-782-operation-events`) — merge first or merge this stacked PR

Closes warocol.com#783

Made with [Cursor](https://cursor.com)