### PR TITLE
fix(pos): aggregate modifier COGS snapshots and ingredient quantities

### DIFF
--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -2143,6 +2143,30 @@ async def _get_last_purchase_prices(conn, ingredient_ids: List[str], tenant_id: 
     return {r["ingredient_id"]: float(r["unit_cost"]) for r in rows}
 
 
+# Aggregate qty/cost when product recipe and modifier share an ingredient; replace on
+# same-source retry so re-running capture for one source does not double-count.
+_ORDER_ITEM_INGREDIENT_UPSERT = """
+ON CONFLICT (order_item_id, ingredient_id) DO UPDATE SET
+  quantity = CASE
+    WHEN order_item_ingredients.source_type IS NOT DISTINCT FROM EXCLUDED.source_type
+     AND order_item_ingredients.source_id IS NOT DISTINCT FROM EXCLUDED.source_id
+    THEN EXCLUDED.quantity
+    ELSE order_item_ingredients.quantity + EXCLUDED.quantity
+  END,
+  unit_cost = COALESCE(order_item_ingredients.unit_cost, EXCLUDED.unit_cost),
+  total_cost = CASE
+    WHEN COALESCE(EXCLUDED.unit_cost, order_item_ingredients.unit_cost) IS NOT NULL THEN
+      (CASE
+        WHEN order_item_ingredients.source_type IS NOT DISTINCT FROM EXCLUDED.source_type
+         AND order_item_ingredients.source_id IS NOT DISTINCT FROM EXCLUDED.source_id
+        THEN EXCLUDED.quantity
+        ELSE order_item_ingredients.quantity + EXCLUDED.quantity
+      END) * COALESCE(EXCLUDED.unit_cost, order_item_ingredients.unit_cost)
+    ELSE NULL
+  END
+"""
+
+
 async def _capture_order_item_ingredients(
     conn,
     order_item_id,
@@ -2157,7 +2181,7 @@ async def _capture_order_item_ingredients(
     - product_recipes (source_type = 'product_recipe')
     - product_base_recipes → base_recipe_templates (source_type = 'base_recipe')
 
-    Idempotent via ON CONFLICT (order_item_id, ingredient_id) DO NOTHING.
+    Idempotent per source on conflict; aggregates qty/cost across product + modifier.
     """
     rows = await conn.fetch(
         """
@@ -2214,8 +2238,8 @@ async def _capture_order_item_ingredients(
                 quantity, unit, unit_cost, total_cost,
                 source_type, source_id, created_at
             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::uuid, NOW())
-            ON CONFLICT (order_item_id, ingredient_id) DO NOTHING
-            """,
+            """
+            + _ORDER_ITEM_INGREDIENT_UPSERT,
             order_item_id,
             r["ingredient_id"],
             r["ingredient_name"],
@@ -2362,7 +2386,7 @@ async def _capture_modifier_ingredient_snapshot(
     """
     Insert a single ingredient snapshot for a modifier that has ingredient_id set.
     source_type = 'MODIFIER_RECIPE', source_id = modifier_id.
-    Idempotent via ON CONFLICT (order_item_id, ingredient_id) DO NOTHING.
+    Idempotent per source on conflict; aggregates with product recipe rows.
     """
     ing_qty = modifier_ingredient.get("ingredient_quantity")
     if not ing_qty:
@@ -2389,8 +2413,8 @@ async def _capture_modifier_ingredient_snapshot(
             quantity, unit, unit_cost, total_cost,
             source_type, source_id, created_at
         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::uuid, NOW())
-        ON CONFLICT (order_item_id, ingredient_id) DO NOTHING
-        """,
+        """
+        + _ORDER_ITEM_INGREDIENT_UPSERT,
         order_item_id,
         ingredient_id,
         modifier_ingredient["ingredient_name"],

--- a/tests/test_order_item_ingredient_snapshots.py
+++ b/tests/test_order_item_ingredient_snapshots.py
@@ -1,0 +1,182 @@
+"""COGS snapshot aggregation when product recipe and modifier share an ingredient (#321)."""
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services import pos_cart_service
+
+
+CARNE_INGREDIENT_ID = uuid4()
+PRODUCT_ID = uuid4()
+ORDER_ITEM_ID = uuid4()
+MODIFIER_ID = uuid4()
+TENANT_ID = uuid4()
+BASE_RECIPE_SOURCE_ID = uuid4()
+
+
+def _product_recipe_row(quantity: float = 150.0):
+    return {
+        "source_id": str(BASE_RECIPE_SOURCE_ID),
+        "source_type": "PRODUCT_RECIPE",
+        "ingredient_id": CARNE_INGREDIENT_ID,
+        "ingredient_name": "Carne de Res",
+        "quantity": quantity,
+        "unit": "gr",
+    }
+
+
+def _modifier_ingredient_row(quantity: float = 150.0):
+    return {
+        "ingredient_id": CARNE_INGREDIENT_ID,
+        "ingredient_quantity": quantity,
+        "ingredient_unit": "gr",
+        "ingredient_name": "Carne de Res",
+        "controla_inventario": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_capture_helpers_use_aggregate_upsert_sql():
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(return_value=[_product_recipe_row()])
+    mock_conn.execute = AsyncMock()
+
+    with patch(
+        "app.services.pos_cart_service.resolve_recipe_quantity_to_base_unit",
+        new=AsyncMock(return_value=150.0),
+    ), patch(
+        "app.services.pos_cart_service._get_last_purchase_prices",
+        new=AsyncMock(return_value={str(CARNE_INGREDIENT_ID): 10.0}),
+    ):
+        await pos_cart_service._capture_order_item_ingredients(
+            mock_conn,
+            ORDER_ITEM_ID,
+            PRODUCT_ID,
+            1.0,
+            str(TENANT_ID),
+        )
+
+    product_sql = mock_conn.execute.await_args.args[0]
+    assert "order_item_ingredients.quantity + EXCLUDED.quantity" in product_sql
+    assert "DO NOTHING" not in product_sql
+
+    mock_conn.reset_mock()
+    with patch(
+        "app.services.pos_cart_service.resolve_recipe_quantity_to_base_unit",
+        new=AsyncMock(return_value=150.0),
+    ), patch(
+        "app.services.pos_cart_service._get_last_purchase_prices",
+        new=AsyncMock(return_value={str(CARNE_INGREDIENT_ID): 10.0}),
+    ):
+        await pos_cart_service._capture_modifier_ingredient_snapshot(
+            mock_conn,
+            ORDER_ITEM_ID,
+            _modifier_ingredient_row(),
+            MODIFIER_ID,
+            1.0,
+            1.0,
+            str(TENANT_ID),
+        )
+
+    modifier_sql = mock_conn.execute.await_args.args[0]
+    assert "order_item_ingredients.quantity + EXCLUDED.quantity" in modifier_sql
+    assert "DO NOTHING" not in modifier_sql
+
+
+@pytest.mark.asyncio
+async def test_modifier_then_product_snapshot_totals_300gr_carne():
+    """Santa inquisición base + Carne adición: 150gr + 150gr aggregated snapshot."""
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(return_value=[_product_recipe_row()])
+    mock_conn.execute = AsyncMock()
+    captured = []
+
+    async def record_execute(query, *args):
+        captured.append((query, args))
+
+    mock_conn.execute = AsyncMock(side_effect=record_execute)
+
+    with patch(
+        "app.services.pos_cart_service.resolve_recipe_quantity_to_base_unit",
+        new=AsyncMock(return_value=150.0),
+    ), patch(
+        "app.services.pos_cart_service._get_last_purchase_prices",
+        new=AsyncMock(return_value={str(CARNE_INGREDIENT_ID): 10.0}),
+    ):
+        await pos_cart_service._capture_modifier_ingredient_snapshot(
+            mock_conn,
+            ORDER_ITEM_ID,
+            _modifier_ingredient_row(),
+            MODIFIER_ID,
+            1.0,
+            1.0,
+            str(TENANT_ID),
+        )
+        await pos_cart_service._capture_order_item_ingredients(
+            mock_conn,
+            ORDER_ITEM_ID,
+            PRODUCT_ID,
+            1.0,
+            str(TENANT_ID),
+        )
+
+    assert len(captured) == 2
+    modifier_args = captured[0][1]
+    product_args = captured[1][1]
+    assert modifier_args[3] == pytest.approx(150.0)
+    assert modifier_args[6] == pytest.approx(1500.0)
+    assert product_args[3] == pytest.approx(150.0)
+    assert product_args[6] == pytest.approx(1500.0)
+
+
+@pytest.mark.asyncio
+async def test_modifier_snapshot_multiplies_modifier_qty():
+    mock_conn = AsyncMock()
+    mock_conn.execute = AsyncMock()
+
+    with patch(
+        "app.services.pos_cart_service.resolve_recipe_quantity_to_base_unit",
+        new=AsyncMock(return_value=150.0),
+    ), patch(
+        "app.services.pos_cart_service._get_last_purchase_prices",
+        new=AsyncMock(return_value={str(CARNE_INGREDIENT_ID): 10.0}),
+    ):
+        await pos_cart_service._capture_modifier_ingredient_snapshot(
+            mock_conn,
+            ORDER_ITEM_ID,
+            _modifier_ingredient_row(),
+            MODIFIER_ID,
+            1.0,
+            2.0,
+            str(TENANT_ID),
+        )
+
+    args = mock_conn.execute.await_args.args
+    assert args[4] == pytest.approx(300.0)
+    assert args[7] == pytest.approx(3000.0)
+
+
+@pytest.mark.asyncio
+async def test_same_source_retry_sends_replace_branch_in_sql():
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(return_value=[_product_recipe_row()])
+    mock_conn.execute = AsyncMock()
+
+    with patch(
+        "app.services.pos_cart_service.resolve_recipe_quantity_to_base_unit",
+        new=AsyncMock(return_value=150.0),
+    ), patch(
+        "app.services.pos_cart_service._get_last_purchase_prices",
+        new=AsyncMock(return_value={str(CARNE_INGREDIENT_ID): 10.0}),
+    ):
+        await pos_cart_service._capture_order_item_ingredients(
+            mock_conn, ORDER_ITEM_ID, PRODUCT_ID, 1.0, str(TENANT_ID),
+        )
+        await pos_cart_service._capture_order_item_ingredients(
+            mock_conn, ORDER_ITEM_ID, PRODUCT_ID, 1.0, str(TENANT_ID),
+        )
+
+    sql = mock_conn.execute.await_args.args[0]
+    assert "THEN EXCLUDED.quantity" in sql
+    assert mock_conn.execute.await_count == 2


### PR DESCRIPTION
## Summary
- Replace `ON CONFLICT DO NOTHING` with aggregate upsert on `order_item_ingredients` so product recipe + modifier rows for the same ingredient sum qty and `total_cost`.
- Same-source retries replace quantity (no double-count); cross-source conflicts add (Santa Inquisición + Carne adición → 300gr).
- Unit tests for upsert SQL, modifier_qty ×2, and checkout capture order.

Closes #321

Epic: uno0uno/warocol.com#967 (batch 1)

## Test plan
- [ ] `pytest tests/test_order_item_ingredient_snapshots.py`
- [ ] POS sale: product with base recipe + modifier sharing ingredient → one `order_item_ingredients` row with summed qty
- [ ] COGS GL (6135/1435) amount matches `SUM(order_item_ingredients.total_cost)` for order
- [ ] Modifier qty 2 on linked ingredient → snapshot qty = recipe × item_qty × modifier_qty
- [ ] Order #14357-style regression: inventory −300gr Carne, snapshot 300gr, COGS aligned

## Manual verification
1. Complete POS order: Santa Inquisición + Carne de Res adición.
2. Query `order_item_ingredients` for the line — expect single Carne row, quantity 300 (gr).
3. Compare `tenant_journal_entries` COGS line to movement consumption cost.


Made with [Cursor](https://cursor.com)