### PR TITLE
feat(menu): atomic resale product + ingredient create (#846)

### DIFF
--- a/app/models/product.py
+++ b/app/models/product.py
@@ -1,5 +1,5 @@
 # Product models for menu management
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from typing import Optional, List, Literal, Dict, Any
 from uuid import UUID
 from datetime import datetime
@@ -109,6 +109,49 @@ class ProductCreate(ProductBase):
         ge=0,
         description="Operational/perceived unit cost set by the tenant",
     )
+    auto_resale_ingredient: bool = Field(
+        False,
+        description=(
+            "When true with is_resale and empty recipe: atomically create a linked "
+            "tenant ingredient (und, is_resale) + product_recipes row (qty 1)."
+        ),
+    )
+    resale_unit_weight_gr: Optional[float] = Field(
+        None,
+        gt=0,
+        description="Weight/volume per und for auto-created resale ingredient (required when auto_resale_ingredient)",
+    )
+    resale_unit_weight_unit: Literal["gr", "ml"] = Field(
+        "gr",
+        description="Unit for resale_unit_weight_gr on auto-created ingredient",
+    )
+    resale_ingredient_type: Literal["food", "supply"] = Field(
+        "food",
+        description="Ingredient type for auto-created resale ingredient",
+    )
+    resale_ingredient_category: Optional[str] = Field(
+        None,
+        max_length=255,
+        description="Ingredient category label; defaults to menu category name when omitted",
+    )
+
+    @model_validator(mode="after")
+    def validate_auto_resale_ingredient(self):
+        if not self.auto_resale_ingredient:
+            return self
+        if not self.is_resale:
+            raise ValueError("auto_resale_ingredient requires is_resale=true")
+        if self.ingredients:
+            raise ValueError("auto_resale_ingredient cannot be combined with ingredients")
+        if self.recipe_bases:
+            raise ValueError("auto_resale_ingredient cannot be combined with recipe_bases")
+        if self.recipe_base_ids:
+            raise ValueError("auto_resale_ingredient cannot be combined with recipe_base_ids")
+        if self.product_base_type_id:
+            raise ValueError("auto_resale_ingredient cannot be combined with product_base_type_id")
+        if self.resale_unit_weight_gr is None:
+            raise ValueError("resale_unit_weight_gr is required when auto_resale_ingredient is true")
+        return self
 
 class ProductUpdate(BaseModel):
     """Update product fields"""
@@ -163,6 +206,10 @@ class Product(ProductBase):
     recipe_base_ids: List[UUID] = Field(default=[], description="DEPRECATED: associated recipe base IDs (sourced from recipe_bases for backwards compat).")
     recipe_bases: List[RecipeBaseLink] = Field(default=[], description="Recipe bases with per-product quantity multiplier (Issue #517).")
     modifier_groups: List[ModifierGroup] = Field(default=[], description="Modifier groups for this product")
+    resale_ingredient_id: Optional[UUID] = Field(
+        None,
+        description="Linked resale ingredient id when created via auto_resale_ingredient",
+    )
 
     # Calculated fields (real = costo_calculado, operativo = costo_percibido)
     margen_real_pct: Optional[float] = None

--- a/app/routers/products.py
+++ b/app/routers/products.py
@@ -41,6 +41,15 @@ async def create_product_endpoint(
     - Automatically calculated cost based on ingredients
     - Calculated margin (percentage and value)
 
+    **Atomic resale** (`auto_resale_ingredient=true`): requires `is_resale=true`, empty
+    recipe arrays, and `resale_unit_weight_gr`. Creates tenant ingredient (und, is_resale)
+    + product + one `product_recipes` row in the same transaction. Response includes
+    `resale_ingredient_id` (also in `ingredients[0].ingredient_id`).
+
+    **Duplicate names**: ingredient and product names are unique per tenant in separate
+    indexes — the same display name on both rows is allowed. Ingredient duplicate → 409
+    with ingredient message; product duplicate → 409 with product message (txn rolls back).
+
     Requires valid session with tenant context.
     """
     return await create_product_with_recipe(request, product_data)

--- a/app/services/products_service.py
+++ b/app/services/products_service.py
@@ -14,6 +14,8 @@ from app.services import cost_resolution_service
 from app.services.aws_s3_service import AWSS3Service
 from app.services.ingredient_purchase_units_service import resolve_to_base_unit
 from app.services.open_priced_service import assert_single_open_priced_per_tenant
+from app.services.ingredients_service import create_tenant_ingredient
+from app.models.ingredient import TenantIngredientCreate, PurchaseUnitInput
 import asyncpg
 import logging
 
@@ -112,6 +114,26 @@ def _normalize_recipe_bases(
         return [(rid, qty) for rid, qty in seen.items()]
     return []
 
+
+async def _resolve_resale_ingredient_category(
+    conn,
+    tenant_id: UUID,
+    category_id: UUID,
+    override: Optional[str],
+) -> str:
+    """Category string for auto-created resale ingredients."""
+    if override and override.strip():
+        return override.strip()
+    row = await conn.fetchrow(
+        "SELECT name FROM categories WHERE id = $1 AND tenant_id = $2",
+        category_id,
+        tenant_id,
+    )
+    if row and row.get("name"):
+        return row["name"]
+    return "Reventa"
+
+
 async def create_product_with_recipe(
     request: Request,
     product_data: ProductCreate
@@ -139,13 +161,44 @@ async def create_product_with_recipe(
             product_data.recipe_base_ids,
         )
         has_recipe_bases = len(normalized_bases) > 0
-        tracks_inventory = has_ingredients or has_recipe_bases
+        auto_resale = product_data.auto_resale_ingredient
+        tracks_inventory = has_ingredients or has_recipe_bases or auto_resale
+        auto_resale_ingredient_id: Optional[UUID] = None
 
         async with get_db_connection() as conn:
             # Start transaction
             async with conn.transaction():
                 if product_data.open_priced:
                     await assert_single_open_priced_per_tenant(conn, tenant_id)
+
+                if auto_resale:
+                    ingredient_category = await _resolve_resale_ingredient_category(
+                        conn,
+                        tenant_id,
+                        product_data.category_id,
+                        product_data.resale_ingredient_category,
+                    )
+                    costo_ingredient = None
+                    if product_data.costo_percibido is not None:
+                        costo_ingredient = float(product_data.costo_percibido)
+                    ing_result = await create_tenant_ingredient(
+                        conn,
+                        tenant_id,
+                        TenantIngredientCreate(
+                            name=product_data.name.strip(),
+                            unit="und",
+                            type=product_data.resale_ingredient_type,
+                            category=ingredient_category,
+                            is_resale=True,
+                            unit_weight_gr=product_data.resale_unit_weight_gr,
+                            unit_weight_unit=product_data.resale_unit_weight_unit,
+                            costo_unitario=costo_ingredient,
+                            purchase_units=[
+                                PurchaseUnitInput(purchase_unit="und", is_default=True),
+                            ],
+                        ),
+                    )
+                    auto_resale_ingredient_id = UUID(ing_result["id"])
 
                 # 1. Insert product
                 # NOTE: controla_stock is ALWAYS True - all products control inventory
@@ -203,14 +256,28 @@ async def create_product_with_recipe(
                         )
 
                 # 3. Insert recipe ingredients
-                if product_data.ingredients:
-                    recipe_query = """
-                        INSERT INTO product_recipes (
-                            product_id, ingredient_id, quantity, unit, tenant_id
-                        )
-                        VALUES ($1, $2, $3, $4, $5)
-                    """
-
+                recipe_query = """
+                    INSERT INTO product_recipes (
+                        product_id, ingredient_id, quantity, unit, tenant_id
+                    )
+                    VALUES ($1, $2, $3, $4, $5)
+                """
+                if auto_resale_ingredient_id:
+                    base_qty, base_unit = await resolve_to_base_unit(
+                        conn,
+                        auto_resale_ingredient_id,
+                        1,
+                        "und",
+                    )
+                    await conn.execute(
+                        recipe_query,
+                        product_id,
+                        auto_resale_ingredient_id,
+                        base_qty,
+                        base_unit,
+                        tenant_id,
+                    )
+                elif product_data.ingredients:
                     for ingredient in product_data.ingredients:
                         base_qty, base_unit = await resolve_to_base_unit(
                             conn,
@@ -245,7 +312,10 @@ async def create_product_with_recipe(
                     )
 
                 # 6. Get complete product with recipe
-                return await get_product_by_id(request, product_id, conn)
+                response = await get_product_by_id(request, product_id, conn)
+                if auto_resale_ingredient_id:
+                    response.data.resale_ingredient_id = auto_resale_ingredient_id
+                return response
 
     except HTTPException:
         raise
@@ -338,7 +408,7 @@ async def get_product_by_id(
                 FROM product p
                 LEFT JOIN categories c ON p.category_id = c.id
                 LEFT JOIN tenant_category_stations tcs ON tcs.category_id = p.category_id AND tcs.tenant_id = p.tenant_id
-                LEFT JOIN kitchen_stations ks ON ks.id = tcs.station_id
+                LEFT JOIN kitchen_stations ks ON ks.id = COALESCE(p.station_id, tcs.station_id)
                 WHERE p.id = $1 AND p.tenant_id = $2
             """
 
@@ -561,7 +631,7 @@ async def get_products_list(
                 LEFT JOIN direct_costs dc ON p.id = dc.product_id
                 LEFT JOIN base_costs bc ON p.id = bc.product_id
                 LEFT JOIN tenant_category_stations tcs ON tcs.category_id = p.category_id AND tcs.tenant_id = p.tenant_id
-                LEFT JOIN kitchen_stations ks ON ks.id = tcs.station_id
+                LEFT JOIN kitchen_stations ks ON ks.id = COALESCE(p.station_id, tcs.station_id)
                 WHERE p.tenant_id = $1
             """
 

--- a/tests/test_product_auto_resale.py
+++ b/tests/test_product_auto_resale.py
@@ -1,0 +1,205 @@
+"""Atomic resale product + ingredient create (warocol.com#846)."""
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import asyncpg
+import pytest
+from fastapi import HTTPException, Request
+from pydantic import ValidationError
+
+from app.core.middleware import SessionContext
+from app.models.product import ProductCreate
+from app.services.products_service import create_product_with_recipe
+
+
+def _session():
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@warocol.com",
+        "name": "Test",
+        "expires_at": None,
+        "is_active": True,
+    })
+
+
+def _base_product_create(**overrides):
+    tenant_id = overrides.pop("tenant_id", uuid4())
+    data = {
+        "name": "Gaseosa 350ml",
+        "price": Decimal("5000"),
+        "category_id": uuid4(),
+        "tenant_id": tenant_id,
+        "is_resale": True,
+        "auto_resale_ingredient": True,
+        "resale_unit_weight_gr": 350.0,
+        "resale_unit_weight_unit": "ml",
+        "ingredients": [],
+    }
+    data.update(overrides)
+    return ProductCreate(**data)
+
+
+def test_product_create_auto_resale_requires_is_resale():
+    with pytest.raises(ValidationError):
+        _base_product_create(is_resale=False)
+
+
+def test_product_create_auto_resale_rejects_ingredients():
+    with pytest.raises(ValidationError):
+        _base_product_create(
+            ingredients=[{
+                "ingredient_id": uuid4(),
+                "quantity": 1,
+                "unit": "und",
+            }],
+        )
+
+
+def test_product_create_auto_resale_requires_unit_weight():
+    with pytest.raises(ValidationError):
+        _base_product_create(resale_unit_weight_gr=None)
+
+
+@pytest.mark.asyncio
+async def test_create_product_auto_resale_happy_path():
+    request = MagicMock(spec=Request)
+    session = _session()
+    product_id = uuid4()
+    ingredient_id = uuid4()
+    persist_calls = []
+    create_ingredient_calls = []
+
+    async def _fetchrow(query, *args):
+        if "INSERT INTO product" in query:
+            return {
+                "id": product_id,
+                "created_at": datetime.now(timezone.utc),
+                "updated_at": datetime.now(timezone.utc),
+            }
+        if "SELECT name FROM categories" in query:
+            return {"name": "Bebidas"}
+        return None
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=_fetchrow)
+    conn.execute = AsyncMock()
+
+    async def _persist(pid, tid, c, *, tracks_inventory):
+        persist_calls.append(tracks_inventory)
+
+    async def _create_ingredient(conn, tenant_id, data):
+        create_ingredient_calls.append(data)
+        return {"id": str(ingredient_id)}
+
+    @asynccontextmanager
+    async def _txn():
+        yield
+
+    conn.transaction.return_value = _txn()
+
+    @asynccontextmanager
+    async def _db_ctx():
+        yield conn
+
+    product_data = _base_product_create(tenant_id=session.tenant_id)
+    mock_response = MagicMock()
+    mock_response.data = MagicMock()
+
+    with patch("app.services.products_service.require_valid_session", return_value=session), \
+         patch("app.services.products_service.get_db_connection", side_effect=_db_ctx), \
+         patch("app.services.products_service.create_tenant_ingredient", AsyncMock(side_effect=_create_ingredient)), \
+         patch("app.services.products_service.resolve_to_base_unit", AsyncMock(return_value=(Decimal("1"), "und"))), \
+         patch("app.services.products_service.cost_resolution_service.persist_product_costo_calculado", AsyncMock(side_effect=_persist)), \
+         patch("app.services.products_service.menu_history_service.get_product_snapshot", AsyncMock(return_value=None)), \
+         patch("app.services.products_service.get_product_by_id", AsyncMock(return_value=mock_response)):
+        result = await create_product_with_recipe(request, product_data)
+
+    assert result is mock_response
+    assert result.data.resale_ingredient_id == ingredient_id
+    assert len(create_ingredient_calls) == 1
+    assert create_ingredient_calls[0].unit == "und"
+    assert create_ingredient_calls[0].is_resale is True
+    assert create_ingredient_calls[0].unit_weight_gr == 350.0
+    assert persist_calls == [True]
+    recipe_inserts = [c for c in conn.execute.call_args_list if len(c[0]) >= 5]
+    assert len(recipe_inserts) >= 1
+
+
+@pytest.mark.asyncio
+async def test_create_product_auto_resale_ingredient_duplicate_409():
+    request = MagicMock(spec=Request)
+    session = _session()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={"name": "Bebidas"})
+    conn.execute = AsyncMock()
+    conn.transaction = MagicMock()
+
+    @asynccontextmanager
+    async def _txn():
+        yield
+
+    conn.transaction.return_value = _txn()
+
+    @asynccontextmanager
+    async def _db_ctx():
+        yield conn
+
+    product_data = _base_product_create(tenant_id=session.tenant_id)
+
+    with patch("app.services.products_service.require_valid_session", return_value=session), \
+         patch("app.services.products_service.get_db_connection", side_effect=_db_ctx), \
+         patch(
+             "app.services.products_service.create_tenant_ingredient",
+             AsyncMock(side_effect=HTTPException(status_code=409, detail="ingredient exists")),
+         ):
+        with pytest.raises(HTTPException) as exc:
+            await create_product_with_recipe(request, product_data)
+
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_create_product_auto_resale_product_duplicate_rolls_back():
+    request = MagicMock(spec=Request)
+    session = _session()
+    ingredient_id = uuid4()
+
+    async def _fetchrow(query, *args):
+        if "SELECT name FROM categories" in query:
+            return {"name": "Bebidas"}
+        if "INSERT INTO product" in query:
+            raise asyncpg.UniqueViolationError("duplicate key")
+        return None
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=_fetchrow)
+    conn.execute = AsyncMock()
+    conn.transaction = MagicMock()
+
+    @asynccontextmanager
+    async def _txn():
+        yield
+
+    conn.transaction.return_value = _txn()
+
+    @asynccontextmanager
+    async def _db_ctx():
+        yield conn
+
+    product_data = _base_product_create(tenant_id=session.tenant_id)
+
+    with patch("app.services.products_service.require_valid_session", return_value=session), \
+         patch("app.services.products_service.get_db_connection", side_effect=_db_ctx), \
+         patch(
+             "app.services.products_service.create_tenant_ingredient",
+             AsyncMock(return_value={"id": str(ingredient_id)}),
+         ):
+        with pytest.raises(HTTPException) as exc:
+            await create_product_with_recipe(request, product_data)
+
+    assert exc.value.status_code == 409
+    assert "producto" in exc.value.detail.lower()

--- a/tests/test_product_create_bind.py
+++ b/tests/test_product_create_bind.py
@@ -1,4 +1,4 @@
-"""Regression: create_product INSERT must pass 19 bind args (#279, #745)."""
+"""Regression: create_product INSERT must pass 20 bind args (#279, #745)."""
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -74,7 +74,7 @@ async def test_create_product_insert_passes_19_bind_args_in_order():
         result = await create_product_with_recipe(request, product_data)
 
     assert result is mock_response
-    assert len(insert_args) == 19
+    assert len(insert_args) == 20
     # $7 controla_stock=True, $8 is_available, $9 is_available_online,
     # $10 is_available_table_qr, $11 is_combo
     assert insert_args[6] is True  # controla_stock


### PR DESCRIPTION
## Summary
Adds `auto_resale_ingredient` to `POST /menu/products` so one request creates a linked resale ingredient (`und`, `is_resale`, `unit_weight_*`), menu product (`is_resale=true`), and a single `product_recipes` row (qty 1) inside the existing DB transaction.

## Stack
Python 3.9 · FastAPI · asyncpg

## Changes
- `app/models/product.py`: new request fields + validator; `resale_ingredient_id` on response
- `app/services/products_service.py`: atomic branch calling `create_tenant_ingredient` before product insert
- `app/routers/products.py`: documented duplicate-name semantics (ingredient vs product 409)
- `tests/test_product_auto_resale.py`: happy path, validation, duplicate handling
- `tests/test_product_create_bind.py`: expect 20 INSERT bind args

## Testing
- `python3 -m pytest tests/test_product_auto_resale.py tests/test_product_create_bind.py tests/test_product_duplicate_name.py tests/test_product_perceived_cost.py -v`

Closes uno0uno/warocol.com#846

Made with [Cursor](https://cursor.com)