### PR TITLE
feat(promotions): tenant promotion CRUD API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, online_cart, online_verification, address_profile, analytics, online_orders, notifications, customer_portal, leads, waros, billing, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
+from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, customer_portal, leads, waros, billing, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
 from app.config import settings
 from app.core.logging import setup_logging
 from app.core.exceptions import api_exception_handler, general_exception_handler, APIError
@@ -199,6 +199,7 @@ app.include_router(public_restaurant.router, prefix="/public/restaurant", tags=[
 app.include_router(public_table_qr.router, prefix="/public/table-qr", tags=["public-table-qr"])
 app.include_router(table_qr_requests.router, prefix="/table-qr-requests", tags=["table-qr-requests"])
 app.include_router(tenant_config.router, prefix="/api/tenant", tags=["tenant-config"])
+app.include_router(promotions.router)  # /api/promotions — tenant promotion CRUD (#980)
 app.include_router(stations.router, prefix="/api/stations", tags=["stations"])
 app.include_router(tables.router, prefix="/tables", tags=["tables"])
 app.include_router(comandas.router, prefix="/api/comandas", tags=["comandas"])

--- a/app/models/tenant_promotion.py
+++ b/app/models/tenant_promotion.py
@@ -1,0 +1,140 @@
+"""Pydantic models for tenant promotions (warocol.com#980)."""
+from datetime import datetime, time
+from enum import Enum
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class PromoType(str, Enum):
+    PERCENT_OFF = "percent_off"
+    FIXED_OFF = "fixed_off"
+    BOGO = "bogo"
+
+
+class ScopeType(str, Enum):
+    ALL_PRODUCTS = "all_products"
+    CATEGORIES = "categories"
+    PRODUCTS = "products"
+
+
+def _validate_schedule_window(
+    *,
+    start_time: time,
+    end_time: time,
+    crosses_midnight: bool,
+) -> None:
+    if not crosses_midnight and end_time <= start_time:
+        raise ValueError(
+            "end_time must be after start_time when crosses_midnight is false"
+        )
+
+
+class PromotionScheduleInput(BaseModel):
+    days_of_week: int = Field(
+        ...,
+        ge=1,
+        le=127,
+        description="Bitmask Mon=1, Tue=2, Wed=4, Thu=8, Fri=16, Sat=32, Sun=64",
+    )
+    start_time: time
+    end_time: time
+    crosses_midnight: bool = False
+    sort_order: int = Field(0, ge=0, le=32767)
+
+    @model_validator(mode="after")
+    def _validate_window(self):
+        _validate_schedule_window(
+            start_time=self.start_time,
+            end_time=self.end_time,
+            crosses_midnight=self.crosses_midnight,
+        )
+        return self
+
+
+class PromotionScheduleResponse(PromotionScheduleInput):
+    id: UUID
+
+
+class PromotionCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    promo_type: PromoType
+    value_json: Dict[str, Any] = Field(default_factory=dict)
+    scope_type: ScopeType
+    category_ids: List[UUID] = Field(default_factory=list)
+    product_ids: List[UUID] = Field(default_factory=list)
+    schedules: List[PromotionScheduleInput] = Field(default_factory=list)
+    priority: int = Field(0, ge=0, le=32767)
+    is_active: bool = True
+    stackable: bool = False
+    starts_at: Optional[datetime] = None
+    ends_at: Optional[datetime] = None
+
+    @model_validator(mode="after")
+    def _validate_scope_and_values(self):
+        if self.scope_type == ScopeType.CATEGORIES and not self.category_ids:
+            raise ValueError("category_ids required when scope_type is categories")
+        if self.scope_type == ScopeType.PRODUCTS and not self.product_ids:
+            raise ValueError("product_ids required when scope_type is products")
+        if self.starts_at and self.ends_at and self.ends_at <= self.starts_at:
+            raise ValueError("ends_at must be after starts_at")
+        if self.promo_type == PromoType.PERCENT_OFF:
+            pct = self.value_json.get("percent")
+            if pct is None or not (0 < float(pct) <= 100):
+                raise ValueError("percent_off requires value_json.percent in (0, 100]")
+        elif self.promo_type == PromoType.FIXED_OFF:
+            if self.value_json.get("amount_cop") is None:
+                raise ValueError("fixed_off requires value_json.amount_cop")
+        elif self.promo_type == PromoType.BOGO:
+            buy = self.value_json.get("buy_qty")
+            get = self.value_json.get("get_qty")
+            if not buy or not get or int(buy) < 1 or int(get) < 1:
+                raise ValueError("bogo requires value_json.buy_qty and get_qty >= 1")
+        return self
+
+
+class PromotionUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=120)
+    promo_type: Optional[PromoType] = None
+    value_json: Optional[Dict[str, Any]] = None
+    scope_type: Optional[ScopeType] = None
+    category_ids: Optional[List[UUID]] = None
+    product_ids: Optional[List[UUID]] = None
+    schedules: Optional[List[PromotionScheduleInput]] = None
+    priority: Optional[int] = Field(None, ge=0, le=32767)
+    is_active: Optional[bool] = None
+    stackable: Optional[bool] = None
+    starts_at: Optional[datetime] = None
+    ends_at: Optional[datetime] = None
+
+
+class PromotionResponse(BaseModel):
+    id: UUID
+    tenant_id: UUID
+    name: str
+    promo_type: PromoType
+    value_json: Dict[str, Any]
+    scope_type: ScopeType
+    category_ids: List[UUID]
+    product_ids: List[UUID]
+    schedules: List[PromotionScheduleResponse]
+    priority: int
+    is_active: bool
+    stackable: bool
+    starts_at: Optional[datetime] = None
+    ends_at: Optional[datetime] = None
+    is_currently_active: Optional[bool] = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class PromotionListResponse(BaseModel):
+    success: bool = True
+    total: int
+    data: List[PromotionResponse]
+
+
+class PromotionSingleResponse(BaseModel):
+    success: bool = True
+    data: PromotionResponse

--- a/app/routers/promotions.py
+++ b/app/routers/promotions.py
@@ -1,0 +1,114 @@
+"""Tenant promotion CRUD and POS active read (warocol.com#980)."""
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query, Request
+
+from app.core.permissions import Module, require_module
+from app.models.tenant_promotion import PromotionCreate, PromotionUpdate
+from app.services import promotions_service
+
+router = APIRouter(prefix="/api/promotions", tags=["promotions"])
+
+_CONFLICT_DOC = promotions_service.CONFLICT_RULES_DOC
+
+
+@router.get(
+    "",
+    dependencies=[Depends(require_module(Module.MI_NEGOCIO))],
+    summary="List tenant promotions",
+    description=(
+        "Returns promotions for the current tenant ordered by priority (desc). "
+        f"Conflict rules: {_CONFLICT_DOC}"
+    ),
+)
+async def list_promotions_endpoint(
+    request: Request,
+    include_inactive: bool = Query(
+        False, description="Include deactivated promotions (admin)."
+    ),
+    at: Optional[datetime] = Query(
+        None,
+        description="Optional ISO timestamp; when set, each row includes is_currently_active.",
+    ),
+):
+    return await promotions_service.list_promotions(
+        request,
+        include_inactive=include_inactive,
+        at=at,
+    )
+
+
+@router.post(
+    "",
+    status_code=201,
+    dependencies=[Depends(require_module(Module.MI_NEGOCIO))],
+    summary="Create promotion",
+    description=f"Create a tenant promotion. {_CONFLICT_DOC}",
+)
+async def create_promotion_endpoint(request: Request, body: PromotionCreate):
+    return await promotions_service.create_promotion(request, body)
+
+
+@router.get(
+    "/active",
+    dependencies=[Depends(require_module(Module.POS))],
+    summary="List promotions with active status for POS",
+    description=(
+        "Read-only endpoint for POS. Evaluates schedules in America/Bogota. "
+        f"{_CONFLICT_DOC}"
+    ),
+)
+async def list_active_promotions_endpoint(
+    request: Request,
+    at: Optional[datetime] = Query(
+        None,
+        description="Evaluation timestamp (ISO). Defaults to now in America/Bogota.",
+    ),
+    only_current: bool = Query(
+        False,
+        description="When true, return only promotions active at `at`.",
+    ),
+):
+    evaluation_at = at or promotions_service.default_at_bogota()
+    return await promotions_service.list_active_promotions(
+        request,
+        evaluation_at,
+        only_current=only_current,
+    )
+
+
+@router.get(
+    "/{promotion_id}",
+    dependencies=[Depends(require_module(Module.MI_NEGOCIO))],
+    summary="Get promotion by id",
+)
+async def get_promotion_endpoint(
+    request: Request,
+    promotion_id: UUID,
+    at: Optional[datetime] = Query(None),
+):
+    return await promotions_service.get_promotion(request, promotion_id, at=at)
+
+
+@router.patch(
+    "/{promotion_id}",
+    dependencies=[Depends(require_module(Module.MI_NEGOCIO))],
+    summary="Update promotion",
+)
+async def update_promotion_endpoint(
+    request: Request,
+    promotion_id: UUID,
+    body: PromotionUpdate,
+):
+    return await promotions_service.update_promotion(request, promotion_id, body)
+
+
+@router.delete(
+    "/{promotion_id}",
+    dependencies=[Depends(require_module(Module.MI_NEGOCIO))],
+    summary="Delete promotion",
+)
+async def delete_promotion_endpoint(request: Request, promotion_id: UUID):
+    return await promotions_service.delete_promotion(request, promotion_id)

--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -1,0 +1,536 @@
+"""Tenant promotion CRUD and schedule evaluation (warocol.com#980)."""
+import json
+import logging
+from datetime import datetime, time
+from typing import Any, Dict, List, Optional, Sequence, Set
+from uuid import UUID
+from zoneinfo import ZoneInfo
+
+import asyncpg
+from fastapi import HTTPException, Request
+
+from app.core.exceptions import AuthenticationError
+from app.core.middleware import require_valid_session
+from app.database import get_db_connection
+from app.models.tenant_promotion import (
+    PromotionCreate,
+    PromotionUpdate,
+    ScopeType,
+)
+
+logger = logging.getLogger(__name__)
+
+BOGOTA = ZoneInfo("America/Bogota")
+
+# v1 contract: higher priority wins; default non-stackable (documented on router).
+CONFLICT_RULES_DOC = (
+    "When multiple promotions match a line, the highest priority wins. "
+    "stackable=false (default) means one promotion per line. "
+    "Manual order-level discounts are applied separately in checkout (batch #982)."
+)
+
+
+def day_bit_for_datetime(at: datetime) -> int:
+    """Monday=1<<0 … Sunday=1<<6 in America/Bogota."""
+    local = at.astimezone(BOGOTA)
+    return 1 << local.weekday()
+
+
+def time_in_schedule_window(
+    at: datetime,
+    *,
+    days_of_week: int,
+    start_time: time,
+    end_time: time,
+    crosses_midnight: bool,
+) -> bool:
+    local = at.astimezone(BOGOTA)
+    current = local.time()
+    today_bit = day_bit_for_datetime(local)
+    if crosses_midnight:
+        if (days_of_week & today_bit) and current >= start_time:
+            return True
+        yesterday_bit = 1 << ((local.weekday() - 1) % 7)
+        if (days_of_week & yesterday_bit) and current < end_time:
+            return True
+        return False
+    if not (days_of_week & today_bit):
+        return False
+    return start_time <= current < end_time
+
+
+def is_active_at(
+    at: datetime,
+    *,
+    is_active: bool,
+    starts_at: Optional[datetime],
+    ends_at: Optional[datetime],
+    schedules: Sequence[Dict[str, Any]],
+) -> bool:
+    """Return whether a promotion rule is active at `at` (evaluated in Bogotá)."""
+    if not is_active:
+        return False
+    if starts_at is not None and at < starts_at:
+        return False
+    if ends_at is not None and at >= ends_at:
+        return False
+    if not schedules:
+        return True
+    for row in schedules:
+        if time_in_schedule_window(
+            at,
+            days_of_week=int(row["days_of_week"]),
+            start_time=row["start_time"],
+            end_time=row["end_time"],
+            crosses_midnight=bool(row["crosses_midnight"]),
+        ):
+            return True
+    return False
+
+
+def product_in_scope(
+    *,
+    scope_type: str,
+    category_ids: Set[UUID],
+    product_ids: Set[UUID],
+    product_id: UUID,
+    category_id: Optional[UUID],
+) -> bool:
+    if scope_type == ScopeType.ALL_PRODUCTS.value:
+        return True
+    if scope_type == ScopeType.PRODUCTS.value:
+        return product_id in product_ids
+    if scope_type == ScopeType.CATEGORIES.value:
+        return category_id is not None and category_id in category_ids
+    return False
+
+
+def _parse_value_json(raw: Any) -> Dict[str, Any]:
+    if raw is None:
+        return {}
+    if isinstance(raw, str):
+        return json.loads(raw)
+    return dict(raw)
+
+
+def _row_to_schedule(row: asyncpg.Record) -> Dict[str, Any]:
+    return {
+        "id": row["id"],
+        "days_of_week": row["days_of_week"],
+        "start_time": row["start_time"],
+        "end_time": row["end_time"],
+        "crosses_midnight": row["crosses_midnight"],
+        "sort_order": row["sort_order"],
+    }
+
+
+def _serialize_promotion(
+    promo_row: asyncpg.Record,
+    schedules: List[asyncpg.Record],
+    category_ids: List[UUID],
+    product_ids: List[UUID],
+    *,
+    at: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    schedule_dicts = [_row_to_schedule(r) for r in schedules]
+    payload: Dict[str, Any] = {
+        "id": str(promo_row["id"]),
+        "tenant_id": str(promo_row["tenant_id"]),
+        "name": promo_row["name"],
+        "promo_type": promo_row["promo_type"],
+        "value_json": _parse_value_json(promo_row["value_json"]),
+        "scope_type": promo_row["scope_type"],
+        "category_ids": [str(cid) for cid in category_ids],
+        "product_ids": [str(pid) for pid in product_ids],
+        "schedules": [
+            {
+                "id": str(s["id"]),
+                "days_of_week": s["days_of_week"],
+                "start_time": s["start_time"].isoformat(),
+                "end_time": s["end_time"].isoformat(),
+                "crosses_midnight": s["crosses_midnight"],
+                "sort_order": s["sort_order"],
+            }
+            for s in schedule_dicts
+        ],
+        "priority": promo_row["priority"],
+        "is_active": promo_row["is_active"],
+        "stackable": promo_row["stackable"],
+        "starts_at": promo_row["starts_at"].isoformat() if promo_row["starts_at"] else None,
+        "ends_at": promo_row["ends_at"].isoformat() if promo_row["ends_at"] else None,
+        "created_at": promo_row["created_at"].isoformat(),
+        "updated_at": promo_row["updated_at"].isoformat(),
+    }
+    if at is not None:
+        payload["is_currently_active"] = is_active_at(
+            at,
+            is_active=promo_row["is_active"],
+            starts_at=promo_row["starts_at"],
+            ends_at=promo_row["ends_at"],
+            schedules=schedule_dicts,
+        )
+    return payload
+
+
+async def _load_scope_ids(
+    conn: asyncpg.Connection, promotion_id: UUID
+) -> tuple[List[UUID], List[UUID]]:
+    cat_rows = await conn.fetch(
+        """
+        SELECT category_id FROM tenant_promotion_scope_categories
+        WHERE promotion_id = $1
+        """,
+        promotion_id,
+    )
+    prod_rows = await conn.fetch(
+        """
+        SELECT product_id FROM tenant_promotion_scope_products
+        WHERE promotion_id = $1
+        """,
+        promotion_id,
+    )
+    return [r["category_id"] for r in cat_rows], [r["product_id"] for r in prod_rows]
+
+
+async def _load_schedules(conn: asyncpg.Connection, promotion_id: UUID) -> List[asyncpg.Record]:
+    return await conn.fetch(
+        """
+        SELECT id, days_of_week, start_time, end_time, crosses_midnight, sort_order
+        FROM tenant_promotion_schedules
+        WHERE promotion_id = $1
+        ORDER BY sort_order, start_time
+        """,
+        promotion_id,
+    )
+
+
+async def _replace_scope(
+    conn: asyncpg.Connection,
+    promotion_id: UUID,
+    tenant_id: UUID,
+    scope_type: str,
+    category_ids: List[UUID],
+    product_ids: List[UUID],
+) -> None:
+    await conn.execute(
+        "DELETE FROM tenant_promotion_scope_categories WHERE promotion_id = $1",
+        promotion_id,
+    )
+    await conn.execute(
+        "DELETE FROM tenant_promotion_scope_products WHERE promotion_id = $1",
+        promotion_id,
+    )
+    if scope_type == ScopeType.CATEGORIES.value:
+        for category_id in category_ids:
+            owned = await conn.fetchval(
+                """
+                SELECT 1 FROM categories
+                WHERE id = $1 AND tenant_id = $2
+                """,
+                category_id,
+                tenant_id,
+            )
+            if not owned:
+                raise HTTPException(status_code=400, detail=f"Category {category_id} not found")
+            await conn.execute(
+                """
+                INSERT INTO tenant_promotion_scope_categories (promotion_id, category_id)
+                VALUES ($1, $2)
+                ON CONFLICT DO NOTHING
+                """,
+                promotion_id,
+                category_id,
+            )
+    elif scope_type == ScopeType.PRODUCTS.value:
+        for product_id in product_ids:
+            owned = await conn.fetchval(
+                """
+                SELECT 1 FROM product
+                WHERE id = $1 AND tenant_id = $2
+                """,
+                product_id,
+                tenant_id,
+            )
+            if not owned:
+                raise HTTPException(status_code=400, detail=f"Product {product_id} not found")
+            await conn.execute(
+                """
+                INSERT INTO tenant_promotion_scope_products (promotion_id, product_id)
+                VALUES ($1, $2)
+                ON CONFLICT DO NOTHING
+                """,
+                promotion_id,
+                product_id,
+            )
+
+
+async def _replace_schedules(
+    conn: asyncpg.Connection,
+    promotion_id: UUID,
+    schedules: Sequence[Any],
+) -> None:
+    await conn.execute(
+        "DELETE FROM tenant_promotion_schedules WHERE promotion_id = $1",
+        promotion_id,
+    )
+    for sched in schedules:
+        await conn.execute(
+            """
+            INSERT INTO tenant_promotion_schedules (
+                promotion_id, days_of_week, start_time, end_time,
+                crosses_midnight, sort_order
+            )
+            VALUES ($1, $2, $3, $4, $5, $6)
+            """,
+            promotion_id,
+            sched.days_of_week,
+            sched.start_time,
+            sched.end_time,
+            sched.crosses_midnight,
+            sched.sort_order,
+        )
+
+
+async def _get_owned_promotion(conn: asyncpg.Connection, promotion_id: UUID, tenant_id: UUID):
+    row = await conn.fetchrow(
+        "SELECT * FROM tenant_promotions WHERE id = $1 AND tenant_id = $2",
+        promotion_id,
+        tenant_id,
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Promotion not found")
+    return row
+
+
+async def list_promotions(
+    request: Request,
+    *,
+    include_inactive: bool = False,
+    at: Optional[datetime] = None,
+) -> dict:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    query = """
+        SELECT * FROM tenant_promotions
+        WHERE tenant_id = $1
+    """
+    if not include_inactive:
+        query += " AND is_active = true"
+    query += " ORDER BY priority DESC, name"
+
+    async with get_db_connection(use_transaction=False) as conn:
+        rows = await conn.fetch(query, tenant_id)
+        data = []
+        for row in rows:
+            schedules = await _load_schedules(conn, row["id"])
+            category_ids, product_ids = await _load_scope_ids(conn, row["id"])
+            data.append(
+                _serialize_promotion(
+                    row, schedules, category_ids, product_ids, at=at
+                )
+            )
+
+    return {"success": True, "total": len(data), "data": data}
+
+
+async def get_promotion(
+    request: Request,
+    promotion_id: UUID,
+    *,
+    at: Optional[datetime] = None,
+) -> dict:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    async with get_db_connection(use_transaction=False) as conn:
+        row = await _get_owned_promotion(conn, promotion_id, tenant_id)
+        schedules = await _load_schedules(conn, promotion_id)
+        category_ids, product_ids = await _load_scope_ids(conn, promotion_id)
+
+    return {
+        "success": True,
+        "data": _serialize_promotion(
+            row, schedules, category_ids, product_ids, at=at
+        ),
+    }
+
+
+async def create_promotion(request: Request, body: PromotionCreate) -> dict:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    try:
+        async with get_db_connection() as conn:
+            row = await conn.fetchrow(
+                """
+                INSERT INTO tenant_promotions (
+                    tenant_id, name, promo_type, value_json, scope_type,
+                    priority, is_active, stackable, starts_at, ends_at
+                )
+                VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8, $9, $10)
+                RETURNING *
+                """,
+                tenant_id,
+                body.name.strip(),
+                body.promo_type.value,
+                json.dumps(body.value_json),
+                body.scope_type.value,
+                body.priority,
+                body.is_active,
+                body.stackable,
+                body.starts_at,
+                body.ends_at,
+            )
+            promotion_id = row["id"]
+            await _replace_schedules(conn, promotion_id, body.schedules)
+            await _replace_scope(
+                conn,
+                promotion_id,
+                tenant_id,
+                body.scope_type.value,
+                body.category_ids,
+                body.product_ids,
+            )
+            schedules = await _load_schedules(conn, promotion_id)
+            category_ids, product_ids = await _load_scope_ids(conn, promotion_id)
+    except asyncpg.UniqueViolationError:
+        raise HTTPException(
+            status_code=409,
+            detail="Ya existe una promoción con ese nombre",
+        ) from None
+
+    logger.info("Created promotion %r for tenant %s", body.name, tenant_id)
+    return {
+        "success": True,
+        "data": _serialize_promotion(row, schedules, category_ids, product_ids),
+    }
+
+
+async def update_promotion(
+    request: Request,
+    promotion_id: UUID,
+    body: PromotionUpdate,
+) -> dict:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    data = body.model_dump(exclude_unset=True)
+    if not data:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    schedules = data.pop("schedules", None)
+    category_ids = data.pop("category_ids", None)
+    product_ids = data.pop("product_ids", None)
+
+    if "name" in data and data["name"] is not None:
+        data["name"] = data["name"].strip()
+    if "promo_type" in data and data["promo_type"] is not None:
+        data["promo_type"] = data["promo_type"].value
+    if "scope_type" in data and data["scope_type"] is not None:
+        data["scope_type"] = data["scope_type"].value
+    if "value_json" in data and data["value_json"] is not None:
+        data["value_json"] = json.dumps(data["value_json"])
+
+    async with get_db_connection() as conn:
+        existing = await _get_owned_promotion(conn, promotion_id, tenant_id)
+
+        if data:
+            set_parts = []
+            params: List[Any] = []
+            idx = 1
+            for key, value in data.items():
+                if key == "value_json":
+                    set_parts.append(f"value_json = ${idx}::jsonb")
+                else:
+                    set_parts.append(f"{key} = ${idx}")
+                params.append(value)
+                idx += 1
+            set_parts.append("updated_at = NOW()")
+            params.extend([promotion_id, tenant_id])
+            row = await conn.fetchrow(
+                f"""
+                UPDATE tenant_promotions
+                SET {", ".join(set_parts)}
+                WHERE id = ${idx} AND tenant_id = ${idx + 1}
+                RETURNING *
+                """,
+                *params,
+            )
+        else:
+            row = existing
+
+        scope_type = data.get("scope_type", row["scope_type"])
+        if schedules is not None:
+            await _replace_schedules(conn, promotion_id, schedules)
+        if category_ids is not None or product_ids is not None or "scope_type" in data:
+            cats = category_ids if category_ids is not None else (
+                await _load_scope_ids(conn, promotion_id)
+            )[0]
+            prods = product_ids if product_ids is not None else (
+                await _load_scope_ids(conn, promotion_id)
+            )[1]
+            if scope_type == ScopeType.CATEGORIES.value and not cats:
+                raise HTTPException(status_code=400, detail="category_ids required for categories scope")
+            if scope_type == ScopeType.PRODUCTS.value and not prods:
+                raise HTTPException(status_code=400, detail="product_ids required for products scope")
+            await _replace_scope(
+                conn, promotion_id, tenant_id, scope_type, cats, prods
+            )
+
+        schedules_rows = await _load_schedules(conn, promotion_id)
+        cats, prods = await _load_scope_ids(conn, promotion_id)
+
+    return {
+        "success": True,
+        "data": _serialize_promotion(row, schedules_rows, cats, prods),
+    }
+
+
+async def delete_promotion(request: Request, promotion_id: UUID) -> dict:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    async with get_db_connection() as conn:
+        await _get_owned_promotion(conn, promotion_id, tenant_id)
+        await conn.execute(
+            "DELETE FROM tenant_promotions WHERE id = $1 AND tenant_id = $2",
+            promotion_id,
+            tenant_id,
+        )
+
+    return {"success": True, "message": "Promotion deleted successfully"}
+
+
+async def list_active_promotions(
+    request: Request,
+    at: datetime,
+    *,
+    only_current: bool = False,
+) -> dict:
+    """List tenant promotions with is_currently_active for POS (read-only)."""
+    result = await list_promotions(
+        request,
+        include_inactive=False,
+        at=at,
+    )
+    if only_current:
+        result["data"] = [
+            row for row in result["data"] if row.get("is_currently_active")
+        ]
+        result["total"] = len(result["data"])
+    return result
+
+
+def default_at_bogota() -> datetime:
+    return datetime.now(tz=BOGOTA)

--- a/sql/20260529_tenant_promotions.sql
+++ b/sql/20260529_tenant_promotions.sql
@@ -1,0 +1,56 @@
+-- Tenant-scoped POS promotions (warocol.com#980) — greenfield; do NOT reuse legacy promotions.
+CREATE TABLE IF NOT EXISTS tenant_promotions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    name VARCHAR(120) NOT NULL,
+    promo_type TEXT NOT NULL,
+    value_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    scope_type TEXT NOT NULL,
+    priority INTEGER NOT NULL DEFAULT 0,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    stackable BOOLEAN NOT NULL DEFAULT false,
+    starts_at TIMESTAMPTZ,
+    ends_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT tenant_promotions_promo_type_check
+        CHECK (promo_type = ANY (ARRAY['percent_off'::text, 'fixed_off'::text, 'bogo'::text])),
+    CONSTRAINT tenant_promotions_scope_type_check
+        CHECK (scope_type = ANY (ARRAY['all_products'::text, 'categories'::text, 'products'::text])),
+    CONSTRAINT tenant_promotions_name_tenant_unique UNIQUE (tenant_id, name)
+);
+
+COMMENT ON TABLE tenant_promotions IS
+    'Tenant POS promotion rules. v1 conflict: higher priority wins; non-stackable (stackable=false default).';
+
+CREATE INDEX IF NOT EXISTS idx_tenant_promotions_tenant_active
+    ON tenant_promotions (tenant_id, is_active, priority DESC);
+
+CREATE TABLE IF NOT EXISTS tenant_promotion_schedules (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    promotion_id UUID NOT NULL REFERENCES tenant_promotions(id) ON DELETE CASCADE,
+    days_of_week SMALLINT NOT NULL,
+    start_time TIME NOT NULL,
+    end_time TIME NOT NULL,
+    crosses_midnight BOOLEAN NOT NULL DEFAULT false,
+    sort_order SMALLINT NOT NULL DEFAULT 0,
+    CONSTRAINT tenant_promotion_schedules_days_check
+        CHECK (days_of_week >= 1 AND days_of_week <= 127),
+    CONSTRAINT tenant_promotion_schedules_window_check
+        CHECK (crosses_midnight OR end_time > start_time)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_promotion_schedules_promotion
+    ON tenant_promotion_schedules (promotion_id, sort_order);
+
+CREATE TABLE IF NOT EXISTS tenant_promotion_scope_categories (
+    promotion_id UUID NOT NULL REFERENCES tenant_promotions(id) ON DELETE CASCADE,
+    category_id UUID NOT NULL REFERENCES categories(id) ON DELETE CASCADE,
+    PRIMARY KEY (promotion_id, category_id)
+);
+
+CREATE TABLE IF NOT EXISTS tenant_promotion_scope_products (
+    promotion_id UUID NOT NULL REFERENCES tenant_promotions(id) ON DELETE CASCADE,
+    product_id UUID NOT NULL REFERENCES product(id) ON DELETE CASCADE,
+    PRIMARY KEY (promotion_id, product_id)
+);

--- a/tests/test_promotions_crud.py
+++ b/tests/test_promotions_crud.py
@@ -1,0 +1,185 @@
+"""Scope resolution and promotion router smoke tests (warocol.com#980)."""
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.core.permissions import Module
+from app.models.tenant_promotion import PromotionCreate, PromoType, ScopeType
+from app.routers.promotions import router as promotions_router
+from app.services.promotions_service import product_in_scope
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_session(role: str):
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": role,
+    })
+
+
+def _enforce_db_ctx():
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+
+    return _ctx
+
+
+def test_bogo_create_requires_buy_and_get_qty():
+    with pytest.raises(ValidationError):
+        PromotionCreate(
+            name="2x1",
+            promo_type=PromoType.BOGO,
+            value_json={"buy_qty": 2},
+            scope_type=ScopeType.ALL_PRODUCTS,
+        )
+
+
+def test_bogo_create_valid():
+    body = PromotionCreate(
+        name="2x1 cervezas",
+        promo_type=PromoType.BOGO,
+        value_json={"buy_qty": 2, "get_qty": 1},
+        scope_type=ScopeType.ALL_PRODUCTS,
+    )
+    assert body.promo_type == PromoType.BOGO
+
+
+def test_product_in_scope_all_products():
+    pid = uuid4()
+    cid = uuid4()
+    assert product_in_scope(
+        scope_type="all_products",
+        category_ids=set(),
+        product_ids=set(),
+        product_id=pid,
+        category_id=cid,
+    )
+
+
+def test_product_in_scope_by_product_id():
+    pid = uuid4()
+    other = uuid4()
+    assert product_in_scope(
+        scope_type="products",
+        category_ids=set(),
+        product_ids={pid},
+        product_id=pid,
+        category_id=None,
+    )
+    assert not product_in_scope(
+        scope_type="products",
+        category_ids=set(),
+        product_ids={pid},
+        product_id=other,
+        category_id=None,
+    )
+
+
+def test_product_in_scope_by_category():
+    pid = uuid4()
+    cid = uuid4()
+    assert product_in_scope(
+        scope_type="categories",
+        category_ids={cid},
+        product_ids=set(),
+        product_id=pid,
+        category_id=cid,
+    )
+
+
+def test_owner_passes_list_promotions_under_enforce():
+    session = _build_session(role="owner")
+    app = FastAPI()
+    app.include_router(promotions_router)
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.services.promotions_service.list_promotions",
+             new=AsyncMock(return_value={"success": True, "total": 0, "data": []}),
+         ):
+        client = TestClient(app)
+        response = client.get("/api/promotions")
+
+    assert response.status_code == 200
+
+
+def test_cashier_passes_active_promotions_under_enforce():
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(promotions_router)
+
+    cashier_modules = frozenset({Module.POS, Module.VENTAS, Module.MENU})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ), \
+         patch(
+             "app.services.promotions_service.list_active_promotions",
+             new=AsyncMock(return_value={"success": True, "total": 0, "data": []}),
+         ):
+        client = TestClient(app)
+        response = client.get(
+            "/api/promotions/active",
+            params={"at": datetime(2026, 5, 29, 18, 0, tzinfo=timezone.utc).isoformat()},
+        )
+
+    assert response.status_code == 200
+
+
+def test_cashier_denied_create_promotion_under_enforce():
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(promotions_router)
+
+    cashier_modules = frozenset({Module.POS, Module.VENTAS})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ):
+        client = TestClient(app)
+        response = client.post(
+            "/api/promotions",
+            json={
+                "name": "2x1",
+                "promo_type": "bogo",
+                "value_json": {"buy_qty": 2, "get_qty": 1},
+                "scope_type": "all_products",
+            },
+        )
+
+    assert response.status_code == 403

--- a/tests/test_promotions_schedule.py
+++ b/tests/test_promotions_schedule.py
@@ -1,0 +1,104 @@
+"""Schedule matching for tenant promotions (warocol.com#980)."""
+from datetime import datetime, time
+from zoneinfo import ZoneInfo
+
+from app.services.promotions_service import (
+    BOGOTA,
+    day_bit_for_datetime,
+    is_active_at,
+    time_in_schedule_window,
+)
+
+# Mon–Fri bitmask (Mon=1, Tue=2, Wed=4, Thu=8, Fri=16)
+WEEKDAYS = 1 + 2 + 4 + 8 + 16
+
+
+def _at(iso: str) -> datetime:
+    return datetime.fromisoformat(iso)
+
+
+def test_day_bit_monday_bogota():
+    monday = _at("2026-05-25T12:00:00-05:00")
+    assert day_bit_for_datetime(monday) == 1
+
+
+def test_happy_hour_active_inside_window():
+    at = _at("2026-05-29T18:30:00-05:00")  # Thursday
+    assert time_in_schedule_window(
+        at,
+        days_of_week=WEEKDAYS,
+        start_time=time(17, 0),
+        end_time=time(20, 0),
+        crosses_midnight=False,
+    )
+
+
+def test_happy_hour_inactive_outside_window():
+    at = _at("2026-05-29T14:00:00-05:00")
+    assert not time_in_schedule_window(
+        at,
+        days_of_week=WEEKDAYS,
+        start_time=time(17, 0),
+        end_time=time(20, 0),
+        crosses_midnight=False,
+    )
+
+
+def test_overnight_schedule_active_after_midnight():
+    # Thursday 22:00–06:00 window is still active Friday 01:30
+    at = _at("2026-05-29T01:30:00-05:00")  # Friday early morning
+    assert time_in_schedule_window(
+        at,
+        days_of_week=1 << 3,  # Thursday
+        start_time=time(22, 0),
+        end_time=time(6, 0),
+        crosses_midnight=True,
+    )
+
+
+def test_is_active_at_no_schedules_always_on_when_enabled():
+    at = _at("2026-05-29T12:00:00-05:00")
+    assert is_active_at(
+        at,
+        is_active=True,
+        starts_at=None,
+        ends_at=None,
+        schedules=[],
+    )
+
+
+def test_is_active_at_respects_campaign_dates():
+    at = _at("2026-06-01T12:00:00-05:00")
+    starts = _at("2026-05-01T00:00:00-05:00")
+    ends = _at("2026-05-31T23:59:59-05:00")
+    assert not is_active_at(
+        at,
+        is_active=True,
+        starts_at=starts,
+        ends_at=ends,
+        schedules=[],
+    )
+
+
+def test_is_active_at_with_schedule_row():
+    at = _at("2026-05-29T18:00:00-05:00")
+    schedules = [
+        {
+            "days_of_week": WEEKDAYS,
+            "start_time": time(17, 0),
+            "end_time": time(21, 0),
+            "crosses_midnight": False,
+        }
+    ]
+    assert is_active_at(
+        at,
+        is_active=True,
+        starts_at=None,
+        ends_at=None,
+        schedules=schedules,
+    )
+
+
+def test_bogota_offset_is_minus_five():
+    at = datetime.now(tz=BOGOTA)
+    assert str(at.tzinfo) == "America/Bogota"


### PR DESCRIPTION
## Summary
- Add greenfield `tenant_promotions` schema with schedules and scope junctions (no legacy `promotions` reuse)
- CRUD under `/api/promotions` with `Module.MI_NEGOCIO`
- POS read endpoint `GET /api/promotions/active?at=` with Bogotá schedule evaluation
- Unit tests for schedule matching, scope resolution, and permission smoke

## Test plan
- [x] `pytest tests/test_promotions_schedule.py tests/test_promotions_crud.py -v` (16 passed)
- [ ] Apply migration `sql/20260529_tenant_promotions.sql` on dev DB
- [ ] HTTPie: create BOGO + happy-hour promo, query `/api/promotions/active?at=`

Refs uno0uno/warocol.com#980

Made with [Cursor](https://cursor.com)