### PR TITLE
feat(tables): add optional POS short code (#927)

### DIFF
--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -20,11 +20,21 @@ router = APIRouter(tags=["Tables"])
 class CreateTableRequest(BaseModel):
     name: str = Field(..., max_length=50, description="e.g. 'Mesa 1', 'Barra 2'")
     capacity: Optional[int] = Field(None, gt=0)
+    code: Optional[str] = Field(
+        None,
+        max_length=4,
+        description="Short POS code (1–4 alphanumeric). Inferred from name when omitted.",
+    )
 
 
 class UpdateTableRequest(BaseModel):
     name: Optional[str] = Field(None, max_length=50)
     capacity: Optional[int] = Field(None, gt=0)
+    code: Optional[str] = Field(
+        None,
+        max_length=4,
+        description="Short POS code. Send empty string to re-infer from name.",
+    )
 
 
 class TabModifier(BaseModel):
@@ -64,7 +74,7 @@ async def create_table(request: Request, body: CreateTableRequest):
     """
     Create a new table for the tenant.
     """
-    return await tables_service.create_table(request, body.name, body.capacity)
+    return await tables_service.create_table(request, body.name, body.capacity, body.code)
 
 
 @router.put("/{table_id}", dependencies=[Depends(require_module(Module.POS))])
@@ -73,7 +83,7 @@ async def update_table(request: Request, table_id: UUID, body: UpdateTableReques
     Update a table's name and/or capacity.
     Status is NOT editable here — use session endpoints to change status.
     """
-    return await tables_service.update_table(request, table_id, body.name, body.capacity)
+    return await tables_service.update_table(request, table_id, body.model_dump(exclude_unset=True))
 
 
 @router.patch("/{table_id}/activate", dependencies=[Depends(require_module(Module.POS))])

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -26,6 +26,7 @@ from app.services.pos_cart_service import (
     _capture_order_item_ingredients,
     _PAYMENT_VOID_ROLES,
 )
+from app.utils.table_code import infer_table_code, normalize_table_code, resolve_unique_code
 from app.services.tip_tax_service import (
     compute_tip_tax_amount,
     normalize_tip_payload,
@@ -125,6 +126,45 @@ def _distribute_discount(items: List[dict], discount_amount: float) -> List[dict
     return items
 
 
+async def _tenant_table_codes(conn, tenant_id, exclude_table_id=None) -> set[str]:
+    rows = await conn.fetch(
+        """
+        SELECT code FROM tables
+        WHERE tenant_id = $1
+          AND code IS NOT NULL
+          AND deleted_at IS NULL
+          AND ($2::uuid IS NULL OR id != $2)
+        """,
+        tenant_id,
+        exclude_table_id,
+    )
+    return {str(r["code"]).upper() for r in rows}
+
+
+async def _resolve_table_code(
+    conn,
+    tenant_id,
+    name: str,
+    *,
+    is_bar: bool = False,
+    explicit_code: Optional[str] = None,
+    exclude_table_id=None,
+) -> str:
+    if is_bar:
+        return "BAR"
+
+    used = await _tenant_table_codes(conn, tenant_id, exclude_table_id)
+
+    if explicit_code is not None and str(explicit_code).strip():
+        normalized = normalize_table_code(explicit_code)
+        if normalized and normalized.upper() in used:
+            raise APIError(f"Table code '{normalized}' is already in use", status_code=409)
+        return normalized or infer_table_code(name)
+
+    proposed = infer_table_code(name)
+    return resolve_unique_code(proposed, used)
+
+
 async def _ensure_bar_table(conn, tenant_id) -> None:
     """
     Ensure a permanent bar table and its open session exist for the tenant.
@@ -137,8 +177,8 @@ async def _ensure_bar_table(conn, tenant_id) -> None:
     if not bar_row:
         bar_row = await conn.fetchrow(
             """
-            INSERT INTO tables (tenant_id, name, capacity, status, is_bar)
-            VALUES ($1, 'Barra', NULL, 'open', TRUE)
+            INSERT INTO tables (tenant_id, name, capacity, status, is_bar, code)
+            VALUES ($1, 'Barra', NULL, 'open', TRUE, 'BAR')
             RETURNING id, status
             """,
             tenant_id,
@@ -193,6 +233,7 @@ async def list_tables(request: Request, include_inactive: bool = False) -> dict:
                 SELECT
                     t.id,
                     t.name,
+                    t.code,
                     t.capacity,
                     t.status,
                     t.is_active,
@@ -282,6 +323,7 @@ async def create_table(
     request: Request,
     name: str,
     capacity: Optional[int],
+    code: Optional[str] = None,
 ) -> dict:
     """
     Create a new table for the tenant.
@@ -294,16 +336,24 @@ async def create_table(
 
         async with get_db_connection() as conn:
             async with conn.transaction():
+                try:
+                    resolved_code = await _resolve_table_code(
+                        conn, tenant_id, name, explicit_code=code,
+                    )
+                except ValueError as exc:
+                    raise APIError(str(exc), status_code=400) from exc
+
                 row = await conn.fetchrow(
                     """
-                    INSERT INTO tables (tenant_id, name, capacity)
-                    VALUES ($1, $2, $3)
-                    RETURNING id, name, capacity, status, is_active, is_bar,
+                    INSERT INTO tables (tenant_id, name, capacity, code)
+                    VALUES ($1, $2, $3, $4)
+                    RETURNING id, name, code, capacity, status, is_active, is_bar,
                               qr_enabled, qr_public_token, created_at
                     """,
                     tenant_id,
                     name,
                     capacity,
+                    resolved_code,
                 )
                 module_on = await conn.fetchval(
                     """
@@ -320,7 +370,7 @@ async def create_table(
                         UPDATE tables
                         SET qr_public_token = $1
                         WHERE id = $2 AND tenant_id = $3
-                        RETURNING id, name, capacity, status, is_active, is_bar,
+                        RETURNING id, name, code, capacity, status, is_active, is_bar,
                                   qr_enabled, qr_public_token, created_at
                         """,
                         token,
@@ -328,10 +378,10 @@ async def create_table(
                         tenant_id,
                     )
 
-        logger.info(f"Table created: {row['id']} ({name}) for tenant {tenant_id}")
+        logger.info(f"Table created: {row['id']} ({name}, code={row['code']}) for tenant {tenant_id}")
         return {"success": True, "data": _format_table_simple(row)}
 
-    except AuthenticationError:
+    except (AuthenticationError, APIError):
         raise
     except Exception as e:
         logger.error(f"Error creating table: {e}")
@@ -341,11 +391,11 @@ async def create_table(
 async def update_table(
     request: Request,
     table_id: UUID,
-    name: Optional[str],
-    capacity: Optional[int],
+    updates: dict,
 ) -> dict:
     """
-    Update a table's name and/or capacity (status is NOT editable here).
+    Update a table's name, code, and/or capacity (status is NOT editable here).
+    Only keys present in ``updates`` are applied (see router model_dump exclude_unset).
     """
     try:
         session_context = require_valid_session(request)
@@ -355,31 +405,93 @@ async def update_table(
 
         async with get_db_connection() as conn:
             existing = await conn.fetchrow(
-                "SELECT id FROM tables WHERE id = $1 AND tenant_id = $2 AND is_active = true",
+                """
+                SELECT id, name, is_bar, code
+                FROM tables
+                WHERE id = $1 AND tenant_id = $2 AND is_active = true AND deleted_at IS NULL
+                """,
                 table_id,
                 tenant_id,
             )
             if not existing:
                 raise NotFoundError("Table not found")
 
+            if not updates:
+                row = await conn.fetchrow(
+                    """
+                    SELECT id, name, code, capacity, status, is_active, is_bar,
+                           qr_enabled, qr_public_token, created_at
+                    FROM tables WHERE id = $1 AND tenant_id = $2
+                    """,
+                    table_id,
+                    tenant_id,
+                )
+                return {"success": True, "data": _format_table_simple(row)}
+
+            set_clauses: List[str] = []
+            params: List[Any] = [table_id, tenant_id]
+            idx = 3
+            effective_name = updates.get("name", existing["name"])
+
+            if "name" in updates:
+                set_clauses.append(f"name = ${idx}")
+                params.append(updates["name"])
+                idx += 1
+
+            if "capacity" in updates:
+                set_clauses.append(f"capacity = ${idx}")
+                params.append(updates["capacity"])
+                idx += 1
+
+            if "code" in updates:
+                if existing["is_bar"]:
+                    raise APIError("Bar table code cannot be changed", status_code=400)
+                raw_code = updates["code"]
+                try:
+                    if raw_code is None or (isinstance(raw_code, str) and not raw_code.strip()):
+                        resolved_code = await _resolve_table_code(
+                            conn,
+                            tenant_id,
+                            effective_name,
+                            explicit_code=None,
+                            exclude_table_id=table_id,
+                        )
+                    else:
+                        normalized = normalize_table_code(raw_code)
+                        used = await _tenant_table_codes(conn, tenant_id, exclude_table_id=table_id)
+                        if normalized and normalized.upper() in used:
+                            raise APIError(
+                                f"Table code '{normalized}' is already in use",
+                                status_code=409,
+                            )
+                        resolved_code = normalized or await _resolve_table_code(
+                            conn,
+                            tenant_id,
+                            effective_name,
+                            explicit_code=None,
+                            exclude_table_id=table_id,
+                        )
+                except ValueError as exc:
+                    raise APIError(str(exc), status_code=400) from exc
+
+                set_clauses.append(f"code = ${idx}")
+                params.append(resolved_code)
+                idx += 1
+
             row = await conn.fetchrow(
-                """
+                f"""
                 UPDATE tables
-                SET
-                    name     = COALESCE($3, name),
-                    capacity = COALESCE($4, capacity)
+                SET {", ".join(set_clauses)}
                 WHERE id = $1 AND tenant_id = $2
-                RETURNING id, name, capacity, status, is_active, created_at
+                RETURNING id, name, code, capacity, status, is_active, is_bar,
+                          qr_enabled, qr_public_token, created_at
                 """,
-                table_id,
-                tenant_id,
-                name,
-                capacity,
+                *params,
             )
 
         return {"success": True, "data": _format_table_simple(row)}
 
-    except (AuthenticationError, NotFoundError):
+    except (AuthenticationError, NotFoundError, APIError):
         raise
     except Exception as e:
         logger.error(f"Error updating table {table_id}: {e}")
@@ -2928,6 +3040,7 @@ def _format_table_row(row: dict) -> dict:
     result = {
         "id": str(row["id"]),
         "name": row["name"],
+        "code": row.get("code"),
         "capacity": row["capacity"],
         "status": row["status"],
         "is_active": row["is_active"],
@@ -3190,6 +3303,7 @@ def _format_table_simple(row: dict) -> dict:
     return {
         "id": str(row["id"]),
         "name": row["name"],
+        "code": row.get("code"),
         "capacity": row["capacity"],
         "status": row["status"],
         "is_active": row["is_active"],

--- a/app/utils/table_code.py
+++ b/app/utils/table_code.py
@@ -1,0 +1,50 @@
+"""Table short codes for POS floor plan display (warocol.com#927)."""
+from __future__ import annotations
+
+import re
+from typing import Iterable, Optional
+
+_CODE_RE = re.compile(r"^[A-Za-z0-9]{1,4}$")
+_DIGITS_RE = re.compile(r"\d+")
+
+
+def infer_table_code(name: str) -> str:
+    """Mirror front tableShortId: first digit run, else first 3 letters uppercased."""
+    cleaned = (name or "").strip()
+    if not cleaned:
+        return "?"
+    match = _DIGITS_RE.search(cleaned)
+    if match:
+        return match.group(0)[:4]
+    return cleaned[:3].upper()
+
+
+def normalize_table_code(code: Optional[str]) -> Optional[str]:
+    if code is None:
+        return None
+    trimmed = code.strip()
+    if not trimmed:
+        return None
+    if len(trimmed) > 4:
+        raise ValueError("Table code must be at most 4 characters")
+    if not _CODE_RE.fullmatch(trimmed):
+        raise ValueError("Table code must be 1–4 alphanumeric characters")
+    return trimmed.upper()
+
+
+def resolve_unique_code(proposed: str, used: Iterable[str]) -> str:
+    """Return proposed code or a suffixed variant when already taken in tenant."""
+    base = proposed[:4]
+    taken = {c.upper() for c in used if c}
+    if base.upper() not in taken:
+        return base.upper()
+
+    for suffix in "ABCDEFGHJKLMNPQRSTUVWXYZ":
+        if len(base) >= 4:
+            candidate = base[:3] + suffix
+        else:
+            candidate = base + suffix
+        if candidate.upper() not in taken:
+            return candidate.upper()
+
+    raise ValueError("Unable to assign a unique table code")

--- a/scripts/backfill_table_codes.py
+++ b/scripts/backfill_table_codes.py
@@ -1,0 +1,83 @@
+"""
+Backfill tables.code from existing names (warocol.com#927).
+
+Uses the same inference as POS tableShortId. Resolves tenant-level collisions
+with single-letter suffixes. Bar tables get BAR.
+
+Requires DB access (SSH tunnel or local):
+    ssh -L 5432:localhost:5432 warolabs -N &
+    cd api_warocol.com && python scripts/backfill_table_codes.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import asyncpg
+from dotenv import load_dotenv
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from app.utils.table_code import infer_table_code, resolve_unique_code  # noqa: E402
+
+load_dotenv(ROOT / ".env")
+
+DB_CONFIG = {
+    "host": "localhost",
+    "port": int(os.getenv("NUXT_PRIVATE_DB_PORT", "5432")),
+    "user": os.getenv("NUXT_PRIVATE_DB_USER"),
+    "password": os.getenv("NUXT_PRIVATE_DB_PASSWORD"),
+    "database": os.getenv("NUXT_PRIVATE_DB_NAME"),
+}
+
+
+async def main() -> None:
+    conn = await asyncpg.connect(**DB_CONFIG)
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT id, tenant_id, name, is_bar, code
+            FROM tables
+            WHERE deleted_at IS NULL
+            ORDER BY tenant_id, created_at, id
+            """
+        )
+
+        by_tenant: dict[str, set[str]] = {}
+        updated = 0
+
+        for row in rows:
+            tenant_key = str(row["tenant_id"])
+            used = by_tenant.setdefault(tenant_key, set())
+
+            if row["code"]:
+                used.add(str(row["code"]).upper())
+                continue
+
+            if row["is_bar"]:
+                proposed = "BAR"
+            else:
+                proposed = infer_table_code(row["name"])
+
+            code = resolve_unique_code(proposed, used)
+            used.add(code.upper())
+
+            await conn.execute(
+                "UPDATE tables SET code = $1 WHERE id = $2",
+                code,
+                row["id"],
+            )
+            updated += 1
+            print(f"  {row['name']!r} -> {code}")
+
+        print(f"\nDone. Updated {updated} table(s).")
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/sql/20260528_add_tables_code.sql
+++ b/sql/20260528_add_tables_code.sql
@@ -1,0 +1,11 @@
+-- warocol.com#927 — optional short code for POS floor plan tiles
+
+ALTER TABLE tables
+    ADD COLUMN IF NOT EXISTS code varchar(4) NULL;
+
+COMMENT ON COLUMN tables.code IS
+    'Short POS display code (max 4 chars). Optional; inferred from name when blank.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS tables_tenant_code_unique
+    ON tables (tenant_id, upper(code))
+    WHERE code IS NOT NULL AND deleted_at IS NULL;

--- a/tests/test_table_code.py
+++ b/tests/test_table_code.py
@@ -1,0 +1,30 @@
+import pytest
+
+from app.utils.table_code import infer_table_code, normalize_table_code, resolve_unique_code
+
+
+def test_infer_table_code_digits():
+    assert infer_table_code("Mesa 12") == "12"
+    assert infer_table_code("VIP Norte 2") == "2"
+
+
+def test_infer_table_code_letters():
+    assert infer_table_code("Terraza VIP") == "TER"
+
+
+def test_normalize_table_code():
+    assert normalize_table_code(" t1 ") == "T1"
+    assert normalize_table_code(None) is None
+    assert normalize_table_code("") is None
+
+
+def test_normalize_table_code_invalid():
+    with pytest.raises(ValueError):
+        normalize_table_code("ABCDE")
+    with pytest.raises(ValueError):
+        normalize_table_code("A B")
+
+
+def test_resolve_unique_code():
+    assert resolve_unique_code("12", {"12"}) == "12A"
+    assert resolve_unique_code("TER", set()) == "TER"


### PR DESCRIPTION
## Summary
- Adds `tables.code` (varchar 4, optional, unique per tenant)
- SQL migration + `scripts/backfill_table_codes.py` for existing rows
- Create/update infer code from name when omitted; bar tables use `BAR`

Companion: uno0uno/warocol.com#928 (front)

## Test plan
- [ ] Run `sql/20260528_add_tables_code.sql` on prod
- [ ] Run `python3 scripts/backfill_table_codes.py` via SSH tunnel
- [ ] `GET /api/tables` returns `code`
- [ ] Create table without code → inferred code saved
- [ ] Duplicate code in tenant → 409

Closes uno0uno/warocol.com#927 (API half)

Made with [Cursor](https://cursor.com)