### PR TITLE
feat(api): type exclusion and scope priority in cart promo evaluator

### DIFF
--- a/.wr/1012.yaml
+++ b/.wr/1012.yaml
@@ -1,0 +1,36 @@
+issue: 1012
+title: "feat(api): type exclusion and scope priority in cart promo evaluator"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-1012-promo-evaluator-conflicts
+epic: 1010
+depends_on: 1011
+
+paths:
+  - app/services/promotions_service.py
+  - tests/test_promo_cart_evaluation.py
+
+ac:
+  - _pick_best_promotion_for_line applies promo_type_block_map before winner selection
+  - equal priority: scope rank products > categories > all_products, then name tie-break
+  - tests: BOGO + percent + fixed on same SKU → exactly one applies
+  - tests: default map blocks percent/fixed when BOGO competes at same priority
+  - tests: higher priority percent wins over BOGO block rule
+  - manual order discount still stacks after promo (apply_manual_discount_to_evaluated_lines unchanged)
+
+out_of_scope:
+  - stackable multi-promo stacking
+  - overlap advisory on promo CRUD (#1014)
+  - POS/client preview parity (#1015)
+  - priority admin UI (#1013)
+
+hints:
+  entry: "_pick_best_promotion_for_line — promotions_service.py"
+  wire_cart: "evaluate_cart_promotions accepts promo_type_block_map (default via normalize)"
+  wire_checkout: "evaluate_checkout_promotions loads tenant_public_profiles.promo_type_block_map"
+  tests: "pytest tests/test_promo_cart_evaluation.py -v"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -783,11 +783,64 @@ def _promo_matches_line(
     )
 
 
+def _scope_specificity_rank(scope_type: str) -> int:
+    if scope_type == ScopeType.PRODUCTS.value:
+        return 2
+    if scope_type == ScopeType.CATEGORIES.value:
+        return 1
+    return 0
+
+
+def _promo_rank_key(promo: Dict[str, Any]) -> tuple:
+    return (
+        int(promo.get("priority") or 0),
+        _scope_specificity_rank(str(promo.get("scope_type") or "")),
+        promo.get("name") or "",
+    )
+
+
+def _promo_block_rank_key(promo: Dict[str, Any]) -> tuple:
+    return (
+        int(promo.get("priority") or 0),
+        _scope_specificity_rank(str(promo.get("scope_type") or "")),
+    )
+
+
+def _filter_type_blocked_candidates(
+    matches: Sequence[Dict[str, Any]],
+    type_block_map: Dict[str, List[str]],
+) -> List[Dict[str, Any]]:
+    if not matches:
+        return []
+    eligible: List[Dict[str, Any]] = []
+    for candidate in matches:
+        candidate_type = str(candidate.get("promo_type") or "")
+        candidate_rank = _promo_block_rank_key(candidate)
+        blocked = False
+        for other in matches:
+            if other is candidate:
+                continue
+            blocked_types = type_block_map.get(str(other.get("promo_type") or "")) or []
+            if candidate_type not in blocked_types:
+                continue
+            other_rank = _promo_block_rank_key(other)
+            if other_rank > candidate_rank:
+                blocked = True
+                break
+            if other_rank == candidate_rank:
+                blocked = True
+                break
+        if not blocked:
+            eligible.append(candidate)
+    return eligible
+
+
 def _pick_best_promotion_for_line(
     promotions: Sequence[Dict[str, Any]],
     *,
     product_id: UUID,
     category_id: Optional[UUID],
+    promo_type_block_map: Optional[Dict[str, Any]] = None,
 ) -> Optional[Dict[str, Any]]:
     matches = [
         p for p in promotions
@@ -795,7 +848,11 @@ def _pick_best_promotion_for_line(
     ]
     if not matches:
         return None
-    return max(matches, key=lambda p: (int(p.get("priority") or 0), p.get("name") or ""))
+    block_map = normalize_promo_type_block_map(promo_type_block_map)
+    eligible = _filter_type_blocked_candidates(matches, block_map)
+    if not eligible:
+        return None
+    return max(eligible, key=_promo_rank_key)
 
 
 def _compute_line_promo_savings(line: Dict[str, Any], promo: Dict[str, Any]) -> int:
@@ -839,6 +896,8 @@ def _compute_line_promo_savings(line: Dict[str, Any], promo: Dict[str, Any]) -> 
 def evaluate_cart_promotions(
     lines: Sequence[Dict[str, Any]],
     promotions: Sequence[Dict[str, Any]],
+    *,
+    promo_type_block_map: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
     Evaluate active promotions against checkout lines.
@@ -868,6 +927,7 @@ def evaluate_cart_promotions(
                 promotions,
                 product_id=product_id,
                 category_id=category_id,
+                promo_type_block_map=promo_type_block_map,
             )
         promo_savings = 0
         promo_meta: Dict[str, Any] = {}
@@ -1025,7 +1085,22 @@ async def evaluate_checkout_promotions(
     """DB-backed promo evaluation + optional manual discount stacking."""
     evaluation_at = at or default_at_bogota()
     promotions = await load_promotions_for_evaluation(conn, tenant_id, evaluation_at)
-    evaluated = evaluate_cart_promotions(lines, promotions)
+    profile_row = await conn.fetchrow(
+        """
+        SELECT promo_type_block_map
+        FROM tenant_public_profiles
+        WHERE tenant_id = $1
+        """,
+        tenant_id,
+    )
+    type_block_map = normalize_promo_type_block_map(
+        profile_row["promo_type_block_map"] if profile_row else None
+    )
+    evaluated = evaluate_cart_promotions(
+        lines,
+        promotions,
+        promo_type_block_map=type_block_map,
+    )
     manual_discount = float(manual_discount_amount or 0)
     if discount_type and discount_value is not None and discount_value > 0:
         if discount_type == "percent":

--- a/tests/test_promo_cart_evaluation.py
+++ b/tests/test_promo_cart_evaluation.py
@@ -61,7 +61,7 @@ def test_percent_off_scoped_product():
         _line(subtotal=10000, product_id=product_id),
         _line(subtotal=5000, product_id=other_id),
     ]
-    result = evaluate_cart_promotions(lines, promos=[promo])
+    result = evaluate_cart_promotions(lines, [promo])
     assert result["promo_savings"] == 1000
     assert result["subtotal_after_promos"] == 14000
 
@@ -78,7 +78,7 @@ def test_manual_discount_stacks_after_promo():
 
 def test_ineligible_lines_unchanged():
     lines = [_line(subtotal=8000, quantity=2)]
-    result = evaluate_cart_promotions(lines, promos=[])
+    result = evaluate_cart_promotions(lines, [])
     assert result["promo_savings"] == 0
     assert result["subtotal_after_promos"] == 8000
 
@@ -98,7 +98,7 @@ def test_percent_off_category_scoped():
         _line(subtotal=10000, category_id=category_id),
         _line(subtotal=5000, category_id=other_category),
     ]
-    result = evaluate_cart_promotions(lines, promos=[promo])
+    result = evaluate_cart_promotions(lines, [promo])
     assert result["promo_savings"] == 1000
     assert result["subtotal_after_promos"] == 14000
     assert result["lines"][0]["promotion_name"] == "Happy hour Cervezas"
@@ -117,7 +117,7 @@ def test_percent_off_category_large_menu():
     lines = [
         _line(subtotal=1000, category_id=category_id) for _ in range(150)
     ]
-    result = evaluate_cart_promotions(lines, promos=[promo])
+    result = evaluate_cart_promotions(lines, [promo])
     assert result["promo_savings"] == 30000
     assert result["subtotal_after_promos"] == 120000
 
@@ -135,7 +135,7 @@ def test_promo_opt_out_skips_line_promotion():
         {**_line(subtotal=10000, product_id=product_id), "promo_opt_out": True},
         _line(subtotal=5000, product_id=product_id),
     ]
-    result = evaluate_cart_promotions(lines, promos=[promo])
+    result = evaluate_cart_promotions(lines, [promo])
     assert result["lines"][0]["promo_savings"] == 0
     assert result["lines"][0].get("promotion_name") is None
     assert result["lines"][1]["promo_savings"] == 500
@@ -156,9 +156,101 @@ def test_manual_discount_after_promo_opt_out():
         {**_line(subtotal=10000, product_id=product_id), "promo_opt_out": True},
         _line(subtotal=10000, product_id=product_id),
     ]
-    evaluated = evaluate_cart_promotions(lines, promos=[promo])
+    evaluated = evaluate_cart_promotions(lines, [promo])
     checkout = apply_manual_discount_to_evaluated_lines(evaluated, 900)
     assert checkout["promo_savings"] == 1000
     assert checkout["subtotal_after_promos"] == 19000
     assert checkout["manual_discount_amount"] == 900
     assert checkout["total_amount"] == 18100
+
+
+def test_three_promo_types_one_winner_per_line():
+    """BOGO + percent + fixed on one SKU — exactly one promo applies (warocol.com#1012)."""
+    product_id = uuid4()
+    lines = [_line(subtotal=20000, quantity=2, product_id=product_id)]
+    bogo = _promo(
+        promo_type="bogo",
+        value_json={"buy_qty": 1, "get_qty": 1},
+        name="BOGO deal",
+        priority=10,
+    )
+    percent = _promo(
+        promo_type="percent_off",
+        value_json={"percent": 30},
+        name="Percent deal",
+        priority=10,
+    )
+    fixed = _promo(
+        promo_type="fixed_off",
+        value_json={"amount_cop": 5000},
+        name="Fixed deal",
+        priority=10,
+    )
+    result = evaluate_cart_promotions(lines, [percent, fixed, bogo])
+    assert result["lines"][0]["promotion_name"] == "BOGO deal"
+    assert result["promo_savings"] == 10000
+
+
+def test_bogo_blocks_percent_and_fixed_at_equal_priority():
+    product_id = uuid4()
+    lines = [_line(subtotal=20000, quantity=2, product_id=product_id)]
+    bogo = _promo(
+        promo_type="bogo",
+        value_json={"buy_qty": 1, "get_qty": 1},
+        name="BOGO",
+        priority=5,
+    )
+    percent = _promo(
+        promo_type="percent_off",
+        value_json={"percent": 50},
+        name="Half off",
+        priority=5,
+    )
+    result = evaluate_cart_promotions(lines, [bogo, percent])
+    assert result["lines"][0]["promotion_name"] == "BOGO"
+    assert result["promo_savings"] == 10000
+
+
+def test_higher_priority_percent_wins_over_bogo_block():
+    product_id = uuid4()
+    lines = [_line(subtotal=10000, quantity=1, product_id=product_id)]
+    bogo = _promo(
+        promo_type="bogo",
+        value_json={"buy_qty": 1, "get_qty": 1},
+        name="BOGO",
+        priority=0,
+    )
+    percent = _promo(
+        promo_type="percent_off",
+        value_json={"percent": 30},
+        name="VIP percent",
+        priority=20,
+    )
+    result = evaluate_cart_promotions(lines, [bogo, percent])
+    assert result["lines"][0]["promotion_name"] == "VIP percent"
+    assert result["promo_savings"] == 3000
+
+
+def test_product_scope_beats_category_at_equal_priority():
+    product_id = uuid4()
+    category_id = uuid4()
+    lines = [_line(subtotal=10000, quantity=1, product_id=product_id, category_id=category_id)]
+    category_promo = _promo(
+        promo_type="percent_off",
+        value_json={"percent": 50},
+        scope_type="categories",
+        name="Category wide",
+        priority=10,
+    )
+    category_promo["category_ids"] = {category_id}
+    product_promo = _promo(
+        promo_type="percent_off",
+        value_json={"percent": 10},
+        scope_type="products",
+        name="Product specific",
+        priority=10,
+    )
+    product_promo["product_ids"] = {product_id}
+    result = evaluate_cart_promotions(lines, [category_promo, product_promo])
+    assert result["lines"][0]["promotion_name"] == "Product specific"
+    assert result["promo_savings"] == 1000


### PR DESCRIPTION
## Summary
- Apply tenant `promo_type_block_map` in `_pick_best_promotion_for_line` before winner selection (priority overrides blocks).
- Tie-break equal priority by scope specificity (product > category > all_products), then name.
- Load tenant block map in `evaluate_checkout_promotions`; add multi-promo conflict unit tests.

Closes #1012

**Stacked on:** #343 (`wr-1011-promo-conflict-settings`) — merge #1011 first.

## Test plan
- [x] `pytest tests/test_promo_cart_evaluation.py -v`
- [ ] POS/mesa checkout still applies one promo per line with tenant block defaults

## wr-context
See `.wr/1012.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)