### PR TITLE
feat(api): compute receipt taxes on net_total and expose promo breakdown for email

### DIFF
--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -265,6 +265,11 @@ class SendReceiptRequest(BaseModel):
     invoice_number: Optional[int] = None
     invoice_cufe: Optional[str] = None
     tip_amount: float = Field(0.0, ge=0, description="Tip amount captured at checkout — shown as a separate line on the receipt (warocol.com#637).")
+    promo_savings: float = Field(0.0, ge=0, description="Total promotion savings applied at checkout (warocol.com#992).")
+    promo_breakdown: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description="Per-promotion savings breakdown for receipt display.",
+    )
 
 
 class AddPaymentRequest(BaseModel):
@@ -312,6 +317,8 @@ async def send_receipt_email(request: Request, receipt_data: SendReceiptRequest)
         invoice_number=receipt_data.invoice_number,
         invoice_cufe=receipt_data.invoice_cufe,
         tip_amount=receipt_data.tip_amount,
+        promo_savings=receipt_data.promo_savings,
+        promo_breakdown=receipt_data.promo_breakdown,
     )
     return {"success": success}
 

--- a/app/services/email_helpers.py
+++ b/app/services/email_helpers.py
@@ -486,6 +486,8 @@ async def send_pos_receipt_email(
     invoice_cufe: Optional[str] = None,
     tip_amount: float = 0.0,
     tip_label: Optional[str] = None,
+    promo_savings: float = 0.0,
+    promo_breakdown: Optional[List[Dict[str, Any]]] = None,
 ) -> bool:
     """
     Send a POS receipt email to the customer after a point-of-sale order completes.
@@ -539,6 +541,8 @@ async def send_pos_receipt_email(
             invoice_cufe=invoice_cufe,
             tip_amount=tip_amount,
             tip_label=resolved_tip_label,
+            promo_savings=promo_savings,
+            promo_breakdown=promo_breakdown,
         )
         subject = get_pos_receipt_subject(order_number, business_name=business_name)
 

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -3236,17 +3236,18 @@ async def send_invoice_email(
                 detail="El PDF de la factura aún no está disponible. Reintentá en unos segundos.",
             )
 
-        # 3. Tax breakdown — same helpers get_order_by_id uses.
+        # 3. Tax breakdown — net line base matches GL / cierre_service.
         tax_config = await _get_tenant_tax_config(conn, tenant_id)
         items_for_tax = await conn.fetch(
             """SELECT COALESCE(p.tax_category, 'standard') AS tax_category,
-                      COALESCE(oi.subtotal, 0) AS subtotal
+                      COALESCE(oi.net_total, oi.subtotal, 0) AS subtotal
                FROM order_items oi
                JOIN product p ON p.id = oi.product_id
                WHERE oi.order_id = $1""",
             order_id,
         )
         std_tax, liq_tax, tax_label = _compute_tax_breakdown(items_for_tax, tax_config)
+        promo_summary = await _get_order_promo_summary(conn, order_id)
 
         # 4. Items in the shape `pos_receipt_template` expects.
         item_rows = await conn.fetch(
@@ -3286,10 +3287,14 @@ async def send_invoice_email(
         )
 
     discount_amount = float(order_row['discount_amount']) if order_row['discount_amount'] is not None else 0.0
-    # Subtotal: only carried into the template when there's a discount (the
-    # template falls back to total_amount when no discount). Matches the POS
-    # cart caller convention at pos_cart_service.py:1577.
-    subtotal_for_email = sum(float(it['subtotal']) for it in item_rows) if discount_amount > 0 else 0.0
+    promo_savings = float(promo_summary["promo_savings"])
+    promo_breakdown = promo_summary["promo_breakdown"]
+    # Subtotal: gross list total when manual discount or promos need a reference line.
+    subtotal_for_email = (
+        sum(float(it['subtotal']) for it in item_rows)
+        if discount_amount > 0 or promo_savings > 0
+        else 0.0
+    )
 
     success = await send_pos_receipt_email(
         customer_email=recipient_email,
@@ -3308,6 +3313,8 @@ async def send_invoice_email(
         standard_tax=std_tax,
         liquor_tax=liq_tax,
         standard_tax_label=tax_label,
+        promo_savings=promo_savings,
+        promo_breakdown=promo_breakdown,
         invoice_prefix=invoice_row['prefix'],
         invoice_number=int(invoice_row['invoice_number']),
         invoice_cufe=invoice_row['cufe'],

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -2016,36 +2016,19 @@ async def complete_pos_order(
                 _liquor_tax = 0.0
                 _standard_tax_label = "Impuesto"
                 try:
+                    from app.services.orders_service import _compute_tax_breakdown
+
                     items_tax_rows = await conn.fetch(
                         """SELECT COALESCE(p.tax_category, 'standard') AS tax_category,
-                                  COALESCE(oi.subtotal, 0) AS subtotal
+                                  COALESCE(oi.net_total, oi.subtotal, 0) AS subtotal
                            FROM order_items oi
                            JOIN product p ON p.id = oi.product_id
                            WHERE oi.order_id = $1""",
                         order_id
                     )
-                    std_subtotal = sum(float(r['subtotal']) for r in items_tax_rows if r['tax_category'] == 'standard')
-                    liq_subtotal = sum(float(r['subtotal']) for r in items_tax_rows if r['tax_category'] == 'liquor')
-
-                    if tax_config.get('inc_applicable') and std_subtotal > 0:
-                        rate = float(tax_config['inc_rate'])
-                        if tax_config.get('inc_included_in_price'):
-                            _standard_tax = round(std_subtotal * rate / (1 + rate))
-                        else:
-                            _standard_tax = round(std_subtotal * rate)
-                        pct = round(rate * 100)
-                        _standard_tax_label = f"INC {pct}%"
-                    elif tax_config.get('iva_applicable') and std_subtotal > 0:
-                        rate = float(tax_config['iva_rate'])
-                        if tax_config.get('iva_included_in_price'):
-                            _standard_tax = round(std_subtotal * rate / (1 + rate))
-                        else:
-                            _standard_tax = round(std_subtotal * rate)
-                        pct = round(rate * 100)
-                        _standard_tax_label = f"IVA {pct}%"
-
-                    if tax_config.get('liquor_tax_applicable') and liq_subtotal > 0:
-                        _liquor_tax = round(liq_subtotal * 0.05)
+                    _standard_tax, _liquor_tax, _standard_tax_label = _compute_tax_breakdown(
+                        items_tax_rows, tax_config
+                    )
                 except Exception as e:
                     logger.warning(f"Tax breakdown computation failed for order {order_id}: {e}")
 
@@ -2144,7 +2127,12 @@ async def complete_pos_order(
                         business_city=_business_city,
                         business_phone=_business_phone,
                         discount_amount=float(_discount_amount) if _discount_amount else 0.0,
-                        subtotal=float(cart_subtotal) if _discount_amount else 0.0,
+                        subtotal=float(cart_subtotal) if (_discount_amount or _promo_savings > 0) else 0.0,
+                        standard_tax=_standard_tax,
+                        liquor_tax=_liquor_tax,
+                        standard_tax_label=_standard_tax_label,
+                        promo_savings=_promo_savings,
+                        promo_breakdown=_promo_breakdown,
                         tip_amount=float(tip_amount),
                     )
                 )

--- a/app/templates/pos_receipt_template.py
+++ b/app/templates/pos_receipt_template.py
@@ -59,6 +59,8 @@ def get_pos_receipt_text(
     invoice_cufe: Optional[str] = None,
     tip_amount: float = 0.0,
     tip_label: str = "Propina",
+    promo_savings: float = 0.0,
+    promo_breakdown: Optional[List[Dict[str, Any]]] = None,
 ) -> str:
     date_str = _format_bogota_date(order_date)
     payment_label = _PAYMENT_LABELS.get(payment_method, payment_method)
@@ -92,8 +94,20 @@ def get_pos_receipt_text(
 
     # Build totals block
     totals_lines = []
-    if discount_amount > 0 and subtotal > 0:
+    _promo_breakdown = promo_breakdown or []
+    _has_promo = promo_savings > 0 or len(_promo_breakdown) > 0
+    _has_manual_discount = discount_amount > 0
+    if (_has_promo or _has_manual_discount) and subtotal > 0:
         totals_lines.append(f"Subtotal: {_format_cop(subtotal)}")
+    if _promo_breakdown:
+        for promo in _promo_breakdown:
+            promo_name = promo.get("promotion_name") or promo.get("name") or "Promoción"
+            savings = float(promo.get("savings") or promo.get("amount") or 0)
+            if savings > 0:
+                totals_lines.append(f"{promo_name}: -{_format_cop(savings)}")
+    elif promo_savings > 0:
+        totals_lines.append(f"Promoción: -{_format_cop(promo_savings)}")
+    if _has_manual_discount:
         totals_lines.append(f"Descuento: -{_format_cop(discount_amount)}")
     if standard_tax > 0:
         totals_lines.append(f"{standard_tax_label}: {_format_cop(standard_tax)}")

--- a/tests/test_invoice_send_email.py
+++ b/tests/test_invoice_send_email.py
@@ -111,6 +111,7 @@ async def test_send_invoice_email_happy_path():
     fetchrow = [_order_row(), _invoice_row(), _profile_row()]
     fetch = [
         [],  # tax items (empty → no tax)
+        [],  # promo summary (no applied promos)
         [{'id': uuid4(), 'quantity': 1, 'subtotal': 200.0, 'product_name': 'tomate barranca'}],
         [],  # modifiers for item
     ]
@@ -141,6 +142,8 @@ async def test_send_invoice_email_happy_path():
     assert kwargs['order_date'].year == 2026
     assert kwargs['order_date'].month == 5
     assert kwargs['order_date'].day == 13
+    assert kwargs['promo_savings'] == 0.0
+    assert kwargs['promo_breakdown'] == []
 
 
 # ── Cross-tenant guard ───────────────────────────────────────────────────────
@@ -238,6 +241,7 @@ async def test_send_invoice_email_ses_failure_502():
 
     fetchrow = [_order_row(), _invoice_row(), _profile_row()]
     fetch = [
+        [],
         [],
         [{'id': uuid4(), 'quantity': 1, 'subtotal': 200.0, 'product_name': 'tomate barranca'}],
         [],

--- a/tests/test_pos_receipt_template.py
+++ b/tests/test_pos_receipt_template.py
@@ -1,7 +1,12 @@
-"""Tests for POS receipt template tip label (warocol.com#977)."""
+"""Tests for POS receipt template tip label (warocol.com#977) and promo totals (#337)."""
 from datetime import datetime, timezone
 
+from app.services.orders_service import _compute_tax_breakdown
 from app.templates.pos_receipt_template import get_pos_receipt_text
+
+
+def _sample_item(name: str = "Cafe", subtotal: float = 100000):
+    return {"quantity": 1, "subtotal": subtotal, "product": {"name": name}}
 
 
 def test_pos_receipt_uses_custom_tip_label():
@@ -28,3 +33,51 @@ def test_pos_receipt_tip_label_defaults_to_propina():
         tip_amount=5000,
     )
     assert "Propina: $5.000" in text
+
+
+def test_pos_receipt_promo_only_shows_promo_lines_without_manual_discount():
+    """Promo-only order renders gross subtotal + promo savings, no Descuento line."""
+    text = get_pos_receipt_text(
+        order_number=44,
+        total_amount=90000,
+        payment_method="cash",
+        items=[_sample_item(subtotal=100000)],
+        order_date=datetime(2026, 5, 29, 12, 0, tzinfo=timezone.utc),
+        subtotal=100000,
+        promo_savings=10000,
+        promo_breakdown=[
+            {
+                "promotion_name": "2x1 cervezas",
+                "promo_type": "bogo",
+                "savings": 10000,
+            }
+        ],
+        standard_tax=14370,
+        standard_tax_label="IVA 19%",
+    )
+    assert "Subtotal: $100.000" in text
+    assert "2x1 cervezas: -$10.000" in text
+    assert "Descuento:" not in text
+    assert "IVA 19%: $14.370" in text
+    assert "TOTAL: $90.000" in text
+
+
+def test_compute_tax_breakdown_prefers_net_line_base():
+    """Tax on net_total must be lower than gross subtotal for the same order."""
+    tax_config = {
+        "inc_applicable": False,
+        "iva_applicable": True,
+        "iva_rate": 0.19,
+        "iva_included_in_price": True,
+        "liquor_tax_applicable": False,
+    }
+    gross_rows = [{"tax_category": "standard", "subtotal": 100000.0}]
+    net_rows = [{"tax_category": "standard", "subtotal": 90000.0}]
+
+    gross_tax, _, _ = _compute_tax_breakdown(gross_rows, tax_config)
+    net_tax, _, label = _compute_tax_breakdown(net_rows, tax_config)
+
+    assert label == "IVA 19%"
+    assert net_tax < gross_tax
+    assert net_tax == 14370
+    assert gross_tax == 15966


### PR DESCRIPTION
## Summary
- Compute POS complete and invoice email taxes on `COALESCE(oi.net_total, oi.subtotal, 0)` via shared `_compute_tax_breakdown`
- Extend receipt template, email helper, and `SendReceiptRequest` with optional `promo_savings` / `promo_breakdown`
- Wire promo summary from checkout eval (POS) and `_get_order_promo_summary` (invoice email)

Closes #337

## Test plan
- [x] `pytest tests/test_pos_receipt_template.py tests/test_invoice_send_email.py`
- [ ] Complete a promo-only POS order → response `standard_tax` reflects net base
- [ ] Send receipt email from success modal with promo breakdown lines visible
- [ ] `POST /api/orders/{id}/invoice/send-email` on promo order includes promo lines + net tax


Made with [Cursor](https://cursor.com)