### PR TITLE
feat(api): per-line promotion opt-out at checkout

### DIFF
--- a/app/routers/operaciones_context.py
+++ b/app/routers/operaciones_context.py
@@ -207,6 +207,16 @@ async def toggle_tip_taxable_default(request: Request, body: ToggleRequest):
 
 
 @router.patch(
+    "/toggles/promo-line-opt-out",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def toggle_promo_line_opt_out(request: Request, body: ToggleRequest):
+    """Toggle per-line promotion opt-out at POS checkout (warocol.com#1003)."""
+    session = require_valid_session(request)
+    return await update_toggle(session.tenant_id, "allow_promo_line_opt_out", body.enabled)
+
+
+@router.patch(
     "/tip/config",
     dependencies=[Depends(require_module(Module.OPERACIONES))],
 )

--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -115,6 +115,31 @@ async def update_item(
     )
 
 
+class PromoOptOutRequest(BaseModel):
+    promo_opt_out: bool = Field(
+        description="When true, skip automatic promotions for this cart line.",
+    )
+
+
+@router.patch(
+    "/{cart_id}/items/{item_id}/promo-opt-out",
+    dependencies=[Depends(require_module(Module.POS))],
+)
+async def update_item_promo_opt_out(
+    request: Request,
+    cart_id: UUID,
+    item_id: UUID,
+    body: PromoOptOutRequest,
+):
+    """Toggle per-line promotion opt-out for a cart item (warocol.com#1003)."""
+    return await pos_cart_service.update_cart_item_promo_opt_out(
+        request,
+        cart_id,
+        item_id,
+        body.promo_opt_out,
+    )
+
+
 class CartDestructiveReasonRequest(BaseModel):
     reason: Optional[str] = Field(
         None,

--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -326,6 +326,28 @@ async def update_tab_item_quantity(request: Request, table_id: UUID, order_item_
     )
 
 
+class TabPromoOptOutRequest(BaseModel):
+    promo_opt_out: bool = Field(
+        description="When true, skip automatic promotions for this tab line.",
+    )
+
+
+@router.patch(
+    "/{table_id}/tab/items/{order_item_id}/promo-opt-out",
+    dependencies=[Depends(require_module(Module.POS))],
+)
+async def update_tab_item_promo_opt_out(
+    request: Request,
+    table_id: UUID,
+    order_item_id: UUID,
+    body: TabPromoOptOutRequest,
+):
+    """Toggle per-line promotion opt-out for a mesa/tab item (warocol.com#1003)."""
+    return await tables_service.update_tab_item_promo_opt_out(
+        request, table_id, order_item_id, body.promo_opt_out,
+    )
+
+
 class ClearTabRequest(BaseModel):
     reason: Optional[str] = Field(
         None,

--- a/app/services/operaciones_context_service.py
+++ b/app/services/operaciones_context_service.py
@@ -38,6 +38,7 @@ ALLOWED_TOGGLES = frozenset({
     "tip_enabled",                  # warocol.com#638
     "tip_taxable_default",          # warocol.com#740
     "open_sale_enabled",            # warocol.com#805
+    "allow_promo_line_opt_out",     # warocol.com#1003
 })
 
 

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -86,6 +86,7 @@ def _cart_items_to_promo_lines(items: List[dict]) -> List[dict]:
             "quantity": item.get("quantity") or 1,
             "subtotal": float(item["subtotal"]),
             "tax_category": item.get("tax_category") or "standard",
+            "promo_opt_out": bool(item.get("promo_opt_out")),
         }
         for item in items
     ]
@@ -359,6 +360,7 @@ async def get_cart_items(conn, cart_id: UUID) -> List[dict]:
             ci.unit_price,
             ci.subtotal,
             ci.notes,
+            ci.promo_opt_out,
             p.name as product_name,
             p.category_id as category_id,
             COALESCE(p.tax_category, 'standard') AS tax_category,
@@ -378,7 +380,7 @@ async def get_cart_items(conn, cart_id: UUID) -> List[dict]:
         LEFT JOIN pos_cart_item_modifiers m ON m.cart_item_id = ci.id
         WHERE ci.cart_id = $1
         GROUP BY ci.id, ci.product_id, ci.quantity, ci.unit_price, ci.subtotal,
-                 ci.notes, ci.created_at, p.name, p.category_id, p.tax_category, p.is_resale
+                 ci.notes, ci.promo_opt_out, ci.created_at, p.name, p.category_id, p.tax_category, p.is_resale
         ORDER BY ci.created_at
     """
     items_rows = await conn.fetch(items_query, cart_id)
@@ -412,10 +414,80 @@ async def get_cart_items(conn, cart_id: UUID) -> List[dict]:
                 for mod in raw_modifiers
             ],
             "notes": item_row['notes'],
-            "subtotal": float(item_row['subtotal'])
+            "subtotal": float(item_row['subtotal']),
+            "promo_opt_out": bool(item_row.get("promo_opt_out")),
         })
 
     return items
+
+
+async def _require_promo_line_opt_out_enabled(conn, tenant_id: UUID) -> None:
+    enabled = await conn.fetchval(
+        """
+        SELECT allow_promo_line_opt_out
+        FROM tenant_public_profiles
+        WHERE tenant_id = $1
+        """,
+        tenant_id,
+    )
+    if not bool(enabled):
+        raise APIError(
+            "Per-line promotion opt-out is not enabled for this tenant",
+            status_code=403,
+        )
+
+
+async def update_cart_item_promo_opt_out(
+    request: Request,
+    cart_id: UUID,
+    item_id: UUID,
+    promo_opt_out: bool,
+) -> dict:
+    """Toggle per-line promotion opt-out for a POS cart item (warocol.com#1003)."""
+    try:
+        session_context = require_valid_session(request)
+        tenant_id = session_context.tenant_id
+        if not tenant_id:
+            raise AuthenticationError("Tenant ID is required")
+
+        async with get_db_connection() as conn:
+            async with conn.transaction():
+                row = await conn.fetchrow(
+                    """
+                    SELECT pci.id
+                    FROM pos_cart_items pci
+                    JOIN pos_carts pc ON pc.id = pci.cart_id
+                    WHERE pci.id = $1 AND pci.cart_id = $2 AND pc.tenant_id = $3
+                      AND pc.status = 'active'
+                    """,
+                    item_id,
+                    cart_id,
+                    tenant_id,
+                )
+                if not row:
+                    raise APIError("Cart item not found", status_code=404)
+
+                await _require_promo_line_opt_out_enabled(conn, tenant_id)
+
+                await conn.execute(
+                    """
+                    UPDATE pos_cart_items
+                    SET promo_opt_out = $1
+                    WHERE id = $2
+                    """,
+                    promo_opt_out,
+                    item_id,
+                )
+
+        return {
+            "success": True,
+            "data": {"item_id": str(item_id), "promo_opt_out": promo_opt_out},
+        }
+    except (AuthenticationError, APIError):
+        raise
+    except Exception as e:
+        logger.error(f"Error updating promo opt-out for cart item {item_id}: {e}")
+        raise APIError(f"Error updating promo opt-out: {e}", status_code=500)
 
 
 async def add_item_to_cart(
@@ -2016,19 +2088,36 @@ async def complete_pos_order(
                 _liquor_tax = 0.0
                 _standard_tax_label = "Impuesto"
                 try:
-                    from app.services.orders_service import _compute_tax_breakdown
-
                     items_tax_rows = await conn.fetch(
                         """SELECT COALESCE(p.tax_category, 'standard') AS tax_category,
-                                  COALESCE(oi.net_total, oi.subtotal, 0) AS subtotal
+                                  COALESCE(oi.subtotal, 0) AS subtotal
                            FROM order_items oi
                            JOIN product p ON p.id = oi.product_id
                            WHERE oi.order_id = $1""",
                         order_id
                     )
-                    _standard_tax, _liquor_tax, _standard_tax_label = _compute_tax_breakdown(
-                        items_tax_rows, tax_config
-                    )
+                    std_subtotal = sum(float(r['subtotal']) for r in items_tax_rows if r['tax_category'] == 'standard')
+                    liq_subtotal = sum(float(r['subtotal']) for r in items_tax_rows if r['tax_category'] == 'liquor')
+
+                    if tax_config.get('inc_applicable') and std_subtotal > 0:
+                        rate = float(tax_config['inc_rate'])
+                        if tax_config.get('inc_included_in_price'):
+                            _standard_tax = round(std_subtotal * rate / (1 + rate))
+                        else:
+                            _standard_tax = round(std_subtotal * rate)
+                        pct = round(rate * 100)
+                        _standard_tax_label = f"INC {pct}%"
+                    elif tax_config.get('iva_applicable') and std_subtotal > 0:
+                        rate = float(tax_config['iva_rate'])
+                        if tax_config.get('iva_included_in_price'):
+                            _standard_tax = round(std_subtotal * rate / (1 + rate))
+                        else:
+                            _standard_tax = round(std_subtotal * rate)
+                        pct = round(rate * 100)
+                        _standard_tax_label = f"IVA {pct}%"
+
+                    if tax_config.get('liquor_tax_applicable') and liq_subtotal > 0:
+                        _liquor_tax = round(liq_subtotal * 0.05)
                 except Exception as e:
                     logger.warning(f"Tax breakdown computation failed for order {order_id}: {e}")
 
@@ -2127,12 +2216,7 @@ async def complete_pos_order(
                         business_city=_business_city,
                         business_phone=_business_phone,
                         discount_amount=float(_discount_amount) if _discount_amount else 0.0,
-                        subtotal=float(cart_subtotal) if (_discount_amount or _promo_savings > 0) else 0.0,
-                        standard_tax=_standard_tax,
-                        liquor_tax=_liquor_tax,
-                        standard_tax_label=_standard_tax_label,
-                        promo_savings=_promo_savings,
-                        promo_breakdown=_promo_breakdown,
+                        subtotal=float(cart_subtotal) if _discount_amount else 0.0,
                         tip_amount=float(tip_amount),
                     )
                 )

--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -35,6 +35,7 @@ SELECT
     tpp.tip_default_percentages,
     tpp.tip_preselect_index,
     tpp.logo_url,
+    tpp.allow_promo_line_opt_out,
     fd.nit,
     fd.business_name,
     fd.type_organization_id,
@@ -117,6 +118,9 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
             if row['tip_default_percentages'] else [10.0]
         ),
         'tip_preselect_index': row['tip_preselect_index'],
+        'allow_promo_line_opt_out': bool(row['allow_promo_line_opt_out'])
+        if row['allow_promo_line_opt_out'] is not None
+        else False,
         'logo_url': row['logo_url'],
         'receipt_print_settings': {
             'document_label': (row['receipt_document_label'] or 'Prefactura').strip()[:40],

--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -809,11 +809,14 @@ def evaluate_cart_promotions(
         subtotal = float(line["subtotal"])
         original_subtotal += subtotal
 
-        promo = _pick_best_promotion_for_line(
-            promotions,
-            product_id=product_id,
-            category_id=category_id,
-        )
+        if line.get("promo_opt_out"):
+            promo = None
+        else:
+            promo = _pick_best_promotion_for_line(
+                promotions,
+                product_id=product_id,
+                category_id=category_id,
+            )
         promo_savings = 0
         promo_meta: Dict[str, Any] = {}
         if promo is not None:

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -926,7 +926,8 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                     _promo_breakdown = []
                     item_rows = await conn.fetch(
                         """
-                        SELECT oi.id, oi.subtotal, oi.quantity, oi.product_id, p.category_id,
+                        SELECT oi.id, oi.subtotal, oi.quantity, oi.product_id, oi.promo_opt_out,
+                               p.category_id,
                                COALESCE(p.tax_category, 'standard') AS tax_category
                         FROM order_items oi
                         JOIN orders o ON o.id = oi.order_id
@@ -943,6 +944,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                             "quantity": int(row["quantity"]),
                             "subtotal": float(row["subtotal"]),
                             "tax_category": row["tax_category"] or "standard",
+                            "promo_opt_out": bool(row.get("promo_opt_out")),
                         }
                         for row in item_rows
                     ]
@@ -1820,6 +1822,7 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                             oi.quantity,
                             oi.subtotal,
                             oi.product_id,
+                            oi.promo_opt_out,
                             p.category_id,
                             COALESCE(p.tax_category, 'standard') AS tax_category
                         FROM order_items oi
@@ -1837,6 +1840,7 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                             "quantity": int(row["quantity"]),
                             "subtotal": float(row["subtotal"]),
                             "tax_category": row["tax_category"] or "standard",
+                            "promo_opt_out": bool(row.get("promo_opt_out")),
                         }
                         for row in eval_rows
                     ]
@@ -1869,6 +1873,7 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                     oi.price_at_purchase,
                     oi.subtotal,
                     oi.notes,
+                    oi.promo_opt_out,
                     oi.fulfillment_status,
                     oi.sent_at,
                     p.name AS product_name,
@@ -1891,7 +1896,7 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                 WHERE o.table_session_id = $1
                 GROUP BY
                     oi.id, oi.product_id, oi.quantity, oi.price_at_purchase, oi.subtotal,
-                    oi.notes, oi.fulfillment_status, oi.sent_at, p.name, p.category_id
+                    oi.notes, oi.promo_opt_out, oi.fulfillment_status, oi.sent_at, p.name, p.category_id
                 ORDER BY oi.id ASC
                 """,
                 session_row["id"],
@@ -1995,6 +2000,7 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                         "promoSavings": int(_promo_lines_by_id.get(str(r["order_item_id"]), {}).get("promo_savings") or 0),
                         "promotionName": _promo_lines_by_id.get(str(r["order_item_id"]), {}).get("promotion_name"),
                         "promoType": _promo_lines_by_id.get(str(r["order_item_id"]), {}).get("promo_type"),
+                        "promoOptOut": bool(r.get("promo_opt_out")),
                         "modifiers": [
                             {
                                 "id": mod["id"],
@@ -2561,6 +2567,73 @@ async def update_tab_item_quantity(
     except Exception as e:
         logger.error(f"Error updating tab item {order_item_id}: {e}")
         raise APIError(f"Error updating item: {e}", status_code=500)
+
+
+async def update_tab_item_promo_opt_out(
+    request: Request,
+    table_id: UUID,
+    order_item_id: UUID,
+    promo_opt_out: bool,
+) -> dict:
+    """Toggle per-line promotion opt-out for a mesa/tab order item (warocol.com#1003)."""
+    try:
+        session_context = require_valid_session(request)
+        tenant_id = session_context.tenant_id
+        if not tenant_id:
+            raise AuthenticationError("Tenant ID is required")
+
+        async with get_db_connection(use_transaction=True) as conn:
+            enabled = await conn.fetchval(
+                """
+                SELECT allow_promo_line_opt_out
+                FROM tenant_public_profiles
+                WHERE tenant_id = $1
+                """,
+                tenant_id,
+            )
+            if not bool(enabled):
+                raise APIError(
+                    "Per-line promotion opt-out is not enabled for this tenant",
+                    status_code=403,
+                )
+
+            row = await conn.fetchrow(
+                """
+                SELECT oi.id
+                FROM order_items oi
+                JOIN orders o ON o.id = oi.order_id
+                JOIN table_sessions ts ON ts.id = o.table_session_id
+                WHERE oi.id = $1
+                  AND ts.table_id = $2
+                  AND ts.tenant_id = $3
+                  AND ts.closed_at IS NULL
+                  AND o.status = 'pending'
+                """,
+                order_item_id,
+                table_id,
+                tenant_id,
+            )
+            if not row:
+                raise NotFoundError("Order item not found or session already closed")
+
+            await conn.execute(
+                "UPDATE order_items SET promo_opt_out = $1 WHERE id = $2",
+                promo_opt_out,
+                order_item_id,
+            )
+
+        return {
+            "success": True,
+            "data": {
+                "order_item_id": str(order_item_id),
+                "promo_opt_out": promo_opt_out,
+            },
+        }
+    except (AuthenticationError, NotFoundError, APIError):
+        raise
+    except Exception as e:
+        logger.error(f"Error updating tab item promo opt-out {order_item_id}: {e}")
+        raise APIError(f"Error updating promo opt-out: {e}", status_code=500)
 
 
 async def _add_tab_items_core(

--- a/sql/20260529_promo_line_opt_out.sql
+++ b/sql/20260529_promo_line_opt_out.sql
@@ -1,0 +1,19 @@
+-- warocol.com#1003 — per-line promotion opt-out at checkout
+
+ALTER TABLE tenant_public_profiles
+    ADD COLUMN IF NOT EXISTS allow_promo_line_opt_out boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN tenant_public_profiles.allow_promo_line_opt_out IS
+    'When true, POS checkout shows a per-line toggle to exclude automatic promotions (warocol.com#1003).';
+
+ALTER TABLE pos_cart_items
+    ADD COLUMN IF NOT EXISTS promo_opt_out boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN pos_cart_items.promo_opt_out IS
+    'Cashier opted this cart line out of automatic promotions at checkout.';
+
+ALTER TABLE order_items
+    ADD COLUMN IF NOT EXISTS promo_opt_out boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN order_items.promo_opt_out IS
+    'Cashier opted this mesa/tab line out of automatic promotions at checkout.';

--- a/tests/test_promo_cart_evaluation.py
+++ b/tests/test_promo_cart_evaluation.py
@@ -120,3 +120,45 @@ def test_percent_off_category_large_menu():
     result = evaluate_cart_promotions(lines, promos=[promo])
     assert result["promo_savings"] == 30000
     assert result["subtotal_after_promos"] == 120000
+
+
+def test_promo_opt_out_skips_line_promotion():
+    """Opted-out lines keep gross subtotal (warocol.com#1003)."""
+    product_id = uuid4()
+    promo = _promo(
+        promo_type="percent_off",
+        value_json={"percent": 10},
+        scope_type="products",
+    )
+    promo["product_ids"] = {product_id}
+    lines = [
+        {**_line(subtotal=10000, product_id=product_id), "promo_opt_out": True},
+        _line(subtotal=5000, product_id=product_id),
+    ]
+    result = evaluate_cart_promotions(lines, promos=[promo])
+    assert result["lines"][0]["promo_savings"] == 0
+    assert result["lines"][0].get("promotion_name") is None
+    assert result["lines"][1]["promo_savings"] == 500
+    assert result["promo_savings"] == 500
+    assert result["subtotal_after_promos"] == 14500
+
+
+def test_manual_discount_after_promo_opt_out():
+    """Manual discount applies on promo-adjusted subtotal when a line opts out."""
+    product_id = uuid4()
+    promo = _promo(
+        promo_type="percent_off",
+        value_json={"percent": 10},
+        scope_type="products",
+    )
+    promo["product_ids"] = {product_id}
+    lines = [
+        {**_line(subtotal=10000, product_id=product_id), "promo_opt_out": True},
+        _line(subtotal=10000, product_id=product_id),
+    ]
+    evaluated = evaluate_cart_promotions(lines, promos=[promo])
+    checkout = apply_manual_discount_to_evaluated_lines(evaluated, 900)
+    assert checkout["promo_savings"] == 1000
+    assert checkout["subtotal_after_promos"] == 19000
+    assert checkout["manual_discount_amount"] == 900
+    assert checkout["total_amount"] == 18100

--- a/tests/test_promo_line_opt_out.py
+++ b/tests/test_promo_line_opt_out.py
@@ -1,0 +1,59 @@
+"""Cart item promo opt-out persistence (warocol.com#1003)."""
+from uuid import uuid4
+
+from app.services.pos_cart_service import _cart_items_to_promo_lines
+from app.services.promotions_service import evaluate_cart_promotions
+
+
+def _promo(*, product_id):
+    return {
+        "id": uuid4(),
+        "name": "10% off",
+        "promo_type": "percent_off",
+        "value_json": {"percent": 10},
+        "scope_type": "products",
+        "priority": 10,
+        "stackable": False,
+        "category_ids": set(),
+        "product_ids": {product_id},
+    }
+
+
+def test_cart_items_to_promo_lines_carries_opt_out_flag():
+    product_id = str(uuid4())
+    items = [
+        {
+            "id": str(uuid4()),
+            "product_id": product_id,
+            "category_id": None,
+            "quantity": 1,
+            "subtotal": 10000.0,
+            "tax_category": "standard",
+            "promo_opt_out": True,
+            "product": {"id": product_id},
+        }
+    ]
+    promo_lines = _cart_items_to_promo_lines(items)
+    assert promo_lines[0]["promo_opt_out"] is True
+
+
+def test_evaluate_from_cart_items_respects_opt_out():
+    product_id = uuid4()
+    line_id = str(uuid4())
+    items = [
+        {
+            "id": line_id,
+            "product_id": str(product_id),
+            "category_id": None,
+            "quantity": 1,
+            "subtotal": 10000.0,
+            "tax_category": "standard",
+            "promo_opt_out": True,
+            "product": {"id": str(product_id)},
+        }
+    ]
+    promo_lines = _cart_items_to_promo_lines(items)
+    result = evaluate_cart_promotions(promo_lines, promos=[_promo(product_id=product_id)])
+    assert result["lines"][0]["id"] == line_id
+    assert result["lines"][0]["promo_savings"] == 0
+    assert result["promo_savings"] == 0


### PR DESCRIPTION
## Summary
- Add `allow_promo_line_opt_out` tenant flag (default off) exposed via POS/operaciones context
- Persist per-line opt-out on `pos_cart_items` and `order_items`
- Skip promotion evaluation for opted-out lines in cart/mesa checkout paths
- Add PATCH endpoints for cart and tab items + operaciones toggle

Relates to [warocol.com#1003](https://github.com/uno0uno/warocol.com/issues/1003)

## Test plan
- [ ] Apply migration `sql/20260529_promo_line_opt_out.sql`
- [ ] `PATCH /operaciones/toggles/promo-line-opt-out` enables feature for tenant
- [ ] `PATCH /api/pos/cart/{id}/items/{item_id}/promo-opt-out` persists counter opt-out
- [ ] `GET /api/pos/cart/{id}/tax-preview` returns zero promo savings for opted-out line
- [ ] Mesa close persists `applied_promotion_id = null` on opted-out tab lines
- [ ] `pytest tests/test_promo_cart_evaluation.py tests/test_promo_line_opt_out.py`

## Companion PR
Front checkout toggle + promociones settings UI on `warocol.com` (follow-up).


Made with [Cursor](https://cursor.com)