### PR TITLE
feat(pos): open-priced product validation and POS context (warocol.com#795)

### DIFF
--- a/app/models/product.py
+++ b/app/models/product.py
@@ -72,6 +72,10 @@ class ProductBase(BaseModel):
     is_available_table_qr: bool = Field(False, description="Whether product appears on the table QR menu")
     is_combo: bool = Field(False, description="Whether product is a combo")
     is_resale: bool = Field(False, description="Whether product is a resale product (not prepared)")
+    open_priced: bool = Field(
+        False,
+        description="When true, POS may send a custom unit_price (venta libre); at most one per tenant",
+    )
     allow_modifiers: bool = Field(True, description="Whether product allows modifiers")
     tax_category: Literal['standard', 'liquor', 'exempt'] = Field("standard", description="Tax classification: standard (INC/IVA), liquor (IVA licores 5%), exempt (no tax)")
     station_id: Optional[UUID] = None
@@ -123,6 +127,7 @@ class ProductUpdate(BaseModel):
     is_available_table_qr: Optional[bool] = None
     is_combo: Optional[bool] = None
     is_resale: Optional[bool] = None
+    open_priced: Optional[bool] = None
     allow_modifiers: Optional[bool] = None
     tax_category: Optional[Literal['standard', 'liquor', 'exempt']] = Field(None, description="Tax classification: standard, liquor, exempt")
     ingredients: Optional[List[RecipeIngredientBase]] = Field(None, description="Updated recipe ingredients")

--- a/app/services/open_priced_service.py
+++ b/app/services/open_priced_service.py
@@ -1,0 +1,167 @@
+"""Open-priced (venta libre) line price validation for POS tab and cart writes."""
+import logging
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from app.core.exceptions import APIError, NotFoundError, ValidationError
+
+logger = logging.getLogger(__name__)
+
+_PRICE_TOLERANCE = Decimal("0.01")
+
+
+def _to_money(value: Any) -> Decimal:
+    return Decimal(str(value)).quantize(Decimal("0.01"))
+
+
+def _prices_match(catalog: Decimal, requested: Decimal) -> bool:
+    return abs(catalog - requested) <= _PRICE_TOLERANCE
+
+
+async def fetch_product_pricing_map(
+    conn,
+    tenant_id: UUID,
+    product_ids: List[UUID],
+) -> Dict[str, Dict[str, Any]]:
+    """Prefetch catalog price + open_priced flag for a set of products."""
+    if not product_ids:
+        return {}
+    rows = await conn.fetch(
+        """
+        SELECT id, price, open_priced
+        FROM product
+        WHERE tenant_id = $1 AND id = ANY($2::uuid[])
+        """,
+        tenant_id,
+        product_ids,
+    )
+    return {
+        str(row["id"]): {
+            "price": _to_money(row["price"]),
+            "open_priced": bool(row["open_priced"]),
+        }
+        for row in rows
+    }
+
+
+def resolve_line_unit_price(
+    pricing: Optional[Dict[str, Any]],
+    product_id: UUID,
+    requested_unit_price: Any,
+    modifiers: Optional[List] = None,
+) -> Decimal:
+    """
+    Return the unit price to persist for a POS line.
+
+    - Normal products: requested must match catalog (within tolerance).
+    - Open-priced: any positive price; modifiers not allowed (MVP).
+    """
+    key = str(product_id)
+    if pricing is None or key not in pricing:
+        raise NotFoundError(f"Product {product_id} not found")
+
+    row = pricing[key]
+    catalog = row["price"]
+    open_priced = row["open_priced"]
+    mods = modifiers or []
+
+    if open_priced:
+        if mods:
+            raise ValidationError(
+                "Open-priced items cannot include modifiers",
+                details={"product_id": key},
+            )
+        resolved = _to_money(requested_unit_price)
+        if resolved <= 0:
+            raise ValidationError(
+                "Open-priced unit price must be greater than zero",
+                details={"product_id": key},
+            )
+        return resolved
+
+    if mods:
+        # Modifiers allowed; unit_price is base only — still must match catalog.
+        pass
+
+    resolved = _to_money(requested_unit_price)
+    if not _prices_match(catalog, resolved):
+        raise ValidationError(
+            "Unit price does not match catalog price for this product",
+            details={
+                "product_id": key,
+                "catalog_price": float(catalog),
+                "requested_price": float(resolved),
+            },
+        )
+    return catalog
+
+
+def validate_items_unit_prices(
+    pricing_map: Dict[str, Dict[str, Any]],
+    items: List[dict],
+) -> None:
+    """Validate and normalize unit_price on each item dict in place."""
+    for item in items:
+        product_id = item["product_id"]
+        resolved = resolve_line_unit_price(
+            pricing_map,
+            product_id,
+            item["unit_price"],
+            item.get("modifiers"),
+        )
+        item["unit_price"] = float(resolved)
+
+
+async def assert_single_open_priced_per_tenant(
+    conn,
+    tenant_id: UUID,
+    *,
+    exclude_product_id: Optional[UUID] = None,
+) -> None:
+    """Ensure at most one open_priced product exists for the tenant."""
+    row = await conn.fetchrow(
+        """
+        SELECT id, name
+        FROM product
+        WHERE tenant_id = $1
+          AND open_priced = true
+          AND ($2::uuid IS NULL OR id != $2)
+        LIMIT 1
+        """,
+        tenant_id,
+        exclude_product_id,
+    )
+    if row:
+        raise APIError(
+            f"Tenant already has an open-priced product: {row['name']}",
+            status_code=409,
+            details={"existing_product_id": str(row["id"])},
+        )
+
+
+async def fetch_open_sale_product(
+    conn,
+    tenant_id: UUID,
+) -> Optional[Dict[str, str]]:
+    """Return {id, name} for the tenant's open-priced shell product, if exactly one."""
+    rows = await conn.fetch(
+        """
+        SELECT id, name
+        FROM product
+        WHERE tenant_id = $1
+          AND open_priced = true
+          AND is_available = true
+        ORDER BY name
+        """,
+        tenant_id,
+    )
+    if len(rows) == 1:
+        return {"id": str(rows[0]["id"]), "name": rows[0]["name"]}
+    if len(rows) > 1:
+        logger.warning(
+            "Tenant %s has %s open_priced products; open_sale_product omitted",
+            tenant_id,
+            len(rows),
+        )
+    return None

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -25,6 +25,11 @@ from app.services.accounting_service import void_order_journal_entry_in_txn
 from app.services.ingredient_purchase_units_service import resolve_recipe_quantity_to_base_unit
 from app.services.comandas_service import fire_comandas, finalize_open_comandas
 from app.services.operation_events_service import DOMAIN_POS, record_operation_event
+from app.services.open_priced_service import (
+    fetch_product_pricing_map,
+    resolve_line_unit_price,
+    validate_items_unit_prices,
+)
 import logging
 
 logger = logging.getLogger(__name__)
@@ -214,6 +219,10 @@ async def create_cart_with_batch_items(
                 cart_id = cart_row['id']
                 logger.info(f"Created cart {cart_id} (customer: {customer_id or 'anonymous'})")
 
+                product_ids = list({item["product_id"] for item in items})
+                pricing_map = await fetch_product_pricing_map(conn, tenant_id, product_ids)
+                validate_items_unit_prices(pricing_map, items)
+
                 # Add all items in batch
                 item_ids = []
                 for item in items:
@@ -383,6 +392,13 @@ async def add_item_to_cart(
 
         async with get_db_connection() as conn:
             async with conn.transaction():
+                pricing_map = await fetch_product_pricing_map(conn, tenant_id, [product_id])
+                unit_price = float(
+                    resolve_line_unit_price(
+                        pricing_map, product_id, unit_price, modifiers
+                    )
+                )
+
                 # Calculate subtotal
                 modifiers_total = sum(mod['price'] for mod in modifiers)
                 subtotal = (unit_price + modifiers_total) * quantity
@@ -436,6 +452,8 @@ async def add_item_to_cart(
 
     except AuthenticationError as e:
         raise e
+    except APIError as e:
+        raise e
     except Exception as e:
         logger.error(f"Error adding item to cart: {str(e)}")
         raise APIError(f"Error adding item to cart: {str(e)}", status_code=500)
@@ -472,6 +490,32 @@ async def update_cart_item(
 
                 if not item_exists:
                     raise APIError("Cart item not found", status_code=404)
+
+                product_row = await conn.fetchrow(
+                    """
+                    SELECT pci.product_id
+                    FROM pos_cart_items pci
+                    JOIN pos_carts pc ON pc.id = pci.cart_id
+                    WHERE pci.id = $1 AND pci.cart_id = $2 AND pc.tenant_id = $3
+                    """,
+                    item_id,
+                    cart_id,
+                    tenant_id,
+                )
+                if not product_row:
+                    raise APIError("Cart item not found", status_code=404)
+
+                pricing_map = await fetch_product_pricing_map(
+                    conn, tenant_id, [product_row["product_id"]]
+                )
+                unit_price = float(
+                    resolve_line_unit_price(
+                        pricing_map,
+                        product_row["product_id"],
+                        unit_price,
+                        modifiers,
+                    )
+                )
 
                 # Calculate new subtotal
                 modifiers_total = sum(mod['price'] for mod in modifiers)

--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -13,6 +13,7 @@ from uuid import UUID
 
 from app.database import get_db_connection
 from app.services.invoicing_readiness_service import get_readiness
+from app.services.open_priced_service import fetch_open_sale_product
 
 
 _CONTEXT_QUERY = """
@@ -86,6 +87,7 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
         if row is None:
             return None
         members_rows = await conn.fetch(_MEMBERS_QUERY, tenant_id)
+        open_sale_product = await fetch_open_sale_product(conn, tenant_id)
 
     readiness = await get_readiness(tenant_id)
     invoicing_ready = bool(readiness and readiness.get('ready'))
@@ -131,6 +133,7 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
             'liquor_tax_applicable': bool(row['liquor_tax_applicable']) if row['liquor_tax_applicable'] is not None else False,
         },
         'invoicing_ready': invoicing_ready,
+        'open_sale_product': open_sale_product,
         'members': [
             {
                 'id': str(r['id']),

--- a/app/services/products_service.py
+++ b/app/services/products_service.py
@@ -13,6 +13,7 @@ from app.services import menu_history_service
 from app.services import cost_resolution_service
 from app.services.aws_s3_service import AWSS3Service
 from app.services.ingredient_purchase_units_service import resolve_to_base_unit
+from app.services.open_priced_service import assert_single_open_priced_per_tenant
 import asyncpg
 import logging
 
@@ -143,16 +144,19 @@ async def create_product_with_recipe(
         async with get_db_connection() as conn:
             # Start transaction
             async with conn.transaction():
+                if product_data.open_priced:
+                    await assert_single_open_priced_per_tenant(conn, tenant_id)
+
                 # 1. Insert product
                 # NOTE: controla_stock is ALWAYS True - all products control inventory
                 product_query = """
                     INSERT INTO product (
                         name, description, price, category_id, product_base_type_id, preparation_time,
                         controla_stock, is_available, is_available_online, is_available_table_qr,
-                        is_combo, is_resale, allow_modifiers,
+                        is_combo, is_resale, open_priced, allow_modifiers,
                         tax_category, tenant_id, station_id, kitchen_name, image_url, costo_percibido
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
                     RETURNING id, created_at, updated_at
                 """
                 product_result = await conn.fetchrow(
@@ -169,6 +173,7 @@ async def create_product_with_recipe(
                     product_data.is_available_table_qr,
                     product_data.is_combo,
                     product_data.is_resale,
+                    product_data.open_priced,
                     product_data.allow_modifiers,
                     product_data.tax_category,
                     tenant_id,
@@ -284,6 +289,7 @@ async def get_product_by_id(
                     p.is_available_table_qr,
                     p.is_combo,
                     p.is_resale,
+                    p.open_priced,
                     p.allow_modifiers,
                     p.tax_category,
                     p.costo_calculado,
@@ -534,6 +540,7 @@ async def get_products_list(
                     p.is_available_table_qr,
                     p.is_combo,
                     p.is_resale,
+                    p.open_priced,
                     p.allow_modifiers,
                     p.tax_category,
                     COALESCE(dc.direct_cost, 0) + COALESCE(bc.base_cost, 0) as costo_calculado,
@@ -888,6 +895,13 @@ async def update_product_with_recipe(
 
             # Start transaction
             async with conn.transaction():
+                if product_data.open_priced is True:
+                    await assert_single_open_priced_per_tenant(
+                        conn,
+                        tenant_id,
+                        exclude_product_id=product_id,
+                    )
+
                 # 1. Build update query dynamically based on provided fields
                 # NOTE: controla_stock is ALWAYS excluded from updates - it's always True
                 update_fields = []

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -1506,6 +1506,7 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                     oi.quantity,
                     oi.price_at_purchase,
                     oi.subtotal,
+                    oi.notes,
                     oi.fulfillment_status,
                     oi.sent_at,
                     p.name AS product_name
@@ -1608,6 +1609,7 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                         "quantity": r["quantity"],
                         "unitPrice": float(r["price_at_purchase"]),
                         "subtotal": float(r["subtotal"]),
+                        "notes": r["notes"],
                         "fulfillmentStatus": r["fulfillment_status"],
                         "sentAt": r["sent_at"].isoformat() if r["sent_at"] else None,
                     }

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -30,6 +30,10 @@ from app.services.orders_service import _compute_tax_breakdown
 from app.services.ingredient_purchase_units_service import resolve_recipe_quantity_to_base_unit
 from app.services.comandas_service import fire_comandas
 from app.services.operation_events_service import DOMAIN_POS, record_operation_event
+from app.services.open_priced_service import (
+    fetch_product_pricing_map,
+    validate_items_unit_prices,
+)
 import logging
 
 logger = logging.getLogger(__name__)
@@ -2060,6 +2064,8 @@ async def _add_tab_items_core(
     }
     product_ids = list({item["product_id"] for item in items})
     product_names = await _prefetch_product_names(conn, tenant_id, product_ids)
+    pricing_map = await fetch_product_pricing_map(conn, tenant_id, product_ids)
+    validate_items_unit_prices(pricing_map, items)
 
     for item in items:
         mod_sum = sum(float(m.get("price", 0)) for m in (item.get("modifiers") or []))

--- a/sql/20260521_product_open_priced.sql
+++ b/sql/20260521_product_open_priced.sql
@@ -1,0 +1,10 @@
+-- warocol.com#795: open-priced (venta libre) shell product flag
+ALTER TABLE product
+    ADD COLUMN IF NOT EXISTS open_priced BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN product.open_priced IS
+    'When true, POS may send a custom unit_price for this product (venta libre). At most one per tenant.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_product_one_open_priced_per_tenant
+    ON product (tenant_id)
+    WHERE open_priced = true;

--- a/tests/test_open_priced.py
+++ b/tests/test_open_priced.py
@@ -1,0 +1,81 @@
+"""Open-priced (venta libre) unit price validation — warocol.com#795."""
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from app.core.exceptions import NotFoundError, ValidationError
+from app.services import open_priced_service
+
+
+def _pricing(catalog: str, open_priced: bool = False):
+    pid = uuid4()
+    return (
+        pid,
+        {
+            str(pid): {
+                "price": Decimal(catalog),
+                "open_priced": open_priced,
+            }
+        },
+    )
+
+
+def test_open_priced_accepts_custom_unit_price():
+    product_id, pricing = _pricing("10000", open_priced=True)
+    resolved = open_priced_service.resolve_line_unit_price(
+        pricing, product_id, 25000, []
+    )
+    assert resolved == Decimal("25000.00")
+
+
+def test_open_priced_rejects_zero_price():
+    product_id, pricing = _pricing("1", open_priced=True)
+    with pytest.raises(ValidationError):
+        open_priced_service.resolve_line_unit_price(pricing, product_id, 0, [])
+
+
+def test_open_priced_rejects_modifiers():
+    product_id, pricing = _pricing("1", open_priced=True)
+    with pytest.raises(ValidationError):
+        open_priced_service.resolve_line_unit_price(
+            pricing,
+            product_id,
+            5000,
+            [{"id": None, "name": "Extra", "price": 1}],
+        )
+
+
+def test_catalog_product_requires_matching_price():
+    product_id, pricing = _pricing("15000.00")
+    resolved = open_priced_service.resolve_line_unit_price(
+        pricing, product_id, 15000, []
+    )
+    assert resolved == Decimal("15000.00")
+
+
+def test_catalog_product_rejects_price_mismatch():
+    product_id, pricing = _pricing("15000")
+    with pytest.raises(ValidationError):
+        open_priced_service.resolve_line_unit_price(pricing, product_id, 20000, [])
+
+
+def test_catalog_product_allows_small_rounding_tolerance():
+    product_id, pricing = _pricing("10.00")
+    resolved = open_priced_service.resolve_line_unit_price(
+        pricing, product_id, 10.009, []
+    )
+    assert resolved == Decimal("10.00")
+
+
+def test_missing_product_raises_not_found():
+    product_id = uuid4()
+    with pytest.raises(NotFoundError):
+        open_priced_service.resolve_line_unit_price({}, product_id, 10, [])
+
+
+def test_validate_items_normalizes_unit_price_in_place():
+    pid, pricing = _pricing("12000")
+    items = [{"product_id": pid, "quantity": 1, "unit_price": 12000.0}]
+    open_priced_service.validate_items_unit_prices(pricing, items)
+    assert items[0]["unit_price"] == 12000.0

--- a/tests/test_tables_tab_operation_events.py
+++ b/tests/test_tables_tab_operation_events.py
@@ -1,4 +1,5 @@
 """Operation audit events for mesa/barra tab flows (warocol.com#783, #786)."""
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -46,12 +47,18 @@ async def test_add_tab_items_core_records_tab_item_added_per_line():
         "notes": "Sin cebolla",
     }]
 
+    pricing_map = {
+        str(product_id): {"price": Decimal("15.00"), "open_priced": False},
+    }
     with patch(
         "app.services.tables_service._record_tab_operation_event",
         side_effect=capture_record,
     ), patch(
         "app.services.tables_service._prefetch_product_names",
         new=AsyncMock(return_value={str(product_id): "Hamburguesa"}),
+    ), patch(
+        "app.services.tables_service.fetch_product_pricing_map",
+        new=AsyncMock(return_value=pricing_map),
     ), patch(
         "app.services.tables_service._capture_order_item_ingredients",
         new=AsyncMock(),


### PR DESCRIPTION
## Summary
- Adds `product.open_priced` (migration + partial unique index per tenant).
- Validates `unit_price` on tab add and cart add/batch/update: catalog match for normal products, custom positive price for open-priced (no modifiers).
- Persists `open_priced` on product create/update with single-shell enforcement.
- Exposes `open_sale_product` on `GET /api/pos/restaurant-context` for #796.

## Stack
Python 3.9 · FastAPI · Postgres

## Testing
- `pytest tests/test_open_priced.py` (8 tests)
- `pytest tests/test_tables_tab_operation_events.py::test_add_tab_items_core_records_tab_item_added_per_line`

## Deploy note
Run `sql/20260521_product_open_priced.sql` on prod before merge.

Relates to uno0uno/warocol.com#795

Made with [Cursor](https://cursor.com)