### PR TITLE
fix(api): expose modifier max_limit in POS products include_modifiers

### DIFF
--- a/app/services/products_service.py
+++ b/app/services/products_service.py
@@ -490,6 +490,7 @@ async def get_product_by_id(
                         m.price,
                         m.is_available,
                         m.is_default,
+                        m.max_limit,
                         m.sort_order
                     FROM modifiers m
                     WHERE m.modifier_group_id = ANY($1::uuid[])
@@ -509,6 +510,7 @@ async def get_product_by_id(
                         'price': mod['price'],
                         'is_available': mod['is_available'],
                         'is_default': mod['is_default'],
+                        'max_limit': mod['max_limit'],
                         'sort_order': mod['sort_order']
                     })
 
@@ -830,6 +832,7 @@ async def get_products_list(
                                 m.price,
                                 m.is_available,
                                 m.is_default,
+                                m.max_limit,
                                 m.sort_order
                             FROM modifiers m
                             WHERE m.modifier_group_id = ANY($1::uuid[])
@@ -849,6 +852,7 @@ async def get_products_list(
                                 'price': mod['price'],
                                 'is_available': mod['is_available'],
                                 'is_default': mod['is_default'],
+                                'max_limit': mod['max_limit'],
                                 'sort_order': mod['sort_order']
                             })
 

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -95,6 +95,11 @@ class TestProductsListEndpoint:
             if len(data["data"]) > 0:
                 product = data["data"][0]
                 assert "modifier_groups" in product
+                for group in product.get("modifier_groups", []):
+                    modifiers = group.get("modifiers", [])
+                    if modifiers:
+                        assert "max_limit" in modifiers[0]
+                        break
 
     @pytest.mark.asyncio
     async def test_get_products_invalid_page(self, client: AsyncClient):


### PR DESCRIPTION
## Summary
- Add `max_limit` to modifier SELECT and JSON payload when loading products with `include_modifiers=true` (POS cache path)
- Mirror same field on single-product detail fetch for parity
- Extend product test to assert `max_limit` on modifiers when present

## Test plan
- [ ] `GET /menu/products?include_modifiers=true` — each modifier includes `max_limit` matching DB/admin
- [ ] POS: set Carne **Máx = 2** in `/menu/modificadores` → reload POS → stepper allows ×2 (warocol.com#968)
- [ ] `pytest tests/test_products.py::TestProducts::test_get_products_include_modifiers` passes when authenticated

Closes #323
Companion: enables admin **Máx** for warocol.com#968 POS stepper

Made with [Cursor](https://cursor.com)