### PR TITLE
fix(tables): register per-table QR admin routes

### DIFF
--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -64,6 +64,10 @@ class UpdateTabItemRequest(BaseModel):
     )
 
 
+class TableQrToggleRequest(BaseModel):
+    enabled: bool
+
+
 @router.get("", dependencies=[Depends(require_module(Module.POS))])
 async def list_tables(request: Request, include_inactive: bool = Query(False)):
     """
@@ -109,6 +113,24 @@ async def deactivate_table(request: Request, table_id: UUID):
     Issue: https://github.com/uno0uno/warocol.com/issues/436
     """
     return await tables_service.deactivate_table(request, table_id)
+
+
+@router.patch("/{table_id}/qr", dependencies=[Depends(require_module(Module.POS))])
+async def set_table_qr_enabled(request: Request, table_id: UUID, body: TableQrToggleRequest):
+    """
+    Enable/disable per-table QR ordering. Generates public token on first enable.
+    Issue: https://github.com/uno0uno/warocol.com/issues/976 (api-warolabs#266)
+    """
+    return await tables_service.set_table_qr_enabled(request, table_id, body.enabled)
+
+
+@router.post("/{table_id}/qr-token/regenerate", dependencies=[Depends(require_module(Module.POS))])
+async def regenerate_table_qr_token(request: Request, table_id: UUID):
+    """
+    Issue a new public QR token; previous printed codes stop resolving.
+    Issue: https://github.com/uno0uno/warocol.com/issues/976 (api-warolabs#266)
+    """
+    return await tables_service.regenerate_table_qr_token(request, table_id)
 
 
 @router.delete("/{table_id}", dependencies=[Depends(require_module(Module.POS))])

--- a/tests/test_table_qr_tokens.py
+++ b/tests/test_table_qr_tokens.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 from app.core.exceptions import APIError
 from app.core.middleware import SessionContext
 from app.routers import public_table_qr as public_table_qr_router
+from app.routers import tables as tables_router
 from app.services import public_table_qr_service, tables_service
 
 
@@ -167,3 +168,57 @@ async def test_set_table_qr_enabled_generates_token():
         result = await tables_service.set_table_qr_enabled(MagicMock(), table_id, True)
         assert result["data"]["qr_public_token"] == token
         assert result["data"]["qr_enabled"] is True
+
+
+def test_patch_table_qr_route_delegates_to_service():
+    """HTTP layer: PATCH /tables/{id}/qr is registered (warocol.com#976)."""
+    app = FastAPI()
+    app.include_router(tables_router.router, prefix="/tables")
+    table_id = uuid4()
+    payload = {
+        "success": True,
+        "data": {
+            "id": str(table_id),
+            "name": "Mesa 1",
+            "qr_enabled": True,
+            "qr_public_token": "tok-abc",
+        },
+    }
+
+    with patch(
+        "app.routers.tables.tables_service.set_table_qr_enabled",
+        new_callable=AsyncMock,
+        return_value=payload,
+    ):
+        client = TestClient(app)
+        res = client.patch(f"/tables/{table_id}/qr", json={"enabled": True})
+
+    assert res.status_code == 200
+    assert res.json()["data"]["qr_enabled"] is True
+
+
+def test_post_table_qr_token_regenerate_route_delegates_to_service():
+    """HTTP layer: POST /tables/{id}/qr-token/regenerate is registered (warocol.com#976)."""
+    app = FastAPI()
+    app.include_router(tables_router.router, prefix="/tables")
+    table_id = uuid4()
+    payload = {
+        "success": True,
+        "data": {
+            "id": str(table_id),
+            "name": "Mesa 1",
+            "qr_enabled": True,
+            "qr_public_token": "tok-new",
+        },
+    }
+
+    with patch(
+        "app.routers.tables.tables_service.regenerate_table_qr_token",
+        new_callable=AsyncMock,
+        return_value=payload,
+    ):
+        client = TestClient(app)
+        res = client.post(f"/tables/{table_id}/qr-token/regenerate")
+
+    assert res.status_code == 200
+    assert res.json()["data"]["qr_public_token"] == "tok-new"


### PR DESCRIPTION
## Summary
- Add `PATCH /tables/{table_id}/qr` (`{ enabled: bool }`) → `set_table_qr_enabled`
- Add `POST /tables/{table_id}/qr-token/regenerate` → `regenerate_table_qr_token`
- HTTP tests confirm routes are registered (service logic unchanged)

Fixes https://github.com/uno0uno/warocol.com/issues/976

## Test plan
- [x] `pytest tests/test_table_qr_tokens.py` (7 passed)
- [ ] Deploy API → `/operaciones/mesas` → toggle QR on mesa → 200, token generated
- [ ] Copy link / download PNG work
- [ ] Inactive mesa → 409 (expected)


Made with [Cursor](https://cursor.com)