### PR TITLE
fix(cierre): stop double-counting cash tips in cashExpected

### DIFF
--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -1106,6 +1106,23 @@ async def _resolve_suggested_opening_cash(
     return await _fetch_tenant_default_opening_cash(conn, tenant_id)
 
 
+def _compute_cash_expected(
+    opening_cash: float,
+    total_cash: float,
+    cash_tips: float,
+    total_sales: float,
+    gastos_efectivo: float,
+) -> float:
+    """Expected drawer cash: opening float + cash received − cash expenses.
+
+    When total_cash already includes tip settlement (all-cash), do not add
+    cash_tips again. Otherwise cash_tips is additive (split-pay / card tips).
+    """
+    if total_cash >= total_sales + cash_tips:
+        return opening_cash + total_cash - gastos_efectivo
+    return opening_cash + total_cash + cash_tips - gastos_efectivo
+
+
 async def _compute_preview(
     conn,
     tenant_id: UUID,
@@ -1308,7 +1325,13 @@ async def _compute_preview(
     total_charged = float(sales_row["total_sales"]) + tip_settlement_total(
         total_tips, total_tip_tax,
     )
-    cash_expected = float(opening_cash) + total_cash + cash_tips - gastos_efectivo
+    cash_expected = _compute_cash_expected(
+        float(opening_cash),
+        total_cash,
+        cash_tips,
+        float(sales_row["total_sales"]),
+        gastos_efectivo,
+    )
 
     return {
         "totalSales":       float(sales_row["total_sales"]),

--- a/tests/test_cierre_preview_cash.py
+++ b/tests/test_cierre_preview_cash.py
@@ -1,0 +1,49 @@
+"""Unit tests for cierre preview cashExpected (warocol.com#948)."""
+from app.services.cierre_service import _compute_cash_expected
+
+
+def test_cash_expected_all_cash_tips_embedded_in_total_cash():
+    """Repro: opening 200k + totalCash 459k (sales+tips) must not add cashTips again."""
+    result = _compute_cash_expected(
+        opening_cash=200_000.0,
+        total_cash=459_000.0,
+        cash_tips=99_000.0,
+        total_sales=360_000.0,
+        gastos_efectivo=0.0,
+    )
+    assert result == 659_000.0
+
+
+def test_cash_expected_split_pay_cash_sales_only():
+    """Regression: cash portion excludes tips settled on card — keep additive branch."""
+    result = _compute_cash_expected(
+        opening_cash=50_000.0,
+        total_cash=100_000.0,
+        cash_tips=0.0,
+        total_sales=360_000.0,
+        gastos_efectivo=10_000.0,
+    )
+    assert result == 140_000.0
+
+
+def test_cash_expected_exact_equality_uses_embedded_branch():
+    result = _compute_cash_expected(
+        opening_cash=0.0,
+        total_cash=459_000.0,
+        cash_tips=99_000.0,
+        total_sales=360_000.0,
+        gastos_efectivo=5_000.0,
+    )
+    assert result == 454_000.0
+
+
+def test_cash_expected_additive_when_cash_tips_not_embedded():
+    """When total_cash is sales-only, cash_tips must be added."""
+    result = _compute_cash_expected(
+        opening_cash=100_000.0,
+        total_cash=200_000.0,
+        cash_tips=30_000.0,
+        total_sales=360_000.0,
+        gastos_efectivo=0.0,
+    )
+    assert result == 330_000.0


### PR DESCRIPTION
## Summary
- Add `_compute_cash_expected()` helper in `_compute_preview` to avoid double-counting cash tips when they are already embedded in `totalCash` (all-cash repro).
- When `totalCash >= totalSales + cashTips`, use `opening + totalCash - gastos`; otherwise keep additive `+ cashTips` for split-pay.

Fixes uno0uno/warocol.com#948

## Test plan
- [x] `pytest tests/test_cierre_preview_cash.py` — all-cash repro (659000), split-pay regression, edge cases
- [ ] Manual: `GET /cierre/preview` day-complete with all-cash + tips → `cashExpected = openingCash + totalCash`
- [ ] Manual: split card+cash with tips on card → no double-count


Made with [Cursor](https://cursor.com)