### PR TITLE
fix(orders): return modifier quantity in order items detail

### DIFF
--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -945,7 +945,8 @@ async def get_order_items(
                         id,
                         modifier_id,
                         modifier_name,
-                        price_at_purchase
+                        price_at_purchase,
+                        quantity
                     FROM order_item_modifiers
                     WHERE order_item_id = $1
                 """
@@ -956,7 +957,8 @@ async def get_order_items(
                         "id": str(mod['id']),  # order_item_modifier ID for deletion
                         "modifier_id": str(mod['modifier_id']) if mod['modifier_id'] else None,
                         "name": mod['modifier_name'],
-                        "price": float(mod['price_at_purchase'])
+                        "price": float(mod['price_at_purchase']),
+                        "quantity": int(mod['quantity'] or 1),
                     }
                     for mod in modifiers_rows
                 ]


### PR DESCRIPTION
## Summary
- Include `order_item_modifiers.quantity` in `GET /orders/{id}/items` modifier objects (default 1)
- Aligns with mesa tab / comanda pattern from #970

## Test plan
- [ ] `GET /orders/{id}/items` for an order with modifier qty > 1 returns `modifiers[].quantity`
- [ ] Deploy before or with warocol.com PR #974

## Related
- Front: https://github.com/uno0uno/warocol.com/pull/974
- Issue: https://github.com/uno0uno/warocol.com/issues/973