### PR TITLE
feat(billing): annual-only subscription subscribe API

### DIFF
--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -37,7 +37,7 @@ tenant_router = APIRouter(prefix="/billing", tags=["Billing"])
 class SubscribeBody(BaseModel):
     """Body for POST /billing/subscribe"""
     plan_id: UUID
-    billing_cycle: str = "monthly"  # "monthly" | "annual"
+    billing_cycle: str = "annual"  # new subscriptions: annual only (#877)
     payer_email: Optional[str] = None
 
 
@@ -70,13 +70,13 @@ async def subscribe(body: SubscribeBody, request: Request):
     3. Guarda wompi_link_id y status='pending' en DB
     4. Retorna checkout_url para redirigir al checkout de Wompi
 
-    billing_cycle debe ser 'monthly' o 'annual'.
+    billing_cycle debe ser 'annual' para nuevas suscripciones (#877).
     """
-    if body.billing_cycle not in ("monthly", "annual"):
+    if body.billing_cycle != "annual":
         from fastapi import HTTPException
         raise HTTPException(
             status_code=422,
-            detail="billing_cycle debe ser 'monthly' o 'annual'",
+            detail="Las suscripciones nuevas solo están disponibles con ciclo anual (billing_cycle='annual').",
         )
 
     session = require_valid_session(request)
@@ -85,11 +85,7 @@ async def subscribe(body: SubscribeBody, request: Request):
     async with get_db_connection() as conn:
         plan = await billing_service.get_plan_for_subscribe(conn, body.plan_id)
 
-        amount = (
-            plan["price_monthly"]
-            if body.billing_cycle == "monthly"
-            else plan["price_annual"]
-        )
+        amount = plan["price_annual"]
 
         # Strip any base path from frontend_url to get the root host
         # e.g. "http://localhost:8080/waro-colombia" → "http://localhost:8080"

--- a/tests/test_billing_subscribe_cycle.py
+++ b/tests/test_billing_subscribe_cycle.py
@@ -1,0 +1,64 @@
+"""POST /billing/subscribe — annual-only for new subscriptions (#877)."""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.routers.billing import tenant_router
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_app():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    session = SessionContext({
+        "user_id": user_id,
+        "tenant_id": tenant_id,
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": "owner",
+    })
+    app = FastAPI()
+    app.include_router(tenant_router)
+    return app, session
+
+
+def test_subscribe_rejects_monthly_billing_cycle():
+    app, session = _build_app()
+    plan_id = uuid4()
+
+    @asynccontextmanager
+    async def _enforce_db():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetchrow = AsyncMock(return_value=None)
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.routers.billing.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db):
+        client = TestClient(app)
+        res = client.post(
+            "/billing/subscribe",
+            json={"plan_id": str(plan_id), "billing_cycle": "monthly"},
+        )
+
+    assert res.status_code == 422
+    assert "anual" in res.json()["detail"].lower()


### PR DESCRIPTION
## Summary
- `POST /billing/subscribe` defaults `billing_cycle` to `annual` and returns **422** if `monthly` is sent
- Payment link amount always uses `price_annual`
- Test: `tests/test_billing_subscribe_cycle.py`

## Testing
- `python3 -m pytest tests/test_billing_subscribe_cycle.py -q`

Companion: uno0uno/warocol.com#877 (front PR closes issue)
Refs uno0uno/warocol.com#877

Made with [Cursor](https://cursor.com)