### PR TITLE
fix(pos): persist modifier quantity on mesa tab and comanda

### DIFF
--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -41,6 +41,7 @@ class TabModifier(BaseModel):
     id: Optional[str] = None
     name: Optional[str] = None
     price: float = 0.0
+    quantity: float = Field(default=1.0, gt=0)
 
 
 class TabItem(BaseModel):
@@ -265,7 +266,7 @@ async def add_tab_items(request: Request, table_id: UUID, body: TabAddRequest):
             "quantity": item.quantity,
             "unit_price": item.unit_price,
             "modifiers": [
-                {"id": m.id, "name": m.name, "price": m.price}
+                {"id": m.id, "name": m.name, "price": m.price, "quantity": m.quantity}
                 for m in (item.modifiers or [])
             ],
             "notes": item.notes,

--- a/app/services/comandas_service.py
+++ b/app/services/comandas_service.py
@@ -243,7 +243,7 @@ async def _fire_with_conn(
             # Build modifiers_snapshot from order_item_modifiers
             mod_rows = await conn.fetch(
                 """
-                SELECT modifier_name, price_at_purchase
+                SELECT modifier_name, price_at_purchase, quantity
                 FROM order_item_modifiers
                 WHERE order_item_id = $1
                 ORDER BY created_at
@@ -251,7 +251,11 @@ async def _fire_with_conn(
                 order_item_id,
             )
             modifiers_snapshot = [
-                {"name": m['modifier_name'], "price": float(m['price_at_purchase'])}
+                {
+                    "name": m['modifier_name'],
+                    "price": float(m['price_at_purchase']),
+                    "quantity": int(m['quantity']),
+                }
                 for m in mod_rows
             ] if mod_rows else None
 

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -52,6 +52,10 @@ _QR_TOKEN_URLSAFE_BYTES = 32
 _QR_TOKEN_MAX_ATTEMPTS = 5
 
 
+def _modifier_unit_total(mod: dict) -> float:
+    return float(mod.get("price", 0)) * float(mod.get("quantity", 1))
+
+
 async def _generate_unique_qr_token(conn) -> str:
     """Opaque token for public table QR URLs (api-warolabs#266)."""
     for _ in range(_QR_TOKEN_MAX_ATTEMPTS):
@@ -1795,7 +1799,8 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                             json_build_object(
                                 'id', oim.modifier_id::text,
                                 'name', oim.modifier_name,
-                                'price', oim.price_at_purchase
+                                'price', oim.price_at_purchase,
+                                'quantity', oim.quantity
                             ) ORDER BY oim.created_at
                         ) FILTER (WHERE oim.order_item_id IS NOT NULL),
                         '[]'::json
@@ -1908,6 +1913,7 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                                 "id": mod["id"],
                                 "name": mod["name"],
                                 "price": float(mod["price"]),
+                                "quantity": int(mod.get("quantity") or 1),
                             }
                             for mod in (
                                 json.loads(r["modifiers"])
@@ -2030,6 +2036,7 @@ def _modifiers_from_request_item(item: dict) -> List[Dict[str, Any]]:
             "id": m.get("id"),
             "name": m.get("name"),
             "price": float(m.get("price", 0)),
+            "quantity": float(m.get("quantity", 1)),
         }
         for m in (item.get("modifiers") or [])
     ]
@@ -2413,7 +2420,11 @@ async def update_tab_item_quantity(
             modifiers = await _fetch_order_item_modifiers(conn, order_item_id)
 
             modifier_sum = await conn.fetchval(
-                "SELECT COALESCE(SUM(price_at_purchase), 0) FROM order_item_modifiers WHERE order_item_id = $1",
+                """
+                SELECT COALESCE(SUM(price_at_purchase * quantity), 0)
+                FROM order_item_modifiers
+                WHERE order_item_id = $1
+                """,
                 order_item_id,
             )
             effective_unit_price = float(row["price_at_purchase"]) + float(modifier_sum)
@@ -2510,7 +2521,7 @@ async def _add_tab_items_core(
     validate_items_unit_prices(pricing_map, items)
 
     for item in items:
-        mod_sum = sum(float(m.get("price", 0)) for m in (item.get("modifiers") or []))
+        mod_sum = sum(_modifier_unit_total(m) for m in (item.get("modifiers") or []))
         logger.info(
             f"[add_tab_items] item product_id={item['product_id']} "
             f"qty={item['quantity']} unit_price={item['unit_price']} "
@@ -2520,7 +2531,7 @@ async def _add_tab_items_core(
     batch_amount = sum(
         item["quantity"] * (
             item["unit_price"]
-            + sum(float(m.get("price", 0)) for m in (item.get("modifiers") or []))
+            + sum(_modifier_unit_total(m) for m in (item.get("modifiers") or []))
         )
         for item in items
     )
@@ -2573,7 +2584,7 @@ async def _add_tab_items_core(
         logger.info(f"[add_tab_items] created new order {order_id}")
 
     for item in items:
-        modifier_unit_total = sum(float(m.get("price", 0)) for m in (item.get("modifiers") or []))
+        modifier_unit_total = sum(_modifier_unit_total(m) for m in (item.get("modifiers") or []))
         subtotal = item["quantity"] * (item["unit_price"] + modifier_unit_total)
         item_notes = (item.get("notes") or "").strip() or None
         order_item_row = await conn.fetchrow(

--- a/tests/test_tables_tab_modifier_inventory.py
+++ b/tests/test_tables_tab_modifier_inventory.py
@@ -77,6 +77,74 @@ async def test_add_tab_items_core_deducts_modifier_inventory():
 
 
 @pytest.mark.asyncio
+async def test_add_tab_items_core_persists_modifier_quantity():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    session_id = uuid4()
+    order_id = uuid4()
+    product_id = uuid4()
+    order_item_id = uuid4()
+    modifier_id = uuid4()
+
+    session_row = {
+        "session_id": session_id,
+        "table_name": "Mesa 3",
+        "is_bar": False,
+        "effective_waiter_member_id": None,
+    }
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(side_effect=[
+        session_row,
+        None,
+        {"id": order_id, "order_number": 42, "total_amount": 61.0},
+        {"id": order_item_id},
+    ])
+    mock_conn.fetch = AsyncMock(return_value=[])
+    mock_conn.execute = AsyncMock()
+
+    items = [{
+        "product_id": product_id,
+        "quantity": 1,
+        "unit_price": 25.0,
+        "modifiers": [{
+            "id": str(modifier_id),
+            "name": "Carne de Res",
+            "price": 9.0,
+            "quantity": 3,
+        }],
+    }]
+
+    pricing_map = {str(product_id): {"price": Decimal("25.00"), "open_priced": False}}
+
+    with patch(
+        "app.services.tables_service._record_tab_operation_event",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.tables_service._prefetch_product_names",
+        new=AsyncMock(return_value={str(product_id): "Santa inquisición"}),
+    ), patch(
+        "app.services.tables_service.fetch_product_pricing_map",
+        new=AsyncMock(return_value=pricing_map),
+    ), patch(
+        "app.services.tables_service._capture_order_item_ingredients",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.tables_service._deduct_modifier_inventory_for_order_item",
+        new=AsyncMock(),
+    ):
+        await tables_service._add_tab_items_core(
+            mock_conn, tenant_id, user_id, table_id, items
+        )
+
+    insert_call = mock_conn.execute.call_args_list[0]
+    assert insert_call.args[5] == 3
+
+    order_item_insert = mock_conn.fetchrow.call_args_list[3]
+    assert order_item_insert.args[5] == 25.0 + 9.0 * 3
+
+
+@pytest.mark.asyncio
 async def test_remove_tab_item_returns_inventory_from_snapshots():
     tenant_id = uuid4()
     user_id = uuid4()


### PR DESCRIPTION
## Summary
- Accept `modifiers[].quantity` on `POST /tables/{id}/tab/add` and persist to `order_item_modifiers.quantity`
- Use `price × quantity` for tab subtotals, batch totals, and tab item qty updates
- Return modifier `quantity` in `GET /tables/{id}/current` tab_items
- Include `quantity` (and price) in comanda `modifiers_snapshot`
- Add test for tab add with modifier quantity > 1

Related: uno0uno/warocol.com#970 (PR 1 of 2 — front print templates follow in warocol.com PR 2)

## Test plan
- [x] `pytest tests/test_tables_tab_modifier_inventory.py -q` (4 passed)
- [ ] Manual: mesa tab add Santa Inquisición + Carne ×3 → subtotal 52, GET current returns qty=3
- [ ] Manual: fire comanda → kitchen ticket snapshot includes `"quantity": 3`
- [ ] Manual: increment tab item qty on line with Carne ×3 → subtotal recalculates correctly


Made with [Cursor](https://cursor.com)