### PR TITLE
feat(facturacion): receipt print settings API (#930)

### DIFF
--- a/app/routers/tenant_config.py
+++ b/app/routers/tenant_config.py
@@ -164,6 +164,15 @@ async def update_tax_config_endpoint(
     return await tenant_config_service.update_tax_config(request, data)
 
 
+def _normalize_receipt_document_label(raw) -> str:
+    label = (raw or 'Prefactura').strip()
+    if not label:
+        return 'Prefactura'
+    if len(label) > 40:
+        raise HTTPException(status_code=400, detail='Document label must be at most 40 characters')
+    return label
+
+
 @router.get("/fiscal-data", dependencies=[Depends(require_module(Module.MI_NEGOCIO))])
 async def get_fiscal_data(request: Request):
     """
@@ -202,6 +211,10 @@ async def get_fiscal_data(request: Request):
             'city_id': row['city_id'],
             'phone': row['phone'],
             'email': row['email'],
+            'receipt_document_label': _normalize_receipt_document_label(row['receipt_document_label']),
+            'show_logo_on_receipts': row['show_logo_on_receipts']
+            if row['show_logo_on_receipts'] is not None
+            else True,
         },
     }
 
@@ -217,12 +230,16 @@ async def update_fiscal_data(request: Request, data: dict = Body(...)):
     session = require_valid_session(request)
     tenant_id = session.tenant_id
 
+    document_label = _normalize_receipt_document_label(data.get('receipt_document_label'))
+    show_logo = bool(data.get('show_logo_on_receipts', True))
+
     async with get_db_connection() as conn:
         await conn.execute(
             """INSERT INTO tenant_fiscal_data (tenant_id, nit, business_name,
                    type_organization_id, tax_regime_id, tax_level_id,
-                   fiscal_address, city, city_id, phone, email, updated_at)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, now())
+                   fiscal_address, city, city_id, phone, email,
+                   receipt_document_label, show_logo_on_receipts, updated_at)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, now())
                ON CONFLICT (tenant_id) DO UPDATE SET
                    nit = EXCLUDED.nit,
                    business_name = EXCLUDED.business_name,
@@ -234,6 +251,8 @@ async def update_fiscal_data(request: Request, data: dict = Body(...)):
                    city_id = EXCLUDED.city_id,
                    phone = EXCLUDED.phone,
                    email = EXCLUDED.email,
+                   receipt_document_label = EXCLUDED.receipt_document_label,
+                   show_logo_on_receipts = EXCLUDED.show_logo_on_receipts,
                    updated_at = now()""",
             tenant_id,
             data.get('nit'),
@@ -246,6 +265,8 @@ async def update_fiscal_data(request: Request, data: dict = Body(...)):
             data.get('city_id', 149),
             data.get('phone'),
             data.get('email'),
+            document_label,
+            show_logo,
         )
 
     return {'success': True, 'message': 'Datos fiscales actualizados'}

--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -34,6 +34,7 @@ SELECT
     tpp.tip_taxable_default,
     tpp.tip_default_percentages,
     tpp.tip_preselect_index,
+    tpp.logo_url,
     fd.nit,
     fd.business_name,
     fd.type_organization_id,
@@ -44,6 +45,8 @@ SELECT
     fd.city_id,
     fd.phone           AS fiscal_phone,
     fd.email           AS fiscal_email,
+    fd.receipt_document_label,
+    fd.show_logo_on_receipts,
     ttc.inc_applicable,
     ttc.inc_rate,
     ttc.inc_included_in_price,
@@ -113,6 +116,13 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
             if row['tip_default_percentages'] else [10.0]
         ),
         'tip_preselect_index': row['tip_preselect_index'],
+        'logo_url': row['logo_url'],
+        'receipt_print_settings': {
+            'document_label': (row['receipt_document_label'] or 'Prefactura').strip()[:40],
+            'show_logo': bool(row['show_logo_on_receipts'])
+            if row['show_logo_on_receipts'] is not None
+            else True,
+        },
         'fiscal_data': {
             'nit': row['nit'],
             'business_name': row['business_name'],

--- a/sql/20260529_add_receipt_print_settings.sql
+++ b/sql/20260529_add_receipt_print_settings.sql
@@ -1,0 +1,11 @@
+-- warocol.com#930 — POS receipt print personalization (epic #929)
+
+ALTER TABLE tenant_fiscal_data
+    ADD COLUMN IF NOT EXISTS receipt_document_label varchar(40) NULL DEFAULT 'Prefactura',
+    ADD COLUMN IF NOT EXISTS show_logo_on_receipts boolean NOT NULL DEFAULT true;
+
+COMMENT ON COLUMN tenant_fiscal_data.receipt_document_label IS
+    'Custom title on POS prefactura/factura tickets (e.g. Prefactura, Orden de compra).';
+
+COMMENT ON COLUMN tenant_fiscal_data.show_logo_on_receipts IS
+    'When true, POS thermal prints include tenant logo_url from public profile.';


### PR DESCRIPTION
## Summary
- Adds `receipt_document_label` and `show_logo_on_receipts` to `tenant_fiscal_data`
- Extends GET/PUT `/api/tenant/fiscal-data`
- Exposes `receipt_print_settings` + `logo_url` on `/api/pos/restaurant-context`

Companion front PR: uno0uno/warocol.com wr-930-receipt-print-settings

## Deploy
```bash
cat sql/20260529_add_receipt_print_settings.sql | docker exec -i saifer-postgres-1 psql -U saifer -d postresWaroLabs
```

## Test plan
- [ ] Migration applies cleanly
- [ ] GET/PUT fiscal-data returns new fields
- [ ] GET restaurant-context includes `receipt_print_settings` and `logo_url`

Closes uno0uno/warocol.com#930 (API half)

Made with [Cursor](https://cursor.com)