### PR TITLE
fix(tables): cancel pending orders on liberar mesa without payment

### DIFF
--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -1265,6 +1265,14 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                             reason=reason,
                         )
 
+                    if pending_count and pending_count > 0:
+                        cancelled_count = await _cancel_pending_session_orders_on_release(
+                            conn,
+                            tenant_id,
+                            session_row["id"],
+                        )
+                        pending_count = max(0, int(pending_count) - cancelled_count)
+
                 if not split_mode:
                     # Close session
                     await conn.execute(
@@ -1292,42 +1300,42 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                             tenant_id,
                         )
 
-                # Auto-fire hook: if comandas enabled, fire all 'new' items for this session
-                # This ensures any items added but not explicitly fired get sent at checkout
-                try:
-                    _prof = await conn.fetchrow(
-                        "SELECT comandas_enabled FROM tenant_public_profiles WHERE tenant_id = $1",
-                        tenant_id
-                    )
-                    if _prof and _prof["comandas_enabled"]:
-                        # Find all pending orders for this session (they might have been completed just above)
-                        # We need to fire them. fire_comandas handles 'new' status check.
-                        session_orders = await conn.fetch(
-                            "SELECT id FROM orders WHERE table_session_id = $1",
-                            session_row["id"]
+                # Auto-fire hook: checkout only — skip on liberar mesa (#330)
+                if payment_method:
+                    try:
+                        _prof = await conn.fetchrow(
+                            "SELECT comandas_enabled FROM tenant_public_profiles WHERE tenant_id = $1",
+                            tenant_id
                         )
-                        for _order in session_orders:
-                            await fire_comandas(
-                                order_id=_order["id"],
-                                tenant_id=tenant_id,
-                                source_type='table',
-                                table_display_name=table_row["name"],
-                                conn=conn
+                        if _prof and _prof["comandas_enabled"]:
+                            # Find all pending orders for this session (they might have been completed just above)
+                            # We need to fire them. fire_comandas handles 'new' status check.
+                            session_orders = await conn.fetch(
+                                "SELECT id FROM orders WHERE table_session_id = $1",
+                                session_row["id"]
                             )
+                            for _order in session_orders:
+                                await fire_comandas(
+                                    order_id=_order["id"],
+                                    tenant_id=tenant_id,
+                                    source_type='table',
+                                    table_display_name=table_row["name"],
+                                    conn=conn
+                                )
 
-                        # Mesa: auto-deliver open comandas on payment. Barra: kitchen closes
-                        # them manually (warocol.com#799).
-                        if not is_bar_table:
-                            session_order_ids = [_o["id"] for _o in session_orders]
-                            await conn.execute("""
-                                UPDATE comandas
-                                SET status = 'delivered', delivered_at = NOW(), updated_at = NOW()
-                                WHERE order_id = ANY($1::uuid[])
-                                  AND tenant_id = $2
-                                  AND status IN ('pending', 'preparing', 'ready')
-                            """, session_order_ids, tenant_id)
-                except Exception as _fe:
-                    logger.error(f"Auto-fire failed during close_session for table {table_id}: {_fe}")
+                            # Mesa: auto-deliver open comandas on payment. Barra: kitchen closes
+                            # them manually (warocol.com#799).
+                            if not is_bar_table:
+                                session_order_ids = [_o["id"] for _o in session_orders]
+                                await conn.execute("""
+                                    UPDATE comandas
+                                    SET status = 'delivered', delivered_at = NOW(), updated_at = NOW()
+                                    WHERE order_id = ANY($1::uuid[])
+                                      AND tenant_id = $2
+                                      AND status IN ('pending', 'preparing', 'ready')
+                                """, session_order_ids, tenant_id)
+                    except Exception as _fe:
+                        logger.error(f"Auto-fire failed during close_session for table {table_id}: {_fe}")
 
         if split_mode:
             # Compute paid_total and remaining for the split response
@@ -2143,6 +2151,59 @@ async def _record_tab_cleared_pending_lines(
             ),
         )
     return len(pending_lines)
+
+
+async def _cancel_pending_session_orders_on_release(
+    conn,
+    tenant_id: UUID,
+    session_id: UUID,
+) -> int:
+    """Cancel pending orders and comandas when liberar mesa without payment (#330)."""
+    await conn.execute(
+        """
+        UPDATE comanda_items
+        SET status = 'cancelled',
+            cancelled_at = NOW(),
+            order_item_id = NULL
+        WHERE order_item_id IN (
+            SELECT oi.id
+            FROM order_items oi
+            JOIN orders o ON o.id = oi.order_id
+            WHERE o.table_session_id = $1 AND o.status = 'pending'
+        )
+        """,
+        session_id,
+    )
+
+    await conn.execute(
+        """
+        UPDATE comandas
+        SET status = 'cancelled', updated_at = NOW()
+        WHERE order_id IN (
+            SELECT id FROM orders
+            WHERE table_session_id = $1 AND status = 'pending'
+        )
+          AND tenant_id = $2
+          AND status IN ('pending', 'preparing', 'ready')
+        """,
+        session_id,
+        tenant_id,
+    )
+
+    cancelled = await conn.fetchval(
+        """
+        WITH cancelled AS (
+            UPDATE orders
+            SET status = 'cancelled',
+                payment_status = NULL
+            WHERE table_session_id = $1 AND status = 'pending'
+            RETURNING id
+        )
+        SELECT COUNT(*) FROM cancelled
+        """,
+        session_id,
+    )
+    return int(cancelled or 0)
 
 
 async def _return_tab_item_inventory_from_snapshots(

--- a/tests/test_close_session_release.py
+++ b/tests/test_close_session_release.py
@@ -1,0 +1,132 @@
+"""close_session release path — cancel pending orders on liberar mesa (#330)."""
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.exceptions import APIError
+from app.services import tables_service
+
+
+def _mock_conn(*, session_id, pending_count=1, pending_line_count=1, cancelled_count=1):
+    executed: list[str] = []
+    fetchval_calls: list[str] = []
+    mock_conn = AsyncMock()
+
+    async def track_execute(sql, *args):
+        executed.append(sql.strip())
+
+    async def track_fetchval(sql, *args):
+        fetchval_calls.append(sql.strip())
+        if "COUNT(*) FROM orders WHERE table_session_id" in sql and "pending" in sql:
+            if len([c for c in fetchval_calls if "COUNT(*) FROM orders" in c]) == 1:
+                return pending_count
+            return cancelled_count
+        if "COUNT(*) FROM order_items" in sql:
+            return pending_line_count
+        return cancelled_count
+
+    mock_conn.execute = AsyncMock(side_effect=track_execute)
+    mock_conn.fetchrow = AsyncMock(
+        side_effect=[
+            {"id": uuid4(), "is_bar": False, "name": "Mesa 1"},
+            {"id": session_id, "effective_waiter_member_id": None},
+        ]
+    )
+    mock_conn.fetchval = AsyncMock(side_effect=track_fetchval)
+    mock_conn.fetch = AsyncMock(return_value=[])
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+    return mock_conn, executed, fetchval_calls
+
+
+def _connection_cm(mock_conn):
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+    return mock_cm
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_session_orders_on_release_updates_comandas_and_orders():
+    tenant_id = uuid4()
+    session_id = uuid4()
+    mock_conn, executed, fetchval_calls = _mock_conn(session_id=session_id)
+
+    cancelled = await tables_service._cancel_pending_session_orders_on_release(
+        mock_conn,
+        tenant_id,
+        session_id,
+    )
+
+    assert cancelled == 1
+    assert any("UPDATE comanda_items" in s and "cancelled" in s for s in executed)
+    assert any("UPDATE comandas" in s and "cancelled" in s for s in executed)
+    assert any("UPDATE orders" in s and "cancelled" in s for s in fetchval_calls)
+
+
+@pytest.mark.asyncio
+async def test_close_session_release_cancels_pending_orders():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    session_id = uuid4()
+
+    mock_conn, _, _ = _mock_conn(session_id=session_id, pending_count=2, pending_line_count=2)
+    mock_cm = _connection_cm(mock_conn)
+
+    with patch("app.services.tables_service.require_valid_session") as mock_sess, \
+         patch("app.services.tables_service.get_db_connection", return_value=mock_cm), \
+         patch(
+             "app.services.tables_service._record_tab_cleared_pending_lines",
+             new=AsyncMock(return_value=2),
+         ), \
+         patch(
+             "app.services.tables_service._cancel_pending_session_orders_on_release",
+             new=AsyncMock(return_value=2),
+         ) as mock_cancel, \
+         patch(
+             "app.services.tables_service.fire_comandas",
+             new=AsyncMock(),
+         ) as mock_fire:
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+        result = await tables_service.close_session(
+            MagicMock(),
+            table_id,
+            payment_method=None,
+            reason="Cliente se fue",
+        )
+
+    mock_cancel.assert_called_once()
+    mock_fire.assert_not_called()
+    assert result["data"]["pending_orders"] == 0
+
+
+@pytest.mark.asyncio
+async def test_close_session_release_without_reason_raises_400():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    session_id = uuid4()
+
+    mock_conn, _, _ = _mock_conn(session_id=session_id, pending_count=1, pending_line_count=1)
+    mock_cm = _connection_cm(mock_conn)
+
+    with patch("app.services.tables_service.require_valid_session") as mock_sess, \
+         patch("app.services.tables_service.get_db_connection", return_value=mock_cm):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+        with pytest.raises(APIError) as exc:
+            await tables_service.close_session(
+                MagicMock(),
+                table_id,
+                payment_method=None,
+                reason="",
+            )
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## Summary
- Cancel pending session orders (and comandas) when staff use **Liberar mesa** without payment
- Skip auto-fire / auto-deliver comandas on release; keep checkout behavior unchanged
- Add regression tests for the release path

Closes #330

## Test plan
- [x] `pytest tests/test_close_session_release.py -v` (3 tests)
- [ ] Manual: liberar mesa with pending items → orders `cancelled`, bitácora `tab_cleared`
- [ ] Manual: checkout with payment still completes orders and fires comandas
- [ ] Manual: `DELETE /tab` (vaciar cuenta) unchanged


Made with [Cursor](https://cursor.com)