### PR TITLE
feat(api): persist payment void reason and log event

### DIFF
--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -332,6 +332,10 @@ async def void_cart_payment(
     payment_id: str,
     body: VoidPaymentRequest,
     request: Request,
+    channel: Literal["mostrador", "barra"] = Query(
+        "mostrador",
+        description="POS channel for bitácora (warocol.com#785)",
+    ),
 ):
     """
     Issue warocol.com#649 — soft-delete a partial payment on a cart's order.
@@ -343,6 +347,7 @@ async def void_cart_payment(
         cart_id=cart_id,
         payment_id=payment_id,
         reason=body.reason,
+        channel=channel,
     )
 
 

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -1073,6 +1073,7 @@ async def void_order_payment(
     cart_id: str,
     payment_id: str,
     reason: Optional[str] = None,
+    channel: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Issue warocol.com#649 — soft-delete a partial payment on a POS cart's order.
@@ -1143,8 +1144,9 @@ async def void_order_payment(
 
                 # 4. Mark payment as voided (soft delete).
                 await conn.execute(
-                    "UPDATE order_payments SET voided_at = NOW() WHERE id = $1",
+                    "UPDATE order_payments SET voided_at = NOW(), void_reason = $2 WHERE id = $1",
                     payment_row["id"],
+                    normalized_reason,
                 )
 
                 # 5. Recompute paid total ignoring voided rows.
@@ -1177,6 +1179,30 @@ async def void_order_payment(
                     await void_order_journal_entry_in_txn(
                         conn, tenant_id, order_id, user_id, normalized_reason,
                     )
+
+                await record_operation_event(
+                    conn,
+                    tenant_id,
+                    domain=DOMAIN_POS,
+                    channel=_normalize_cart_channel(channel),
+                    action="payment_voided",
+                    actor_user_id=user_id,
+                    pos_cart_id=payment_row["pos_cart_id"],
+                    order_id=order_id,
+                    reason=normalized_reason,
+                    payload={
+                        "voided_ids": [str(payment_id)],
+                        "order_ids": [str(order_id)],
+                        "payment_method": payment_row["payment_method"],
+                        "amount": float(payment_row["amount"]),
+                        "cash_received": (
+                            float(payment_row["cash_received"])
+                            if payment_row["cash_received"] is not None
+                            else None
+                        ),
+                        "reopened": reopened,
+                    },
+                )
 
         logger.info(
             f"Payment {payment_id} voided (order={order_id}, paid_total={paid_total}, reopened={reopened})"

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -3072,6 +3072,12 @@ async def void_table_payment(
                         status_code=403,
                     )
 
+                table_meta = await conn.fetchrow(
+                    "SELECT is_bar FROM tables WHERE id = $1 AND tenant_id = $2",
+                    table_id, tenant_id,
+                )
+                mesa_channel = "barra" if table_meta and table_meta["is_bar"] else "mesa"
+
                 # 4. Find sibling rows (proportional split): same session,
                 # same method, same paid_at, not voided. Lock them all.
                 sibling_rows = await conn.fetch(
@@ -3096,8 +3102,9 @@ async def void_table_payment(
 
                 # 5. Soft-delete all siblings atomically.
                 await conn.execute(
-                    "UPDATE order_payments SET voided_at = NOW() WHERE id = ANY($1::uuid[])",
+                    "UPDATE order_payments SET voided_at = NOW(), void_reason = $2 WHERE id = ANY($1::uuid[])",
                     [r["id"] for r in sibling_rows],
+                    normalized_reason,
                 )
 
                 # 6. Recompute session-wide paid_total / remaining.
@@ -3152,6 +3159,32 @@ async def void_table_payment(
                         await void_order_journal_entry_in_txn(
                             conn, tenant_id, affected_order_id, user_id, normalized_reason,
                         )
+
+                void_amount = sum(float(r["amount"]) for r in sibling_rows)
+                await record_operation_event(
+                    conn,
+                    tenant_id,
+                    domain=DOMAIN_POS,
+                    channel=mesa_channel,
+                    action="payment_voided",
+                    actor_user_id=user_id,
+                    table_id=table_id,
+                    table_session_id=session_row["id"],
+                    order_id=target["order_id"],
+                    reason=normalized_reason,
+                    payload={
+                        "voided_ids": voided_ids,
+                        "order_ids": [str(oid) for oid in affected_order_ids],
+                        "payment_method": target["payment_method"],
+                        "amount": void_amount,
+                        "cash_received": (
+                            float(target["cash_received"])
+                            if target["cash_received"] is not None
+                            else None
+                        ),
+                        "reopened": reopened,
+                    },
+                )
 
         logger.info(
             f"Mesa payments voided: session={session_row['id']} group_size={len(voided_ids)} paid_total={paid_total} reopened={reopened}"

--- a/dbdoc/public.order_payments.md
+++ b/dbdoc/public.order_payments.md
@@ -15,6 +15,7 @@
 | notes | text |  | true |  |  |  |
 | cash_received | numeric(12,2) |  | true |  |  | Cash handed over by the customer for this split payment line. Always NULL for non-cash methods. Change due is derived: cash_received - amount. |
 | voided_at | timestamp with time zone |  | true |  |  | Soft-delete marker (warocol.com#649). NULL means active. When set, the row is excluded from paid_total computations and the parent order is reopened if this row had closed it. |
+| void_reason | text |  | true |  |  | Motivo de anulación (#649/#785). NULL mientras el pago está activo. |
 
 ## Constraints
 

--- a/sql/20260521_add_order_payments_void_reason.sql
+++ b/sql/20260521_add_order_payments_void_reason.sql
@@ -1,0 +1,6 @@
+-- warocol.com#785 — persist payment void reason on order_payments
+ALTER TABLE order_payments
+    ADD COLUMN IF NOT EXISTS void_reason TEXT NULL;
+
+COMMENT ON COLUMN order_payments.void_reason IS
+    'Motivo de anulación (#649/#785). NULL mientras el pago está activo.';

--- a/tests/test_payment_void_operation_events.py
+++ b/tests/test_payment_void_operation_events.py
@@ -1,0 +1,206 @@
+"""Payment void reason persistence and operation events (warocol.com#785)."""
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services import pos_cart_service, tables_service
+
+
+def _txn_conn():
+    mock_conn = AsyncMock()
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+    return mock_conn, mock_cm
+
+
+@pytest.mark.asyncio
+async def test_void_order_payment_persists_reason_and_records_event():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    cart_id = uuid4()
+    payment_id = uuid4()
+    order_id = uuid4()
+    recorded = []
+    void_updates = []
+
+    payment_row = {
+        "id": payment_id,
+        "order_id": order_id,
+        "amount": 50.0,
+        "payment_method": "cash",
+        "cash_received": 60.0,
+        "created_by_user_id": user_id,
+        "voided_at": None,
+        "pos_cart_id": cart_id,
+        "total_amount": 100.0,
+        "tip_amount": 0,
+        "tip_tax_amount": 0,
+        "payment_status": "partial",
+        "order_status": "active",
+    }
+
+    mock_conn, mock_cm = _txn_conn()
+    mock_conn.fetchrow = AsyncMock(side_effect=[
+        payment_row,
+        {"paid": 0},
+    ])
+
+    async def track_execute(sql, *args):
+        if "void_reason" in sql:
+            void_updates.append(args)
+
+    mock_conn.execute = AsyncMock(side_effect=track_execute)
+
+    async def capture_event(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    with patch("app.services.pos_cart_service.require_valid_session") as mock_sess, \
+         patch("app.services.pos_cart_service.get_db_connection", return_value=mock_cm), \
+         patch(
+             "app.services.pos_cart_service.record_operation_event",
+             side_effect=capture_event,
+         ):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id, role="admin")
+        await pos_cart_service.void_order_payment(
+            MagicMock(),
+            str(cart_id),
+            str(payment_id),
+            reason="Cliente se arrepintió",
+            channel="barra",
+        )
+
+    assert len(void_updates) == 1
+    assert void_updates[0][1] == "Cliente se arrepintió"
+    assert len(recorded) == 1
+    assert recorded[0]["action"] == "payment_voided"
+    assert recorded[0]["channel"] == "barra"
+    assert recorded[0]["reason"] == "Cliente se arrepintió"
+    assert recorded[0]["actor_user_id"] == user_id
+    assert recorded[0]["payload"]["amount"] == 50.0
+
+
+@pytest.mark.asyncio
+async def test_void_order_payment_empty_reason_defaults_sin_motivo():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    cart_id = uuid4()
+    payment_id = uuid4()
+    order_id = uuid4()
+    void_updates = []
+
+    payment_row = {
+        "id": payment_id,
+        "order_id": order_id,
+        "amount": 10.0,
+        "payment_method": "card",
+        "cash_received": None,
+        "created_by_user_id": user_id,
+        "voided_at": None,
+        "pos_cart_id": cart_id,
+        "total_amount": 10.0,
+        "tip_amount": 0,
+        "tip_tax_amount": 0,
+        "payment_status": "partial",
+        "order_status": "active",
+    }
+
+    mock_conn, mock_cm = _txn_conn()
+    mock_conn.fetchrow = AsyncMock(side_effect=[payment_row, {"paid": 0}])
+
+    async def track_execute(sql, *args):
+        if "void_reason" in sql:
+            void_updates.append(args)
+
+    mock_conn.execute = AsyncMock(side_effect=track_execute)
+
+    with patch("app.services.pos_cart_service.require_valid_session") as mock_sess, \
+         patch("app.services.pos_cart_service.get_db_connection", return_value=mock_cm), \
+         patch("app.services.pos_cart_service.record_operation_event", new=AsyncMock()):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id, role="admin")
+        await pos_cart_service.void_order_payment(
+            MagicMock(), str(cart_id), str(payment_id), reason="  ",
+        )
+
+    assert void_updates[0][1] == "Sin motivo"
+
+
+@pytest.mark.asyncio
+async def test_void_table_payment_records_single_payment_voided_event():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    payment_id = uuid4()
+    session_id = uuid4()
+    order_id = uuid4()
+    paid_at = datetime.now(timezone.utc)
+    recorded = []
+    void_updates = []
+
+    target = {
+        "id": payment_id,
+        "order_id": order_id,
+        "payment_method": "cash",
+        "paid_at": paid_at,
+        "cash_received": 100.0,
+        "created_by_user_id": user_id,
+        "voided_at": None,
+        "table_session_id": session_id,
+    }
+    session_row = {"id": session_id, "table_id": table_id, "closed_at": None}
+    sibling_rows = [
+        {"id": payment_id, "order_id": order_id, "amount": 40.0},
+        {"id": uuid4(), "order_id": uuid4(), "amount": 10.0},
+    ]
+
+    mock_conn, mock_cm = _txn_conn()
+    mock_conn.fetchrow = AsyncMock(side_effect=[
+        target,
+        session_row,
+        {"is_bar": True},
+        {"paid": 0},
+        {"tip_amount": 0, "tip_tax_amount": 0},
+    ])
+    mock_conn.fetch = AsyncMock(side_effect=[
+        sibling_rows,
+        [{"id": order_id, "total_amount": 50.0}],
+    ])
+
+    async def track_execute(sql, *args):
+        if "void_reason" in sql:
+            void_updates.append(args)
+
+    mock_conn.execute = AsyncMock(side_effect=track_execute)
+
+    async def capture_event(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    with patch("app.services.tables_service.require_valid_session") as mock_sess, \
+         patch("app.services.tables_service.get_db_connection", return_value=mock_cm), \
+         patch(
+             "app.services.tables_service.record_operation_event",
+             side_effect=capture_event,
+         ):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id, role="admin")
+        await tables_service.void_table_payment(
+            MagicMock(), table_id, payment_id, reason="Error de caja",
+        )
+
+    assert void_updates[0][1] == "Error de caja"
+    assert len(recorded) == 1
+    assert recorded[0]["action"] == "payment_voided"
+    assert recorded[0]["channel"] == "barra"
+    assert recorded[0]["reason"] == "Error de caja"
+    assert len(recorded[0]["payload"]["voided_ids"]) == 2
+    assert recorded[0]["payload"]["amount"] == 50.0


### PR DESCRIPTION
## Summary
Closes warocol.com#785 — persist payment void `reason` on `order_payments` and emit `payment_voided` operation events for mesa and POS cart voids.

## Stack
- Python 3.9 / FastAPI / Postgres
- Builds on #782–#784 (`gh-784-pos-cart-events`)

## Changes
- `sql/20260521_add_order_payments_void_reason.sql` — ADD `void_reason TEXT NULL`
- `tables_service.py` — persist reason on sibling void; one `payment_voided` event; channel from `tables.is_bar`
- `pos_cart_service.py` — persist reason; `payment_voided` event; optional `channel` param
- `pos_cart.py` — `channel` query on payment void DELETE
- `tests/test_payment_void_operation_events.py` — 3 tests

## Testing
- `python3 -m pytest tests/test_payment_void_operation_events.py -q` — 3 passed
- Apply migration on DB before deploy: `sql/20260521_add_order_payments_void_reason.sql`

Closes warocol.com#785

Made with [Cursor](https://cursor.com)