### PR TITLE
test(promotions): multi-range schedules and category scope (#983)

### DIFF
--- a/tests/test_promo_cart_evaluation.py
+++ b/tests/test_promo_cart_evaluation.py
@@ -81,3 +81,42 @@ def test_ineligible_lines_unchanged():
     result = evaluate_cart_promotions(lines, promos=[])
     assert result["promo_savings"] == 0
     assert result["subtotal_after_promos"] == 8000
+
+
+def test_percent_off_category_scoped():
+    """Happy hour % off all items in a category (warocol.com#983)."""
+    category_id = uuid4()
+    other_category = uuid4()
+    promo = _promo(
+        promo_type="percent_off",
+        value_json={"percent": 10},
+        scope_type="categories",
+        name="Happy hour Cervezas",
+    )
+    promo["category_ids"] = {category_id}
+    lines = [
+        _line(subtotal=10000, category_id=category_id),
+        _line(subtotal=5000, category_id=other_category),
+    ]
+    result = evaluate_cart_promotions(lines, promos=[promo])
+    assert result["promo_savings"] == 1000
+    assert result["subtotal_after_promos"] == 14000
+    assert result["lines"][0]["promotion_name"] == "Happy hour Cervezas"
+    assert result["lines"][1]["promo_savings"] == 0
+
+
+def test_percent_off_category_large_menu():
+    """Category-wide rule applies across many SKUs (warocol.com#983)."""
+    category_id = uuid4()
+    promo = _promo(
+        promo_type="percent_off",
+        value_json={"percent": 20},
+        scope_type="categories",
+    )
+    promo["category_ids"] = {category_id}
+    lines = [
+        _line(subtotal=1000, category_id=category_id) for _ in range(150)
+    ]
+    result = evaluate_cart_promotions(lines, promos=[promo])
+    assert result["promo_savings"] == 30000
+    assert result["subtotal_after_promos"] == 120000

--- a/tests/test_promotions_schedule.py
+++ b/tests/test_promotions_schedule.py
@@ -102,3 +102,49 @@ def test_is_active_at_with_schedule_row():
 def test_bogota_offset_is_minus_five():
     at = datetime.now(tz=BOGOTA)
     assert str(at.tzinfo) == "America/Bogota"
+
+
+def test_is_active_at_multiple_ranges_same_day():
+    """Lunch + dinner windows on the same weekdays (warocol.com#983)."""
+    schedules = [
+        {
+            "days_of_week": WEEKDAYS,
+            "start_time": time(12, 0),
+            "end_time": time(14, 0),
+            "crosses_midnight": False,
+        },
+        {
+            "days_of_week": WEEKDAYS,
+            "start_time": time(17, 0),
+            "end_time": time(20, 0),
+            "crosses_midnight": False,
+        },
+    ]
+    at_lunch = _at("2026-05-29T13:00:00-05:00")
+    at_dinner = _at("2026-05-29T18:30:00-05:00")
+    at_between = _at("2026-05-29T15:00:00-05:00")
+    assert is_active_at(
+        at_lunch, is_active=True, starts_at=None, ends_at=None, schedules=schedules
+    )
+    assert is_active_at(
+        at_dinner, is_active=True, starts_at=None, ends_at=None, schedules=schedules
+    )
+    assert not is_active_at(
+        at_between, is_active=True, starts_at=None, ends_at=None, schedules=schedules
+    )
+
+
+def test_is_active_at_window_end_is_exclusive():
+    """Promo ends at 20:00 — not active at exactly 20:00 (Bogotá)."""
+    schedules = [
+        {
+            "days_of_week": WEEKDAYS,
+            "start_time": time(17, 0),
+            "end_time": time(20, 0),
+            "crosses_midnight": False,
+        }
+    ]
+    at_end = _at("2026-05-29T20:00:00-05:00")
+    assert not is_active_at(
+        at_end, is_active=True, starts_at=None, ends_at=None, schedules=schedules
+    )


### PR DESCRIPTION
## Summary
- Tests for same-day multi-range schedules (lunch + dinner windows)
- Exclusive end boundary at 20:00 Bogotá
- Category-scoped percent-off and 150-line large-menu evaluation

Companion to warocol.com PR for batch #983.

## Test plan
- [ ] `pytest tests/test_promotions_schedule.py tests/test_promo_cart_evaluation.py -v`

Closes uno0uno/warocol.com#983

Made with [Cursor](https://cursor.com)