### PR TITLE
feat(promotions): persist applied promos on order lines

### DIFF
--- a/.wr/984.yaml
+++ b/.wr/984.yaml
@@ -1,0 +1,30 @@
+issue: 984
+title: "feat(promotions): order history, receipts, and reporting hooks"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: both
+branch: wr-984-order-promo-history
+
+paths:
+  - sql/20260529_order_promotions_persist.sql
+  - app/services/promotions_service.py
+  - app/services/pos_cart_service.py
+  - app/services/tables_service.py
+  - app/services/orders_service.py
+  - tests/test_order_promo_persist.py
+  - ../front_nuxt/pages/ventas/[id].vue
+  - ../front_nuxt/pages/pos/checkout.vue
+
+ac:
+  - Closed order shows applied promo(s) in /ventas/[id]
+  - Printed ticket and prefactura show promo label
+  - BOGO + manual discount both visible
+  - API order payload includes promotion breakdown
+
+hints:
+  entry: "promo_persist_fields_from_eval_line — promotions_service"
+  tests: "pytest tests/test_order_promo_persist.py -v"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -44,6 +44,37 @@ POS_LIKE_FILTER_ALIAS_O = (
 )
 
 
+async def _get_order_promo_summary(conn, order_id: UUID) -> Dict[str, Any]:
+    """Aggregate persisted line promos for order detail / reporting (warocol.com#984)."""
+    rows = await conn.fetch(
+        """
+        SELECT
+            oi.applied_promotion_id,
+            tp.name AS promotion_name,
+            tp.promo_type,
+            COALESCE(SUM(oi.promo_savings_allocated), 0) AS savings
+        FROM order_items oi
+        INNER JOIN tenant_promotions tp ON tp.id = oi.applied_promotion_id
+        WHERE oi.order_id = $1
+          AND oi.applied_promotion_id IS NOT NULL
+        GROUP BY oi.applied_promotion_id, tp.name, tp.promo_type
+        ORDER BY savings DESC
+        """,
+        order_id,
+    )
+    breakdown = [
+        {
+            "promotion_id": str(r["applied_promotion_id"]),
+            "promotion_name": r["promotion_name"],
+            "promo_type": r["promo_type"],
+            "savings": float(r["savings"]),
+        }
+        for r in rows
+    ]
+    promo_savings = sum(item["savings"] for item in breakdown)
+    return {"promo_savings": promo_savings, "promo_breakdown": breakdown}
+
+
 def _compute_tax_breakdown(
     items_rows: List[Any],
     tax_config: Dict[str, Any],
@@ -598,6 +629,8 @@ async def get_order_by_id(
             except Exception as _e:
                 logger.warning(f"Tax breakdown failed for order {order_id}: {_e}")
 
+            _promo_summary = await _get_order_promo_summary(conn, order_id)
+
             # Hydrate delivery address inline (None if not a delivery, or address was soft-deleted)
             delivery_address = None
             if order_row['delivery_address_id'] and order_row['addr_line1'] is not None:
@@ -657,6 +690,8 @@ async def get_order_by_id(
                     "standard_tax": _std_tax,
                     "liquor_tax": _liq_tax,
                     "standard_tax_label": _tax_label,
+                    "promo_savings": _promo_summary["promo_savings"],
+                    "promo_breakdown": _promo_summary["promo_breakdown"],
                 }
             }
 
@@ -927,11 +962,16 @@ async def get_order_items(
                     oi.subtotal,
                     oi.discount_allocated,
                     oi.net_total,
+                    oi.applied_promotion_id,
+                    oi.promo_savings_allocated,
+                    tp.name AS promotion_name,
+                    tp.promo_type AS promotion_type,
                     p.id as product_id,
                     p.name as product_name,
                     p.description as product_description
                 FROM order_items oi
                 LEFT JOIN product p ON oi.product_id = p.id
+                LEFT JOIN tenant_promotions tp ON tp.id = oi.applied_promotion_id
                 WHERE oi.order_id = $1
                 ORDER BY oi.created_at
             """
@@ -970,6 +1010,10 @@ async def get_order_items(
                     "subtotal": float(item_row['subtotal']),
                     "discount_allocated": float(item_row['discount_allocated']) if item_row['discount_allocated'] is not None else 0.0,
                     "net_total": float(item_row['net_total']) if item_row['net_total'] is not None else None,
+                    "applied_promotion_id": str(item_row['applied_promotion_id']) if item_row['applied_promotion_id'] else None,
+                    "promo_savings_allocated": float(item_row['promo_savings_allocated']) if item_row['promo_savings_allocated'] is not None else 0.0,
+                    "promotion_name": item_row['promotion_name'],
+                    "promotion_type": item_row['promotion_type'],
                     "product": {
                         "id": str(item_row['product_id']) if item_row['product_id'] else None,
                         "name": item_row['product_name'],

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -1695,19 +1695,23 @@ async def complete_pos_order(
                         )
 
                 # 4. Copy cart items to order_items
+                from app.services.promotions_service import promo_persist_fields_from_eval_line
+
                 for i, item in enumerate(items):
                     eval_line = _eval_by_id.get(item["id"], {})
                     total_alloc = int(eval_line.get("total_discount_allocated") or 0)
                     _da = total_alloc if total_alloc > 0 else None
                     _nt = eval_line.get("net_total") if total_alloc > 0 else None
+                    _promo_id, _promo_savings = promo_persist_fields_from_eval_line(eval_line)
                     # Insert order item
                     _item_notes = (item.get('notes') or '').strip() or None
                     order_item_query = """
                         INSERT INTO order_items (
                             order_id, product_id, quantity, price_at_purchase, subtotal,
-                            discount_allocated, net_total, notes
+                            discount_allocated, net_total, notes,
+                            applied_promotion_id, promo_savings_allocated
                         )
-                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
                         RETURNING id
                     """
                     order_item_row = await conn.fetchrow(
@@ -1720,6 +1724,8 @@ async def complete_pos_order(
                         _da,
                         _nt,
                         _item_notes,
+                        _promo_id,
+                        _promo_savings,
                     )
                     order_item_id = order_item_row['id']
 

--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -801,3 +801,16 @@ async def evaluate_checkout_promotions(
                 round(evaluated["subtotal_after_promos"]),
             )
     return apply_manual_discount_to_evaluated_lines(evaluated, manual_discount)
+
+
+def promo_persist_fields_from_eval_line(
+    eval_line: Dict[str, Any],
+) -> tuple[Optional[UUID], Optional[int]]:
+    """Map evaluated checkout line → order_items promo columns (warocol.com#984)."""
+    promo_id_raw = eval_line.get("promotion_id")
+    savings = float(eval_line.get("promo_savings") or 0)
+    promo_savings = round(savings) if savings > 0 else None
+    promo_uuid: Optional[UUID] = None
+    if promo_id_raw:
+        promo_uuid = promo_id_raw if isinstance(promo_id_raw, UUID) else UUID(str(promo_id_raw))
+    return promo_uuid, promo_savings

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -956,21 +956,27 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                     _promo_savings = float(checkout_eval.get("promo_savings") or 0)
                     _promo_breakdown = checkout_eval.get("promo_breakdown") or []
                     _discount_amount = checkout_eval.get("manual_discount_amount") or None
+                    from app.services.promotions_service import promo_persist_fields_from_eval_line
+
                     eval_by_id = {line["id"]: line for line in checkout_eval["lines"]}
                     for row in item_rows:
                         eval_line = eval_by_id.get(str(row["id"]), {})
                         total_alloc = eval_line.get("total_discount_allocated")
                         net_total = eval_line.get("net_total")
-                        if total_alloc or net_total is not None:
+                        _promo_id, _promo_savings = promo_persist_fields_from_eval_line(eval_line)
+                        if total_alloc or net_total is not None or _promo_id or _promo_savings:
                             await conn.execute(
                                 """
                                 UPDATE order_items
-                                SET discount_allocated = $2, net_total = $3
+                                SET discount_allocated = $2, net_total = $3,
+                                    applied_promotion_id = $4, promo_savings_allocated = $5
                                 WHERE id = $1::uuid
                                 """,
                                 row["id"],
                                 total_alloc,
                                 net_total,
+                                _promo_id,
+                                _promo_savings,
                             )
 
                     # Recalculate pending order totals from net line amounts

--- a/sql/20260529_order_promotions_persist.sql
+++ b/sql/20260529_order_promotions_persist.sql
@@ -1,0 +1,24 @@
+-- warocol.com#984 — persist applied promotions on order lines for history/receipts/reports
+ALTER TABLE order_items
+    ADD COLUMN IF NOT EXISTS promo_savings_allocated numeric(10,2);
+
+COMMENT ON COLUMN order_items.promo_savings_allocated IS
+    'Promotion savings on this line (COP); separate from manual discount in discount_allocated.';
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'order_items_applied_promotion_id_fkey'
+    ) THEN
+        ALTER TABLE order_items
+            ADD CONSTRAINT order_items_applied_promotion_id_fkey
+            FOREIGN KEY (applied_promotion_id)
+            REFERENCES tenant_promotions(id)
+            ON DELETE SET NULL;
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_order_items_applied_promotion_id
+    ON order_items (applied_promotion_id)
+    WHERE applied_promotion_id IS NOT NULL;

--- a/tests/test_order_promo_persist.py
+++ b/tests/test_order_promo_persist.py
@@ -1,0 +1,20 @@
+"""Persist promotion fields on order lines (warocol.com#984)."""
+from uuid import uuid4
+
+from app.services.promotions_service import promo_persist_fields_from_eval_line
+
+
+def test_promo_persist_fields_with_promotion():
+    promo_id = uuid4()
+    applied, savings = promo_persist_fields_from_eval_line({
+        "promotion_id": str(promo_id),
+        "promo_savings": 1500.4,
+    })
+    assert applied == promo_id
+    assert savings == 1500
+
+
+def test_promo_persist_fields_without_promotion():
+    applied, savings = promo_persist_fields_from_eval_line({"promo_savings": 0})
+    assert applied is None
+    assert savings is None


### PR DESCRIPTION
## Summary
- Persist `applied_promotion_id` and `promo_savings_allocated` on `order_items` at POS cart complete and mesa session close.
- Expose `promo_savings` and `promo_breakdown` on `GET /orders/{id}` and promotion fields on order items.
- SQL migration adds column, FK to `tenant_promotions`, and index.

Closes #984

## Test plan
- [ ] Run migration `sql/20260529_order_promotions_persist.sql` on staging
- [ ] `pytest tests/test_order_promo_persist.py -v`
- [ ] POS order with active BOGO → DB rows have `applied_promotion_id`
- [ ] Pair with front PR for ventas/receipt UI

## wr-context
See `.wr/984.yaml` on this branch.

Made with [Cursor](https://cursor.com)