### PR TITLE
fix(api): Pydantic Modifier model must expose max_limit

### DIFF
--- a/app/models/product.py
+++ b/app/models/product.py
@@ -10,6 +10,7 @@ class Modifier(BaseModel):
     id: UUID
     name: str
     price: Decimal
+    max_limit: int = Field(default=1, ge=1, description="Max times this option can be added")
     is_available: Optional[bool] = True
     is_default: Optional[bool] = False
     sort_order: Optional[int] = None


### PR DESCRIPTION
## Summary
- Add `max_limit` to `app/models/product.py` `Modifier` model
- Completes #323 — SQL already returned the column but Pydantic dropped it before JSON

## Test plan
- [ ] `GET /menu/products?include_modifiers=true` → Carne de Res includes `"max_limit": 5`
- [ ] POS Santa Inquisición → stepper allows up to admin **Máx**
- [ ] Hard refresh `/pos` after API reload to refresh product cache

Closes #323

Made with [Cursor](https://cursor.com)