### PR TITLE
feat(api): paginated promotion scope endpoint

### DIFF
--- a/.wr/999.yaml
+++ b/.wr/999.yaml
@@ -1,0 +1,28 @@
+issue: 999
+title: "feat(api): paginated GET /promotions/{id}/scope for alcance popover"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-999-promo-scope-endpoint
+
+paths:
+  - app/routers/promotions.py
+  - app/services/promotions_service.py
+  - tests/test_promotions_crud.py
+
+ac:
+  - GET /api/promotions/{id}/scope returns paginated product/category names
+  - Supports search, page, page_size (max 100)
+  - all_products scope returns empty items
+
+out_of_scope:
+  - Front popover UI (warocol.com#999 front PR)
+
+hints:
+  entry: "list_promotion_scope — promotions_service.py"
+  pattern: "_load_scope_summaries_batch JOIN pattern"
+  tests: "pytest tests/test_promotions_crud.py -v -k scope"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/routers/promotions.py
+++ b/app/routers/promotions.py
@@ -92,6 +92,28 @@ async def get_promotion_endpoint(
     return await promotions_service.get_promotion(request, promotion_id, at=at)
 
 
+@router.get(
+    "/{promotion_id}/scope",
+    dependencies=[Depends(require_module(Module.MI_NEGOCIO))],
+    summary="Paginated promotion scope items",
+    description="Returns product or category names in promotion scope with optional search.",
+)
+async def list_promotion_scope_endpoint(
+    request: Request,
+    promotion_id: UUID,
+    search: Optional[str] = Query(None, description="Filter names within scope."),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+):
+    return await promotions_service.list_promotion_scope(
+        request,
+        promotion_id,
+        search=search,
+        page=page,
+        page_size=page_size,
+    )
+
+
 @router.patch(
     "/{promotion_id}",
     dependencies=[Depends(require_module(Module.MI_NEGOCIO))],

--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -432,6 +432,114 @@ async def get_promotion(
     }
 
 
+async def list_promotion_scope(
+    request: Request,
+    promotion_id: UUID,
+    *,
+    search: Optional[str] = None,
+    page: int = 1,
+    page_size: int = 50,
+) -> dict:
+    """Paginated scope item names for promotions list popover (warocol.com#999)."""
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    page = max(1, page)
+    page_size = min(max(1, page_size), 100)
+    offset = (page - 1) * page_size
+    search_term = search.strip() if search and search.strip() else None
+    search_pattern = f"%{search_term}%" if search_term else None
+
+    async with get_db_connection(use_transaction=False) as conn:
+        row = await _get_owned_promotion(conn, promotion_id, tenant_id)
+        scope_type = row["scope_type"]
+
+        if scope_type == ScopeType.ALL_PRODUCTS.value:
+            return {
+                "success": True,
+                "data": {
+                    "scope_type": scope_type,
+                    "promotion_name": row["name"],
+                    "items": [],
+                    "total": 0,
+                    "page": page,
+                    "page_size": page_size,
+                },
+            }
+
+        if scope_type == ScopeType.CATEGORIES.value:
+            count_row = await conn.fetchrow(
+                """
+                SELECT COUNT(*) AS total
+                FROM tenant_promotion_scope_categories sc
+                LEFT JOIN categories c ON c.id = sc.category_id
+                WHERE sc.promotion_id = $1
+                  AND ($2::text IS NULL OR c.name ILIKE $2)
+                """,
+                promotion_id,
+                search_pattern,
+            )
+            rows = await conn.fetch(
+                """
+                SELECT sc.category_id AS id, c.name
+                FROM tenant_promotion_scope_categories sc
+                LEFT JOIN categories c ON c.id = sc.category_id
+                WHERE sc.promotion_id = $1
+                  AND ($2::text IS NULL OR c.name ILIKE $2)
+                ORDER BY c.name NULLS LAST, sc.category_id
+                LIMIT $3 OFFSET $4
+                """,
+                promotion_id,
+                search_pattern,
+                page_size,
+                offset,
+            )
+        else:
+            count_row = await conn.fetchrow(
+                """
+                SELECT COUNT(*) AS total
+                FROM tenant_promotion_scope_products sp
+                LEFT JOIN product p ON p.id = sp.product_id
+                WHERE sp.promotion_id = $1
+                  AND ($2::text IS NULL OR p.name ILIKE $2)
+                """,
+                promotion_id,
+                search_pattern,
+            )
+            rows = await conn.fetch(
+                """
+                SELECT sp.product_id AS id, p.name
+                FROM tenant_promotion_scope_products sp
+                LEFT JOIN product p ON p.id = sp.product_id
+                WHERE sp.promotion_id = $1
+                  AND ($2::text IS NULL OR p.name ILIKE $2)
+                ORDER BY p.name NULLS LAST, sp.product_id
+                LIMIT $3 OFFSET $4
+                """,
+                promotion_id,
+                search_pattern,
+                page_size,
+                offset,
+            )
+
+        total = int(count_row["total"]) if count_row else 0
+
+    items = [{"id": str(r["id"]), "name": r["name"] or "(sin nombre)"} for r in rows]
+    return {
+        "success": True,
+        "data": {
+            "scope_type": scope_type,
+            "promotion_name": row["name"],
+            "items": items,
+            "total": total,
+            "page": page,
+            "page_size": page_size,
+        },
+    }
+
+
 async def create_promotion(request: Request, body: PromotionCreate) -> dict:
     session = require_valid_session(request)
     tenant_id = session.tenant_id

--- a/tests/test_promotions_crud.py
+++ b/tests/test_promotions_crud.py
@@ -162,6 +162,47 @@ def test_cashier_passes_active_promotions_under_enforce():
     assert response.status_code == 200
 
 
+def test_list_promotion_scope_endpoint():
+    promo_id = uuid4()
+    session = _build_session()
+    app = FastAPI()
+    app.include_router(promotions_router)
+
+    scope_payload = {
+        "success": True,
+        "data": {
+            "scope_type": "products",
+            "promotion_name": "2x1",
+            "items": [{"id": str(uuid4()), "name": "Cerveza"}],
+            "total": 1,
+            "page": 1,
+            "page_size": 50,
+        },
+    }
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=frozenset({Module.MI_NEGOCIO})),
+         ), \
+         patch(
+             "app.services.promotions_service.list_promotion_scope",
+             new=AsyncMock(return_value=scope_payload),
+         ):
+        client = TestClient(app)
+        response = client.get(
+            f"/api/promotions/{promo_id}/scope",
+            params={"search": "cer", "page": 1, "page_size": 50},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["scope_type"] == "products"
+    assert body["data"]["total"] == 1
+
+
 def test_scope_summary_products_preview_capped_at_three():
     pid1, pid2, pid3, pid4 = uuid4(), uuid4(), uuid4(), uuid4()
     scope = _scope_summary_from_pairs(


### PR DESCRIPTION
## Summary
- Adds `GET /api/promotions/{id}/scope` with optional `search`, `page`, and `page_size`
- Returns paginated product or category names for a promotion's scope
- Companion to warocol.com#999 (merge before front PR)

## Test plan
- [ ] `GET /api/promotions/{id}/scope` on a products-scoped promo returns names + total
- [ ] `search` filters within scope; pagination works for 50+ items
- [ ] `all_products` scope returns empty items

## wr-context
See `.wr/999.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)