### PR TITLE
feat(pos): persist reason on destructive tab and cart endpoints

### DIFF
--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -2,7 +2,7 @@
 POS Cart Router
 Endpoints for managing POS cart persistence
 """
-from fastapi import APIRouter, Depends, Request, Query
+from fastapi import APIRouter, Body, Depends, Request, Query
 from typing import List, Optional, Any, Dict, Literal
 from uuid import UUID
 from datetime import date, datetime
@@ -115,6 +115,13 @@ async def update_item(
     )
 
 
+class CartDestructiveReasonRequest(BaseModel):
+    reason: Optional[str] = Field(
+        None,
+        description="Motivo de eliminación / vaciar carrito (bitácora POS)",
+    )
+
+
 @router.delete("/{cart_id}/items/{item_id}", dependencies=[Depends(require_module(Module.POS))])
 async def remove_item(
     request: Request,
@@ -128,6 +135,7 @@ async def remove_item(
         None,
         description="Optional tenant_members.id (served-by attribution, #575)",
     ),
+    body: CartDestructiveReasonRequest = Body(default_factory=CartDestructiveReasonRequest),
 ):
     """
     Remove item from cart
@@ -138,6 +146,7 @@ async def remove_item(
         item_id,
         channel=channel,
         actor_member_id=actor_member_id,
+        reason=body.reason,
     )
 
 
@@ -153,6 +162,7 @@ async def clear_cart(
         None,
         description="Optional tenant_members.id (served-by attribution, #575)",
     ),
+    body: CartDestructiveReasonRequest = Body(default_factory=CartDestructiveReasonRequest),
 ):
     """
     Clear all items from cart
@@ -162,6 +172,7 @@ async def clear_cart(
         cart_id,
         channel=channel,
         actor_member_id=actor_member_id,
+        reason=body.reason,
     )
 
 

--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -57,6 +57,10 @@ class TabAddRequest(BaseModel):
 
 class UpdateTabItemRequest(BaseModel):
     quantity: int = Field(..., ge=1)
+    reason: Optional[str] = Field(
+        None,
+        description="warocol.com#786 — required when decreasing qty of a fired tab line",
+    )
 
 
 @router.get("", dependencies=[Depends(require_module(Module.POS))])
@@ -154,6 +158,10 @@ class CloseSessionRequest(BaseModel):
     tip_source: Literal['preset', 'custom', 'none'] = Field('none', description="warocol.com#639 — how the tip was chosen. Must agree with tip_amount.")
     tip_taxable: bool = Field(False, description="warocol.com#740 — apply consumption tax to tip_amount when true (gravada).")
     served_by_member_id: Optional[UUID] = Field(None, description="warocol.com#663 — waiter assigned at checkout. Applied to all completed orders in the session.")
+    reason: Optional[str] = Field(
+        None,
+        description="Motivo de liberación — required when closing without payment and pending tab lines exist",
+    )
 
 
 class AddSessionPaymentRequest(BaseModel):
@@ -193,6 +201,7 @@ async def close_session(request: Request, table_id: UUID, body: CloseSessionRequ
         tip_source=body.tip_source,
         tip_taxable=body.tip_taxable,
         served_by_member_id=body.served_by_member_id,
+        reason=body.reason,
     )
 
 
@@ -289,16 +298,29 @@ async def remove_tab_item(
 @router.patch("/{table_id}/tab/items/{order_item_id}", dependencies=[Depends(require_module(Module.POS))])
 async def update_tab_item_quantity(request: Request, table_id: UUID, order_item_id: UUID, body: UpdateTabItemRequest):
     """Update the quantity of an order item in the running tab."""
-    return await tables_service.update_tab_item_quantity(request, table_id, order_item_id, body.quantity)
+    return await tables_service.update_tab_item_quantity(
+        request, table_id, order_item_id, body.quantity, body.reason,
+    )
+
+
+class ClearTabRequest(BaseModel):
+    reason: Optional[str] = Field(
+        None,
+        description="Motivo de vaciar cuenta — required when pending tab lines exist",
+    )
 
 
 @router.delete("/{table_id}/tab", dependencies=[Depends(require_module(Module.POS))])
-async def clear_tab(request: Request, table_id: UUID):
+async def clear_tab(
+    request: Request,
+    table_id: UUID,
+    body: ClearTabRequest = Body(default_factory=ClearTabRequest),
+):
     """
     Delete all pending orders for the active session without closing it.
     The table stays open and ready for new orders.
     """
-    return await tables_service.clear_tab(request, table_id)
+    return await tables_service.clear_tab(request, table_id, body.reason)
 
 
 @router.post("/{table_id}/bill", dependencies=[Depends(require_module(Module.POS))])

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -649,6 +649,7 @@ async def _record_cart_operation_event(
     pos_cart_item_id: Optional[UUID] = None,
     payload: Optional[Dict[str, Any]] = None,
     actor_member_id: Optional[UUID] = None,
+    reason: Optional[str] = None,
 ) -> None:
     merged_payload = dict(payload) if payload else {}
     if pos_cart_item_id:
@@ -663,7 +664,13 @@ async def _record_cart_operation_event(
         actor_member_id=actor_member_id,
         pos_cart_id=pos_cart_id,
         payload=merged_payload,
+        reason=reason,
     )
+
+
+def _normalize_cart_audit_reason(reason: Optional[str]) -> Optional[str]:
+    normalized = (reason or "").strip()
+    return normalized or None
 
 
 async def remove_item_from_cart(
@@ -672,6 +679,7 @@ async def remove_item_from_cart(
     item_id: UUID,
     channel: str = "mostrador",
     actor_member_id: Optional[UUID] = None,
+    reason: Optional[str] = None,
 ) -> dict:
     """
     Remove an item from cart
@@ -714,6 +722,7 @@ async def remove_item_from_cart(
                     pos_cart_id=cart_id,
                     pos_cart_item_id=item_id,
                     actor_member_id=actor_member_id,
+                    reason=_normalize_cart_audit_reason(reason),
                     payload=_build_cart_line_payload(
                         product_id=row["product_id"],
                         product_name=row["product_name"],
@@ -755,6 +764,7 @@ async def clear_cart(
     cart_id: UUID,
     channel: str = "mostrador",
     actor_member_id: Optional[UUID] = None,
+    reason: Optional[str] = None,
 ) -> dict:
     """
     Clear all items from cart
@@ -809,6 +819,7 @@ async def clear_cart(
                         pos_cart_id=cart_id,
                         pos_cart_item_id=line["cart_item_id"],
                         actor_member_id=actor_member_id,
+                        reason=_normalize_cart_audit_reason(reason),
                         payload=_build_cart_line_payload(
                             product_id=line["product_id"],
                             product_name=line["product_name"],

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -813,7 +813,7 @@ async def open_session(
         raise APIError(f"Error opening session: {e}", status_code=500)
 
 
-async def close_session(request: Request, table_id: UUID, payment_method: Optional[str] = None, customer_id: Optional[str] = None, credit_due_date: Optional[date] = None, payment_method_id: Optional[UUID] = None, discount_type: Optional[str] = None, discount_value: Optional[float] = None, split_mode: bool = False, split_first_amount: float = 0.0, *, split_first_cash_received: Optional[float] = None, cash_received: Optional[float] = None, tip_amount: float = 0, tip_source: str = 'none', tip_taxable: bool = False, served_by_member_id: Optional[UUID] = None) -> dict:
+async def close_session(request: Request, table_id: UUID, payment_method: Optional[str] = None, customer_id: Optional[str] = None, credit_due_date: Optional[date] = None, payment_method_id: Optional[UUID] = None, discount_type: Optional[str] = None, discount_value: Optional[float] = None, split_mode: bool = False, split_first_amount: float = 0.0, *, split_first_cash_received: Optional[float] = None, cash_received: Optional[float] = None, tip_amount: float = 0, tip_source: str = 'none', tip_taxable: bool = False, served_by_member_id: Optional[UUID] = None, reason: Optional[str] = None) -> dict:
     """
     Close the active session for a table.
     If payment_method is provided, marks all pending orders as completed with that payment method.
@@ -847,6 +847,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
     try:
         session_context = require_valid_session(request)
         tenant_id = session_context.tenant_id
+        user_id = session_context.user_id
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
 
@@ -1236,6 +1237,30 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                     "SELECT COUNT(*) FROM orders WHERE table_session_id = $1 AND status = 'pending'",
                     session_row["id"],
                 )
+
+                if not split_mode and not payment_method:
+                    pending_line_count = await conn.fetchval(
+                        """
+                        SELECT COUNT(*) FROM order_items oi
+                        JOIN orders o ON o.id = oi.order_id
+                        WHERE o.table_session_id = $1 AND o.status = 'pending'
+                        """,
+                        session_row["id"],
+                    )
+                    if pending_line_count and pending_line_count > 0:
+                        if not _normalize_audit_reason(reason):
+                            raise APIError(
+                                "Motivo requerido para liberar la mesa con productos pendientes",
+                                status_code=400,
+                            )
+                        await _record_tab_cleared_pending_lines(
+                            conn,
+                            tenant_id,
+                            user_id=user_id,
+                            table_id=table_id,
+                            session_id=session_row["id"],
+                            reason=reason,
+                        )
 
                 if not split_mode:
                     # Close session
@@ -2024,6 +2049,73 @@ def _tab_item_requires_remove_reason(
     return comanda_item_row is not None
 
 
+def _normalize_audit_reason(reason: Optional[str]) -> Optional[str]:
+    normalized = (reason or "").strip()
+    return normalized or None
+
+
+async def _record_tab_cleared_pending_lines(
+    conn,
+    tenant_id: UUID,
+    *,
+    user_id: UUID,
+    table_id: UUID,
+    session_id: UUID,
+    reason: Optional[str],
+) -> int:
+    """Emit tab_cleared for each pending order line (bitácora). Returns line count."""
+    tab_ctx = await _fetch_tab_operation_context(conn, tenant_id, table_id)
+    if not tab_ctx:
+        return 0
+
+    pending_lines = await conn.fetch(
+        """
+        SELECT
+            oi.id AS order_item_id,
+            oi.product_id,
+            oi.quantity,
+            oi.price_at_purchase,
+            oi.subtotal,
+            oi.notes,
+            o.id AS order_id,
+            o.order_number,
+            p.name AS product_name
+        FROM order_items oi
+        JOIN orders o ON o.id = oi.order_id
+        JOIN product p ON p.id = oi.product_id
+        WHERE o.table_session_id = $1 AND o.status = 'pending'
+        """,
+        session_id,
+    )
+    event_reason = _normalize_audit_reason(reason)
+    for line in pending_lines:
+        line_modifiers = await _fetch_order_item_modifiers(conn, line["order_item_id"])
+        await _record_tab_operation_event(
+            conn,
+            tenant_id,
+            user_id=user_id,
+            table_id=table_id,
+            tab_ctx=tab_ctx,
+            action="tab_cleared",
+            order_id=line["order_id"],
+            order_item_id=line["order_item_id"],
+            reason=event_reason,
+            payload=_build_tab_item_payload(
+                product_id=line["product_id"],
+                product_name=line["product_name"],
+                quantity=line["quantity"],
+                unit_price=line["price_at_purchase"],
+                subtotal=line["subtotal"],
+                modifiers=line_modifiers,
+                notes=line["notes"],
+                table_id=table_id,
+                table_name=tab_ctx["table_name"],
+                order_number=line["order_number"],
+            ),
+        )
+    return len(pending_lines)
+
+
 async def remove_tab_item(
     request: Request,
     table_id: UUID,
@@ -2176,7 +2268,7 @@ async def remove_tab_item(
 
 
 async def update_tab_item_quantity(
-    request: Request, table_id: UUID, order_item_id: UUID, quantity: int
+    request: Request, table_id: UUID, order_item_id: UUID, quantity: int, reason: Optional[str] = None
 ) -> dict:
     """Update quantity of an order item in the running tab."""
     if quantity < 1:
@@ -2193,7 +2285,7 @@ async def update_tab_item_quantity(
                 """
                 SELECT
                     oi.id, oi.product_id, oi.quantity, oi.price_at_purchase,
-                    oi.subtotal, oi.notes,
+                    oi.subtotal, oi.notes, oi.fulfillment_status,
                     o.id AS order_id, o.total_amount, o.order_number,
                     p.name AS product_name,
                     t.name AS table_name,
@@ -2217,6 +2309,20 @@ async def update_tab_item_quantity(
                 raise NotFoundError("Order item not found or session already closed")
 
             old_quantity = float(row["quantity"])
+            comanda_item_row = await conn.fetchrow(
+                "SELECT id, comanda_id FROM comanda_items WHERE order_item_id = $1",
+                order_item_id,
+            )
+            normalized_reason = _normalize_audit_reason(reason)
+            if quantity < old_quantity and _tab_item_requires_remove_reason(
+                row["fulfillment_status"], comanda_item_row
+            ):
+                if not normalized_reason:
+                    raise APIError(
+                        "Motivo requerido para reducir cantidad de un producto enviado a cocina",
+                        status_code=400,
+                    )
+            event_reason = normalized_reason or None
             tab_ctx = {
                 "channel": "barra" if row["is_bar"] else "mesa",
                 "table_name": row["table_name"],
@@ -2267,10 +2373,11 @@ async def update_tab_item_quantity(
                 order_id=row["order_id"],
                 order_item_id=order_item_id,
                 payload=payload,
+                reason=event_reason,
             )
 
         return {"success": True, "data": {"order_item_id": str(order_item_id), "quantity": quantity, "subtotal": new_subtotal}}
-    except (AuthenticationError, NotFoundError):
+    except (AuthenticationError, NotFoundError, APIError):
         raise
     except Exception as e:
         logger.error(f"Error updating tab item {order_item_id}: {e}")
@@ -3077,7 +3184,7 @@ def _format_table_row(row: dict) -> dict:
     return result
 
 
-async def clear_tab(request: Request, table_id: UUID) -> dict:
+async def clear_tab(request: Request, table_id: UUID, reason: Optional[str] = None) -> dict:
     """
     Delete all pending orders (and their items) linked to the active session of a table.
     Does NOT close the session — the table stays open and ready for new orders.
@@ -3099,53 +3206,28 @@ async def clear_tab(request: Request, table_id: UUID) -> dict:
                 if not session_row:
                     raise NotFoundError("No open session found for this table")
 
-                tab_ctx = await _fetch_tab_operation_context(conn, tenant_id, table_id)
-                if tab_ctx:
-                    pending_lines = await conn.fetch(
-                        """
-                        SELECT
-                            oi.id AS order_item_id,
-                            oi.product_id,
-                            oi.quantity,
-                            oi.price_at_purchase,
-                            oi.subtotal,
-                            oi.notes,
-                            o.id AS order_id,
-                            o.order_number,
-                            p.name AS product_name
-                        FROM order_items oi
-                        JOIN orders o ON o.id = oi.order_id
-                        JOIN product p ON p.id = oi.product_id
-                        WHERE o.table_session_id = $1 AND o.status = 'pending'
-                        """,
-                        session_row["id"],
+                pending_line_count = await conn.fetchval(
+                    """
+                    SELECT COUNT(*) FROM order_items oi
+                    JOIN orders o ON o.id = oi.order_id
+                    WHERE o.table_session_id = $1 AND o.status = 'pending'
+                    """,
+                    session_row["id"],
+                )
+                if pending_line_count and pending_line_count > 0:
+                    if not _normalize_audit_reason(reason):
+                        raise APIError(
+                            "Motivo requerido para vaciar la cuenta",
+                            status_code=400,
+                        )
+                    await _record_tab_cleared_pending_lines(
+                        conn,
+                        tenant_id,
+                        user_id=user_id,
+                        table_id=table_id,
+                        session_id=session_row["id"],
+                        reason=reason,
                     )
-                    for line in pending_lines:
-                        line_modifiers = await _fetch_order_item_modifiers(
-                            conn, line["order_item_id"]
-                        )
-                        await _record_tab_operation_event(
-                            conn,
-                            tenant_id,
-                            user_id=user_id,
-                            table_id=table_id,
-                            tab_ctx=tab_ctx,
-                            action="tab_cleared",
-                            order_id=line["order_id"],
-                            order_item_id=line["order_item_id"],
-                            payload=_build_tab_item_payload(
-                                product_id=line["product_id"],
-                                product_name=line["product_name"],
-                                quantity=line["quantity"],
-                                unit_price=line["price_at_purchase"],
-                                subtotal=line["subtotal"],
-                                modifiers=line_modifiers,
-                                notes=line["notes"],
-                                table_id=table_id,
-                                table_name=tab_ctx["table_name"],
-                                order_number=line["order_number"],
-                            ),
-                        )
 
                 # Cancel comanda_items that point at the order_items we're
                 # about to delete. Two reasons:

--- a/tests/test_pos_cart_operation_events.py
+++ b/tests/test_pos_cart_operation_events.py
@@ -133,3 +133,119 @@ async def test_clear_cart_emits_cart_cleared_per_line():
     assert len(recorded) == 1
     assert recorded[0]["action"] == "cart_cleared"
     assert recorded[0]["channel"] == "mostrador"
+
+
+@pytest.mark.asyncio
+async def test_remove_item_passes_reason_to_event():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    cart_id = uuid4()
+    item_id = uuid4()
+    recorded = []
+
+    row = {
+        "id": item_id,
+        "product_id": uuid4(),
+        "quantity": 1,
+        "unit_price": 8.0,
+        "subtotal": 8.0,
+        "notes": None,
+        "product_name": "Jugo",
+    }
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(return_value=row)
+    mock_conn.fetch = AsyncMock(return_value=[])
+    mock_conn.execute = AsyncMock()
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+
+    async def capture(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("app.services.pos_cart_service.require_valid_session") as mock_sess, \
+         patch("app.services.pos_cart_service.get_db_connection", return_value=mock_cm), \
+         patch("app.services.pos_cart_service.update_cart_total", new=AsyncMock()), \
+         patch(
+             "app.services.pos_cart_service._record_cart_operation_event",
+             side_effect=capture,
+         ):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+        await pos_cart_service.remove_item_from_cart(
+            MagicMock(),
+            cart_id,
+            item_id,
+            reason="  Duplicado  ",
+        )
+
+    assert recorded[0]["reason"] == "Duplicado"
+
+
+@pytest.mark.asyncio
+async def test_clear_cart_passes_reason_to_events():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    cart_id = uuid4()
+    line_id = uuid4()
+    recorded = []
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(return_value={"id": cart_id})
+    mock_conn.fetch = AsyncMock(side_effect=[
+        [
+            {
+                "cart_item_id": line_id,
+                "product_id": uuid4(),
+                "quantity": 1,
+                "unit_price": 4.0,
+                "subtotal": 4.0,
+                "notes": None,
+                "product_name": "Pan",
+            },
+        ],
+        [],
+    ])
+    mock_conn.execute = AsyncMock()
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+
+    async def capture(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("app.services.pos_cart_service.require_valid_session") as mock_sess, \
+         patch("app.services.pos_cart_service.get_db_connection", return_value=mock_cm), \
+         patch(
+             "app.services.pos_cart_service._record_cart_operation_event",
+             side_effect=capture,
+         ):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+        await pos_cart_service.clear_cart(
+            MagicMock(),
+            cart_id,
+            reason="Cambio de pedido",
+        )
+
+    assert len(recorded) == 1
+    assert recorded[0]["reason"] == "Cambio de pedido"

--- a/tests/test_tables_tab_operation_events.py
+++ b/tests/test_tables_tab_operation_events.py
@@ -433,3 +433,199 @@ async def test_remove_fired_item_with_reason_records_event():
     assert len(recorded) == 1
     assert recorded[0]["reason"] == "Cliente cambió de opinión"
     assert recorded[0]["comanda_item_id"] == comanda_item_id
+
+
+@pytest.mark.asyncio
+async def test_fired_qty_decrease_without_reason_raises_400():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    order_item_id = uuid4()
+    order_id = uuid4()
+    session_id = uuid4()
+
+    row = {
+        "id": order_item_id,
+        "product_id": uuid4(),
+        "quantity": 3,
+        "price_at_purchase": 10.0,
+        "subtotal": 30.0,
+        "notes": None,
+        "fulfillment_status": "sent",
+        "order_id": order_id,
+        "total_amount": 30.0,
+        "order_number": 5,
+        "table_name": "Mesa 1",
+        "is_bar": False,
+        "table_session_id": session_id,
+        "effective_waiter_member_id": None,
+    }
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(side_effect=[row, None])
+    mock_conn.fetch = AsyncMock(return_value=[])
+    mock_conn.fetchval = AsyncMock(return_value=0)
+    mock_conn.execute = AsyncMock()
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("app.services.tables_service.require_valid_session") as mock_sess, \
+         patch("app.services.tables_service.get_db_connection", return_value=mock_cm):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+        with pytest.raises(APIError) as exc:
+            await tables_service.update_tab_item_quantity(
+                MagicMock(), table_id, order_item_id, 2, reason="",
+            )
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_fired_qty_decrease_with_reason_records_event():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    order_item_id = uuid4()
+    order_id = uuid4()
+    session_id = uuid4()
+    recorded = []
+
+    async def capture_record(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    row = {
+        "id": order_item_id,
+        "product_id": uuid4(),
+        "quantity": 3,
+        "price_at_purchase": 10.0,
+        "subtotal": 30.0,
+        "notes": None,
+        "fulfillment_status": "preparing",
+        "order_id": order_id,
+        "total_amount": 30.0,
+        "order_number": 7,
+        "table_name": "Barra",
+        "is_bar": True,
+        "table_session_id": session_id,
+        "effective_waiter_member_id": None,
+    }
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(side_effect=[row, None])
+    mock_conn.fetch = AsyncMock(return_value=[])
+    mock_conn.fetchval = AsyncMock(return_value=0)
+    mock_conn.execute = AsyncMock()
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("app.services.tables_service.require_valid_session") as mock_sess, \
+         patch("app.services.tables_service.get_db_connection", return_value=mock_cm), \
+         patch(
+             "app.services.tables_service._record_tab_operation_event",
+             side_effect=capture_record,
+         ):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+        await tables_service.update_tab_item_quantity(
+            MagicMock(),
+            table_id,
+            order_item_id,
+            2,
+            reason="  Error de captura  ",
+        )
+
+    assert len(recorded) == 1
+    assert recorded[0]["action"] == "tab_item_qty_changed"
+    assert recorded[0]["reason"] == "Error de captura"
+
+
+@pytest.mark.asyncio
+async def test_clear_tab_pending_without_reason_raises_400():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    session_id = uuid4()
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(return_value={"id": session_id})
+    mock_conn.fetchval = AsyncMock(return_value=2)
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("app.services.tables_service.require_valid_session") as mock_sess, \
+         patch("app.services.tables_service.get_db_connection", return_value=mock_cm):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+        with pytest.raises(APIError) as exc:
+            await tables_service.clear_tab(MagicMock(), table_id, reason="")
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_clear_tab_records_reason_on_tab_cleared():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    session_id = uuid4()
+    recorded = []
+
+    async def capture_cleared(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(return_value={"id": session_id})
+    mock_conn.fetchval = AsyncMock(side_effect=[1, 0])
+    mock_conn.execute = AsyncMock()
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("app.services.tables_service.require_valid_session") as mock_sess, \
+         patch("app.services.tables_service.get_db_connection", return_value=mock_cm), \
+         patch(
+             "app.services.tables_service._record_tab_cleared_pending_lines",
+             side_effect=capture_cleared,
+         ):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+        await tables_service.clear_tab(
+            MagicMock(), table_id, reason="Cliente se fue",
+        )
+
+    assert len(recorded) == 1
+    assert recorded[0]["reason"] == "Cliente se fue"


### PR DESCRIPTION
## Summary

Adds `reason` (motivo) to POS destructive API endpoints so bitácora (`tenant_operation_events.reason`) is populated when the front sends motivo from destructive flows (warocol.com#958 batch 2).

- `DELETE /tables/{id}/tab` — body `{ reason }`; required when pending lines exist
- `POST /tables/{id}/close` — `CloseSessionRequest.reason`; required when closing without payment and pending tab lines exist; emits `tab_cleared` per line
- `PATCH /tables/{id}/tab/items/{id}` — `reason` required when decreasing qty on a fired line (mirrors DELETE guard)
- `DELETE /pos/cart/{id}` and `DELETE /pos/cart/{id}/items/{id}` — body `{ reason }`; stored on cart events

Closes #316

## Test plan

- [ ] `pytest tests/test_tables_tab_operation_events.py tests/test_pos_cart_operation_events.py`
- [ ] Clear bar tab with motivo → bitácora shows `tab_cleared` with reason
- [ ] Liberar mesa/barra without payment (pending lines) → requires reason; events recorded
- [ ] Decrease fired tab item qty with motivo → `tab_item_qty_changed` includes reason
- [ ] Remove cart line / clear cart with motivo → `cart_line_removed` / `cart_cleared` include reason
- [ ] Companion: wire `reason` in warocol.com `$fetch` for `executeBannerClose` / `executeClearBarTab` / cart destructive (if not already in #960)

## Notes

- Void payment motivo (#649) unchanged
- `discard_table_session` out of scope

Made with [Cursor](https://cursor.com)