### PR TITLE
fix(pos): normalize tip persistence for single and split settlement

### DIFF
--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -261,6 +261,9 @@ class AddPaymentRequest(BaseModel):
     payment_method: str = Field(..., description="cash | card | digital | credit or custom slug")
     payment_method_id: Optional[str] = Field(None, description="UUID of payment_methods row")
     cash_received: Optional[float] = Field(None, description="Issue #524 — cash handed over by the customer. NULL for non-cash. Must be >= amount when set.")
+    tip_amount: Optional[float] = Field(None, ge=0, description="Optional canonical tip override for an in-progress split settlement. Persists on the order header, not on order_payments.")
+    tip_source: Optional[Literal['preset', 'custom', 'none']] = Field(None, description="Optional tip source patch paired with tip_amount for split settlement updates.")
+    tip_taxable: Optional[bool] = Field(None, description="Optional gravada flag for split settlement tip updates.")
 
 
 class AddPaymentResponse(BaseModel):
@@ -319,6 +322,9 @@ async def add_cart_payment(
         payment_method=payment_data.payment_method,
         payment_method_id=payment_data.payment_method_id,
         cash_received=payment_data.cash_received,
+        tip_amount=payment_data.tip_amount,
+        tip_source=payment_data.tip_source,
+        tip_taxable=payment_data.tip_taxable,
     )
 
 

--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -151,6 +151,9 @@ class AddSessionPaymentRequest(BaseModel):
     payment_method: str = Field(..., description="cash | card | digital")
     payment_method_id: Optional[UUID] = Field(None, description="UUID of the selected payment_methods row")
     cash_received: Optional[float] = Field(None, description="Issue #524 — cash handed over for this payment when payment_method='cash'. Must be >= amount.")
+    tip_amount: Optional[float] = Field(None, ge=0, description="Optional session tip override during follow-up split settlement. Persists on the first completed order header.")
+    tip_source: Optional[Literal['preset', 'custom', 'none']] = Field(None, description="Optional tip source patch paired with tip_amount for split session updates.")
+    tip_taxable: Optional[bool] = Field(None, description="Optional gravada flag for split session tip updates.")
 
 
 @router.post("/{table_id}/close", dependencies=[Depends(require_module(Module.POS))])
@@ -194,6 +197,9 @@ async def add_session_payment(request: Request, table_id: UUID, body: AddSession
         request, table_id,
         body.amount, body.payment_method, body.payment_method_id,
         cash_received=body.cash_received,
+        tip_amount=body.tip_amount,
+        tip_source=body.tip_source,
+        tip_taxable=body.tip_taxable,
     )
 
 

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -18,6 +18,7 @@ from app.services.email_helpers import send_pos_receipt_email
 from app.services.cierre_service import _get_tenant_tax_config, _post_order_gl_entry, _post_order_cogs_gl_entry
 from app.services.tip_tax_service import (
     compute_tip_tax_amount,
+    normalize_tip_payload,
     split_settlement_amount_due,
     tip_settlement_total,
 )
@@ -947,6 +948,9 @@ async def add_order_payment(
     payment_method: str,
     payment_method_id: Optional[str] = None,
     cash_received: Optional[float] = None,
+    tip_amount: Optional[float] = None,
+    tip_source: Optional[str] = None,
+    tip_taxable: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """
     Add a partial payment to a POS cart's underlying order.
@@ -999,7 +1003,8 @@ async def add_order_payment(
                 # 2. Fetch + lock the order linked to this cart via pos_cart_id
                 order_row = await conn.fetchrow(
                     """
-                    SELECT id, total_amount, tip_amount, tip_tax_amount, status, payment_status
+                    SELECT id, total_amount, tip_amount, tip_source, tip_taxable,
+                           tip_tax_amount, status, payment_status
                     FROM orders
                     WHERE pos_cart_id = $1 AND tenant_id = $2
                     ORDER BY created_at DESC
@@ -1024,10 +1029,55 @@ async def add_order_payment(
                     raise APIError("Order is already fully paid", status_code=409)
 
                 total_amount = float(order_row["total_amount"])
+                resolved_tip_amount = float(order_row["tip_amount"] or 0)
+                resolved_tip_source = order_row["tip_source"] or "none"
+                resolved_tip_taxable = bool(order_row["tip_taxable"])
+                resolved_tip_tax_amount = float(order_row["tip_tax_amount"] or 0)
+
+                if any(value is not None for value in (tip_amount, tip_source, tip_taxable)):
+                    try:
+                        resolved_tip_amount, resolved_tip_source, resolved_tip_taxable = normalize_tip_payload(
+                            resolved_tip_amount if tip_amount is None else tip_amount,
+                            resolved_tip_source if tip_source is None else tip_source,
+                            resolved_tip_taxable if tip_taxable is None else tip_taxable,
+                        )
+                    except ValueError as exc:
+                        raise APIError(str(exc), status_code=400)
+
+                    if resolved_tip_amount > 0:
+                        tip_enabled = await conn.fetchval(
+                            "SELECT tip_enabled FROM tenant_public_profiles WHERE tenant_id = $1",
+                            tenant_id,
+                        )
+                        if not bool(tip_enabled):
+                            raise APIError("Tipping is not enabled for this tenant", status_code=400)
+                        tax_config = await _get_tenant_tax_config(conn, tenant_id)
+                        resolved_tip_tax_amount = compute_tip_tax_amount(
+                            resolved_tip_amount, resolved_tip_taxable, tax_config,
+                        )
+                    else:
+                        resolved_tip_tax_amount = 0.0
+
+                    await conn.execute(
+                        """
+                        UPDATE orders
+                        SET tip_amount = $2,
+                            tip_source = $3,
+                            tip_taxable = $4,
+                            tip_tax_amount = $5
+                        WHERE id = $1
+                        """,
+                        order_id,
+                        resolved_tip_amount,
+                        resolved_tip_source,
+                        resolved_tip_taxable,
+                        resolved_tip_tax_amount,
+                    )
+
                 amount_due = split_settlement_amount_due(
                     total_amount,
-                    float(order_row["tip_amount"] or 0),
-                    float(order_row["tip_tax_amount"] or 0),
+                    resolved_tip_amount,
+                    resolved_tip_tax_amount,
                 )
 
                 # 3. Insert payment record
@@ -1108,6 +1158,10 @@ async def add_order_payment(
                 "paid_total": paid_total,
                 "remaining": remaining,
                 "is_complete": is_complete,
+                "tip_amount": resolved_tip_amount,
+                "tip_source": resolved_tip_source,
+                "tip_taxable": resolved_tip_taxable,
+                "tip_tax_amount": resolved_tip_tax_amount,
             }
         }
 
@@ -1352,19 +1406,14 @@ async def complete_pos_order(
                     resolved_served_by = served_by_member_id
 
         # warocol.com#637 — tip validation (fail fast, before the transaction).
-        # Coerce (0, anything) → (0, 'none') for idempotency. Reject inconsistent
-        # combinations to match the DB CHECK from migration 079.
-        if tip_amount < 0:
-            raise APIError("tip_amount must be non-negative", status_code=400)
-        if tip_source not in ('preset', 'custom', 'none'):
-            raise APIError(f"invalid tip_source: {tip_source!r}", status_code=400)
-        if tip_amount == 0:
-            tip_source = 'none'  # coerce stray sources to none
-        else:
-            if tip_source == 'none':
-                raise APIError("tip_source cannot be 'none' when tip_amount > 0", status_code=400)
-            if not tip_enabled:
-                raise APIError("Tipping is not enabled for this tenant", status_code=400)
+        try:
+            tip_amount, tip_source, _tip_taxable = normalize_tip_payload(
+                tip_amount, tip_source, tip_taxable,
+            )
+        except ValueError as exc:
+            raise APIError(str(exc), status_code=400)
+        if tip_amount > 0 and not tip_enabled:
+            raise APIError("Tipping is not enabled for this tenant", status_code=400)
 
         _is_bar_sale = False
         _bar_display_name: Optional[str] = None

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -23,6 +23,7 @@ from app.services.pos_cart_service import (
 )
 from app.services.tip_tax_service import (
     compute_tip_tax_amount,
+    normalize_tip_payload,
     split_settlement_amount_due,
     tip_settlement_total,
 )
@@ -701,14 +702,12 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
     If payment_method is provided, marks all pending orders as completed with that payment method.
     """
     # warocol.com#639 — tip validation (same rules as pos_cart.complete_pos_order)
-    if tip_amount < 0:
-        raise APIError("tip_amount must be non-negative", status_code=400)
-    if tip_source not in ('preset', 'custom', 'none'):
-        raise APIError(f"invalid tip_source: {tip_source!r}", status_code=400)
-    if tip_amount == 0:
-        tip_source = 'none'
-    elif tip_source == 'none':
-        raise APIError("tip_source cannot be 'none' when tip_amount > 0", status_code=400)
+    try:
+        tip_amount, tip_source, tip_taxable = normalize_tip_payload(
+            tip_amount, tip_source, tip_taxable,
+        )
+    except ValueError as exc:
+        raise APIError(str(exc), status_code=400)
     resolved_served_by: Optional[UUID] = None
     if served_by_member_id is not None:
         session_context_pre = require_valid_session(request)
@@ -1256,6 +1255,9 @@ async def add_session_payment(
     payment_method: str,
     payment_method_id: Optional[UUID] = None,
     cash_received: Optional[float] = None,
+    tip_amount: Optional[float] = None,
+    tip_source: Optional[str] = None,
+    tip_taxable: Optional[bool] = None,
 ) -> dict:
     """
     Add a partial payment to an open mesa session that is in split payment mode.
@@ -1303,6 +1305,65 @@ async def add_session_payment(
 
                 session_total = sum(float(r["total_amount"]) for r in order_rows)
                 order_ids = [r["id"] for r in order_rows]
+                session_tip_row = await conn.fetchrow(
+                    """
+                    SELECT id,
+                           COALESCE(tip_amount, 0) AS tip_amount,
+                           COALESCE(tip_source, 'none') AS tip_source,
+                           COALESCE(tip_taxable, false) AS tip_taxable,
+                           COALESCE(tip_tax_amount, 0) AS tip_tax_amount
+                    FROM orders
+                    WHERE table_session_id = $1 AND status = 'completed'
+                    ORDER BY created_at
+                    LIMIT 1
+                    FOR UPDATE
+                    """,
+                    session_row["id"],
+                )
+                resolved_tip_amount = float(session_tip_row["tip_amount"] or 0) if session_tip_row else 0.0
+                resolved_tip_source = session_tip_row["tip_source"] if session_tip_row else "none"
+                resolved_tip_taxable = bool(session_tip_row["tip_taxable"]) if session_tip_row else False
+                resolved_tip_tax_amount = float(session_tip_row["tip_tax_amount"] or 0) if session_tip_row else 0.0
+
+                if any(value is not None for value in (tip_amount, tip_source, tip_taxable)):
+                    try:
+                        resolved_tip_amount, resolved_tip_source, resolved_tip_taxable = normalize_tip_payload(
+                            resolved_tip_amount if tip_amount is None else tip_amount,
+                            resolved_tip_source if tip_source is None else tip_source,
+                            resolved_tip_taxable if tip_taxable is None else tip_taxable,
+                        )
+                    except ValueError as exc:
+                        raise APIError(str(exc), status_code=400)
+
+                    if resolved_tip_amount > 0:
+                        tip_enabled = await conn.fetchval(
+                            "SELECT tip_enabled FROM tenant_public_profiles WHERE tenant_id = $1",
+                            tenant_id,
+                        )
+                        if not bool(tip_enabled):
+                            raise APIError("Tipping is not enabled for this tenant", status_code=400)
+                        tax_config = await _get_tenant_tax_config(conn, tenant_id)
+                        resolved_tip_tax_amount = compute_tip_tax_amount(
+                            resolved_tip_amount, resolved_tip_taxable, tax_config,
+                        )
+                    else:
+                        resolved_tip_tax_amount = 0.0
+
+                    await conn.execute(
+                        """
+                        UPDATE orders
+                        SET tip_amount = $2,
+                            tip_source = $3,
+                            tip_taxable = $4,
+                            tip_tax_amount = $5
+                        WHERE id = $1
+                        """,
+                        session_tip_row["id"],
+                        resolved_tip_amount,
+                        resolved_tip_source,
+                        resolved_tip_taxable,
+                        resolved_tip_tax_amount,
+                    )
 
                 # Distribute this payment proportionally
                 remaining_payment = amount
@@ -1339,20 +1400,10 @@ async def add_session_payment(
                 )
                 paid_total = float(paid_row["paid"])
                 
-                session_tip_row = await conn.fetchrow(
-                    """
-                    SELECT COALESCE(tip_amount, 0) AS tip_amount,
-                           COALESCE(tip_tax_amount, 0) AS tip_tax_amount
-                    FROM orders
-                    WHERE table_session_id = $1 AND status = 'completed'
-                    ORDER BY created_at LIMIT 1
-                    """,
-                    session_row["id"],
-                )
                 amount_due = split_settlement_amount_due(
                     session_total,
-                    float(session_tip_row["tip_amount"] or 0) if session_tip_row else 0.0,
-                    float(session_tip_row["tip_tax_amount"] or 0) if session_tip_row else 0.0,
+                    resolved_tip_amount,
+                    resolved_tip_tax_amount,
                 )
                 remaining = max(0.0, amount_due - paid_total)
                 is_complete = remaining <= 0.01
@@ -1382,6 +1433,10 @@ async def add_session_payment(
                 "paid_total": paid_total,
                 "remaining": remaining,
                 "is_complete": is_complete,
+                "tip_amount": resolved_tip_amount,
+                "tip_source": resolved_tip_source,
+                "tip_taxable": resolved_tip_taxable,
+                "tip_tax_amount": resolved_tip_tax_amount,
                 # Issue warocol.com#649 — real UUID; siblings void via heuristic.
                 "payment_id": first_payment_id,
             },

--- a/app/services/tip_tax_service.py
+++ b/app/services/tip_tax_service.py
@@ -4,7 +4,30 @@ Tip tax helpers — warocol.com#740
 Compute consumption tax on voluntary tips when the tenant/cashier opts in
 (tip gravada). Mirrors POS receipt tax breakdown logic in pos_cart_service.
 """
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
+
+
+VALID_TIP_SOURCES = ("preset", "custom", "none")
+
+
+def normalize_tip_payload(
+    tip_amount: float,
+    tip_source: str,
+    tip_taxable: bool = False,
+) -> Tuple[float, str, bool]:
+    """Normalize tip fields to the canonical order-header shape."""
+    amount = float(tip_amount or 0)
+    source = tip_source or "none"
+
+    if amount < 0:
+        raise ValueError("tip_amount must be non-negative")
+    if source not in VALID_TIP_SOURCES:
+        raise ValueError(f"invalid tip_source: {source!r}")
+    if amount == 0:
+        return 0.0, "none", False
+    if source == "none":
+        raise ValueError("tip_source cannot be 'none' when tip_amount > 0")
+    return amount, source, bool(tip_taxable)
 
 
 def compute_tip_tax_amount(


### PR DESCRIPTION
## Summary
- allow follow-up POS split payments to patch the canonical order-header tip fields instead of leaving tip data frozen at the initial checkout
- allow mesa split-payment follow-up calls to patch the session tip on the first completed order header while keeping `orders` as the source of truth
- centralize tip payload normalization so POS close, mesa close, and split follow-up flows reuse the same validation and settlement math

## Test plan
- [x] `python3 -m py_compile app/services/tip_tax_service.py app/services/pos_cart_service.py app/services/tables_service.py app/routers/pos_cart.py app/routers/tables.py`
- [ ] Manual: create a POS split payment, then add a follow-up payment with `tip_amount` / `tip_source` / `tip_taxable`
- [ ] Manual: create a mesa split close, then add a follow-up payment with a tip patch and verify `remaining` uses the updated tip

Closes uno0uno/warocol.com#910

Made with [Cursor](https://cursor.com)