### PR TITLE
feat(api): require reason when removing fired comanda lines

### DIFF
--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -332,6 +332,10 @@ async def void_cart_payment(
     payment_id: str,
     body: VoidPaymentRequest,
     request: Request,
+    channel: Literal["mostrador", "barra"] = Query(
+        "mostrador",
+        description="POS channel for bitácora (warocol.com#785)",
+    ),
 ):
     """
     Issue warocol.com#649 — soft-delete a partial payment on a cart's order.
@@ -343,6 +347,7 @@ async def void_cart_payment(
         cart_id=cart_id,
         payment_id=payment_id,
         reason=body.reason,
+        channel=channel,
     )
 
 

--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -119,7 +119,15 @@ async def update_item(
 async def remove_item(
     request: Request,
     cart_id: UUID,
-    item_id: UUID
+    item_id: UUID,
+    channel: Literal["mostrador", "barra"] = Query(
+        "mostrador",
+        description="POS channel for bitácora (warocol.com#784)",
+    ),
+    actor_member_id: Optional[UUID] = Query(
+        None,
+        description="Optional tenant_members.id (served-by attribution, #575)",
+    ),
 ):
     """
     Remove item from cart
@@ -127,19 +135,34 @@ async def remove_item(
     return await pos_cart_service.remove_item_from_cart(
         request,
         cart_id,
-        item_id
+        item_id,
+        channel=channel,
+        actor_member_id=actor_member_id,
     )
 
 
 @router.delete("/{cart_id}", dependencies=[Depends(require_module(Module.POS))])
 async def clear_cart(
     request: Request,
-    cart_id: UUID
+    cart_id: UUID,
+    channel: Literal["mostrador", "barra"] = Query(
+        "mostrador",
+        description="POS channel for bitácora (warocol.com#784)",
+    ),
+    actor_member_id: Optional[UUID] = Query(
+        None,
+        description="Optional tenant_members.id (served-by attribution, #575)",
+    ),
 ):
     """
     Clear all items from cart
     """
-    return await pos_cart_service.clear_cart(request, cart_id)
+    return await pos_cart_service.clear_cart(
+        request,
+        cart_id,
+        channel=channel,
+        actor_member_id=actor_member_id,
+    )
 
 
 class CompleteOrderRequest(BaseModel):

--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -250,10 +250,24 @@ async def add_tab_items(request: Request, table_id: UUID, body: TabAddRequest):
     return await tables_service.add_tab_items(request, table_id, items)
 
 
+class RemoveTabItemRequest(BaseModel):
+    reason: Optional[str] = Field(
+        None,
+        description="warocol.com#786 — required when the line was fired to kitchen",
+    )
+
+
 @router.delete("/{table_id}/tab/items/{order_item_id}", dependencies=[Depends(require_module(Module.POS))])
-async def remove_tab_item(request: Request, table_id: UUID, order_item_id: UUID):
+async def remove_tab_item(
+    request: Request,
+    table_id: UUID,
+    order_item_id: UUID,
+    body: RemoveTabItemRequest,
+):
     """Remove an order item from the running tab."""
-    return await tables_service.remove_tab_item(request, table_id, order_item_id)
+    return await tables_service.remove_tab_item(
+        request, table_id, order_item_id, body.reason,
+    )
 
 
 @router.patch("/{table_id}/tab/items/{order_item_id}", dependencies=[Depends(require_module(Module.POS))])

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -1073,6 +1073,7 @@ async def void_order_payment(
     cart_id: str,
     payment_id: str,
     reason: Optional[str] = None,
+    channel: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Issue warocol.com#649 — soft-delete a partial payment on a POS cart's order.
@@ -1143,8 +1144,9 @@ async def void_order_payment(
 
                 # 4. Mark payment as voided (soft delete).
                 await conn.execute(
-                    "UPDATE order_payments SET voided_at = NOW() WHERE id = $1",
+                    "UPDATE order_payments SET voided_at = NOW(), void_reason = $2 WHERE id = $1",
                     payment_row["id"],
+                    normalized_reason,
                 )
 
                 # 5. Recompute paid total ignoring voided rows.
@@ -1177,6 +1179,30 @@ async def void_order_payment(
                     await void_order_journal_entry_in_txn(
                         conn, tenant_id, order_id, user_id, normalized_reason,
                     )
+
+                await record_operation_event(
+                    conn,
+                    tenant_id,
+                    domain=DOMAIN_POS,
+                    channel=_normalize_cart_channel(channel),
+                    action="payment_voided",
+                    actor_user_id=user_id,
+                    pos_cart_id=payment_row["pos_cart_id"],
+                    order_id=order_id,
+                    reason=normalized_reason,
+                    payload={
+                        "voided_ids": [str(payment_id)],
+                        "order_ids": [str(order_id)],
+                        "payment_method": payment_row["payment_method"],
+                        "amount": float(payment_row["amount"]),
+                        "cash_received": (
+                            float(payment_row["cash_received"])
+                            if payment_row["cash_received"] is not None
+                            else None
+                        ),
+                        "reopened": reopened,
+                    },
+                )
 
         logger.info(
             f"Payment {payment_id} voided (order={order_id}, paid_total={paid_total}, reopened={reopened})"

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -24,6 +24,7 @@ from app.services.tip_tax_service import (
 from app.services.accounting_service import void_order_journal_entry_in_txn
 from app.services.ingredient_purchase_units_service import resolve_recipe_quantity_to_base_unit
 from app.services.comandas_service import fire_comandas, finalize_open_comandas
+from app.services.operation_events_service import DOMAIN_POS, record_operation_event
 import logging
 
 logger = logging.getLogger(__name__)
@@ -534,10 +535,93 @@ async def update_cart_item(
         raise APIError(f"Error updating cart item: {str(e)}", status_code=500)
 
 
+def _normalize_cart_channel(channel: Optional[str]) -> str:
+    """POS cart channel for bitácora (#784)."""
+    normalized = (channel or "mostrador").strip().lower()
+    if normalized not in ("mostrador", "barra"):
+        return "mostrador"
+    return normalized
+
+
+async def _fetch_cart_item_modifiers(conn, cart_item_id: UUID) -> List[Dict[str, Any]]:
+    rows = await conn.fetch(
+        """
+        SELECT modifier_id, modifier_name, price
+        FROM pos_cart_item_modifiers
+        WHERE cart_item_id = $1
+        """,
+        cart_item_id,
+    )
+    return [
+        {
+            "id": str(r["modifier_id"]) if r["modifier_id"] else None,
+            "name": r["modifier_name"],
+            "price": float(r["price"]),
+        }
+        for r in rows
+    ]
+
+
+def _build_cart_line_payload(
+    *,
+    product_id: Any,
+    product_name: Optional[str],
+    quantity: Any,
+    unit_price: Any,
+    subtotal: Any,
+    modifiers: List[Dict[str, Any]],
+    notes: Optional[str],
+    table_id: Optional[UUID] = None,
+    table_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    return {
+        "product_id": str(product_id) if product_id else None,
+        "product_name": product_name,
+        "quantity": float(quantity) if quantity is not None else None,
+        "unit_price": float(unit_price),
+        "subtotal": float(subtotal),
+        "modifiers": modifiers,
+        "notes": notes,
+        "table_id": str(table_id) if table_id else None,
+        "table_name": table_name,
+        "order_number": None,
+    }
+
+
+async def _record_cart_operation_event(
+    conn,
+    tenant_id: UUID,
+    *,
+    user_id: UUID,
+    channel: str,
+    action: str,
+    pos_cart_id: UUID,
+    pos_cart_item_id: Optional[UUID] = None,
+    payload: Optional[Dict[str, Any]] = None,
+    actor_member_id: Optional[UUID] = None,
+) -> None:
+    merged_payload = dict(payload) if payload else {}
+    if pos_cart_item_id:
+        merged_payload["pos_cart_item_id"] = str(pos_cart_item_id)
+    await record_operation_event(
+        conn,
+        tenant_id,
+        domain=DOMAIN_POS,
+        channel=_normalize_cart_channel(channel),
+        action=action,
+        actor_user_id=user_id,
+        actor_member_id=actor_member_id,
+        pos_cart_id=pos_cart_id,
+        payload=merged_payload,
+    )
+
+
 async def remove_item_from_cart(
     request: Request,
     cart_id: UUID,
-    item_id: UUID
+    item_id: UUID,
+    channel: str = "mostrador",
+    actor_member_id: Optional[UUID] = None,
 ) -> dict:
     """
     Remove an item from cart
@@ -545,20 +629,61 @@ async def remove_item_from_cart(
     try:
         session_context = require_valid_session(request)
         tenant_id = session_context.tenant_id
+        user_id = session_context.user_id
 
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection() as conn:
             async with conn.transaction():
-                # Delete item (modifiers will cascade)
-                delete_query = """
+                row = await conn.fetchrow(
+                    """
+                    SELECT
+                        pci.id, pci.product_id, pci.quantity, pci.unit_price,
+                        pci.subtotal, pci.notes,
+                        p.name AS product_name
+                    FROM pos_cart_items pci
+                    JOIN pos_carts pc ON pc.id = pci.cart_id
+                    JOIN product p ON p.id = pci.product_id
+                    WHERE pci.id = $1 AND pci.cart_id = $2 AND pc.tenant_id = $3
+                    """,
+                    item_id,
+                    cart_id,
+                    tenant_id,
+                )
+                if not row:
+                    raise APIError("Cart item not found", status_code=404)
+
+                modifiers = await _fetch_cart_item_modifiers(conn, item_id)
+                await _record_cart_operation_event(
+                    conn,
+                    tenant_id,
+                    user_id=user_id,
+                    channel=channel,
+                    action="cart_line_removed",
+                    pos_cart_id=cart_id,
+                    pos_cart_item_id=item_id,
+                    actor_member_id=actor_member_id,
+                    payload=_build_cart_line_payload(
+                        product_id=row["product_id"],
+                        product_name=row["product_name"],
+                        quantity=row["quantity"],
+                        unit_price=row["unit_price"],
+                        subtotal=row["subtotal"],
+                        modifiers=modifiers,
+                        notes=row["notes"],
+                    ),
+                )
+
+                await conn.execute(
+                    """
                     DELETE FROM pos_cart_items
                     WHERE id = $1 AND cart_id = $2
-                """
-                await conn.execute(delete_query, item_id, cart_id)
+                    """,
+                    item_id,
+                    cart_id,
+                )
 
-                # Update cart total
                 await update_cart_total(conn, cart_id)
 
                 logger.info(f"Removed item {item_id} from cart {cart_id}")
@@ -577,7 +702,9 @@ async def remove_item_from_cart(
 
 async def clear_cart(
     request: Request,
-    cart_id: UUID
+    cart_id: UUID,
+    channel: str = "mostrador",
+    actor_member_id: Optional[UUID] = None,
 ) -> dict:
     """
     Clear all items from cart
@@ -585,18 +712,71 @@ async def clear_cart(
     try:
         session_context = require_valid_session(request)
         tenant_id = session_context.tenant_id
+        user_id = session_context.user_id
 
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection() as conn:
             async with conn.transaction():
-                # Delete all items (modifiers will cascade)
-                delete_query = """
+                cart_row = await conn.fetchrow(
+                    """
+                    SELECT id FROM pos_carts
+                    WHERE id = $1 AND tenant_id = $2
+                    """,
+                    cart_id,
+                    tenant_id,
+                )
+                if not cart_row:
+                    raise APIError("Cart not found", status_code=404)
+
+                lines = await conn.fetch(
+                    """
+                    SELECT
+                        pci.id AS cart_item_id,
+                        pci.product_id,
+                        pci.quantity,
+                        pci.unit_price,
+                        pci.subtotal,
+                        pci.notes,
+                        p.name AS product_name
+                    FROM pos_cart_items pci
+                    JOIN product p ON p.id = pci.product_id
+                    WHERE pci.cart_id = $1
+                    """,
+                    cart_id,
+                )
+                for line in lines:
+                    line_modifiers = await _fetch_cart_item_modifiers(
+                        conn, line["cart_item_id"]
+                    )
+                    await _record_cart_operation_event(
+                        conn,
+                        tenant_id,
+                        user_id=user_id,
+                        channel=channel,
+                        action="cart_cleared",
+                        pos_cart_id=cart_id,
+                        pos_cart_item_id=line["cart_item_id"],
+                        actor_member_id=actor_member_id,
+                        payload=_build_cart_line_payload(
+                            product_id=line["product_id"],
+                            product_name=line["product_name"],
+                            quantity=line["quantity"],
+                            unit_price=line["unit_price"],
+                            subtotal=line["subtotal"],
+                            modifiers=line_modifiers,
+                            notes=line["notes"],
+                        ),
+                    )
+
+                await conn.execute(
+                    """
                     DELETE FROM pos_cart_items
                     WHERE cart_id = $1
-                """
-                await conn.execute(delete_query, cart_id)
+                    """,
+                    cart_id,
+                )
 
                 # Update cart total to 0
                 update_query = """

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -1733,6 +1733,7 @@ async def _record_tab_operation_event(
     order_item_id: Optional[UUID] = None,
     comanda_item_id: Optional[UUID] = None,
     payload: Optional[Dict[str, Any]] = None,
+    reason: Optional[str] = None,
 ) -> None:
     await record_operation_event(
         conn,
@@ -1748,10 +1749,27 @@ async def _record_tab_operation_event(
         order_item_id=order_item_id,
         comanda_item_id=comanda_item_id,
         payload=payload,
+        reason=reason,
     )
 
 
-async def remove_tab_item(request: Request, table_id: UUID, order_item_id: UUID) -> dict:
+def _tab_item_requires_remove_reason(
+    fulfillment_status: Optional[str],
+    comanda_item_row: Optional[Any],
+) -> bool:
+    """Fired to kitchen: non-new fulfillment or linked comanda line (warocol.com#786)."""
+    status = fulfillment_status or "new"
+    if status not in ("new", "cancelled"):
+        return True
+    return comanda_item_row is not None
+
+
+async def remove_tab_item(
+    request: Request,
+    table_id: UUID,
+    order_item_id: UUID,
+    reason: Optional[str] = None,
+) -> dict:
     """Remove an order item from the running tab and update the order total."""
     try:
         session_context = require_valid_session(request)
@@ -1765,7 +1783,7 @@ async def remove_tab_item(request: Request, table_id: UUID, order_item_id: UUID)
                 """
                 SELECT
                     oi.id, oi.product_id, oi.quantity, oi.price_at_purchase,
-                    oi.subtotal, oi.notes,
+                    oi.subtotal, oi.notes, oi.fulfillment_status,
                     o.id AS order_id, o.total_amount, o.order_number, o.table_session_id,
                     p.name AS product_name,
                     t.name AS table_name,
@@ -1801,6 +1819,15 @@ async def remove_tab_item(request: Request, table_id: UUID, order_item_id: UUID)
                 "SELECT id, comanda_id FROM comanda_items WHERE order_item_id = $1",
                 order_item_id,
             )
+
+            normalized_reason = (reason or "").strip()
+            if _tab_item_requires_remove_reason(row["fulfillment_status"], comanda_item_row):
+                if not normalized_reason:
+                    raise APIError(
+                        "Motivo requerido para eliminar un producto enviado a cocina",
+                        status_code=400,
+                    )
+            event_reason = normalized_reason or None
             if comanda_item_row:
                 await conn.execute(
                     """
@@ -1858,6 +1885,7 @@ async def remove_tab_item(request: Request, table_id: UUID, order_item_id: UUID)
                 order_id=row["order_id"],
                 order_item_id=order_item_id,
                 comanda_item_id=comanda_item_id,
+                reason=event_reason,
                 payload=_build_tab_item_payload(
                     product_id=row["product_id"],
                     product_name=row["product_name"],
@@ -1880,7 +1908,7 @@ async def remove_tab_item(request: Request, table_id: UUID, order_item_id: UUID)
             )
 
         return {"success": True, "data": {"removed": str(order_item_id)}}
-    except (AuthenticationError, NotFoundError):
+    except (AuthenticationError, NotFoundError, APIError):
         raise
     except Exception as e:
         logger.error(f"Error removing tab item {order_item_id}: {e}")

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -3072,6 +3072,12 @@ async def void_table_payment(
                         status_code=403,
                     )
 
+                table_meta = await conn.fetchrow(
+                    "SELECT is_bar FROM tables WHERE id = $1 AND tenant_id = $2",
+                    table_id, tenant_id,
+                )
+                mesa_channel = "barra" if table_meta and table_meta["is_bar"] else "mesa"
+
                 # 4. Find sibling rows (proportional split): same session,
                 # same method, same paid_at, not voided. Lock them all.
                 sibling_rows = await conn.fetch(
@@ -3096,8 +3102,9 @@ async def void_table_payment(
 
                 # 5. Soft-delete all siblings atomically.
                 await conn.execute(
-                    "UPDATE order_payments SET voided_at = NOW() WHERE id = ANY($1::uuid[])",
+                    "UPDATE order_payments SET voided_at = NOW(), void_reason = $2 WHERE id = ANY($1::uuid[])",
                     [r["id"] for r in sibling_rows],
+                    normalized_reason,
                 )
 
                 # 6. Recompute session-wide paid_total / remaining.
@@ -3152,6 +3159,32 @@ async def void_table_payment(
                         await void_order_journal_entry_in_txn(
                             conn, tenant_id, affected_order_id, user_id, normalized_reason,
                         )
+
+                void_amount = sum(float(r["amount"]) for r in sibling_rows)
+                await record_operation_event(
+                    conn,
+                    tenant_id,
+                    domain=DOMAIN_POS,
+                    channel=mesa_channel,
+                    action="payment_voided",
+                    actor_user_id=user_id,
+                    table_id=table_id,
+                    table_session_id=session_row["id"],
+                    order_id=target["order_id"],
+                    reason=normalized_reason,
+                    payload={
+                        "voided_ids": voided_ids,
+                        "order_ids": [str(oid) for oid in affected_order_ids],
+                        "payment_method": target["payment_method"],
+                        "amount": void_amount,
+                        "cash_received": (
+                            float(target["cash_received"])
+                            if target["cash_received"] is not None
+                            else None
+                        ),
+                        "reopened": reopened,
+                    },
+                )
 
         logger.info(
             f"Mesa payments voided: session={session_row['id']} group_size={len(voided_ids)} paid_total={paid_total} reopened={reopened}"

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -5,7 +5,7 @@ Business logic for table management and session lifecycle.
 Issue: https://github.com/uno0uno/warocol.com/issues/298
 """
 import secrets
-from typing import Optional, List
+from typing import Optional, List, Any, Dict
 from uuid import UUID
 from datetime import date
 from decimal import Decimal
@@ -29,6 +29,7 @@ from app.services.tip_tax_service import (
 from app.services.orders_service import _compute_tax_breakdown
 from app.services.ingredient_purchase_units_service import resolve_recipe_quantity_to_base_unit
 from app.services.comandas_service import fire_comandas
+from app.services.operation_events_service import DOMAIN_POS, record_operation_event
 import logging
 
 logger = logging.getLogger(__name__)
@@ -1616,21 +1617,166 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
         raise APIError(f"Error fetching session: {e}", status_code=500)
 
 
+async def _fetch_tab_operation_context(
+    conn, tenant_id: UUID, table_id: UUID
+) -> Optional[Dict[str, Any]]:
+    """Channel, session, table label, and effective waiter for bitácora events (#783)."""
+    row = await conn.fetchrow(
+        """
+        SELECT
+            t.name AS table_name,
+            t.is_bar,
+            ts.id AS table_session_id,
+            COALESCE(ts.attended_by_member_id, t.assigned_member_id) AS effective_waiter_member_id
+        FROM tables t
+        JOIN table_sessions ts ON ts.table_id = t.id
+        WHERE t.id = $1
+          AND t.tenant_id = $2
+          AND ts.closed_at IS NULL
+        """,
+        table_id,
+        tenant_id,
+    )
+    if not row:
+        return None
+    return {
+        "channel": "barra" if row["is_bar"] else "mesa",
+        "table_name": row["table_name"],
+        "table_session_id": row["table_session_id"],
+        "effective_waiter_member_id": row["effective_waiter_member_id"],
+    }
+
+
+async def _prefetch_product_names(
+    conn, tenant_id: UUID, product_ids: List[Any]
+) -> Dict[str, str]:
+    if not product_ids:
+        return {}
+    rows = await conn.fetch(
+        """
+        SELECT id, name FROM product
+        WHERE tenant_id = $1 AND id = ANY($2::uuid[])
+        """,
+        tenant_id,
+        list(product_ids),
+    )
+    return {str(r["id"]): r["name"] for r in rows}
+
+
+async def _fetch_order_item_modifiers(conn, order_item_id: UUID) -> List[Dict[str, Any]]:
+    rows = await conn.fetch(
+        """
+        SELECT modifier_id, modifier_name, price_at_purchase, quantity
+        FROM order_item_modifiers
+        WHERE order_item_id = $1
+        """,
+        order_item_id,
+    )
+    return [
+        {
+            "id": str(r["modifier_id"]) if r["modifier_id"] else None,
+            "name": r["modifier_name"],
+            "price": float(r["price_at_purchase"]),
+            "quantity": int(r["quantity"]),
+        }
+        for r in rows
+    ]
+
+
+def _build_tab_item_payload(
+    *,
+    product_id: Any,
+    product_name: Optional[str],
+    quantity: Any,
+    unit_price: Any,
+    subtotal: Any,
+    modifiers: List[Dict[str, Any]],
+    notes: Optional[str],
+    table_id: UUID,
+    table_name: str,
+    order_number: Any,
+) -> Dict[str, Any]:
+    return {
+        "product_id": str(product_id) if product_id else None,
+        "product_name": product_name,
+        "quantity": float(quantity) if quantity is not None else None,
+        "unit_price": float(unit_price),
+        "subtotal": float(subtotal),
+        "modifiers": modifiers,
+        "notes": notes,
+        "table_id": str(table_id),
+        "table_name": table_name,
+        "order_number": int(order_number) if order_number is not None else None,
+    }
+
+
+def _modifiers_from_request_item(item: dict) -> List[Dict[str, Any]]:
+    return [
+        {
+            "id": m.get("id"),
+            "name": m.get("name"),
+            "price": float(m.get("price", 0)),
+        }
+        for m in (item.get("modifiers") or [])
+    ]
+
+
+async def _record_tab_operation_event(
+    conn,
+    tenant_id: UUID,
+    *,
+    user_id: UUID,
+    table_id: UUID,
+    tab_ctx: Dict[str, Any],
+    action: str,
+    order_id: Optional[UUID] = None,
+    order_item_id: Optional[UUID] = None,
+    comanda_item_id: Optional[UUID] = None,
+    payload: Optional[Dict[str, Any]] = None,
+) -> None:
+    await record_operation_event(
+        conn,
+        tenant_id,
+        domain=DOMAIN_POS,
+        channel=tab_ctx["channel"],
+        action=action,
+        actor_user_id=user_id,
+        actor_member_id=tab_ctx.get("effective_waiter_member_id"),
+        table_id=table_id,
+        table_session_id=tab_ctx.get("table_session_id"),
+        order_id=order_id,
+        order_item_id=order_item_id,
+        comanda_item_id=comanda_item_id,
+        payload=payload,
+    )
+
+
 async def remove_tab_item(request: Request, table_id: UUID, order_item_id: UUID) -> dict:
     """Remove an order item from the running tab and update the order total."""
     try:
         session_context = require_valid_session(request)
         tenant_id = session_context.tenant_id
+        user_id = session_context.user_id
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection(use_transaction=True) as conn:
             row = await conn.fetchrow(
                 """
-                SELECT oi.id, oi.subtotal, o.id AS order_id, o.total_amount
+                SELECT
+                    oi.id, oi.product_id, oi.quantity, oi.price_at_purchase,
+                    oi.subtotal, oi.notes,
+                    o.id AS order_id, o.total_amount, o.order_number, o.table_session_id,
+                    p.name AS product_name,
+                    t.name AS table_name,
+                    t.is_bar,
+                    COALESCE(ts.attended_by_member_id, t.assigned_member_id)
+                        AS effective_waiter_member_id
                 FROM order_items oi
                 JOIN orders o ON o.id = oi.order_id
                 JOIN table_sessions ts ON ts.id = o.table_session_id
+                JOIN tables t ON t.id = ts.table_id
+                JOIN product p ON p.id = oi.product_id
                 WHERE oi.id = $1
                   AND ts.table_id = $2
                   AND ts.tenant_id = $3
@@ -1640,6 +1786,14 @@ async def remove_tab_item(request: Request, table_id: UUID, order_item_id: UUID)
             )
             if not row:
                 raise NotFoundError("Order item not found or session already closed")
+
+            tab_ctx = {
+                "channel": "barra" if row["is_bar"] else "mesa",
+                "table_name": row["table_name"],
+                "table_session_id": row["table_session_id"],
+                "effective_waiter_member_id": row["effective_waiter_member_id"],
+            }
+            modifiers = await _fetch_order_item_modifiers(conn, order_item_id)
 
             # Cancel linked comanda_item BEFORE deleting order_item (FK: no cascade).
             # If comandas are disabled no row will be found — no-op, continues as before.
@@ -1691,6 +1845,33 @@ async def remove_tab_item(request: Request, table_id: UUID, order_item_id: UUID)
                     comanda_item_row["id"],
                 )
 
+            comanda_item_id = (
+                comanda_item_row["id"] if comanda_item_row else None
+            )
+            await _record_tab_operation_event(
+                conn,
+                tenant_id,
+                user_id=user_id,
+                table_id=table_id,
+                tab_ctx=tab_ctx,
+                action="tab_item_removed",
+                order_id=row["order_id"],
+                order_item_id=order_item_id,
+                comanda_item_id=comanda_item_id,
+                payload=_build_tab_item_payload(
+                    product_id=row["product_id"],
+                    product_name=row["product_name"],
+                    quantity=row["quantity"],
+                    unit_price=row["price_at_purchase"],
+                    subtotal=row["subtotal"],
+                    modifiers=modifiers,
+                    notes=row["notes"],
+                    table_id=table_id,
+                    table_name=row["table_name"],
+                    order_number=row["order_number"],
+                ),
+            )
+
             await conn.execute("DELETE FROM order_items WHERE id = $1", order_item_id)
             new_total = max(0.0, float(row["total_amount"]) - float(row["subtotal"]))
             await conn.execute(
@@ -1715,16 +1896,28 @@ async def update_tab_item_quantity(
     try:
         session_context = require_valid_session(request)
         tenant_id = session_context.tenant_id
+        user_id = session_context.user_id
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection(use_transaction=True) as conn:
             row = await conn.fetchrow(
                 """
-                SELECT oi.id, oi.price_at_purchase, oi.subtotal, o.id AS order_id, o.total_amount
+                SELECT
+                    oi.id, oi.product_id, oi.quantity, oi.price_at_purchase,
+                    oi.subtotal, oi.notes,
+                    o.id AS order_id, o.total_amount, o.order_number,
+                    p.name AS product_name,
+                    t.name AS table_name,
+                    t.is_bar,
+                    ts.id AS table_session_id,
+                    COALESCE(ts.attended_by_member_id, t.assigned_member_id)
+                        AS effective_waiter_member_id
                 FROM order_items oi
                 JOIN orders o ON o.id = oi.order_id
                 JOIN table_sessions ts ON ts.id = o.table_session_id
+                JOIN tables t ON t.id = ts.table_id
+                JOIN product p ON p.id = oi.product_id
                 WHERE oi.id = $1
                   AND ts.table_id = $2
                   AND ts.tenant_id = $3
@@ -1734,6 +1927,15 @@ async def update_tab_item_quantity(
             )
             if not row:
                 raise NotFoundError("Order item not found or session already closed")
+
+            old_quantity = float(row["quantity"])
+            tab_ctx = {
+                "channel": "barra" if row["is_bar"] else "mesa",
+                "table_name": row["table_name"],
+                "table_session_id": row["table_session_id"],
+                "effective_waiter_member_id": row["effective_waiter_member_id"],
+            }
+            modifiers = await _fetch_order_item_modifiers(conn, order_item_id)
 
             modifier_sum = await conn.fetchval(
                 "SELECT COALESCE(SUM(price_at_purchase), 0) FROM order_item_modifiers WHERE order_item_id = $1",
@@ -1750,6 +1952,33 @@ async def update_tab_item_quantity(
             await conn.execute(
                 "UPDATE orders SET total_amount = $1 WHERE id = $2",
                 new_total, row["order_id"],
+            )
+
+            payload = _build_tab_item_payload(
+                product_id=row["product_id"],
+                product_name=row["product_name"],
+                quantity=quantity,
+                unit_price=row["price_at_purchase"],
+                subtotal=new_subtotal,
+                modifiers=modifiers,
+                notes=row["notes"],
+                table_id=table_id,
+                table_name=row["table_name"],
+                order_number=row["order_number"],
+            )
+            payload["old_quantity"] = old_quantity
+            payload["new_quantity"] = float(quantity)
+
+            await _record_tab_operation_event(
+                conn,
+                tenant_id,
+                user_id=user_id,
+                table_id=table_id,
+                tab_ctx=tab_ctx,
+                action="tab_item_qty_changed",
+                order_id=row["order_id"],
+                order_item_id=order_item_id,
+                payload=payload,
             )
 
         return {"success": True, "data": {"order_item_id": str(order_item_id), "quantity": quantity, "subtotal": new_subtotal}}
@@ -1773,7 +2002,12 @@ async def _add_tab_items_core(
     """
     session_row = await conn.fetchrow(
         """
-        SELECT ts.id AS session_id
+        SELECT
+            ts.id AS session_id,
+            t.name AS table_name,
+            t.is_bar,
+            COALESCE(ts.attended_by_member_id, t.assigned_member_id)
+                AS effective_waiter_member_id
         FROM table_sessions ts
         JOIN tables t ON t.id = ts.table_id
         WHERE ts.table_id = $1
@@ -1788,6 +2022,14 @@ async def _add_tab_items_core(
         raise NotFoundError("No open session found for this table")
 
     session_id = session_row["session_id"]
+    tab_ctx = {
+        "channel": "barra" if session_row["is_bar"] else "mesa",
+        "table_name": session_row["table_name"],
+        "table_session_id": session_id,
+        "effective_waiter_member_id": session_row["effective_waiter_member_id"],
+    }
+    product_ids = list({item["product_id"] for item in items})
+    product_names = await _prefetch_product_names(conn, tenant_id, product_ids)
 
     for item in items:
         mod_sum = sum(float(m.get("price", 0)) for m in (item.get("modifiers") or []))
@@ -1889,6 +2131,29 @@ async def _add_tab_items_core(
                 mod.get("price", 0),
                 1,
             )
+
+        await _record_tab_operation_event(
+            conn,
+            tenant_id,
+            user_id=user_id,
+            table_id=table_id,
+            tab_ctx=tab_ctx,
+            action="tab_item_added",
+            order_id=order_id,
+            order_item_id=order_item_id,
+            payload=_build_tab_item_payload(
+                product_id=item["product_id"],
+                product_name=product_names.get(str(item["product_id"])),
+                quantity=item["quantity"],
+                unit_price=item["unit_price"],
+                subtotal=subtotal,
+                modifiers=_modifiers_from_request_item(item),
+                notes=item_notes,
+                table_id=table_id,
+                table_name=tab_ctx["table_name"],
+                order_number=order_number,
+            ),
+        )
 
         try:
             await _capture_order_item_ingredients(
@@ -2529,6 +2794,7 @@ async def clear_tab(request: Request, table_id: UUID) -> dict:
     try:
         session_context = require_valid_session(request)
         tenant_id = session_context.tenant_id
+        user_id = session_context.user_id
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
 
@@ -2541,6 +2807,54 @@ async def clear_tab(request: Request, table_id: UUID) -> dict:
                 )
                 if not session_row:
                     raise NotFoundError("No open session found for this table")
+
+                tab_ctx = await _fetch_tab_operation_context(conn, tenant_id, table_id)
+                if tab_ctx:
+                    pending_lines = await conn.fetch(
+                        """
+                        SELECT
+                            oi.id AS order_item_id,
+                            oi.product_id,
+                            oi.quantity,
+                            oi.price_at_purchase,
+                            oi.subtotal,
+                            oi.notes,
+                            o.id AS order_id,
+                            o.order_number,
+                            p.name AS product_name
+                        FROM order_items oi
+                        JOIN orders o ON o.id = oi.order_id
+                        JOIN product p ON p.id = oi.product_id
+                        WHERE o.table_session_id = $1 AND o.status = 'pending'
+                        """,
+                        session_row["id"],
+                    )
+                    for line in pending_lines:
+                        line_modifiers = await _fetch_order_item_modifiers(
+                            conn, line["order_item_id"]
+                        )
+                        await _record_tab_operation_event(
+                            conn,
+                            tenant_id,
+                            user_id=user_id,
+                            table_id=table_id,
+                            tab_ctx=tab_ctx,
+                            action="tab_cleared",
+                            order_id=line["order_id"],
+                            order_item_id=line["order_item_id"],
+                            payload=_build_tab_item_payload(
+                                product_id=line["product_id"],
+                                product_name=line["product_name"],
+                                quantity=line["quantity"],
+                                unit_price=line["price_at_purchase"],
+                                subtotal=line["subtotal"],
+                                modifiers=line_modifiers,
+                                notes=line["notes"],
+                                table_id=table_id,
+                                table_name=tab_ctx["table_name"],
+                                order_number=line["order_number"],
+                            ),
+                        )
 
                 # Cancel comanda_items that point at the order_items we're
                 # about to delete. Two reasons:

--- a/dbdoc/public.order_payments.md
+++ b/dbdoc/public.order_payments.md
@@ -15,6 +15,7 @@
 | notes | text |  | true |  |  |  |
 | cash_received | numeric(12,2) |  | true |  |  | Cash handed over by the customer for this split payment line. Always NULL for non-cash methods. Change due is derived: cash_received - amount. |
 | voided_at | timestamp with time zone |  | true |  |  | Soft-delete marker (warocol.com#649). NULL means active. When set, the row is excluded from paid_total computations and the parent order is reopened if this row had closed it. |
+| void_reason | text |  | true |  |  | Motivo de anulación (#649/#785). NULL mientras el pago está activo. |
 
 ## Constraints
 

--- a/sql/20260521_add_order_payments_void_reason.sql
+++ b/sql/20260521_add_order_payments_void_reason.sql
@@ -1,0 +1,6 @@
+-- warocol.com#785 — persist payment void reason on order_payments
+ALTER TABLE order_payments
+    ADD COLUMN IF NOT EXISTS void_reason TEXT NULL;
+
+COMMENT ON COLUMN order_payments.void_reason IS
+    'Motivo de anulación (#649/#785). NULL mientras el pago está activo.';

--- a/tests/test_payment_void_operation_events.py
+++ b/tests/test_payment_void_operation_events.py
@@ -1,0 +1,206 @@
+"""Payment void reason persistence and operation events (warocol.com#785)."""
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services import pos_cart_service, tables_service
+
+
+def _txn_conn():
+    mock_conn = AsyncMock()
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+    return mock_conn, mock_cm
+
+
+@pytest.mark.asyncio
+async def test_void_order_payment_persists_reason_and_records_event():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    cart_id = uuid4()
+    payment_id = uuid4()
+    order_id = uuid4()
+    recorded = []
+    void_updates = []
+
+    payment_row = {
+        "id": payment_id,
+        "order_id": order_id,
+        "amount": 50.0,
+        "payment_method": "cash",
+        "cash_received": 60.0,
+        "created_by_user_id": user_id,
+        "voided_at": None,
+        "pos_cart_id": cart_id,
+        "total_amount": 100.0,
+        "tip_amount": 0,
+        "tip_tax_amount": 0,
+        "payment_status": "partial",
+        "order_status": "active",
+    }
+
+    mock_conn, mock_cm = _txn_conn()
+    mock_conn.fetchrow = AsyncMock(side_effect=[
+        payment_row,
+        {"paid": 0},
+    ])
+
+    async def track_execute(sql, *args):
+        if "void_reason" in sql:
+            void_updates.append(args)
+
+    mock_conn.execute = AsyncMock(side_effect=track_execute)
+
+    async def capture_event(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    with patch("app.services.pos_cart_service.require_valid_session") as mock_sess, \
+         patch("app.services.pos_cart_service.get_db_connection", return_value=mock_cm), \
+         patch(
+             "app.services.pos_cart_service.record_operation_event",
+             side_effect=capture_event,
+         ):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id, role="admin")
+        await pos_cart_service.void_order_payment(
+            MagicMock(),
+            str(cart_id),
+            str(payment_id),
+            reason="Cliente se arrepintió",
+            channel="barra",
+        )
+
+    assert len(void_updates) == 1
+    assert void_updates[0][1] == "Cliente se arrepintió"
+    assert len(recorded) == 1
+    assert recorded[0]["action"] == "payment_voided"
+    assert recorded[0]["channel"] == "barra"
+    assert recorded[0]["reason"] == "Cliente se arrepintió"
+    assert recorded[0]["actor_user_id"] == user_id
+    assert recorded[0]["payload"]["amount"] == 50.0
+
+
+@pytest.mark.asyncio
+async def test_void_order_payment_empty_reason_defaults_sin_motivo():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    cart_id = uuid4()
+    payment_id = uuid4()
+    order_id = uuid4()
+    void_updates = []
+
+    payment_row = {
+        "id": payment_id,
+        "order_id": order_id,
+        "amount": 10.0,
+        "payment_method": "card",
+        "cash_received": None,
+        "created_by_user_id": user_id,
+        "voided_at": None,
+        "pos_cart_id": cart_id,
+        "total_amount": 10.0,
+        "tip_amount": 0,
+        "tip_tax_amount": 0,
+        "payment_status": "partial",
+        "order_status": "active",
+    }
+
+    mock_conn, mock_cm = _txn_conn()
+    mock_conn.fetchrow = AsyncMock(side_effect=[payment_row, {"paid": 0}])
+
+    async def track_execute(sql, *args):
+        if "void_reason" in sql:
+            void_updates.append(args)
+
+    mock_conn.execute = AsyncMock(side_effect=track_execute)
+
+    with patch("app.services.pos_cart_service.require_valid_session") as mock_sess, \
+         patch("app.services.pos_cart_service.get_db_connection", return_value=mock_cm), \
+         patch("app.services.pos_cart_service.record_operation_event", new=AsyncMock()):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id, role="admin")
+        await pos_cart_service.void_order_payment(
+            MagicMock(), str(cart_id), str(payment_id), reason="  ",
+        )
+
+    assert void_updates[0][1] == "Sin motivo"
+
+
+@pytest.mark.asyncio
+async def test_void_table_payment_records_single_payment_voided_event():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    payment_id = uuid4()
+    session_id = uuid4()
+    order_id = uuid4()
+    paid_at = datetime.now(timezone.utc)
+    recorded = []
+    void_updates = []
+
+    target = {
+        "id": payment_id,
+        "order_id": order_id,
+        "payment_method": "cash",
+        "paid_at": paid_at,
+        "cash_received": 100.0,
+        "created_by_user_id": user_id,
+        "voided_at": None,
+        "table_session_id": session_id,
+    }
+    session_row = {"id": session_id, "table_id": table_id, "closed_at": None}
+    sibling_rows = [
+        {"id": payment_id, "order_id": order_id, "amount": 40.0},
+        {"id": uuid4(), "order_id": uuid4(), "amount": 10.0},
+    ]
+
+    mock_conn, mock_cm = _txn_conn()
+    mock_conn.fetchrow = AsyncMock(side_effect=[
+        target,
+        session_row,
+        {"is_bar": True},
+        {"paid": 0},
+        {"tip_amount": 0, "tip_tax_amount": 0},
+    ])
+    mock_conn.fetch = AsyncMock(side_effect=[
+        sibling_rows,
+        [{"id": order_id, "total_amount": 50.0}],
+    ])
+
+    async def track_execute(sql, *args):
+        if "void_reason" in sql:
+            void_updates.append(args)
+
+    mock_conn.execute = AsyncMock(side_effect=track_execute)
+
+    async def capture_event(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    with patch("app.services.tables_service.require_valid_session") as mock_sess, \
+         patch("app.services.tables_service.get_db_connection", return_value=mock_cm), \
+         patch(
+             "app.services.tables_service.record_operation_event",
+             side_effect=capture_event,
+         ):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id, role="admin")
+        await tables_service.void_table_payment(
+            MagicMock(), table_id, payment_id, reason="Error de caja",
+        )
+
+    assert void_updates[0][1] == "Error de caja"
+    assert len(recorded) == 1
+    assert recorded[0]["action"] == "payment_voided"
+    assert recorded[0]["channel"] == "barra"
+    assert recorded[0]["reason"] == "Error de caja"
+    assert len(recorded[0]["payload"]["voided_ids"]) == 2
+    assert recorded[0]["payload"]["amount"] == 50.0

--- a/tests/test_pos_cart_operation_events.py
+++ b/tests/test_pos_cart_operation_events.py
@@ -1,0 +1,135 @@
+"""POS cart operation audit events (warocol.com#784)."""
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services import pos_cart_service
+
+
+@pytest.mark.asyncio
+async def test_remove_item_records_cart_line_removed_before_delete():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    cart_id = uuid4()
+    item_id = uuid4()
+    product_id = uuid4()
+    recorded = []
+    deleted = []
+
+    row = {
+        "id": item_id,
+        "product_id": product_id,
+        "quantity": 1,
+        "unit_price": 12.0,
+        "subtotal": 12.0,
+        "notes": None,
+        "product_name": "Café",
+    }
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(return_value=row)
+    mock_conn.fetch = AsyncMock(return_value=[])
+
+    async def track_execute(sql, *args):
+        if "DELETE FROM pos_cart_items" in sql:
+            deleted.append(True)
+
+    mock_conn.execute = AsyncMock(side_effect=track_execute)
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+
+    async def capture(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("app.services.pos_cart_service.require_valid_session") as mock_sess, \
+         patch("app.services.pos_cart_service.get_db_connection", return_value=mock_cm), \
+         patch("app.services.pos_cart_service.update_cart_total", new=AsyncMock()), \
+         patch(
+             "app.services.pos_cart_service._record_cart_operation_event",
+             side_effect=capture,
+         ):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+        await pos_cart_service.remove_item_from_cart(
+            MagicMock(),
+            cart_id,
+            item_id,
+            channel="barra",
+        )
+
+    assert len(recorded) == 1
+    assert recorded[0]["action"] == "cart_line_removed"
+    assert recorded[0]["channel"] == "barra"
+    assert recorded[0]["payload"]["product_name"] == "Café"
+    assert len(deleted) == 1
+
+
+@pytest.mark.asyncio
+async def test_clear_cart_emits_cart_cleared_per_line():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    cart_id = uuid4()
+    line_id = uuid4()
+    recorded = []
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(return_value={"id": cart_id})
+    mock_conn.fetch = AsyncMock(side_effect=[
+        [
+            {
+                "cart_item_id": line_id,
+                "product_id": uuid4(),
+                "quantity": 2,
+                "unit_price": 5.0,
+                "subtotal": 10.0,
+                "notes": None,
+                "product_name": "Agua",
+            },
+        ],
+        [],
+    ])
+    mock_conn.execute = AsyncMock()
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+
+    async def capture(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("app.services.pos_cart_service.require_valid_session") as mock_sess, \
+         patch("app.services.pos_cart_service.get_db_connection", return_value=mock_cm), \
+         patch(
+             "app.services.pos_cart_service._record_cart_operation_event",
+             side_effect=capture,
+         ):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+        await pos_cart_service.clear_cart(
+            MagicMock(),
+            cart_id,
+            channel="mostrador",
+        )
+
+    assert len(recorded) == 1
+    assert recorded[0]["action"] == "cart_cleared"
+    assert recorded[0]["channel"] == "mostrador"

--- a/tests/test_tables_tab_operation_events.py
+++ b/tests/test_tables_tab_operation_events.py
@@ -1,0 +1,244 @@
+"""Operation audit events for mesa/barra tab flows (warocol.com#783)."""
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services import tables_service
+
+
+@pytest.mark.asyncio
+async def test_add_tab_items_core_records_tab_item_added_per_line():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    session_id = uuid4()
+    order_id = uuid4()
+    product_id = uuid4()
+    order_item_id = uuid4()
+    recorded = []
+
+    async def capture_record(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    session_row = {
+        "session_id": session_id,
+        "table_name": "Mesa 3",
+        "is_bar": False,
+        "effective_waiter_member_id": None,
+    }
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(side_effect=[
+        session_row,
+        None,
+        {"id": order_id, "order_number": 42, "total_amount": 15.0},
+        {"id": order_item_id},
+    ])
+    mock_conn.fetch = AsyncMock(return_value=[])
+    mock_conn.execute = AsyncMock()
+
+    items = [{
+        "product_id": product_id,
+        "quantity": 1,
+        "unit_price": 15.0,
+        "modifiers": [{"id": None, "name": "Extra", "price": 0.0}],
+        "notes": "Sin cebolla",
+    }]
+
+    with patch(
+        "app.services.tables_service._record_tab_operation_event",
+        side_effect=capture_record,
+    ), patch(
+        "app.services.tables_service._prefetch_product_names",
+        new=AsyncMock(return_value={str(product_id): "Hamburguesa"}),
+    ), patch(
+        "app.services.tables_service._capture_order_item_ingredients",
+        new=AsyncMock(),
+    ):
+        result = await tables_service._add_tab_items_core(
+            mock_conn, tenant_id, user_id, table_id, items
+        )
+
+    assert result["session_id"] == session_id
+    assert len(recorded) == 1
+    assert recorded[0]["action"] == "tab_item_added"
+    assert recorded[0]["tab_ctx"]["channel"] == "mesa"
+    assert recorded[0]["tab_ctx"]["table_session_id"] == session_id
+    assert recorded[0]["payload"]["product_name"] == "Hamburguesa"
+    assert recorded[0]["payload"]["order_number"] == 42
+
+
+@pytest.mark.asyncio
+async def test_remove_tab_item_records_before_delete():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    order_item_id = uuid4()
+    order_id = uuid4()
+    session_id = uuid4()
+    product_id = uuid4()
+    recorded = []
+    delete_calls = []
+
+    async def capture_record(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    row = {
+        "id": order_item_id,
+        "product_id": product_id,
+        "quantity": 2,
+        "price_at_purchase": 10.0,
+        "subtotal": 20.0,
+        "notes": None,
+        "order_id": order_id,
+        "total_amount": 20.0,
+        "order_number": 7,
+        "table_session_id": session_id,
+        "product_name": "Pizza",
+        "table_name": "Barra 1",
+        "is_bar": True,
+        "effective_waiter_member_id": None,
+    }
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(side_effect=[row, None])
+    mock_conn.fetch = AsyncMock(return_value=[])
+
+    async def track_execute(sql, *args):
+        if "DELETE FROM order_items" in sql:
+            delete_calls.append(True)
+
+    mock_conn.execute = AsyncMock(side_effect=track_execute)
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    mock_request = MagicMock()
+    with patch("app.services.tables_service.require_valid_session") as mock_sess, \
+         patch("app.services.tables_service.get_db_connection", return_value=mock_cm), \
+         patch(
+             "app.services.tables_service._record_tab_operation_event",
+             side_effect=capture_record,
+         ):
+        mock_sess.return_value = MagicMock(
+            tenant_id=tenant_id, user_id=user_id,
+        )
+        await tables_service.remove_tab_item(
+            mock_request, table_id, order_item_id,
+        )
+
+    assert len(recorded) == 1
+    assert recorded[0]["action"] == "tab_item_removed"
+    assert recorded[0]["tab_ctx"]["channel"] == "barra"
+    assert recorded[0]["comanda_item_id"] is None
+    assert recorded[0]["payload"]["product_name"] == "Pizza"
+    assert len(delete_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_add_then_remove_shares_table_session_id():
+    """Integration-style: two events, same table_session_id (#783)."""
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    session_id = uuid4()
+    recorded = []
+
+    async def capture_record(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    # --- add (core only) ---
+    order_id = uuid4()
+    product_id = uuid4()
+    order_item_id = uuid4()
+    mock_conn_add = AsyncMock()
+    mock_conn_add.fetchrow = AsyncMock(side_effect=[
+        {
+            "session_id": session_id,
+            "table_name": "Mesa 1",
+            "is_bar": False,
+            "effective_waiter_member_id": None,
+        },
+        None,
+        {"id": order_id, "order_number": 1, "total_amount": 5.0},
+        {"id": order_item_id},
+    ])
+    mock_conn_add.fetch = AsyncMock(return_value=[])
+    mock_conn_add.execute = AsyncMock()
+
+    with patch(
+        "app.services.tables_service._record_tab_operation_event",
+        side_effect=capture_record,
+    ), patch(
+        "app.services.tables_service._prefetch_product_names",
+        new=AsyncMock(return_value={str(product_id): "Agua"}),
+    ), patch(
+        "app.services.tables_service._capture_order_item_ingredients",
+        new=AsyncMock(),
+    ):
+        await tables_service._add_tab_items_core(
+            mock_conn_add, tenant_id, user_id, table_id,
+            [{"product_id": product_id, "quantity": 1, "unit_price": 5.0, "modifiers": []}],
+        )
+
+    # --- remove ---
+    row = {
+        "id": order_item_id,
+        "product_id": product_id,
+        "quantity": 1,
+        "price_at_purchase": 5.0,
+        "subtotal": 5.0,
+        "notes": None,
+        "order_id": order_id,
+        "total_amount": 5.0,
+        "order_number": 1,
+        "table_session_id": session_id,
+        "product_name": "Agua",
+        "table_name": "Mesa 1",
+        "is_bar": False,
+        "effective_waiter_member_id": None,
+    }
+    mock_conn_rm = AsyncMock()
+    mock_conn_rm.fetchrow = AsyncMock(side_effect=[row, None])
+    mock_conn_rm.fetch = AsyncMock(return_value=[])
+    mock_conn_rm.execute = AsyncMock()
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn_rm.transaction = MagicMock(return_value=_Txn())
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn_rm)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("app.services.tables_service.require_valid_session") as mock_sess, \
+         patch("app.services.tables_service.get_db_connection", return_value=mock_cm), \
+         patch(
+             "app.services.tables_service._record_tab_operation_event",
+             side_effect=capture_record,
+         ):
+        mock_sess.return_value = MagicMock(
+            tenant_id=tenant_id, user_id=user_id,
+        )
+        await tables_service.remove_tab_item(
+            MagicMock(), table_id, order_item_id,
+        )
+
+    assert len(recorded) == 2
+    assert recorded[0]["action"] == "tab_item_added"
+    assert recorded[1]["action"] == "tab_item_removed"
+    assert recorded[0]["tab_ctx"]["table_session_id"] == session_id
+    assert recorded[1]["tab_ctx"]["table_session_id"] == session_id

--- a/tests/test_tables_tab_operation_events.py
+++ b/tests/test_tables_tab_operation_events.py
@@ -1,9 +1,10 @@
-"""Operation audit events for mesa/barra tab flows (warocol.com#783)."""
+"""Operation audit events for mesa/barra tab flows (warocol.com#783, #786)."""
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 
+from app.core.exceptions import APIError
 from app.services import tables_service
 
 
@@ -98,6 +99,7 @@ async def test_remove_tab_item_records_before_delete():
         "table_name": "Barra 1",
         "is_bar": True,
         "effective_waiter_member_id": None,
+        "fulfillment_status": "new",
     }
 
     mock_conn = AsyncMock()
@@ -206,6 +208,7 @@ async def test_add_then_remove_shares_table_session_id():
         "table_name": "Mesa 1",
         "is_bar": False,
         "effective_waiter_member_id": None,
+        "fulfillment_status": "new",
     }
     mock_conn_rm = AsyncMock()
     mock_conn_rm.fetchrow = AsyncMock(side_effect=[row, None])
@@ -242,3 +245,127 @@ async def test_add_then_remove_shares_table_session_id():
     assert recorded[1]["action"] == "tab_item_removed"
     assert recorded[0]["tab_ctx"]["table_session_id"] == session_id
     assert recorded[1]["tab_ctx"]["table_session_id"] == session_id
+
+
+@pytest.mark.asyncio
+async def test_remove_fired_item_without_reason_raises_400():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    order_item_id = uuid4()
+    order_id = uuid4()
+    session_id = uuid4()
+
+    row = {
+        "id": order_item_id,
+        "product_id": uuid4(),
+        "quantity": 1,
+        "price_at_purchase": 10.0,
+        "subtotal": 10.0,
+        "notes": None,
+        "fulfillment_status": "sent",
+        "order_id": order_id,
+        "total_amount": 10.0,
+        "order_number": 3,
+        "table_session_id": session_id,
+        "product_name": "Pasta",
+        "table_name": "Mesa 2",
+        "is_bar": False,
+        "effective_waiter_member_id": None,
+    }
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(side_effect=[row, None])
+    mock_conn.fetch = AsyncMock(return_value=[])
+    mock_conn.execute = AsyncMock()
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("app.services.tables_service.require_valid_session") as mock_sess, \
+         patch("app.services.tables_service.get_db_connection", return_value=mock_cm):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+        with pytest.raises(APIError) as exc:
+            await tables_service.remove_tab_item(
+                MagicMock(), table_id, order_item_id, reason="",
+            )
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_remove_fired_item_with_reason_records_event():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    order_item_id = uuid4()
+    order_id = uuid4()
+    session_id = uuid4()
+    comanda_item_id = uuid4()
+    recorded = []
+
+    async def capture_record(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    row = {
+        "id": order_item_id,
+        "product_id": uuid4(),
+        "quantity": 1,
+        "price_at_purchase": 15.0,
+        "subtotal": 15.0,
+        "notes": None,
+        "fulfillment_status": "preparing",
+        "order_id": order_id,
+        "total_amount": 15.0,
+        "order_number": 9,
+        "table_session_id": session_id,
+        "product_name": "Sopa",
+        "table_name": "Mesa 4",
+        "is_bar": False,
+        "effective_waiter_member_id": None,
+    }
+    comanda_row = {"id": comanda_item_id, "comanda_id": uuid4()}
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(side_effect=[row, comanda_row])
+    mock_conn.fetch = AsyncMock(return_value=[])
+    mock_conn.fetchval = AsyncMock(return_value=1)
+    mock_conn.execute = AsyncMock()
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("app.services.tables_service.require_valid_session") as mock_sess, \
+         patch("app.services.tables_service.get_db_connection", return_value=mock_cm), \
+         patch(
+             "app.services.tables_service._record_tab_operation_event",
+             side_effect=capture_record,
+         ):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+        await tables_service.remove_tab_item(
+            MagicMock(),
+            table_id,
+            order_item_id,
+            reason="  Cliente cambió de opinión  ",
+        )
+
+    assert len(recorded) == 1
+    assert recorded[0]["reason"] == "Cliente cambió de opinión"
+    assert recorded[0]["comanda_item_id"] == comanda_item_id


### PR DESCRIPTION
## Summary
Requires a non-empty removal reason when deleting tab items that were fired to kitchen (non-`new` fulfillment or linked `comanda_items`). Stores reason on `tab_item_removed` operation events.

## Stack
FastAPI / Python 3.9

## Changes
- `tables.py`: `RemoveTabItemRequest` body on DELETE
- `tables_service.py`: validation, `_record_tab_operation_event(reason=...)`, re-raise `APIError`
- `test_tables_tab_operation_events.py`: +2 tests (5 total passing)

## Testing
`python3 -m pytest tests/test_tables_tab_operation_events.py -q`

Closes warocol.com#786

Made with [Cursor](https://cursor.com)