### PR TITLE
feat(accounting): post tips to PUC with split-safe timing

### DIFF
--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -37,6 +37,56 @@ COGS_CODE       = "6135"   # Costo de ventas
 INVENTARIO_CODE = "1435"   # Inventarios — materia prima y suministros
 
 
+def _tip_gl_amounts(
+    tip_amount: Decimal,
+    tip_tax_amount: Decimal,
+    tax_config: Dict[str, Any],
+) -> tuple:
+    """
+    Return (settlement_debit, net_tip_revenue, tip_tax_credit) for GL posting.
+    Mirrors additive vs extractive tip tax from tenant_tax_config.
+    """
+    tip_amt = Decimal(str(tip_amount or 0))
+    tip_tax = Decimal(str(tip_tax_amount or 0))
+    if tip_amt <= 0 and tip_tax <= 0:
+        return Decimal("0"), Decimal("0"), Decimal("0")
+
+    tip_tax_additive = False
+    if tip_tax > 0:
+        if tax_config.get("inc_applicable"):
+            tip_tax_additive = not tax_config.get("inc_included_in_price", True)
+        elif tax_config.get("iva_applicable"):
+            tip_tax_additive = not tax_config.get("iva_included_in_price", False)
+
+    if tip_tax_additive:
+        settlement = tip_amt + tip_tax
+        net_tip_revenue = tip_amt
+    else:
+        settlement = tip_amt
+        net_tip_revenue = tip_amt - tip_tax
+    return settlement, net_tip_revenue, tip_tax
+
+
+async def _resolve_standard_tax_account_id(
+    conn,
+    tenant_id: UUID,
+    tax_config: Dict[str, Any],
+) -> Optional[UUID]:
+    """Resolve INC/IVA credit account for standard (non-liquor) tax, including tip tax."""
+    tax_code = None
+    if tax_config.get("inc_applicable"):
+        tax_code = str(tax_config["inc_gl_account_code"])
+    elif tax_config.get("iva_applicable"):
+        tax_code = str(tax_config["iva_gl_account_code"])
+    if not tax_code:
+        return None
+    tax_row = await conn.fetchrow(
+        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
+        tenant_id, tax_code,
+    )
+    return tax_row["id"] if tax_row else None
+
+
 async def _get_tenant_tax_config(conn, tenant_id: UUID) -> Dict[str, Any]:
     """
     Return tax config for the tenant.  Falls back to all-disabled defaults
@@ -235,6 +285,8 @@ async def _post_order_gl_entry(
     payment_method_id: Optional[UUID],
     tax_config: Dict[str, Any],
     order_number: Optional[int] = None,
+    tip_amount: Decimal = Decimal("0"),
+    tip_tax_amount: Decimal = Decimal("0"),
 ) -> None:
     """
     Post a double-entry GL journal entry for a single completed order (POS or domicilio).
@@ -243,12 +295,15 @@ async def _post_order_gl_entry(
     source_id     = order_id
 
     DR  [payment account]    debit_total   (1105 Caja / 1110 Bancos / 1305 Clientes)
-    CR  4135 Ingresos        net_revenue
-    CR  2495/2408 Impuesto   tax_amount    (only if tax enabled and account resolved)
+    CR  4175 Ingresos        net_revenue (+ net tip when included at checkout)
+    CR  2495/2408 Impuesto   tax_amount    (product + tip tax when applicable)
 
     Tax modes (per tenant_tax_config):
       inc_included_in_price=True  (default): price already includes tax — extract formula
       inc_included_in_price=False           : tax added on top — additive formula
+
+    Tips: pass tip_amount/tip_tax_amount for single-payment checkout. Split flows defer
+    tip to _post_deferred_order_tip_gl when the last payment completes (#912).
 
     Idempotent: skips if an 'orden' entry already exists for this order_id.
     Caller MUST wrap in try/except — GL failure must never roll back the order.
@@ -396,6 +451,16 @@ async def _post_order_gl_entry(
     net_revenue    = debit_total - standard_tax - liquor_tax
     # Invariant: DR debit_total = CR net_revenue + CR standard_tax + CR liquor_tax ✓
 
+    tip_settlement, tip_net_revenue, tip_tax_credit = _tip_gl_amounts(
+        tip_amount, tip_tax_amount, tax_config,
+    )
+    tip_tax_acct_id = None
+    if tip_tax_credit > 0:
+        tip_tax_acct_id = await _resolve_standard_tax_account_id(conn, tenant_id, tax_config)
+    if tip_settlement > 0:
+        debit_total += tip_settlement
+        net_revenue += tip_net_revenue
+
     dt = float(debit_total)
     description = f"#{order_number}" if order_number else f"Venta {order_date.isoformat()} — orden {order_id}"
 
@@ -451,11 +516,158 @@ async def _post_order_gl_entry(
                 f"{description} — IVA licores",
                 line_order,
             )
+            line_order += 1
+        if tip_tax_credit > 0 and tip_tax_acct_id:
+            await conn.execute(
+                """INSERT INTO tenant_journal_lines
+                       (journal_entry_id, account_id, debit, credit, description, line_order)
+                   VALUES ($1, $2, 0, $3, $4, $5)""",
+                entry_id, tip_tax_acct_id, float(tip_tax_credit),
+                f"{description} — propina INC/IVA",
+                line_order,
+            )
 
     logger.info(
         f"[GL] ✅ Posted order entry {entry_id} for order {order_id} "
         f"(total={dt}, net={float(net_revenue)}, "
-        f"inc={float(standard_tax)}, liquor={float(liquor_tax)})"
+        f"inc={float(standard_tax)}, liquor={float(liquor_tax)}, "
+        f"tip={float(tip_settlement)})"
+    )
+
+
+async def _post_deferred_order_tip_gl(
+    conn,
+    tenant_id: UUID,
+    order_id: UUID,
+    tip_amount: Decimal,
+    tip_tax_amount: Decimal,
+    payment_method: str,
+    payment_method_id: Optional[UUID],
+    tax_config: Dict[str, Any],
+    order_number: Optional[int] = None,
+) -> None:
+    """
+    Append tip lines to an existing orden GL entry when split payment completes (#912).
+
+    Single-payment tips are included in _post_order_gl_entry at checkout. Split POS/mesa
+    defer tip until is_complete so follow-up payments can set or change the tip (#910).
+
+    Idempotent: skips when a propina journal line already exists for this order.
+    """
+    tip_settlement, tip_net_revenue, tip_tax_credit = _tip_gl_amounts(
+        tip_amount, tip_tax_amount, tax_config,
+    )
+    if tip_settlement <= 0:
+        return
+
+    existing_tip = await conn.fetchval(
+        """SELECT 1 FROM tenant_journal_lines jl
+           JOIN tenant_journal_entries je ON je.id = jl.journal_entry_id
+           WHERE je.source_module = 'orden' AND je.source_id = $1 AND je.tenant_id = $2
+             AND je.status = 'posted'
+             AND jl.description ILIKE '%propina%'""",
+        order_id, tenant_id,
+    )
+    if existing_tip:
+        logger.info(f"[GL] Order {order_id}: tip already in journal — skip (idempotent)")
+        return
+
+    entry_row = await conn.fetchrow(
+        """SELECT id, total_debit, total_credit, description
+           FROM tenant_journal_entries
+           WHERE source_module = 'orden' AND source_id = $1 AND tenant_id = $2
+             AND status = 'posted'
+           ORDER BY created_at DESC
+           LIMIT 1""",
+        order_id, tenant_id,
+    )
+    if not entry_row:
+        logger.warning(
+            f"[GL] Order {order_id}: no orden entry for deferred tip — skip"
+        )
+        return
+
+    debit_code = None
+    if payment_method_id:
+        pm_row = await conn.fetchrow(
+            """SELECT COALESCE(pm.gl_account_code, pmg.gl_account_code) AS code
+               FROM payment_methods pm
+               JOIN payment_method_groups pmg ON pm.group_id = pmg.id
+               WHERE pm.id = $1""",
+            payment_method_id,
+        )
+        if pm_row and pm_row["code"]:
+            debit_code = pm_row["code"]
+    if not debit_code:
+        debit_code = _SLUG_DEBIT_CODE.get(payment_method or "", "1105")
+
+    debit_acct = await conn.fetchrow(
+        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
+        tenant_id, debit_code,
+    )
+    ingresos_acct = await conn.fetchrow(
+        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
+        tenant_id, INGRESOS_CODE,
+    )
+    if not debit_acct or not ingresos_acct:
+        logger.warning(
+            f"[GL] Deferred tip for order {order_id}: missing debit/ingresos account — skip"
+        )
+        return
+
+    tip_tax_acct_id = None
+    if tip_tax_credit > 0:
+        tip_tax_acct_id = await _resolve_standard_tax_account_id(conn, tenant_id, tax_config)
+
+    entry_id = entry_row["id"]
+    base_description = entry_row["description"] or (
+        f"#{order_number}" if order_number else f"orden {order_id}"
+    )
+    tip_description = f"{base_description} — propina"
+
+    max_line = await conn.fetchval(
+        "SELECT COALESCE(MAX(line_order), -1) FROM tenant_journal_lines WHERE journal_entry_id = $1",
+        entry_id,
+    )
+    line_order = int(max_line) + 1
+    settlement_f = float(tip_settlement)
+    new_debit = float(entry_row["total_debit"]) + settlement_f
+    new_credit = float(entry_row["total_credit"]) + settlement_f
+
+    async with conn.transaction():
+        await conn.execute(
+            """UPDATE tenant_journal_entries
+               SET total_debit = $2, total_credit = $3
+               WHERE id = $1""",
+            entry_id, new_debit, new_credit,
+        )
+        await conn.execute(
+            """INSERT INTO tenant_journal_lines
+                   (journal_entry_id, account_id, debit, credit, description, line_order)
+               VALUES ($1, $2, $3, 0, $4, $5)""",
+            entry_id, debit_acct["id"], settlement_f, tip_description, line_order,
+        )
+        line_order += 1
+        await conn.execute(
+            """INSERT INTO tenant_journal_lines
+                   (journal_entry_id, account_id, debit, credit, description, line_order)
+               VALUES ($1, $2, 0, $3, $4, $5)""",
+            entry_id, ingresos_acct["id"], float(tip_net_revenue),
+            f"{tip_description} — ingreso neto", line_order,
+        )
+        if tip_tax_credit > 0 and tip_tax_acct_id:
+            line_order += 1
+            await conn.execute(
+                """INSERT INTO tenant_journal_lines
+                       (journal_entry_id, account_id, debit, credit, description, line_order)
+                   VALUES ($1, $2, 0, $3, $4, $5)""",
+                entry_id, tip_tax_acct_id, float(tip_tax_credit),
+                f"{tip_description} — INC/IVA", line_order,
+            )
+
+    logger.info(
+        f"[GL] ✅ Appended deferred tip to entry {entry_id} for order {order_id} "
+        f"(tip_settlement={settlement_f})"
     )
 
 

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -15,7 +15,12 @@ from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError
 from app.services.waros_service import evaluate_and_award
 from app.services.email_helpers import send_pos_receipt_email
-from app.services.cierre_service import _get_tenant_tax_config, _post_order_gl_entry, _post_order_cogs_gl_entry
+from app.services.cierre_service import (
+    _get_tenant_tax_config,
+    _post_order_gl_entry,
+    _post_order_cogs_gl_entry,
+    _post_deferred_order_tip_gl,
+)
 from app.services.tip_tax_service import (
     compute_tip_tax_amount,
     normalize_tip_payload,
@@ -1144,6 +1149,29 @@ async def add_order_payment(
                         order_id
                     )
 
+                if is_complete and resolved_tip_amount > 0:
+                    try:
+                        order_meta = await conn.fetchrow(
+                            "SELECT order_number FROM orders WHERE id = $1",
+                            order_id,
+                        )
+                        tip_tax_config = await _get_tenant_tax_config(conn, tenant_id)
+                        await _post_deferred_order_tip_gl(
+                            conn=conn,
+                            tenant_id=tenant_id,
+                            order_id=order_id,
+                            tip_amount=Decimal(str(resolved_tip_amount)),
+                            tip_tax_amount=Decimal(str(resolved_tip_tax_amount)),
+                            payment_method=payment_method,
+                            payment_method_id=UUID(payment_method_id) if payment_method_id else None,
+                            tax_config=tip_tax_config,
+                            order_number=int(order_meta["order_number"]) if order_meta else None,
+                        )
+                    except Exception as _tip_gl_err:
+                        logger.error(
+                            f"Deferred tip GL failed for POS order {order_id}: {_tip_gl_err}"
+                        )
+
         # 6. Fire-and-forget side effects OUTSIDE transaction (only on completion)
         if is_complete:
             try:
@@ -1990,6 +2018,11 @@ async def complete_pos_order(
 
                 # GL journal entry — failure never blocks order completion
                 try:
+                    _gl_tip = Decimal("0")
+                    _gl_tip_tax = Decimal("0")
+                    if not split_mode or _split_is_complete:
+                        _gl_tip = Decimal(str(tip_amount))
+                        _gl_tip_tax = Decimal(str(_tip_tax_amount))
                     await _post_order_gl_entry(
                         conn=conn,
                         tenant_id=tenant_id,
@@ -2000,6 +2033,8 @@ async def complete_pos_order(
                         payment_method_id=payment_method_id,
                         tax_config=tax_config,
                         order_number=int(order_number),
+                        tip_amount=_gl_tip,
+                        tip_tax_amount=_gl_tip_tax,
                     )
                 except Exception as e:
                     logger.error(f"GL entry failed for POS order {order_id}: {e}")

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -15,7 +15,12 @@ from fastapi import Request
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError, NotFoundError
-from app.services.cierre_service import _get_tenant_tax_config, _post_order_gl_entry, _post_order_cogs_gl_entry
+from app.services.cierre_service import (
+    _get_tenant_tax_config,
+    _post_order_gl_entry,
+    _post_order_cogs_gl_entry,
+    _post_deferred_order_tip_gl,
+)
 from app.services.accounting_service import void_order_journal_entry_in_txn
 from app.services.pos_cart_service import (
     _capture_order_item_ingredients,
@@ -983,7 +988,20 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                             session_row["id"],
                         )
                         tax_config = await _get_tenant_tax_config(conn, tenant_id)
+                        first_order_id = await conn.fetchval(
+                            """
+                            SELECT id FROM orders
+                             WHERE table_session_id = $1 AND status = 'completed'
+                             ORDER BY created_at LIMIT 1
+                            """,
+                            session_row["id"],
+                        )
                         for ord_row in completed_orders:
+                            ord_tip = Decimal("0")
+                            ord_tip_tax = Decimal("0")
+                            if not split_mode and first_order_id and ord_row["id"] == first_order_id:
+                                ord_tip = Decimal(str(tip_amount or 0))
+                                ord_tip_tax = Decimal(str(_mesa_tip_tax_amount))
                             await _post_order_gl_entry(
                                 conn=conn,
                                 tenant_id=tenant_id,
@@ -994,6 +1012,8 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                                 payment_method_id=ord_row["payment_method_id"],
                                 tax_config=tax_config,
                                 order_number=int(ord_row["order_number"]),
+                                tip_amount=ord_tip,
+                                tip_tax_amount=ord_tip_tax,
                             )
                             await _post_order_cogs_gl_entry(
                                 conn=conn,
@@ -1053,6 +1073,49 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                                 )
                                 if i == 0:
                                     _split_first_payment_id_mesa = str(inserted_row["id"])
+
+                        # Split tip GL when first payment completes the session (#912)
+                        first_tip_order = await conn.fetchrow(
+                            """
+                            SELECT id, order_number,
+                                   COALESCE(tip_amount, 0) AS tip_amount,
+                                   COALESCE(tip_tax_amount, 0) AS tip_tax_amount
+                            FROM orders
+                            WHERE table_session_id = $1 AND status = 'completed'
+                            ORDER BY created_at LIMIT 1
+                            """,
+                            session_row["id"],
+                        )
+                        if first_tip_order and float(first_tip_order["tip_amount"]) > 0:
+                            split_order_ids = [r["id"] for r in order_rows]
+                            split_paid_row = await conn.fetchrow(
+                                "SELECT COALESCE(SUM(amount), 0) AS paid FROM order_payments WHERE order_id = ANY($1) AND voided_at IS NULL",
+                                split_order_ids,
+                            )
+                            split_paid_total = float(split_paid_row["paid"])
+                            split_amount_due = split_settlement_amount_due(
+                                session_total,
+                                float(first_tip_order["tip_amount"]),
+                                float(first_tip_order["tip_tax_amount"]),
+                            )
+                            if split_amount_due - split_paid_total <= 0.01:
+                                try:
+                                    split_tax_config = await _get_tenant_tax_config(conn, tenant_id)
+                                    await _post_deferred_order_tip_gl(
+                                        conn=conn,
+                                        tenant_id=tenant_id,
+                                        order_id=first_tip_order["id"],
+                                        tip_amount=Decimal(str(first_tip_order["tip_amount"])),
+                                        tip_tax_amount=Decimal(str(first_tip_order["tip_tax_amount"])),
+                                        payment_method=payment_method or "digital",
+                                        payment_method_id=payment_method_id,
+                                        tax_config=split_tax_config,
+                                        order_number=int(first_tip_order["order_number"]),
+                                    )
+                                except Exception as _defer_tip_exc:
+                                    logger.error(
+                                        f"Deferred tip GL failed for mesa session {session_row['id']}: {_defer_tip_exc}"
+                                    )
 
                 else:
                     completed_count = 0
@@ -1414,6 +1477,28 @@ async def add_session_payment(
                         "UPDATE orders SET payment_status = 'paid' WHERE table_session_id = $1 AND status = 'completed' AND payment_status = 'partial'",
                         session_row["id"],
                     )
+                    if resolved_tip_amount > 0 and session_tip_row:
+                        try:
+                            tip_order_meta = await conn.fetchrow(
+                                "SELECT order_number FROM orders WHERE id = $1",
+                                session_tip_row["id"],
+                            )
+                            tip_tax_config = await _get_tenant_tax_config(conn, tenant_id)
+                            await _post_deferred_order_tip_gl(
+                                conn=conn,
+                                tenant_id=tenant_id,
+                                order_id=session_tip_row["id"],
+                                tip_amount=Decimal(str(resolved_tip_amount)),
+                                tip_tax_amount=Decimal(str(resolved_tip_tax_amount)),
+                                payment_method=payment_method,
+                                payment_method_id=payment_method_id,
+                                tax_config=tip_tax_config,
+                                order_number=int(tip_order_meta["order_number"]) if tip_order_meta else None,
+                            )
+                        except Exception as _defer_tip_exc:
+                            logger.error(
+                                f"Deferred tip GL failed for mesa table {table_id}: {_defer_tip_exc}"
+                            )
                     # Close the session
                     await conn.execute(
                         "UPDATE table_sessions SET closed_at = now() WHERE id = $1",


### PR DESCRIPTION
## Summary
- Extend `_post_order_gl_entry()` to include tip + tip tax lines (DR payment account, CR 4175 + tax)
- Single payment: tip posts in the same `orden` journal at checkout
- Split payment (POS + mesa): tip deferred until last payment via `_post_deferred_order_tip_gl()`
- Mesa: tip GL attaches only to the first completed order row (session tip canonical row)

Closes #912

## Manual test checklist
- [ ] **POS single + tip** — complete checkout with tip → `tenant_journal_lines` has propina debit/credit on `source_module='orden'`
- [ ] **POS split + tip on last payment** — first partial has no propina lines; final `add_order_payment` with tip adds deferred lines
- [ ] **Mesa single close + tip** — propina on first order journal only (multi-order session)
- [ ] **Mesa split + tip on last payment** — `add_session_payment` completion appends propina lines
- [ ] **Tip gravada** — tip tax credit line uses tenant INC/IVA account
- [ ] **Idempotency** — retry completion does not duplicate propina lines

## Notes
- Tip revenue credits `4175` (same ingresos account as products)
- Product GL at partial split checkout unchanged (pre-existing behavior)

Made with [Cursor](https://cursor.com)