### PR TITLE
fix(articles): include updated_at in list and related endpoints

### DIFF
--- a/app/models/article.py
+++ b/app/models/article.py
@@ -98,6 +98,7 @@ class ArticleSummary(BaseModel):
     views: Optional[int] = 0
     published: bool
     created_at: datetime
+    updated_at: Optional[datetime] = None
     author_name: Optional[str] = None
     author_avatar: Optional[str] = None
 

--- a/app/services/articles_service.py
+++ b/app/services/articles_service.py
@@ -76,6 +76,7 @@ async def get_articles_list(
                     COALESCE(a.views, 0) as views,
                     a.published,
                     a.created_at,
+                    a.updated_at,
                     p.name as author_name,
                     p.logo_avatar as author_avatar
                 FROM articles a
@@ -100,6 +101,7 @@ async def get_articles_list(
                     views=row['views'],
                     published=row['published'],
                     created_at=row['created_at'],
+                    updated_at=row['updated_at'],
                     author_name=row['author_name'],
                     author_avatar=row['author_avatar']
                 )
@@ -279,6 +281,7 @@ async def get_related_articles(
                     COALESCE(a.views, 0) as views,
                     a.published,
                     a.created_at,
+                    a.updated_at,
                     p.name as author_name,
                     p.logo_avatar as author_avatar
                 FROM articles a
@@ -306,6 +309,7 @@ async def get_related_articles(
                     views=row['views'],
                     published=row['published'],
                     created_at=row['created_at'],
+                    updated_at=row['updated_at'],
                     author_name=row['author_name'],
                     author_avatar=row['author_avatar']
                 )


### PR DESCRIPTION
## Summary

- `GET /blog` and the related-articles query did not select `a.updated_at` from the `articles` table.
- The response always returned `updated_at: null`, breaking downstream consumers that rely on it.
- Adds `a.updated_at` to both SELECTs and the `ArticleSummary` model.

## Why

The frontend sitemap at `front_nuxt/server/routes/sitemap.xml.ts` builds each `<lastmod>` as `updated_at || created_at`. With the API always returning null for `updated_at`, the sitemap kept surfacing the original `created_at` even after content was edited, so Google and other crawlers deprioritized re-crawl of recently modified articles.

Discovered during the 2026-05-26 SEO refresh: 25 articles had their `updated_at` touched in the DB, but the live sitemap still showed dates from March/April because this endpoint dropped the field.

## Changes

- `app/models/article.py`: add `updated_at: Optional[datetime] = None` to `ArticleSummary`.
- `app/services/articles_service.py`: add `a.updated_at` to both queries (list + related) and pass to the model.

Net diff: +5 / -0 lines across 2 files. No schema migration. No behavioral change for callers that ignore `updated_at`.

## Test plan

- [ ] Deploy to warolabs and hit `https://api.warolabs.com/blog?limit=3` — confirm `updated_at` is present and non-null for articles modified today.
- [ ] Refetch `https://warocol.com/sitemap.xml` (after the CF invalidation that the SEO refresh already created) — confirm 25+ entries show `<lastmod>2026-05-26</lastmod>` instead of the older dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)