### PR TITLE
fix(pos-mesa): deduct modifier stock on tab add and return on remove

### DIFF
--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -1711,108 +1711,17 @@ async def complete_pos_order(
                                 modifier_qty
                             )
 
-                            # 5b. Deduct ingredient inventory for modifier if linked
-                            modifier_ingredient_query = """
-                                SELECT
-                                    m.ingredient_id,
-                                    m.ingredient_quantity,
-                                    m.ingredient_unit,
-                                    i.name as ingredient_name,
-                                    i.controla_inventario
-                                FROM modifiers m
-                                LEFT JOIN ingredients i ON m.ingredient_id = i.id
-                                WHERE m.id = $1 AND m.ingredient_id IS NOT NULL
-                            """
-                            modifier_ingredient = await conn.fetchrow(modifier_ingredient_query, modifier['id'])
-
-                            if modifier_ingredient and modifier_ingredient['ingredient_id'] and modifier_ingredient['ingredient_quantity']:
-                                # Apply gr → und conversion if modifier unit differs from ingredient base unit
-                                resolved_mod_qty = await resolve_recipe_quantity_to_base_unit(
-                                    conn,
-                                    modifier_ingredient['ingredient_id'],
-                                    float(modifier_ingredient['ingredient_quantity']),
-                                    modifier_ingredient['ingredient_unit'] or "",
-                                )
-                                # Calculate total quantity: item_qty * modifier_qty * ingredient_quantity
-                                total_deduction = (
-                                    float(item['quantity']) *
-                                    float(modifier_qty) *
-                                    resolved_mod_qty
-                                )
-
-                                # Get current stock
-                                stock_row = await conn.fetchrow(
-                                    """
-                                    SELECT current_stock FROM tenant_inventory
-                                    WHERE ingredient_id = $1 AND tenant_id = $2
-                                    """,
-                                    modifier_ingredient['ingredient_id'],
-                                    tenant_id
-                                )
-
-                                previous_stock = float(stock_row['current_stock']) if stock_row else 0.0
-                                new_stock = previous_stock - total_deduction
-
-                                # Update or insert inventory
-                                if stock_row:
-                                    await conn.execute(
-                                        """
-                                        UPDATE tenant_inventory
-                                        SET current_stock = $1, last_updated = NOW()
-                                        WHERE ingredient_id = $2 AND tenant_id = $3
-                                        """,
-                                        new_stock,
-                                        modifier_ingredient['ingredient_id'],
-                                        tenant_id
-                                    )
-                                else:
-                                    await conn.execute(
-                                        """
-                                        INSERT INTO tenant_inventory (
-                                            tenant_id, ingredient_id, current_stock, minimum_stock, last_updated
-                                        )
-                                        VALUES ($1, $2, $3, 0, NOW())
-                                        """,
-                                        tenant_id,
-                                        modifier_ingredient['ingredient_id'],
-                                        -total_deduction
-                                    )
-
-                                # Create movement record for modifier consumption
-                                await conn.execute(
-                                    """
-                                    INSERT INTO tenant_ingredient_movements (
-                                        tenant_id, ingredient_id, movement_type,
-                                        quantity_change, unit, previous_stock, new_stock,
-                                        reference_table, reference_id, reason, created_by, created_at
-                                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW())
-                                    """,
-                                    tenant_id,
-                                    modifier_ingredient['ingredient_id'],
-                                    'consumption',
-                                    -total_deduction,
-                                    modifier_ingredient['ingredient_unit'] or 'und',
-                                    previous_stock,
-                                    new_stock,
-                                    'orders',
-                                    order_id,
-                                    f"Modificador {modifier['name']} ({modifier_qty}x) - Orden #{order_number}",
-                                    session_context.user_id
-                                )
-
-                                logger.info(
-                                    f"Modifier inventory deducted: {modifier_ingredient['ingredient_name']} "
-                                    f"-{total_deduction}{modifier_ingredient['ingredient_unit']} "
-                                    f"(Modifier: {modifier['name']}, Order #{order_number})"
-                                )
-
-                                # 5c. Capture modifier ingredient snapshot
-                                await _capture_modifier_ingredient_snapshot(
-                                    conn, order_item_id,
-                                    modifier_ingredient, modifier['id'],
-                                    float(item['quantity']), float(modifier_qty),
-                                    tenant_id
-                                )
+                            await _deduct_modifier_inventory_for_order_item(
+                                conn,
+                                tenant_id=tenant_id,
+                                user_id=session_context.user_id,
+                                order_id=order_id,
+                                order_item_id=order_item_id,
+                                order_number=order_number,
+                                item_quantity=float(item['quantity']),
+                                modifier=modifier,
+                                modifier_qty=float(modifier_qty),
+                            )
 
                     # 6. ALWAYS update inventory for all products (no controla_stock check)
                     # Get ALL ingredients for this product:
@@ -2317,6 +2226,128 @@ async def _capture_order_item_ingredients(
             r["source_type"],
             r["source_id"],
         )
+
+
+async def _deduct_modifier_inventory_for_order_item(
+    conn,
+    *,
+    tenant_id,
+    user_id,
+    order_id,
+    order_item_id,
+    order_number,
+    item_quantity: float,
+    modifier: dict,
+    modifier_qty: float = 1,
+) -> None:
+    """Deduct linked-ingredient inventory for one order line modifier (POS + mesa tab)."""
+    modifier_id = modifier.get("id")
+    modifier_name = modifier.get("name", "Modificador")
+    if not modifier_id:
+        return
+
+    modifier_ingredient = await conn.fetchrow(
+        """
+        SELECT
+            m.ingredient_id,
+            m.ingredient_quantity,
+            m.ingredient_unit,
+            i.name as ingredient_name,
+            i.controla_inventario
+        FROM modifiers m
+        LEFT JOIN ingredients i ON m.ingredient_id = i.id
+        WHERE m.id = $1 AND m.ingredient_id IS NOT NULL
+        """,
+        modifier_id,
+    )
+
+    if (
+        not modifier_ingredient
+        or not modifier_ingredient["ingredient_id"]
+        or not modifier_ingredient["ingredient_quantity"]
+    ):
+        return
+
+    resolved_mod_qty = await resolve_recipe_quantity_to_base_unit(
+        conn,
+        modifier_ingredient["ingredient_id"],
+        float(modifier_ingredient["ingredient_quantity"]),
+        modifier_ingredient["ingredient_unit"] or "",
+    )
+    total_deduction = float(item_quantity) * float(modifier_qty) * resolved_mod_qty
+
+    stock_row = await conn.fetchrow(
+        """
+        SELECT current_stock FROM tenant_inventory
+        WHERE ingredient_id = $1 AND tenant_id = $2
+        """,
+        modifier_ingredient["ingredient_id"],
+        tenant_id,
+    )
+
+    previous_stock = float(stock_row["current_stock"]) if stock_row else 0.0
+    new_stock = previous_stock - total_deduction
+
+    if stock_row:
+        await conn.execute(
+            """
+            UPDATE tenant_inventory
+            SET current_stock = $1, last_updated = NOW()
+            WHERE ingredient_id = $2 AND tenant_id = $3
+            """,
+            new_stock,
+            modifier_ingredient["ingredient_id"],
+            tenant_id,
+        )
+    else:
+        await conn.execute(
+            """
+            INSERT INTO tenant_inventory (
+                tenant_id, ingredient_id, current_stock, minimum_stock, last_updated
+            )
+            VALUES ($1, $2, $3, 0, NOW())
+            """,
+            tenant_id,
+            modifier_ingredient["ingredient_id"],
+            -total_deduction,
+        )
+
+    await conn.execute(
+        """
+        INSERT INTO tenant_ingredient_movements (
+            tenant_id, ingredient_id, movement_type,
+            quantity_change, unit, previous_stock, new_stock,
+            reference_table, reference_id, reason, created_by, created_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW())
+        """,
+        tenant_id,
+        modifier_ingredient["ingredient_id"],
+        "consumption",
+        -total_deduction,
+        modifier_ingredient["ingredient_unit"] or "und",
+        previous_stock,
+        new_stock,
+        "orders",
+        order_id,
+        f"Modificador {modifier_name} ({modifier_qty}x) - Orden #{order_number}",
+        user_id,
+    )
+
+    logger.info(
+        f"Modifier inventory deducted: {modifier_ingredient['ingredient_name']} "
+        f"-{total_deduction}{modifier_ingredient['ingredient_unit']} "
+        f"(Modifier: {modifier_name}, Order #{order_number})"
+    )
+
+    await _capture_modifier_ingredient_snapshot(
+        conn,
+        order_item_id,
+        modifier_ingredient,
+        modifier_id,
+        item_quantity,
+        float(modifier_qty),
+        str(tenant_id),
+    )
 
 
 async def _capture_modifier_ingredient_snapshot(

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -25,8 +25,10 @@ from app.services.cierre_service import (
 from app.services.accounting_service import void_order_journal_entry_in_txn
 from app.services.pos_cart_service import (
     _capture_order_item_ingredients,
+    _deduct_modifier_inventory_for_order_item,
     _PAYMENT_VOID_ROLES,
 )
+from app.services.orders_service import _return_ingredient_to_stock
 from app.utils.table_code import infer_table_code, normalize_table_code, resolve_unique_code
 from app.services.tip_tax_service import (
     compute_tip_tax_amount,
@@ -2143,6 +2145,43 @@ async def _record_tab_cleared_pending_lines(
     return len(pending_lines)
 
 
+async def _return_tab_item_inventory_from_snapshots(
+    conn,
+    *,
+    tenant_id: UUID,
+    user_id: UUID,
+    order_id: UUID,
+    order_number: int,
+    order_item_id: UUID,
+    product_name: str,
+) -> None:
+    """Return stock captured in order_item_ingredients when a tab line is removed."""
+    snapshots = await conn.fetch(
+        """
+        SELECT ingredient_id, ingredient_name, quantity, unit
+        FROM order_item_ingredients
+        WHERE order_item_id = $1
+        """,
+        order_item_id,
+    )
+    for snap in snapshots:
+        qty = float(snap["quantity"] or 0)
+        if qty <= 0:
+            continue
+        await _return_ingredient_to_stock(
+            conn,
+            tenant_id,
+            user_id,
+            order_id,
+            order_number,
+            snap["ingredient_id"],
+            qty,
+            snap["unit"] or "und",
+            snap["ingredient_name"],
+            f"Devolución tab: {product_name}",
+        )
+
+
 async def remove_tab_item(
     request: Request,
     table_id: UUID,
@@ -2278,6 +2317,21 @@ async def remove_tab_item(
                     order_number=row["order_number"],
                 ),
             )
+
+            try:
+                await _return_tab_item_inventory_from_snapshots(
+                    conn,
+                    tenant_id=tenant_id,
+                    user_id=user_id,
+                    order_id=row["order_id"],
+                    order_number=row["order_number"],
+                    order_item_id=order_item_id,
+                    product_name=row["product_name"],
+                )
+            except Exception as _ret_exc:
+                logger.error(
+                    f"[tab] inventory return failed for item {order_item_id}: {_ret_exc}"
+                )
 
             await conn.execute("DELETE FROM order_items WHERE id = $1", order_item_id)
             new_total = max(0.0, float(row["total_amount"]) - float(row["subtotal"]))
@@ -2541,6 +2595,7 @@ async def _add_tab_items_core(
         order_item_id = order_item_row["id"]
 
         for mod in item.get("modifiers") or []:
+            modifier_qty = mod.get("quantity", 1)
             await conn.execute(
                 """
                 INSERT INTO order_item_modifiers (
@@ -2553,7 +2608,26 @@ async def _add_tab_items_core(
                 mod.get("id"),
                 mod.get("name"),
                 mod.get("price", 0),
-                1,
+                modifier_qty,
+            )
+
+        try:
+            for mod in item.get("modifiers") or []:
+                modifier_qty = float(mod.get("quantity", 1))
+                await _deduct_modifier_inventory_for_order_item(
+                    conn,
+                    tenant_id=tenant_id,
+                    user_id=user_id,
+                    order_id=order_id,
+                    order_item_id=order_item_id,
+                    order_number=order_number,
+                    item_quantity=float(item["quantity"]),
+                    modifier=mod,
+                    modifier_qty=modifier_qty,
+                )
+        except Exception as _mod_inv_exc:
+            logger.error(
+                f"[tab] modifier inventory deduction failed for item {order_item_id}: {_mod_inv_exc}"
             )
 
         await _record_tab_operation_event(

--- a/tests/test_tables_tab_modifier_inventory.py
+++ b/tests/test_tables_tab_modifier_inventory.py
@@ -1,0 +1,184 @@
+"""Mesa/bar tab modifier inventory deduction (#319)."""
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services import pos_cart_service, tables_service
+
+
+@pytest.mark.asyncio
+async def test_add_tab_items_core_deducts_modifier_inventory():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    session_id = uuid4()
+    order_id = uuid4()
+    product_id = uuid4()
+    order_item_id = uuid4()
+    modifier_id = uuid4()
+
+    session_row = {
+        "session_id": session_id,
+        "table_name": "Mesa 3",
+        "is_bar": False,
+        "effective_waiter_member_id": None,
+    }
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(side_effect=[
+        session_row,
+        None,
+        {"id": order_id, "order_number": 42, "total_amount": 43.0},
+        {"id": order_item_id},
+    ])
+    mock_conn.fetch = AsyncMock(return_value=[])
+    mock_conn.execute = AsyncMock()
+
+    items = [{
+        "product_id": product_id,
+        "quantity": 1,
+        "unit_price": 25.0,
+        "modifiers": [{
+            "id": str(modifier_id),
+            "name": "Tocineta",
+            "price": 4.0,
+        }],
+    }]
+
+    pricing_map = {str(product_id): {"price": Decimal("25.00"), "open_priced": False}}
+    deduct_mock = AsyncMock()
+
+    with patch(
+        "app.services.tables_service._record_tab_operation_event",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.tables_service._prefetch_product_names",
+        new=AsyncMock(return_value={str(product_id): "Santa inquisición"}),
+    ), patch(
+        "app.services.tables_service.fetch_product_pricing_map",
+        new=AsyncMock(return_value=pricing_map),
+    ), patch(
+        "app.services.tables_service._capture_order_item_ingredients",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.tables_service._deduct_modifier_inventory_for_order_item",
+        deduct_mock,
+    ):
+        await tables_service._add_tab_items_core(
+            mock_conn, tenant_id, user_id, table_id, items
+        )
+
+    deduct_mock.assert_called_once()
+    call_kwargs = deduct_mock.call_args.kwargs
+    assert call_kwargs["order_item_id"] == order_item_id
+    assert call_kwargs["modifier"]["name"] == "Tocineta"
+    assert call_kwargs["modifier_qty"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_remove_tab_item_returns_inventory_from_snapshots():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    order_item_id = uuid4()
+    order_id = uuid4()
+    product_id = uuid4()
+
+    row = {
+        "id": order_item_id,
+        "product_id": product_id,
+        "quantity": 1,
+        "price_at_purchase": 25.0,
+        "subtotal": 43.0,
+        "notes": None,
+        "fulfillment_status": "new",
+        "order_id": order_id,
+        "total_amount": 43.0,
+        "order_number": 99,
+        "table_session_id": uuid4(),
+        "product_name": "Santa inquisición",
+        "table_name": "Mesa 1",
+        "is_bar": False,
+        "effective_waiter_member_id": None,
+    }
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(side_effect=[row, None])
+    mock_conn.execute = AsyncMock()
+    return_mock = AsyncMock()
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    mock_request = MagicMock()
+    with patch(
+        "app.services.tables_service.require_valid_session",
+    ) as mock_sess, patch(
+        "app.services.tables_service.get_db_connection",
+        return_value=mock_cm,
+    ), patch(
+        "app.services.tables_service._fetch_order_item_modifiers",
+        new=AsyncMock(return_value=[]),
+    ), patch(
+        "app.services.tables_service._record_tab_operation_event",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.tables_service._return_tab_item_inventory_from_snapshots",
+        return_mock,
+    ):
+        mock_sess.return_value = MagicMock(
+            tenant_id=tenant_id, user_id=user_id,
+        )
+        await tables_service.remove_tab_item(
+            mock_request, table_id, order_item_id
+        )
+
+    return_mock.assert_called_once()
+    assert return_mock.call_args.kwargs["order_item_id"] == order_item_id
+
+
+@pytest.mark.asyncio
+async def test_deduct_modifier_inventory_for_order_item_writes_movement():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    order_id = uuid4()
+    order_item_id = uuid4()
+    modifier_id = uuid4()
+    ingredient_id = uuid4()
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(side_effect=[
+        {
+            "ingredient_id": ingredient_id,
+            "ingredient_quantity": 1,
+            "ingredient_unit": "und",
+            "ingredient_name": "Tocineta",
+            "controla_inventario": True,
+        },
+        {"current_stock": 10.0},
+    ])
+    mock_conn.execute = AsyncMock()
+
+    with patch(
+        "app.services.pos_cart_service.resolve_recipe_quantity_to_base_unit",
+        new=AsyncMock(return_value=1.0),
+    ), patch(
+        "app.services.pos_cart_service._capture_modifier_ingredient_snapshot",
+        new=AsyncMock(),
+    ) as snapshot_mock:
+        await pos_cart_service._deduct_modifier_inventory_for_order_item(
+            mock_conn,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            order_id=order_id,
+            order_item_id=order_item_id,
+            order_number=100,
+            item_quantity=1.0,
+            modifier={"id": modifier_id, "name": "Tocineta"},
+            modifier_qty=1.0,
+        )
+
+    assert mock_conn.execute.await_count >= 2
+    snapshot_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- Extract `_deduct_modifier_inventory_for_order_item` from counter POS so mesa/bar tab add uses the same modifier stock logic as mostrador
- Return `order_item_ingredients` snapshots when removing a tab line to avoid double base-recipe deductions on remove + re-add
- Add unit tests for tab add deduction, tab remove return, and shared helper

## Context
Mostrador already deducted modifier ingredients via `pos_cart_service.complete_cart`; mesa `_add_tab_items_core` only handled base recipes. Closes #319.

## Test plan
- [x] `pytest tests/test_tables_tab_modifier_inventory.py` (3 passed)
- [ ] Mesa: add Santa inquisición + adiciones → verify `tenant_ingredient_movements` includes Tocineta, Papas Fritas, extra Carne
- [ ] Mesa: remove tab item → verify stock returns (no duplicate deduction on re-add)
- [ ] Mostrador: complete sale with modifiers → stock still deducts (refactor parity)
- [ ] Table QR accept with modifiers → same deduction path via `_add_tab_items_core`

Closes #319

Made with [Cursor](https://cursor.com)