### PR TITLE
feat(api): log POS cart actions (counter/bar)

### DIFF
--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -119,7 +119,15 @@ async def update_item(
 async def remove_item(
     request: Request,
     cart_id: UUID,
-    item_id: UUID
+    item_id: UUID,
+    channel: Literal["mostrador", "barra"] = Query(
+        "mostrador",
+        description="POS channel for bitácora (warocol.com#784)",
+    ),
+    actor_member_id: Optional[UUID] = Query(
+        None,
+        description="Optional tenant_members.id (served-by attribution, #575)",
+    ),
 ):
     """
     Remove item from cart
@@ -127,19 +135,34 @@ async def remove_item(
     return await pos_cart_service.remove_item_from_cart(
         request,
         cart_id,
-        item_id
+        item_id,
+        channel=channel,
+        actor_member_id=actor_member_id,
     )
 
 
 @router.delete("/{cart_id}", dependencies=[Depends(require_module(Module.POS))])
 async def clear_cart(
     request: Request,
-    cart_id: UUID
+    cart_id: UUID,
+    channel: Literal["mostrador", "barra"] = Query(
+        "mostrador",
+        description="POS channel for bitácora (warocol.com#784)",
+    ),
+    actor_member_id: Optional[UUID] = Query(
+        None,
+        description="Optional tenant_members.id (served-by attribution, #575)",
+    ),
 ):
     """
     Clear all items from cart
     """
-    return await pos_cart_service.clear_cart(request, cart_id)
+    return await pos_cart_service.clear_cart(
+        request,
+        cart_id,
+        channel=channel,
+        actor_member_id=actor_member_id,
+    )
 
 
 class CompleteOrderRequest(BaseModel):

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -24,6 +24,7 @@ from app.services.tip_tax_service import (
 from app.services.accounting_service import void_order_journal_entry_in_txn
 from app.services.ingredient_purchase_units_service import resolve_recipe_quantity_to_base_unit
 from app.services.comandas_service import fire_comandas, finalize_open_comandas
+from app.services.operation_events_service import DOMAIN_POS, record_operation_event
 import logging
 
 logger = logging.getLogger(__name__)
@@ -534,10 +535,93 @@ async def update_cart_item(
         raise APIError(f"Error updating cart item: {str(e)}", status_code=500)
 
 
+def _normalize_cart_channel(channel: Optional[str]) -> str:
+    """POS cart channel for bitácora (#784)."""
+    normalized = (channel or "mostrador").strip().lower()
+    if normalized not in ("mostrador", "barra"):
+        return "mostrador"
+    return normalized
+
+
+async def _fetch_cart_item_modifiers(conn, cart_item_id: UUID) -> List[Dict[str, Any]]:
+    rows = await conn.fetch(
+        """
+        SELECT modifier_id, modifier_name, price
+        FROM pos_cart_item_modifiers
+        WHERE cart_item_id = $1
+        """,
+        cart_item_id,
+    )
+    return [
+        {
+            "id": str(r["modifier_id"]) if r["modifier_id"] else None,
+            "name": r["modifier_name"],
+            "price": float(r["price"]),
+        }
+        for r in rows
+    ]
+
+
+def _build_cart_line_payload(
+    *,
+    product_id: Any,
+    product_name: Optional[str],
+    quantity: Any,
+    unit_price: Any,
+    subtotal: Any,
+    modifiers: List[Dict[str, Any]],
+    notes: Optional[str],
+    table_id: Optional[UUID] = None,
+    table_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    return {
+        "product_id": str(product_id) if product_id else None,
+        "product_name": product_name,
+        "quantity": float(quantity) if quantity is not None else None,
+        "unit_price": float(unit_price),
+        "subtotal": float(subtotal),
+        "modifiers": modifiers,
+        "notes": notes,
+        "table_id": str(table_id) if table_id else None,
+        "table_name": table_name,
+        "order_number": None,
+    }
+
+
+async def _record_cart_operation_event(
+    conn,
+    tenant_id: UUID,
+    *,
+    user_id: UUID,
+    channel: str,
+    action: str,
+    pos_cart_id: UUID,
+    pos_cart_item_id: Optional[UUID] = None,
+    payload: Optional[Dict[str, Any]] = None,
+    actor_member_id: Optional[UUID] = None,
+) -> None:
+    merged_payload = dict(payload) if payload else {}
+    if pos_cart_item_id:
+        merged_payload["pos_cart_item_id"] = str(pos_cart_item_id)
+    await record_operation_event(
+        conn,
+        tenant_id,
+        domain=DOMAIN_POS,
+        channel=_normalize_cart_channel(channel),
+        action=action,
+        actor_user_id=user_id,
+        actor_member_id=actor_member_id,
+        pos_cart_id=pos_cart_id,
+        payload=merged_payload,
+    )
+
+
 async def remove_item_from_cart(
     request: Request,
     cart_id: UUID,
-    item_id: UUID
+    item_id: UUID,
+    channel: str = "mostrador",
+    actor_member_id: Optional[UUID] = None,
 ) -> dict:
     """
     Remove an item from cart
@@ -545,20 +629,61 @@ async def remove_item_from_cart(
     try:
         session_context = require_valid_session(request)
         tenant_id = session_context.tenant_id
+        user_id = session_context.user_id
 
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection() as conn:
             async with conn.transaction():
-                # Delete item (modifiers will cascade)
-                delete_query = """
+                row = await conn.fetchrow(
+                    """
+                    SELECT
+                        pci.id, pci.product_id, pci.quantity, pci.unit_price,
+                        pci.subtotal, pci.notes,
+                        p.name AS product_name
+                    FROM pos_cart_items pci
+                    JOIN pos_carts pc ON pc.id = pci.cart_id
+                    JOIN product p ON p.id = pci.product_id
+                    WHERE pci.id = $1 AND pci.cart_id = $2 AND pc.tenant_id = $3
+                    """,
+                    item_id,
+                    cart_id,
+                    tenant_id,
+                )
+                if not row:
+                    raise APIError("Cart item not found", status_code=404)
+
+                modifiers = await _fetch_cart_item_modifiers(conn, item_id)
+                await _record_cart_operation_event(
+                    conn,
+                    tenant_id,
+                    user_id=user_id,
+                    channel=channel,
+                    action="cart_line_removed",
+                    pos_cart_id=cart_id,
+                    pos_cart_item_id=item_id,
+                    actor_member_id=actor_member_id,
+                    payload=_build_cart_line_payload(
+                        product_id=row["product_id"],
+                        product_name=row["product_name"],
+                        quantity=row["quantity"],
+                        unit_price=row["unit_price"],
+                        subtotal=row["subtotal"],
+                        modifiers=modifiers,
+                        notes=row["notes"],
+                    ),
+                )
+
+                await conn.execute(
+                    """
                     DELETE FROM pos_cart_items
                     WHERE id = $1 AND cart_id = $2
-                """
-                await conn.execute(delete_query, item_id, cart_id)
+                    """,
+                    item_id,
+                    cart_id,
+                )
 
-                # Update cart total
                 await update_cart_total(conn, cart_id)
 
                 logger.info(f"Removed item {item_id} from cart {cart_id}")
@@ -577,7 +702,9 @@ async def remove_item_from_cart(
 
 async def clear_cart(
     request: Request,
-    cart_id: UUID
+    cart_id: UUID,
+    channel: str = "mostrador",
+    actor_member_id: Optional[UUID] = None,
 ) -> dict:
     """
     Clear all items from cart
@@ -585,18 +712,71 @@ async def clear_cart(
     try:
         session_context = require_valid_session(request)
         tenant_id = session_context.tenant_id
+        user_id = session_context.user_id
 
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection() as conn:
             async with conn.transaction():
-                # Delete all items (modifiers will cascade)
-                delete_query = """
+                cart_row = await conn.fetchrow(
+                    """
+                    SELECT id FROM pos_carts
+                    WHERE id = $1 AND tenant_id = $2
+                    """,
+                    cart_id,
+                    tenant_id,
+                )
+                if not cart_row:
+                    raise APIError("Cart not found", status_code=404)
+
+                lines = await conn.fetch(
+                    """
+                    SELECT
+                        pci.id AS cart_item_id,
+                        pci.product_id,
+                        pci.quantity,
+                        pci.unit_price,
+                        pci.subtotal,
+                        pci.notes,
+                        p.name AS product_name
+                    FROM pos_cart_items pci
+                    JOIN product p ON p.id = pci.product_id
+                    WHERE pci.cart_id = $1
+                    """,
+                    cart_id,
+                )
+                for line in lines:
+                    line_modifiers = await _fetch_cart_item_modifiers(
+                        conn, line["cart_item_id"]
+                    )
+                    await _record_cart_operation_event(
+                        conn,
+                        tenant_id,
+                        user_id=user_id,
+                        channel=channel,
+                        action="cart_cleared",
+                        pos_cart_id=cart_id,
+                        pos_cart_item_id=line["cart_item_id"],
+                        actor_member_id=actor_member_id,
+                        payload=_build_cart_line_payload(
+                            product_id=line["product_id"],
+                            product_name=line["product_name"],
+                            quantity=line["quantity"],
+                            unit_price=line["unit_price"],
+                            subtotal=line["subtotal"],
+                            modifiers=line_modifiers,
+                            notes=line["notes"],
+                        ),
+                    )
+
+                await conn.execute(
+                    """
                     DELETE FROM pos_cart_items
                     WHERE cart_id = $1
-                """
-                await conn.execute(delete_query, cart_id)
+                    """,
+                    cart_id,
+                )
 
                 # Update cart total to 0
                 update_query = """

--- a/tests/test_pos_cart_operation_events.py
+++ b/tests/test_pos_cart_operation_events.py
@@ -1,0 +1,135 @@
+"""POS cart operation audit events (warocol.com#784)."""
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services import pos_cart_service
+
+
+@pytest.mark.asyncio
+async def test_remove_item_records_cart_line_removed_before_delete():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    cart_id = uuid4()
+    item_id = uuid4()
+    product_id = uuid4()
+    recorded = []
+    deleted = []
+
+    row = {
+        "id": item_id,
+        "product_id": product_id,
+        "quantity": 1,
+        "unit_price": 12.0,
+        "subtotal": 12.0,
+        "notes": None,
+        "product_name": "Café",
+    }
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(return_value=row)
+    mock_conn.fetch = AsyncMock(return_value=[])
+
+    async def track_execute(sql, *args):
+        if "DELETE FROM pos_cart_items" in sql:
+            deleted.append(True)
+
+    mock_conn.execute = AsyncMock(side_effect=track_execute)
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+
+    async def capture(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("app.services.pos_cart_service.require_valid_session") as mock_sess, \
+         patch("app.services.pos_cart_service.get_db_connection", return_value=mock_cm), \
+         patch("app.services.pos_cart_service.update_cart_total", new=AsyncMock()), \
+         patch(
+             "app.services.pos_cart_service._record_cart_operation_event",
+             side_effect=capture,
+         ):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+        await pos_cart_service.remove_item_from_cart(
+            MagicMock(),
+            cart_id,
+            item_id,
+            channel="barra",
+        )
+
+    assert len(recorded) == 1
+    assert recorded[0]["action"] == "cart_line_removed"
+    assert recorded[0]["channel"] == "barra"
+    assert recorded[0]["payload"]["product_name"] == "Café"
+    assert len(deleted) == 1
+
+
+@pytest.mark.asyncio
+async def test_clear_cart_emits_cart_cleared_per_line():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    cart_id = uuid4()
+    line_id = uuid4()
+    recorded = []
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(return_value={"id": cart_id})
+    mock_conn.fetch = AsyncMock(side_effect=[
+        [
+            {
+                "cart_item_id": line_id,
+                "product_id": uuid4(),
+                "quantity": 2,
+                "unit_price": 5.0,
+                "subtotal": 10.0,
+                "notes": None,
+                "product_name": "Agua",
+            },
+        ],
+        [],
+    ])
+    mock_conn.execute = AsyncMock()
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+
+    async def capture(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("app.services.pos_cart_service.require_valid_session") as mock_sess, \
+         patch("app.services.pos_cart_service.get_db_connection", return_value=mock_cm), \
+         patch(
+             "app.services.pos_cart_service._record_cart_operation_event",
+             side_effect=capture,
+         ):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+        await pos_cart_service.clear_cart(
+            MagicMock(),
+            cart_id,
+            channel="mostrador",
+        )
+
+    assert len(recorded) == 1
+    assert recorded[0]["action"] == "cart_cleared"
+    assert recorded[0]["channel"] == "mostrador"


### PR DESCRIPTION
## Summary
- Audit `remove_item_from_cart` and `clear_cart` with `cart_line_removed` / `cart_cleared`
- Query params: `channel` (mostrador|barra), optional `actor_member_id`
- Snapshot in payload; `pos_cart_item_id` in payload JSON

## Testing
`python3 -m pytest tests/test_pos_cart_operation_events.py -q` — 2 passed

## Stack
gh-783 → gh-784

Closes warocol.com#784 (API half)

Made with [Cursor](https://cursor.com)