### PR TITLE
fix(arqueo): include tips in payment method breakdown

### DIFF
--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -1071,6 +1071,36 @@ async def _compute_preview(
                 AND op.voided_at IS NULL
           )
         GROUP BY o.payment_method
+
+        UNION ALL
+
+        -- Tip settlement on order header (single-pay and split completion)
+        SELECT
+            pmg.slug AS method,
+            COALESCE(SUM(o.tip_amount + o.tip_tax_amount), 0) AS total
+        FROM orders o
+        JOIN payment_methods pm ON pm.id = o.payment_method_id
+        JOIN payment_method_groups pmg ON pmg.id = pm.group_id
+        WHERE o.tenant_id = $1
+          {status_filter}
+          {date_filter}
+          AND o.payment_method_id IS NOT NULL
+          AND (o.tip_amount > 0 OR o.tip_tax_amount > 0)
+        GROUP BY pmg.slug
+
+        UNION ALL
+
+        SELECT
+            o.payment_method AS method,
+            COALESCE(SUM(o.tip_amount + o.tip_tax_amount), 0) AS total
+        FROM orders o
+        WHERE o.tenant_id = $1
+          {status_filter}
+          {date_filter}
+          AND o.payment_method_id IS NULL
+          AND o.payment_method IS NOT NULL
+          AND (o.tip_amount > 0 OR o.tip_tax_amount > 0)
+        GROUP BY o.payment_method
         """,
         tenant_id, *date_params,
     )
@@ -1153,8 +1183,10 @@ async def _compute_breakdown_rows(
       - Legacy orders (payment_method_id IS NULL): group by payment_method VARCHAR slug
 
     Returns list of {group_slug, method_name, total}, excluding zero-total rows.
-    Orders without an active payment method stay visible as
-    "Sin método registrado" so the breakdown can reconcile with totalSales.
+    Product amounts come from order_payments or orders.total_amount; tips are
+    attributed to each order's closing payment method (order header, not split
+    payment rows). Orders without an active payment method stay visible as
+    "Sin método registrado" so the breakdown can reconcile with totalCharged.
     When period_start_time / period_end_time are supplied, uses exact TIMESTAMPTZ comparison.
     """
     status_filter = "AND status = 'completed'" if completed_only else "AND status IN ('completed', 'pending')"
@@ -1241,6 +1273,54 @@ async def _compute_breakdown_rows(
               WHERE op.order_id = o.id
                 AND op.voided_at IS NULL
           )
+
+        UNION ALL
+
+        -- Tip settlement on order closing method (FK; covers split completion)
+        SELECT
+            pmg.slug        AS group_slug,
+            pm.name         AS method_name,
+            COALESCE(SUM(o.tip_amount + o.tip_tax_amount), 0) AS total
+        FROM orders o
+        JOIN payment_methods pm ON pm.id = o.payment_method_id
+        JOIN payment_method_groups pmg ON pmg.id = pm.group_id
+        WHERE o.tenant_id = $1
+          {status_filter}
+          {date_filter}
+          AND o.payment_method_id IS NOT NULL
+          AND (o.tip_amount > 0 OR o.tip_tax_amount > 0)
+        GROUP BY pmg.slug, pm.name
+
+        UNION ALL
+
+        -- Tip settlement for legacy VARCHAR method
+        SELECT
+            o.payment_method AS group_slug,
+            o.payment_method AS method_name,
+            COALESCE(SUM(o.tip_amount + o.tip_tax_amount), 0) AS total
+        FROM orders o
+        WHERE o.tenant_id = $1
+          {status_filter}
+          {date_filter}
+          AND o.payment_method_id IS NULL
+          AND o.payment_method IS NOT NULL
+          AND (o.tip_amount > 0 OR o.tip_tax_amount > 0)
+        GROUP BY o.payment_method
+
+        UNION ALL
+
+        -- Tip settlement with no payment method tracked
+        SELECT
+            'untracked'                AS group_slug,
+            'Sin método registrado'    AS method_name,
+            COALESCE(SUM(o.tip_amount + o.tip_tax_amount), 0) AS total
+        FROM orders o
+        WHERE o.tenant_id = $1
+          {status_filter}
+          {date_filter}
+          AND o.payment_method_id IS NULL
+          AND o.payment_method IS NULL
+          AND (o.tip_amount > 0 OR o.tip_tax_amount > 0)
         """,
         tenant_id, *date_params,
     )


### PR DESCRIPTION
## Summary

Payment method breakdown in arqueo preview and new cierres now includes tip settlement (`tip_amount + tip_tax_amount`) attributed to each order's closing payment method. Fixes mismatch where breakdown summed to `totalSales` while UI showed `totalCharged`.

Closes uno0uno/warocol.com#918

## Changes

- `_compute_breakdown_rows()`: three new UNION branches for FK method, legacy VARCHAR, and untracked tips
- `_compute_preview()` `method_rows`: mirror tip branches by group slug for `totalCash` / `totalDigital` alignment
- Docstring updated: breakdown reconciles with `totalCharged`

## Historical cierres

**No backfill.** Closed cierres before this fix keep their persisted product-only breakdown. Forward fix applies to preview and newly created cierres only.

## Manual test checklist

- [ ] **Digital tip (prod case):** shift with daviplata breb order + $100k tip → breakdown row includes tip; sum = totalCharged
- [ ] **Cash tip:** order paid cash with tip → cash breakdown row includes tip; `cashExpected` still correct
- [ ] **Split POS:** split payments complete → product from `order_payments`, full tip on order header method (not split across partials)
- [ ] **Mesa session:** tip on first completed order only → attributed to that order's closing method
- [ ] **New cierre Z:** persisted `cierre_payment_breakdown` matches preview breakdown

## Validation

- `ruff check app/services/cierre_service.py` — passed

Made with [Cursor](https://cursor.com)