### PR TITLE
feat(api): tenant promo conflict strategy and type-block defaults

### DIFF
--- a/.wr/1011.yaml
+++ b/.wr/1011.yaml
@@ -1,0 +1,37 @@
+issue: 1011
+title: "feat(api): tenant promo conflict strategy and type-block defaults"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-1011-promo-conflict-settings
+
+paths:
+  - sql/20260529_promo_conflict_settings.sql
+  - app/services/promotions_service.py
+  - app/services/pos_context_service.py
+  - app/services/operaciones_context_service.py
+  - app/routers/operaciones_context.py
+  - tests/test_promo_conflict_settings.py
+
+ac:
+  - tenant_public_profiles stores promo_conflict_strategy (text, default priority)
+  - tenant_public_profiles stores promo_type_block_map (jsonb) with default bogo blocks percent_off and fixed_off on same line
+  - GET /operaciones/restaurant-context and GET /pos/restaurant-context expose both fields
+  - PATCH /operaciones/promo-conflict/config persists strategy + type-block map
+  - CONFLICT_RULES_DOC updated for overlap-allowed admin + one winner at checkout
+  - Front can read settings via existing context endpoints; no admin UI in this batch
+
+out_of_scope:
+  - Evaluator type exclusion logic (#1012)
+  - Editable priority UI (#1013)
+  - Cross-promo overlap advisory (#1014)
+  - POS/client preview parity (#1015)
+
+hints:
+  entry: "update_promo_conflict_config — operaciones_context_service.py"
+  pattern: "update_tip_config UPSERT for non-boolean tenant_public_profiles writes"
+  tests: "pytest tests/test_promo_conflict_settings.py -v"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/routers/operaciones_context.py
+++ b/app/routers/operaciones_context.py
@@ -12,7 +12,7 @@ column whitelist guards against SQL injection.
 from decimal import Decimal
 from uuid import UUID
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -24,9 +24,15 @@ from app.services import table_assignments_service
 from app.services.operaciones_context_service import (
     get_operaciones_context,
     set_open_sale_enabled,
+    update_promo_conflict_config,
     update_tables_label,
     update_tip_config,
     update_toggle,
+)
+from app.services.promotions_service import (
+    DEFAULT_PROMO_CONFLICT_STRATEGY,
+    DEFAULT_PROMO_TYPE_BLOCK_MAP,
+    VALID_PROMO_TYPES,
 )
 
 router = APIRouter(prefix="/operaciones", tags=["Operaciones Context"])
@@ -82,6 +88,40 @@ class TipConfigRequest(BaseModel):
                 f"percentages of length {len(self.percentages)}"
             )
         return self
+
+
+class PromoConflictConfigRequest(BaseModel):
+    """Payload for PATCH /operaciones/promo-conflict/config (warocol.com#1011).
+
+    Non-boolean tenant settings for checkout promo conflict resolution.
+    Evaluator enforcement lands in batch #1012; this batch persists the contract.
+    """
+    promo_conflict_strategy: str = DEFAULT_PROMO_CONFLICT_STRATEGY
+    promo_type_block_map: Dict[str, List[str]] = Field(
+        default_factory=lambda: dict(DEFAULT_PROMO_TYPE_BLOCK_MAP),
+    )
+
+    @field_validator("promo_conflict_strategy")
+    @classmethod
+    def _validate_strategy(cls, v: str) -> str:
+        if v != DEFAULT_PROMO_CONFLICT_STRATEGY:
+            raise ValueError(
+                f"promo_conflict_strategy must be {DEFAULT_PROMO_CONFLICT_STRATEGY!r} for now"
+            )
+        return v
+
+    @field_validator("promo_type_block_map")
+    @classmethod
+    def _validate_type_block_map(cls, v: Dict[str, List[str]]) -> Dict[str, List[str]]:
+        for winner, blocked in v.items():
+            if winner not in VALID_PROMO_TYPES:
+                raise ValueError(f"Unknown promo_type in block map: {winner}")
+            if not blocked:
+                raise ValueError(f"Blocked types for {winner} must be non-empty")
+            for promo_type in blocked:
+                if promo_type not in VALID_PROMO_TYPES:
+                    raise ValueError(f"Unknown blocked promo_type: {promo_type}")
+        return v
 
 
 @router.get(
@@ -214,6 +254,23 @@ async def toggle_promo_line_opt_out(request: Request, body: ToggleRequest):
     """Toggle per-line promotion opt-out at POS checkout (warocol.com#1003)."""
     session = require_valid_session(request)
     return await update_toggle(session.tenant_id, "allow_promo_line_opt_out", body.enabled)
+
+
+@router.patch(
+    "/promo-conflict/config",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def patch_promo_conflict_config(
+    request: Request,
+    body: PromoConflictConfigRequest,
+):
+    """Persist promo conflict strategy + type-block map (warocol.com#1011)."""
+    session = require_valid_session(request)
+    return await update_promo_conflict_config(
+        session.tenant_id,
+        body.promo_conflict_strategy,
+        body.promo_type_block_map,
+    )
 
 
 @router.patch(

--- a/app/services/operaciones_context_service.py
+++ b/app/services/operaciones_context_service.py
@@ -13,12 +13,17 @@ make future divergence local to this module).
 The toggle writer parameterizes the column name dynamically; the
 `ALLOWED_TOGGLES` whitelist prevents SQL injection.
 """
-from typing import Any, Dict, Optional
+import json
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from fastapi import HTTPException
 
 from app.database import get_db_connection
+from app.services.promotions_service import (
+    ALLOWED_PROMO_CONFLICT_STRATEGIES,
+    validate_promo_type_block_map,
+)
 from app.services.open_priced_service import (
     deactivate_open_sale_product,
     ensure_open_sale_product,
@@ -221,6 +226,63 @@ async def update_tip_config(
         "data": {
             "tip_default_percentages": [float(p) for p in row["tip_default_percentages"] or []],
             "tip_preselect_index": row["tip_preselect_index"],
+        },
+    }
+
+
+async def update_promo_conflict_config(
+    tenant_id: UUID,
+    strategy: str,
+    type_block_map: Dict[str, List[str]],
+) -> Dict[str, Any]:
+    """Persist promo conflict strategy + type-block map (warocol.com#1011).
+
+    Non-boolean sibling to update_tip_config. Evaluator consumes these in #1012;
+    this batch only stores and exposes the contract.
+    """
+    if strategy not in ALLOWED_PROMO_CONFLICT_STRATEGIES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unknown promo_conflict_strategy: {strategy}",
+        )
+    try:
+        normalized_map = validate_promo_type_block_map(type_block_map)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    query = """
+        INSERT INTO tenant_public_profiles
+            (tenant_id, slug, display_name, promo_conflict_strategy, promo_type_block_map)
+        SELECT t.id, t.slug, t.name, $2, $3::jsonb
+        FROM tenants t
+        WHERE t.id = $1
+        ON CONFLICT (tenant_id) DO UPDATE
+            SET promo_conflict_strategy = EXCLUDED.promo_conflict_strategy,
+                promo_type_block_map    = EXCLUDED.promo_type_block_map,
+                updated_at              = now()
+        RETURNING promo_conflict_strategy, promo_type_block_map
+    """
+
+    async with get_db_connection() as conn:
+        row = await conn.fetchrow(
+            query,
+            tenant_id,
+            strategy,
+            json.dumps(normalized_map),
+        )
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+
+    block_map = row["promo_type_block_map"]
+    if isinstance(block_map, str):
+        block_map = json.loads(block_map)
+
+    return {
+        "success": True,
+        "data": {
+            "promo_conflict_strategy": row["promo_conflict_strategy"],
+            "promo_type_block_map": block_map,
         },
     }
 

--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -14,6 +14,10 @@ from uuid import UUID
 from app.database import get_db_connection
 from app.services.invoicing_readiness_service import get_readiness
 from app.services.open_priced_service import fetch_open_sale_product
+from app.services.promotions_service import (
+    DEFAULT_PROMO_CONFLICT_STRATEGY,
+    normalize_promo_type_block_map,
+)
 
 
 _CONTEXT_QUERY = """
@@ -36,6 +40,8 @@ SELECT
     tpp.tip_preselect_index,
     tpp.logo_url,
     tpp.allow_promo_line_opt_out,
+    tpp.promo_conflict_strategy,
+    tpp.promo_type_block_map,
     fd.nit,
     fd.business_name,
     fd.type_organization_id,
@@ -121,6 +127,14 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
         'allow_promo_line_opt_out': bool(row['allow_promo_line_opt_out'])
         if row['allow_promo_line_opt_out'] is not None
         else False,
+        'promo_conflict_strategy': (
+            row['promo_conflict_strategy']
+            if row['promo_conflict_strategy'] is not None
+            else DEFAULT_PROMO_CONFLICT_STRATEGY
+        ),
+        'promo_type_block_map': normalize_promo_type_block_map(
+            row['promo_type_block_map']
+        ),
         'logo_url': row['logo_url'],
         'receipt_print_settings': {
             'document_label': (row['receipt_document_label'] or 'Prefactura').strip()[:40],

--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -22,12 +22,64 @@ logger = logging.getLogger(__name__)
 
 BOGOTA = ZoneInfo("America/Bogota")
 
-# v1 contract: higher priority wins; default non-stackable (documented on router).
+VALID_PROMO_TYPES = frozenset({"percent_off", "fixed_off", "bogo"})
+DEFAULT_PROMO_CONFLICT_STRATEGY = "priority"
+ALLOWED_PROMO_CONFLICT_STRATEGIES = frozenset({DEFAULT_PROMO_CONFLICT_STRATEGY})
+DEFAULT_PROMO_TYPE_BLOCK_MAP: Dict[str, List[str]] = {
+    "bogo": ["percent_off", "fixed_off"],
+}
+
+# Checkout contract (documented on promotion router + tenant context).
 CONFLICT_RULES_DOC = (
-    "When multiple promotions match a line, the highest priority wins. "
+    "Overlapping promotions may coexist in admin; at checkout exactly one automatic "
+    "promotion applies per line. When multiple promotions match a line, the tenant "
+    "promo_conflict_strategy applies (default: highest priority wins). "
+    "Tenant promo_type_block_map defines type exclusions on the same line "
+    "(default: BOGO blocks percent_off and fixed_off). "
     "stackable=false (default) means one promotion per line. "
-    "Manual order-level discounts are applied separately in checkout (batch #982)."
+    "Manual order-level discounts are applied separately in checkout."
 )
+
+
+def normalize_promo_type_block_map(
+    raw: Optional[Dict[str, Any]],
+) -> Dict[str, List[str]]:
+    """Return a validated type-block map, falling back to tenant defaults."""
+    if not raw:
+        return dict(DEFAULT_PROMO_TYPE_BLOCK_MAP)
+    normalized: Dict[str, List[str]] = {}
+    for winner, blocked in raw.items():
+        if winner not in VALID_PROMO_TYPES:
+            continue
+        if not isinstance(blocked, list):
+            continue
+        cleaned = [b for b in blocked if isinstance(b, str) and b in VALID_PROMO_TYPES]
+        if cleaned:
+            normalized[winner] = cleaned
+    return normalized or dict(DEFAULT_PROMO_TYPE_BLOCK_MAP)
+
+
+def validate_promo_type_block_map(
+    raw: Dict[str, Any],
+) -> Dict[str, List[str]]:
+    """Validate a type-block map for PATCH writes; raises ValueError on bad input."""
+    if not isinstance(raw, dict):
+        raise ValueError("promo_type_block_map must be an object")
+    normalized: Dict[str, List[str]] = {}
+    for winner, blocked in raw.items():
+        if winner not in VALID_PROMO_TYPES:
+            raise ValueError(f"Unknown promo_type in block map: {winner}")
+        if not isinstance(blocked, list):
+            raise ValueError(f"Blocked types for {winner} must be a list")
+        cleaned: List[str] = []
+        for promo_type in blocked:
+            if not isinstance(promo_type, str) or promo_type not in VALID_PROMO_TYPES:
+                raise ValueError(f"Unknown blocked promo_type: {promo_type}")
+            if promo_type not in cleaned:
+                cleaned.append(promo_type)
+        if cleaned:
+            normalized[winner] = cleaned
+    return normalized or dict(DEFAULT_PROMO_TYPE_BLOCK_MAP)
 
 
 def day_bit_for_datetime(at: datetime) -> int:

--- a/sql/20260529_promo_conflict_settings.sql
+++ b/sql/20260529_promo_conflict_settings.sql
@@ -1,0 +1,21 @@
+-- warocol.com#1011 — tenant promo conflict strategy + type-block defaults
+
+ALTER TABLE tenant_public_profiles
+    ADD COLUMN IF NOT EXISTS promo_conflict_strategy text NOT NULL DEFAULT 'priority';
+
+ALTER TABLE tenant_public_profiles
+    ADD COLUMN IF NOT EXISTS promo_type_block_map jsonb NOT NULL
+    DEFAULT '{"bogo": ["percent_off", "fixed_off"]}'::jsonb;
+
+COMMENT ON COLUMN tenant_public_profiles.promo_conflict_strategy IS
+    'Checkout promo conflict winner strategy; priority = highest priority wins (warocol.com#1011).';
+
+COMMENT ON COLUMN tenant_public_profiles.promo_type_block_map IS
+    'Map of winning promo_type -> blocked promo_types on the same checkout line (warocol.com#1011).';
+
+ALTER TABLE tenant_public_profiles
+    DROP CONSTRAINT IF EXISTS tenant_public_profiles_promo_conflict_strategy_check;
+
+ALTER TABLE tenant_public_profiles
+    ADD CONSTRAINT tenant_public_profiles_promo_conflict_strategy_check
+    CHECK (promo_conflict_strategy IN ('priority'));

--- a/tests/test_promo_conflict_settings.py
+++ b/tests/test_promo_conflict_settings.py
@@ -1,0 +1,99 @@
+"""Tenant promo conflict settings — warocol.com#1011."""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.operaciones_context_service import update_promo_conflict_config
+from app.services.promotions_service import (
+    DEFAULT_PROMO_CONFLICT_STRATEGY,
+    DEFAULT_PROMO_TYPE_BLOCK_MAP,
+    normalize_promo_type_block_map,
+    validate_promo_type_block_map,
+)
+
+
+def test_default_type_block_map():
+    assert DEFAULT_PROMO_TYPE_BLOCK_MAP == {
+        "bogo": ["percent_off", "fixed_off"],
+    }
+
+
+def test_normalize_promo_type_block_map_falls_back_to_default():
+    assert normalize_promo_type_block_map(None) == DEFAULT_PROMO_TYPE_BLOCK_MAP
+    assert normalize_promo_type_block_map({}) == DEFAULT_PROMO_TYPE_BLOCK_MAP
+
+
+def test_normalize_promo_type_block_map_filters_invalid_entries():
+    raw = {
+        "bogo": ["percent_off", "unknown"],
+        "invalid": ["percent_off"],
+    }
+    assert normalize_promo_type_block_map(raw) == {"bogo": ["percent_off"]}
+
+
+def test_validate_promo_type_block_map_rejects_unknown_winner():
+    with pytest.raises(ValueError, match="Unknown promo_type"):
+        validate_promo_type_block_map({"combo": ["percent_off"]})
+
+
+def test_validate_promo_type_block_map_rejects_unknown_blocked_type():
+    with pytest.raises(ValueError, match="Unknown blocked promo_type"):
+        validate_promo_type_block_map({"bogo": ["combo"]})
+
+
+@pytest.mark.asyncio
+async def test_update_promo_conflict_config_persists(monkeypatch):
+    tenant_id = uuid4()
+    row = {
+        "promo_conflict_strategy": DEFAULT_PROMO_CONFLICT_STRATEGY,
+        "promo_type_block_map": {"bogo": ["percent_off", "fixed_off"]},
+    }
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=row)
+
+    @asynccontextmanager
+    async def _ctx():
+        yield conn
+
+    monkeypatch.setattr(
+        "app.services.operaciones_context_service.get_db_connection",
+        _ctx,
+    )
+
+    result = await update_promo_conflict_config(
+        tenant_id,
+        DEFAULT_PROMO_CONFLICT_STRATEGY,
+        dict(DEFAULT_PROMO_TYPE_BLOCK_MAP),
+    )
+
+    assert result["success"] is True
+    assert result["data"]["promo_conflict_strategy"] == "priority"
+    assert result["data"]["promo_type_block_map"] == DEFAULT_PROMO_TYPE_BLOCK_MAP
+    sql = conn.fetchrow.call_args[0][0]
+    assert "promo_conflict_strategy" in sql
+    assert "promo_type_block_map" in sql
+
+
+@pytest.mark.asyncio
+async def test_update_promo_conflict_config_rejects_unknown_strategy():
+    with pytest.raises(HTTPException) as excinfo:
+        await update_promo_conflict_config(
+            uuid4(),
+            "stack_all",
+            dict(DEFAULT_PROMO_TYPE_BLOCK_MAP),
+        )
+    assert excinfo.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_update_promo_conflict_config_rejects_invalid_map():
+    with pytest.raises(HTTPException) as excinfo:
+        await update_promo_conflict_config(
+            uuid4(),
+            DEFAULT_PROMO_CONFLICT_STRATEGY,
+            {"bogo": ["combo"]},
+        )
+    assert excinfo.value.status_code == 422


### PR DESCRIPTION
## Summary
- Add `promo_conflict_strategy` (default `priority`) and `promo_type_block_map` jsonb on `tenant_public_profiles` with migration.
- Expose both via `GET /pos/restaurant-context` and `GET /operaciones/restaurant-context`; persist via `PATCH /operaciones/promo-conflict/config`.
- Update `CONFLICT_RULES_DOC` and shared constants for batch #1012 evaluator work.

Closes uno0uno/warocol.com#1011

## Test plan
- [x] `pytest tests/test_promo_conflict_settings.py -v`
- [ ] Run migration `sql/20260529_promo_conflict_settings.sql` on staging
- [ ] Verify context GET returns defaults for existing tenants
- [ ] PATCH custom type-block map and confirm persistence

## wr-context
See `.wr/1011.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)