### PR TITLE
Add include_all_types param for Productos Todos filter

### DIFF
--- a/app/routers/products.py
+++ b/app/routers/products.py
@@ -84,6 +84,10 @@ async def get_products_endpoint(
     ),
     include_ingredients: bool = Query(default=False, description="Include recipe ingredients in response"),
     include_modifiers: bool = Query(default=False, description="Include modifier groups in response (for POS)"),
+    include_all_types: bool = Query(
+        default=False,
+        description="Include menu and resale products (Productos list Todos filter)",
+    ),
 ):
     """
     Get products list with filters and pagination.
@@ -116,6 +120,7 @@ async def get_products_endpoint(
         sort,
         include_ingredients,
         include_modifiers,
+        include_all_types,
     )
 
 

--- a/app/services/products_service.py
+++ b/app/services/products_service.py
@@ -510,6 +510,7 @@ async def get_products_list(
     sort: Optional[str] = None,
     include_ingredients: bool = False,
     include_modifiers: bool = False,
+    include_all_types: bool = False,
 ) -> ProductsListResponse:
     """Get list of products with filters"""
     try:
@@ -653,9 +654,9 @@ async def get_products_list(
 
             # Filter by is_resale - default to excluding resale products
             # Resale products have their own section, so by default we exclude them
-            # Exception: POS (include_modifiers=true) should show ALL products
+            # Exception: POS (include_modifiers=true) or catalog Todos (include_all_types=true)
             if is_resale is None:
-                if not include_modifiers:
+                if not include_modifiers and not include_all_types:
                     base_query += " AND (is_resale = false OR is_resale IS NULL)"
             else:
                 base_query += f" AND is_resale = ${param_count}"


### PR DESCRIPTION
## Summary
Adds `include_all_types` query param to `GET /menu/products` so the Productos catalog **Todos** filter can return both menu and resale products when `is_resale` is unset.

## Changes
- `app/routers/products.py` — expose `include_all_types` query param
- `app/services/products_service.py` — skip default resale exclusion when true (same exception path as POS `include_modifiers`)

## Testing
- `GET /menu/products` (default) — still excludes resale
- `GET /menu/products?is_resale=false` — menu only
- `GET /menu/products?is_resale=true` — resale only
- `GET /menu/products?include_all_types=true` — both types

Supports [warocol.com#847](https://github.com/uno0uno/warocol.com/issues/847)

Made with [Cursor](https://cursor.com)