### PR TITLE
feat(cierre): require open shift for day-complete closes

### DIFF
--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -976,12 +976,12 @@ def _requires_open_shift(
     period_start_time: Optional[datetime],
     period_end_time: Optional[datetime],
 ) -> bool:
-    """Template and custom timestamp windows require a declared fondo de caja."""
+    """All arqueo windows (template, custom, day-complete) require fondo de caja."""
     if shift_template_id:
         return True
     if period_start_time and period_end_time:
         return True
-    return False
+    return True
 
 
 _PERIOD_WINDOW_OVERLAP_SQL = """

--- a/tests/test_cierre_open_shift.py
+++ b/tests/test_cierre_open_shift.py
@@ -39,5 +39,5 @@ def test_requires_open_shift_custom_times():
     assert _requires_open_shift(None, start, end) is True
 
 
-def test_requires_open_shift_day_complete_optional():
-    assert _requires_open_shift(None, None, None) is False
+def test_requires_open_shift_day_complete_required():
+    assert _requires_open_shift(None, None, None) is True


### PR DESCRIPTION
## Summary

- Day-complete Cierre Z (`shift_template_id` null, no custom `period_start_time`/`period_end_time`) now requires an open `cash_shift_openings` record before `POST /cierre`.
- `_requires_open_shift` returns `True` for the full-calendar-day path; existing 422 message and preview `openingCash` behavior unchanged.
- Unit test renamed to `test_requires_open_shift_day_complete_required`.

Closes uno0uno/warocol.com#945

## Test plan

- [ ] `pytest tests/test_cierre_open_shift.py` (CI)
- [ ] **Manual — day-complete**
  - [ ] `POST /cierre/open-shift` with `{ periodStart, periodEnd }` (same day), `openingCash` > 0, no template/times → 200
  - [ ] `GET /cierre/shift-status` same window → open record or `{ status: 'none', suggestedOpeningCash }`
  - [ ] Preview same window → `openingCash` matches open record
  - [ ] `POST /cierre` same window → 200 with fondo in `cashExpected`
- [ ] **Manual — without open**
  - [ ] `POST /cierre` day-complete without prior open-shift → 422 `Debes abrir el turno con el fondo de caja...`
- [ ] **Regression — template/custom** still require open shift (unchanged)

## Notes

- Front day apertura is batch #946 (`warocol.com`); API may 422 day-complete closes until that ships.
- Epic: uno0uno/warocol.com#944


Made with [Cursor](https://cursor.com)