### PR TITLE
feat(arqueo): API shift opening cash float and cashExpected formula

### DIFF
--- a/app/models/cierre.py
+++ b/app/models/cierre.py
@@ -2,10 +2,23 @@
 Cierre Contable — Pydantic models
 Issue: https://github.com/uno0uno/warocol.com/issues/311
 """
-from typing import Optional, List
+from typing import Any, Dict, Optional, List
 from pydantic import BaseModel, Field
 from datetime import date, datetime
 from uuid import UUID
+
+
+class OpenShiftCreate(BaseModel):
+    period_start: date = Field(alias='periodStart')
+    period_end: date = Field(alias='periodEnd')
+    period_start_time: Optional[datetime] = Field(None, alias='periodStartTime')
+    period_end_time: Optional[datetime] = Field(None, alias='periodEndTime')
+    shift_template_id: Optional[UUID] = Field(None, alias='shiftTemplateId')
+    opening_cash: float = Field(alias='openingCash', ge=0)
+    opening_breakdown: Optional[Dict[str, Any]] = Field(None, alias='openingBreakdown')
+
+    class Config:
+        populate_by_name = True
 
 
 class CierreCreate(BaseModel):
@@ -31,6 +44,7 @@ class CierrePreviewData(BaseModel):
     total_digital: float = Field(alias='totalDigital')
     total_credit: float = Field(alias='totalCredit')
     gastos_efectivo: float = Field(alias='gastosEfectivo')
+    opening_cash: float = Field(0, alias='openingCash')
     cash_expected: float = Field(alias='cashExpected')
     open_tables_count: int = Field(alias='openTablesCount')
 
@@ -56,6 +70,7 @@ class ClosingSummaryOut(BaseModel):
     total_digital: float = Field(alias='totalDigital')
     total_credit: float = Field(alias='totalCredit')
     gastos_efectivo: float = Field(alias='gastosEfectivo')
+    opening_cash: float = Field(0, alias='openingCash')
     cash_expected: float = Field(alias='cashExpected')
     cash_counted: float = Field(alias='cashCounted')
     cash_difference: float = Field(alias='cashDifference')

--- a/app/routers/cierre.py
+++ b/app/routers/cierre.py
@@ -9,7 +9,7 @@ from app.core.permissions import Module, require_module
 from typing import Optional
 from uuid import UUID
 from datetime import date, datetime
-from app.models.cierre import CierreCreate, MonthlyPeriodClose
+from app.models.cierre import CierreCreate, MonthlyPeriodClose, OpenShiftCreate
 from app.services import cierre_service
 
 router = APIRouter(prefix="/cierre", tags=["cierre"])
@@ -151,6 +151,35 @@ async def get_cierre_shift_window(
 
     return await shift_window_service.get_template_window(
         request, shift_template_id, anchor_date
+    )
+
+
+@router.post("/open-shift", dependencies=[Depends(require_module(Module.FINANZAS))])
+async def open_cierre_shift(request: Request, body: OpenShiftCreate):
+    """
+    Open an operational shift with opening cash float (fondo de caja).
+    Issue: warocol.com#920
+    """
+    return await cierre_service.open_shift(request, body)
+
+
+@router.get("/shift-status", dependencies=[Depends(require_module(Module.FINANZAS))])
+async def get_cierre_shift_status(
+    request: Request,
+    period_start: date = Query(..., alias="period_start"),
+    period_end: date = Query(..., alias="period_end"),
+    period_start_time: Optional[datetime] = Query(None, alias="period_start_time"),
+    period_end_time: Optional[datetime] = Query(None, alias="period_end_time"),
+    shift_template_id: Optional[UUID] = Query(None, alias="shift_template_id"),
+):
+    """Return open shift for the resolved window, or status none. Issue: #920"""
+    return await cierre_service.get_shift_status(
+        request,
+        period_start,
+        period_end,
+        period_start_time=period_start_time,
+        period_end_time=period_end_time,
+        shift_template_id=shift_template_id,
     )
 
 

--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -5,6 +5,7 @@ Preview (Cierre X), create close (Cierre Z), list, and detail.
 Issue: https://github.com/uno0uno/warocol.com/issues/311
 """
 import logging
+import json
 from decimal import Decimal
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
@@ -14,7 +15,7 @@ from fastapi import Request, Response
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError
-from app.models.cierre import CierreCreate
+from app.models.cierre import CierreCreate, OpenShiftCreate
 from app.services.tip_tax_service import tip_settlement_total
 
 logger = logging.getLogger(__name__)
@@ -944,6 +945,131 @@ def _build_open_tables_filter(
     return sql, [period_start, period_end]
 
 
+# ---------------------------------------------------------------------------
+# Shift opening helpers (#920)
+# ---------------------------------------------------------------------------
+
+def _effective_period_bounds(
+    period_start: date,
+    period_end: date,
+    period_start_time: Optional[datetime],
+    period_end_time: Optional[datetime],
+) -> tuple:
+    """Calendar day → Bogotá 00:00–23:59:59 unless exact timestamps supplied."""
+    from zoneinfo import ZoneInfo
+    bog = ZoneInfo("America/Bogota")
+    if period_start_time and period_end_time:
+        return period_start_time, period_end_time
+    eff_start = datetime(
+        period_start.year, period_start.month, period_start.day,
+        0, 0, 0, tzinfo=bog,
+    )
+    eff_end = datetime(
+        period_end.year, period_end.month, period_end.day,
+        23, 59, 59, tzinfo=bog,
+    )
+    return eff_start, eff_end
+
+
+def _requires_open_shift(
+    shift_template_id: Optional[UUID],
+    period_start_time: Optional[datetime],
+    period_end_time: Optional[datetime],
+) -> bool:
+    """Template and custom timestamp windows require a declared fondo de caja."""
+    if shift_template_id:
+        return True
+    if period_start_time and period_end_time:
+        return True
+    return False
+
+
+_PERIOD_WINDOW_OVERLAP_SQL = """
+    AND NOT (
+        COALESCE(
+            period_end_time,
+            (period_end::timestamp + INTERVAL '23:59:59') AT TIME ZONE 'America/Bogota'
+        ) <= $2
+        OR
+        COALESCE(
+            period_start_time,
+            period_start::timestamp AT TIME ZONE 'America/Bogota'
+        ) >= $3
+    )
+"""
+
+
+async def _find_overlapping_period_id(
+    conn,
+    tenant_id: UUID,
+    table: str,
+    eff_start: datetime,
+    eff_end: datetime,
+    *,
+    open_only: bool = False,
+) -> Optional[UUID]:
+    if table == "accounting_period":
+        extra = "AND deleted_at IS NULL"
+    elif table == "cash_shift_openings":
+        extra = "AND status = 'open'" if open_only else ""
+    else:
+        raise ValueError(f"Unsupported overlap table: {table}")
+
+    row = await conn.fetchrow(
+        f"""
+        SELECT id FROM {table}
+        WHERE tenant_id = $1
+          {extra}
+          {_PERIOD_WINDOW_OVERLAP_SQL}
+        LIMIT 1
+        """,
+        tenant_id, eff_start, eff_end,
+    )
+    return row["id"] if row else None
+
+
+async def _fetch_open_shift_for_window(
+    conn,
+    tenant_id: UUID,
+    eff_start: datetime,
+    eff_end: datetime,
+):
+    return await conn.fetchrow(
+        f"""
+        SELECT
+            id, opening_cash, opening_breakdown, opened_at, opened_by_user_id,
+            shift_template_id, period_start, period_end,
+            period_start_time, period_end_time
+        FROM cash_shift_openings
+        WHERE tenant_id = $1
+          AND status = 'open'
+          {_PERIOD_WINDOW_OVERLAP_SQL}
+        ORDER BY opened_at DESC
+        LIMIT 1
+        """,
+        tenant_id, eff_start, eff_end,
+    )
+
+
+def _open_shift_row_to_dict(row) -> dict:
+    breakdown = row["opening_breakdown"]
+    if isinstance(breakdown, str):
+        breakdown = json.loads(breakdown)
+    return {
+        "id":                   str(row["id"]),
+        "status":               "open",
+        "openingCash":          float(row["opening_cash"]),
+        "openingBreakdown":     breakdown,
+        "periodStart":          row["period_start"].isoformat(),
+        "periodEnd":            row["period_end"].isoformat(),
+        "periodStartTime":      row["period_start_time"].isoformat() if row["period_start_time"] else None,
+        "periodEndTime":        row["period_end_time"].isoformat() if row["period_end_time"] else None,
+        "shiftTemplateId":      str(row["shift_template_id"]) if row["shift_template_id"] else None,
+        "openedAt":             row["opened_at"].isoformat(),
+        "openedByUserId":       str(row["opened_by_user_id"]) if row["opened_by_user_id"] else None,
+    }
+
+
 async def _compute_preview(
     conn,
     tenant_id: UUID,
@@ -952,6 +1078,7 @@ async def _compute_preview(
     completed_only: bool = False,
     period_start_time: Optional[datetime] = None,
     period_end_time: Optional[datetime] = None,
+    opening_cash: float = 0.0,
 ) -> dict:
     """
     Runs the three aggregation queries (sales, gastos, open tables) and returns
@@ -1145,7 +1272,7 @@ async def _compute_preview(
     total_charged = float(sales_row["total_sales"]) + tip_settlement_total(
         total_tips, total_tip_tax,
     )
-    cash_expected = total_cash + cash_tips - gastos_efectivo
+    cash_expected = float(opening_cash) + total_cash + cash_tips - gastos_efectivo
 
     return {
         "totalSales":       float(sales_row["total_sales"]),
@@ -1154,6 +1281,7 @@ async def _compute_preview(
         "totalTipTax":      total_tip_tax,
         "totalCharged":     total_charged,
         "cashTips":         cash_tips,
+        "openingCash":      float(opening_cash),
         "totalCash":        total_cash,
         "totalCard":        method_totals.get("card", 0.0),
         "totalDigital":     method_totals.get("digital", 0.0),
@@ -1447,6 +1575,131 @@ async def list_active_shift_templates(request: Request) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# POST /cierre/open-shift + GET /cierre/shift-status (#920)
+# ---------------------------------------------------------------------------
+
+async def open_shift(request: Request, body: OpenShiftCreate) -> dict:
+    try:
+        session_context = require_valid_session(request)
+        tenant_id = session_context.tenant_id
+        if not tenant_id:
+            raise AuthenticationError("Tenant ID is required")
+
+        async with get_db_connection(use_transaction=True) as conn:
+            resolved = await resolve_cierre_period_fields(
+                conn,
+                tenant_id,
+                period_start=body.period_start,
+                period_end=body.period_end,
+                period_start_time=body.period_start_time,
+                period_end_time=body.period_end_time,
+                shift_template_id=body.shift_template_id,
+            )
+            eff_start, eff_end = _effective_period_bounds(
+                resolved.period_start,
+                resolved.period_end,
+                resolved.period_start_time,
+                resolved.period_end_time,
+            )
+
+            if await _find_overlapping_period_id(
+                conn, tenant_id, "accounting_period", eff_start, eff_end,
+            ):
+                raise APIError(
+                    "Ya existe un cierre cerrado para este período o uno que se superpone.",
+                    status_code=409,
+                )
+
+            if await _find_overlapping_period_id(
+                conn, tenant_id, "cash_shift_openings", eff_start, eff_end, open_only=True,
+            ):
+                raise APIError(
+                    "Ya hay un turno abierto para este período o uno que se superpone.",
+                    status_code=409,
+                )
+
+            breakdown_json = (
+                json.dumps(body.opening_breakdown)
+                if body.opening_breakdown is not None
+                else None
+            )
+            row = await conn.fetchrow(
+                """
+                INSERT INTO cash_shift_openings (
+                    tenant_id, shift_template_id,
+                    period_start, period_end, period_start_time, period_end_time,
+                    opening_cash, opening_breakdown, opened_by_user_id
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9)
+                RETURNING
+                    id, opening_cash, opening_breakdown, opened_at, opened_by_user_id,
+                    shift_template_id, period_start, period_end,
+                    period_start_time, period_end_time
+                """,
+                tenant_id,
+                resolved.shift_template_id,
+                resolved.period_start,
+                resolved.period_end,
+                resolved.period_start_time,
+                resolved.period_end_time,
+                body.opening_cash,
+                breakdown_json,
+                session_context.user_id,
+            )
+
+        return {"success": True, "data": _open_shift_row_to_dict(row)}
+
+    except (AuthenticationError, APIError):
+        raise
+    except Exception as exc:
+        logger.error(f"Error in open_shift: {exc}")
+        raise APIError(f"Error in open_shift: {exc}", status_code=500)
+
+
+async def get_shift_status(
+    request: Request,
+    period_start: date,
+    period_end: date,
+    period_start_time: Optional[datetime] = None,
+    period_end_time: Optional[datetime] = None,
+    shift_template_id: Optional[UUID] = None,
+) -> dict:
+    try:
+        session_context = require_valid_session(request)
+        tenant_id = session_context.tenant_id
+        if not tenant_id:
+            raise AuthenticationError("Tenant ID is required")
+
+        async with get_db_connection(use_transaction=False) as conn:
+            resolved = await resolve_cierre_period_fields(
+                conn,
+                tenant_id,
+                period_start=period_start,
+                period_end=period_end,
+                period_start_time=period_start_time,
+                period_end_time=period_end_time,
+                shift_template_id=shift_template_id,
+            )
+            eff_start, eff_end = _effective_period_bounds(
+                resolved.period_start,
+                resolved.period_end,
+                resolved.period_start_time,
+                resolved.period_end_time,
+            )
+            row = await _fetch_open_shift_for_window(conn, tenant_id, eff_start, eff_end)
+
+        if not row:
+            return {"success": True, "data": {"status": "none"}}
+
+        return {"success": True, "data": _open_shift_row_to_dict(row)}
+
+    except (AuthenticationError, APIError):
+        raise
+    except Exception as exc:
+        logger.error(f"Error in get_shift_status: {exc}")
+        raise APIError(f"Error in get_shift_status: {exc}", status_code=500)
+
+
+# ---------------------------------------------------------------------------
 # GET /cierre/preview
 # ---------------------------------------------------------------------------
 
@@ -1475,12 +1728,23 @@ async def get_cierre_preview(
                 period_end_time=period_end_time,
                 shift_template_id=shift_template_id,
             )
+            eff_start, eff_end = _effective_period_bounds(
+                resolved.period_start,
+                resolved.period_end,
+                resolved.period_start_time,
+                resolved.period_end_time,
+            )
+            open_shift = await _fetch_open_shift_for_window(
+                conn, tenant_id, eff_start, eff_end,
+            )
+            opening_cash = float(open_shift["opening_cash"]) if open_shift else 0.0
             preview = await _compute_preview(
                 conn, tenant_id,
                 resolved.period_start, resolved.period_end,
                 completed_only=completed_only,
                 period_start_time=resolved.period_start_time,
                 period_end_time=resolved.period_end_time,
+                opening_cash=opening_cash,
             )
             breakdown = await _compute_breakdown_rows(
                 conn, tenant_id,
@@ -1534,43 +1798,13 @@ async def create_cierre(request: Request, body: CierreCreate) -> dict:
                     status_code=422,
                 )
 
-            # 1. Unified overlap check using effective time windows.
-            #    Date-only cierres (single day) are treated as 00:00–23:59:59 Bogotá.
-            #    Timestamped cierres use their exact TIMESTAMPTZ values.
-            #    This allows multiple non-overlapping shifts on the same day.
-            from zoneinfo import ZoneInfo
-            bog = ZoneInfo("America/Bogota")
-            if period_start_time and period_end_time:
-                eff_start = period_start_time
-                eff_end   = period_end_time
-            else:
-                eff_start = datetime(
-                    period_start.year, period_start.month, period_start.day,
-                    0, 0, 0, tzinfo=bog,
-                )
-                eff_end = datetime(
-                    period_end.year, period_end.month, period_end.day,
-                    23, 59, 59, tzinfo=bog,
-                )
+            eff_start, eff_end = _effective_period_bounds(
+                period_start, period_end, period_start_time, period_end_time,
+            )
 
-            overlap = await conn.fetchrow(
-                """
-                SELECT id FROM accounting_period
-                WHERE tenant_id = $1
-                  AND deleted_at IS NULL
-                  AND NOT (
-                    COALESCE(
-                        period_end_time,
-                        (period_end::timestamp + INTERVAL '23:59:59') AT TIME ZONE 'America/Bogota'
-                    ) <= $2
-                    OR
-                    COALESCE(
-                        period_start_time,
-                        period_start::timestamp AT TIME ZONE 'America/Bogota'
-                    ) >= $3
-                  )
-                """,
-                tenant_id, eff_start, eff_end,
+            # 1. Unified overlap check using effective time windows.
+            overlap = await _find_overlapping_period_id(
+                conn, tenant_id, "accounting_period", eff_start, eff_end,
             )
             if overlap:
                 raise APIError(
@@ -1578,12 +1812,24 @@ async def create_cierre(request: Request, body: CierreCreate) -> dict:
                     status_code=409,
                 )
 
+            open_shift = await _fetch_open_shift_for_window(
+                conn, tenant_id, eff_start, eff_end,
+            )
+            if _requires_open_shift(shift_template_id, period_start_time, period_end_time):
+                if not open_shift:
+                    raise APIError(
+                        "Debes abrir el turno con el fondo de caja antes de registrar el cierre.",
+                        status_code=422,
+                    )
+            opening_cash = float(open_shift["opening_cash"]) if open_shift else 0.0
+
             # 2. Preview aggregation (completed only — cash already received)
             preview = await _compute_preview(
                 conn, tenant_id, period_start, period_end,
                 completed_only=True,
                 period_start_time=period_start_time,
                 period_end_time=period_end_time,
+                opening_cash=opening_cash,
             )
 
             # 3. Open tables check — skip for past periods (mesas actuales no pertenecen al período)
@@ -1621,15 +1867,15 @@ async def create_cierre(request: Request, body: CierreCreate) -> dict:
                     total_sales, items_sold,
                     total_tips, total_tip_tax, cash_tips,
                     total_cash, total_card, total_digital, total_credit,
-                    gastos_efectivo, cash_expected, cash_counted, cash_difference,
+                    gastos_efectivo, opening_cash, cash_expected, cash_counted, cash_difference,
                     notes
                 ) VALUES (
                     $1, $2,
                     $3, $4,
                     $5, $6, $7,
                     $8, $9, $10, $11,
-                    $12, $13, $14, $15,
-                    $16
+                    $12, $13, $14, $15, $16,
+                    $17
                 )
                 RETURNING id, created_at
                 """,
@@ -1638,10 +1884,22 @@ async def create_cierre(request: Request, body: CierreCreate) -> dict:
                 preview["totalTips"], preview["totalTipTax"], preview["cashTips"],
                 preview["totalCash"], preview["totalCard"],
                 preview["totalDigital"], preview["totalCredit"],
-                preview["gastosEfectivo"], preview["cashExpected"],
+                preview["gastosEfectivo"], opening_cash, preview["cashExpected"],
                 body.cash_counted, cash_difference,
                 body.notes,
             )
+
+            if open_shift:
+                await conn.execute(
+                    """
+                    UPDATE cash_shift_openings
+                    SET status = 'closed',
+                        accounting_period_id = $2,
+                        closed_at = NOW()
+                    WHERE id = $1 AND tenant_id = $3 AND status = 'open'
+                    """,
+                    open_shift["id"], period_id, tenant_id,
+                )
 
             # 6. Compute and persist payment breakdown
             breakdown_rows = await _compute_breakdown_rows(
@@ -1686,6 +1944,7 @@ async def create_cierre(request: Request, body: CierreCreate) -> dict:
                 "totalTipTax":          preview["totalTipTax"],
                 "totalCharged":         preview["totalCharged"],
                 "cashTips":             preview["cashTips"],
+                "openingCash":          opening_cash,
                 "totalCash":            preview["totalCash"],
                 "totalCard":            preview["totalCard"],
                 "totalDigital":         preview["totalDigital"],
@@ -1719,7 +1978,7 @@ _CIERRE_SUMMARY_COLUMNS = """
     cs.total_sales, cs.items_sold,
     cs.total_tips, cs.total_tip_tax, cs.cash_tips,
     cs.total_cash, cs.total_card, cs.total_digital, cs.total_credit,
-    cs.gastos_efectivo, cs.cash_expected, cs.cash_counted, cs.cash_difference,
+    cs.gastos_efectivo, cs.opening_cash, cs.cash_expected, cs.cash_counted, cs.cash_difference,
     cs.notes
 """
 
@@ -2002,6 +2261,7 @@ def _row_to_dict(row) -> dict:
         "totalDigital":         float(row["total_digital"]),
         "totalCredit":          float(row["total_credit"]),
         "gastosEfectivo":       float(row["gastos_efectivo"]),
+        "openingCash":          float(row["opening_cash"] or 0),
         "cashExpected":         float(row["cash_expected"]),
         "cashCounted":          float(row["cash_counted"]),
         "cashDifference":       float(row["cash_difference"]),

--- a/sql/20260528_add_cash_shift_openings.sql
+++ b/sql/20260528_add_cash_shift_openings.sql
@@ -1,0 +1,29 @@
+-- warocol.com#920 — shift opening cash float (fondo de caja)
+CREATE TABLE IF NOT EXISTS cash_shift_openings (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id uuid NOT NULL REFERENCES tenants(id),
+    shift_template_id uuid REFERENCES tenant_shift_templates(id) ON DELETE SET NULL,
+    period_start date NOT NULL,
+    period_end date NOT NULL,
+    period_start_time timestamptz,
+    period_end_time timestamptz,
+    opening_cash numeric(14,2) NOT NULL CHECK (opening_cash >= 0),
+    opening_breakdown jsonb,
+    status text NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'closed')),
+    opened_at timestamptz NOT NULL DEFAULT now(),
+    opened_by_user_id uuid,
+    accounting_period_id uuid REFERENCES accounting_period(id) ON DELETE SET NULL,
+    closed_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_cash_shift_openings_tenant_status
+    ON cash_shift_openings (tenant_id, status, opened_at DESC);
+
+COMMENT ON TABLE cash_shift_openings IS
+    'Operational shift open record — fondo de caja before Cierre Z (#920).';
+
+ALTER TABLE closing_summary
+    ADD COLUMN IF NOT EXISTS opening_cash numeric(14,2) NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN closing_summary.opening_cash IS
+    'Cash float declared at shift open for this closed period (#920).';

--- a/tests/test_cierre_open_shift.py
+++ b/tests/test_cierre_open_shift.py
@@ -1,0 +1,43 @@
+"""Unit tests for shift opening cash float helpers (warocol.com#920)."""
+from datetime import date, datetime
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+
+from app.services.cierre_service import (
+    _effective_period_bounds,
+    _requires_open_shift,
+)
+
+BOG = ZoneInfo("America/Bogota")
+
+
+def test_effective_period_bounds_uses_timestamps_when_present():
+    start = datetime(2026, 5, 18, 14, 0, tzinfo=BOG)
+    end = datetime(2026, 5, 18, 22, 0, tzinfo=BOG)
+    eff_start, eff_end = _effective_period_bounds(
+        date(2026, 5, 18), date(2026, 5, 18), start, end,
+    )
+    assert eff_start == start
+    assert eff_end == end
+
+
+def test_effective_period_bounds_full_day_bogota():
+    eff_start, eff_end = _effective_period_bounds(
+        date(2026, 5, 18), date(2026, 5, 18), None, None,
+    )
+    assert eff_start == datetime(2026, 5, 18, 0, 0, 0, tzinfo=BOG)
+    assert eff_end == datetime(2026, 5, 18, 23, 59, 59, tzinfo=BOG)
+
+
+def test_requires_open_shift_template_mode():
+    assert _requires_open_shift(uuid4(), None, None) is True
+
+
+def test_requires_open_shift_custom_times():
+    start = datetime(2026, 5, 18, 14, 0, tzinfo=BOG)
+    end = datetime(2026, 5, 18, 22, 0, tzinfo=BOG)
+    assert _requires_open_shift(None, start, end) is True
+
+
+def test_requires_open_shift_day_complete_optional():
+    assert _requires_open_shift(None, None, None) is False


### PR DESCRIPTION
## Summary

Batch 1 of epic #919 — operational shift opening (fondo de caja) for arqueo.

- New `cash_shift_openings` table + `closing_summary.opening_cash`
- `POST /cierre/open-shift` — declare opening cash for a shift window
- `GET /cierre/shift-status` — check if shift is open for a window
- `cashExpected = openingCash + totalCash + cashTips − gastosEfectivo`
- Template/custom timestamp closes require open shift (422); day-complete optional

Closes uno0uno/warocol.com#920

## Migration

**Prod:** applied manually 2026-05-27 (`cash_shift_openings` + `closing_summary.opening_cash`).

File: `sql/20260528_add_cash_shift_openings.sql`

## Manual test checklist

- [ ] POST `/cierre/open-shift` with shift template + `openingCash: 200000`
- [ ] GET `/cierre/shift-status` returns `status: open` + same window
- [ ] GET `/cierre/preview` includes `openingCash` in `cashExpected`
- [ ] POST `/cierre` (Z) without open shift on template mode → 422
- [ ] POST `/cierre` (Z) after open → `openingCash` persisted on close; shift row closed
- [ ] Overlap: second open-shift same window → 409
- [ ] Day-complete close (no template, no times) still works without open shift

## Validation

- `ruff check` on changed files — passed
- `pytest tests/test_cierre_open_shift.py` — 5 passed

## Out of scope

Front UI (#921), carry-forward (#922), GL, POS gate

Made with [Cursor](https://cursor.com)