### PR TITLE
feat(api): overlap advisory on promo create/update

### DIFF
--- a/.wr/1014.yaml
+++ b/.wr/1014.yaml
@@ -1,0 +1,37 @@
+issue: 1014
+title: "feat(promotions): overlap advisory on promo create/edit (warn only)"
+repo: both
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-1014-promo-overlap-advisory
+
+paths:
+  - api_warocol.com/app/services/promotions_service.py
+  - api_warocol.com/app/models/tenant_promotion.py
+  - api_warocol.com/app/routers/promotions.py
+  - front_nuxt/components/promociones/PromocionPanel.vue
+  - front_nuxt/utils/promotionPreview.ts
+  - api_warocol.com/tests/test_promotions_crud.py
+
+ac:
+  - Overlap detector expands category scope to product SKUs; intersects days/times and starts_at/ends_at against other active promos
+  - API returns advisory payload on create/update with overlap_warnings and requires_acknowledgment
+  - Front shows warning panel listing conflicting promos and affected product count
+  - Save allowed after warning; high-risk (priority 0 tie) requires acknowledgment or priority > 0
+  - Server validates intra-promo schedule overlap with HTTP 400
+
+out_of_scope:
+  - Hard-blocking overlaps globally or 409 on overlap
+  - Strict mode tenant setting
+  - POS preview parity (#1015)
+
+hints:
+  entry: "promotions_service.py:detect_promotion_overlaps — called from create/update before persist"
+  pattern: "promotionPreview.ts:178-207 — schedules_overlap parity in Python"
+  tests: "pytest tests/test_promotions_crud.py -v -k overlap"
+
+skip:
+  audits: [ux, color, typography]
+
+epic: 1010

--- a/app/models/tenant_promotion.py
+++ b/app/models/tenant_promotion.py
@@ -70,6 +70,7 @@ class PromotionCreate(BaseModel):
     stackable: bool = False
     starts_at: Optional[datetime] = None
     ends_at: Optional[datetime] = None
+    overlap_acknowledged: bool = False
 
     @model_validator(mode="after")
     def _validate_scope_and_values(self):
@@ -107,6 +108,7 @@ class PromotionUpdate(BaseModel):
     stackable: Optional[bool] = None
     starts_at: Optional[datetime] = None
     ends_at: Optional[datetime] = None
+    overlap_acknowledged: bool = False
 
 
 class PromotionResponse(BaseModel):

--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -157,6 +157,253 @@ def product_in_scope(
     return False
 
 
+def _time_to_minutes(value: Any) -> int:
+    if isinstance(value, time):
+        return value.hour * 60 + value.minute
+    text = str(value)
+    hours, minutes = text[:5].split(":")
+    return int(hours) * 60 + int(minutes)
+
+
+def schedules_overlap(
+    a: Dict[str, Any],
+    b: Dict[str, Any],
+) -> bool:
+    """Pairwise schedule overlap (parity with front promotionPreview.ts)."""
+    if not (int(a["days_of_week"]) & int(b["days_of_week"])):
+        return False
+    a_start = _time_to_minutes(a["start_time"])
+    a_end = _time_to_minutes(a["end_time"])
+    b_start = _time_to_minutes(b["start_time"])
+    b_end = _time_to_minutes(b["end_time"])
+    if not a.get("crosses_midnight") and not b.get("crosses_midnight"):
+        return a_start < b_end and b_start < a_end
+    return True
+
+
+def find_intra_promo_schedule_overlap(
+    schedules: Sequence[Any],
+) -> Optional[str]:
+    """Return Spanish error when two rows in the same promo overlap."""
+    rows: List[Dict[str, Any]] = []
+    for sched in schedules:
+        if isinstance(sched, dict):
+            rows.append(sched)
+        else:
+            rows.append({
+                "days_of_week": sched.days_of_week,
+                "start_time": sched.start_time,
+                "end_time": sched.end_time,
+                "crosses_midnight": sched.crosses_midnight,
+            })
+    for i in range(len(rows)):
+        for j in range(i + 1, len(rows)):
+            if schedules_overlap(rows[i], rows[j]):
+                return (
+                    f"Los horarios {i + 1} y {j + 1} "
+                    "se superponen en los mismos días."
+                )
+    return None
+
+
+def schedule_lists_overlap(
+    schedules_a: Sequence[Dict[str, Any]],
+    schedules_b: Sequence[Dict[str, Any]],
+) -> bool:
+    if not schedules_a or not schedules_b:
+        return True
+    return any(
+        schedules_overlap(a, b)
+        for a in schedules_a
+        for b in schedules_b
+    )
+
+
+def campaign_dates_overlap(
+    starts_a: Optional[datetime],
+    ends_a: Optional[datetime],
+    starts_b: Optional[datetime],
+    ends_b: Optional[datetime],
+) -> bool:
+    if ends_a is not None and starts_b is not None and ends_a <= starts_b:
+        return False
+    if ends_b is not None and starts_a is not None and ends_b <= starts_a:
+        return False
+    return True
+
+
+def product_scopes_overlap(
+    product_ids_a: Optional[Set[UUID]],
+    product_ids_b: Optional[Set[UUID]],
+) -> bool:
+    if product_ids_a is None or product_ids_b is None:
+        return True
+    return bool(product_ids_a & product_ids_b)
+
+
+async def _expand_scope_product_ids(
+    conn: asyncpg.Connection,
+    tenant_id: UUID,
+    *,
+    scope_type: str,
+    category_ids: Sequence[UUID],
+    product_ids: Sequence[UUID],
+) -> Optional[Set[UUID]]:
+    if scope_type == ScopeType.ALL_PRODUCTS.value:
+        return None
+    if scope_type == ScopeType.PRODUCTS.value:
+        return set(product_ids)
+    if not category_ids:
+        return set()
+    rows = await conn.fetch(
+        """
+        SELECT id FROM product
+        WHERE tenant_id = $1 AND category_id = ANY($2::uuid[])
+        """,
+        tenant_id,
+        list(category_ids),
+    )
+    return {row["id"] for row in rows}
+
+
+async def _count_tenant_products(conn: asyncpg.Connection, tenant_id: UUID) -> int:
+    row = await conn.fetchrow(
+        "SELECT COUNT(*) AS total FROM product WHERE tenant_id = $1",
+        tenant_id,
+    )
+    return int(row["total"]) if row else 0
+
+
+async def _shared_product_count(
+    conn: asyncpg.Connection,
+    tenant_id: UUID,
+    product_ids_a: Optional[Set[UUID]],
+    product_ids_b: Optional[Set[UUID]],
+) -> int:
+    if product_ids_a is None and product_ids_b is None:
+        return await _count_tenant_products(conn, tenant_id)
+    if product_ids_a is None:
+        return len(product_ids_b or set())
+    if product_ids_b is None:
+        return len(product_ids_a)
+    return len(product_ids_a & product_ids_b)
+
+
+def _schedule_dicts_from_inputs(schedules: Sequence[Any]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for sched in schedules:
+        if isinstance(sched, dict):
+            rows.append({
+                "days_of_week": int(sched["days_of_week"]),
+                "start_time": sched["start_time"],
+                "end_time": sched["end_time"],
+                "crosses_midnight": bool(sched.get("crosses_midnight", False)),
+            })
+        else:
+            rows.append({
+                "days_of_week": int(sched.days_of_week),
+                "start_time": sched.start_time,
+                "end_time": sched.end_time,
+                "crosses_midnight": bool(sched.crosses_midnight),
+            })
+    return rows
+
+
+async def detect_promotion_overlaps(
+    conn: asyncpg.Connection,
+    tenant_id: UUID,
+    candidate: Dict[str, Any],
+    *,
+    exclude_promotion_id: Optional[UUID] = None,
+) -> List[Dict[str, Any]]:
+    """Compare candidate promo against other active tenant promos."""
+    peer_rows = await conn.fetch(
+        """
+        SELECT * FROM tenant_promotions
+        WHERE tenant_id = $1 AND is_active = true
+        ORDER BY priority DESC, name
+        """,
+        tenant_id,
+    )
+    candidate_products = await _expand_scope_product_ids(
+        conn,
+        tenant_id,
+        scope_type=candidate["scope_type"],
+        category_ids=candidate.get("category_ids") or [],
+        product_ids=candidate.get("product_ids") or [],
+    )
+    candidate_schedules = candidate.get("schedules") or []
+
+    warnings: List[Dict[str, Any]] = []
+    for peer in peer_rows:
+        if exclude_promotion_id and peer["id"] == exclude_promotion_id:
+            continue
+        peer_cats, peer_prods = await _load_scope_ids(conn, peer["id"])
+        peer_products = await _expand_scope_product_ids(
+            conn,
+            tenant_id,
+            scope_type=peer["scope_type"],
+            category_ids=peer_cats,
+            product_ids=peer_prods,
+        )
+        if not product_scopes_overlap(candidate_products, peer_products):
+            continue
+        if not campaign_dates_overlap(
+            candidate.get("starts_at"),
+            candidate.get("ends_at"),
+            peer["starts_at"],
+            peer["ends_at"],
+        ):
+            continue
+        peer_schedules = [_row_to_schedule(r) for r in await _load_schedules(conn, peer["id"])]
+        if not schedule_lists_overlap(candidate_schedules, peer_schedules):
+            continue
+        shared_count = await _shared_product_count(
+            conn,
+            tenant_id,
+            candidate_products,
+            peer_products,
+        )
+        peer_priority = int(peer["priority"])
+        candidate_priority = int(candidate.get("priority") or 0)
+        risk = "high" if peer_priority == candidate_priority else "medium"
+        warnings.append({
+            "promotion_id": str(peer["id"]),
+            "promotion_name": peer["name"],
+            "priority": peer_priority,
+            "shared_product_count": shared_count,
+            "risk": risk,
+        })
+    return warnings
+
+
+def _requires_overlap_acknowledgment(
+    warnings: Sequence[Dict[str, Any]],
+    *,
+    priority: int,
+    overlap_acknowledged: bool,
+) -> bool:
+    if overlap_acknowledged or priority > 0:
+        return False
+    return any(w.get("risk") == "high" for w in warnings)
+
+
+def _overlap_advisory_response(
+    warnings: Sequence[Dict[str, Any]],
+    *,
+    requires_acknowledgment: bool,
+    data: Optional[Dict[str, Any]] = None,
+) -> dict:
+    payload: Dict[str, Any] = {
+        "success": True,
+        "overlap_warnings": list(warnings),
+        "requires_acknowledgment": requires_acknowledgment,
+    }
+    if data is not None:
+        payload["data"] = data
+    return payload
+
+
 def _parse_value_json(raw: Any) -> Dict[str, Any]:
     if raw is None:
         return {}
@@ -598,8 +845,37 @@ async def create_promotion(request: Request, body: PromotionCreate) -> dict:
     if not tenant_id:
         raise AuthenticationError("Tenant ID is required")
 
+    intra_overlap = find_intra_promo_schedule_overlap(body.schedules)
+    if intra_overlap:
+        raise HTTPException(status_code=400, detail=intra_overlap)
+
+    candidate = {
+        "scope_type": body.scope_type.value,
+        "category_ids": body.category_ids,
+        "product_ids": body.product_ids,
+        "schedules": _schedule_dicts_from_inputs(body.schedules),
+        "starts_at": body.starts_at,
+        "ends_at": body.ends_at,
+        "priority": body.priority,
+    }
+
     try:
         async with get_db_connection() as conn:
+            overlap_warnings = await detect_promotion_overlaps(
+                conn,
+                tenant_id,
+                candidate,
+            )
+            if _requires_overlap_acknowledgment(
+                overlap_warnings,
+                priority=body.priority,
+                overlap_acknowledged=body.overlap_acknowledged,
+            ):
+                return _overlap_advisory_response(
+                    overlap_warnings,
+                    requires_acknowledgment=True,
+                )
+
             row = await conn.fetchrow(
                 """
                 INSERT INTO tenant_promotions (
@@ -639,10 +915,11 @@ async def create_promotion(request: Request, body: PromotionCreate) -> dict:
         ) from None
 
     logger.info("Created promotion %r for tenant %s", body.name, tenant_id)
-    return {
-        "success": True,
-        "data": _serialize_promotion(row, schedules, scope),
-    }
+    return _overlap_advisory_response(
+        overlap_warnings,
+        requires_acknowledgment=False,
+        data=_serialize_promotion(row, schedules, scope),
+    )
 
 
 async def update_promotion(
@@ -662,6 +939,12 @@ async def update_promotion(
     schedules = data.pop("schedules", None)
     category_ids = data.pop("category_ids", None)
     product_ids = data.pop("product_ids", None)
+    overlap_acknowledged = data.pop("overlap_acknowledged", False)
+
+    if schedules is not None:
+        intra_overlap = find_intra_promo_schedule_overlap(schedules)
+        if intra_overlap:
+            raise HTTPException(status_code=400, detail=intra_overlap)
 
     if "name" in data and data["name"] is not None:
         data["name"] = data["name"].strip()
@@ -674,6 +957,47 @@ async def update_promotion(
 
     async with get_db_connection() as conn:
         existing = await _get_owned_promotion(conn, promotion_id, tenant_id)
+
+        scope_type = data.get("scope_type", existing["scope_type"])
+        merged_cats = category_ids if category_ids is not None else (
+            await _load_scope_ids(conn, promotion_id)
+        )[0]
+        merged_prods = product_ids if product_ids is not None else (
+            await _load_scope_ids(conn, promotion_id)
+        )[1]
+        merged_schedules_rows = (
+            await _load_schedules(conn, promotion_id)
+            if schedules is None
+            else schedules
+        )
+        merged_priority = data.get("priority", existing["priority"])
+        merged_starts = data.get("starts_at", existing["starts_at"])
+        merged_ends = data.get("ends_at", existing["ends_at"])
+
+        candidate = {
+            "scope_type": scope_type,
+            "category_ids": merged_cats,
+            "product_ids": merged_prods,
+            "schedules": _schedule_dicts_from_inputs(merged_schedules_rows),
+            "starts_at": merged_starts,
+            "ends_at": merged_ends,
+            "priority": merged_priority,
+        }
+        overlap_warnings = await detect_promotion_overlaps(
+            conn,
+            tenant_id,
+            candidate,
+            exclude_promotion_id=promotion_id,
+        )
+        if _requires_overlap_acknowledgment(
+            overlap_warnings,
+            priority=int(merged_priority),
+            overlap_acknowledged=overlap_acknowledged,
+        ):
+            return _overlap_advisory_response(
+                overlap_warnings,
+                requires_acknowledgment=True,
+            )
 
         if data:
             set_parts = []
@@ -721,10 +1045,11 @@ async def update_promotion(
         schedules_rows = await _load_schedules(conn, promotion_id)
         scope = await _load_scope_summary(conn, promotion_id)
 
-    return {
-        "success": True,
-        "data": _serialize_promotion(row, schedules_rows, scope),
-    }
+    return _overlap_advisory_response(
+        overlap_warnings,
+        requires_acknowledgment=False,
+        data=_serialize_promotion(row, schedules_rows, scope),
+    )
 
 
 async def delete_promotion(request: Request, promotion_id: UUID) -> dict:

--- a/tests/test_promotions_crud.py
+++ b/tests/test_promotions_crud.py
@@ -18,7 +18,10 @@ from app.services.promotions_service import (
     _empty_scope_summary,
     _scope_summary_from_pairs,
     _serialize_promotion,
+    campaign_dates_overlap,
+    find_intra_promo_schedule_overlap,
     product_in_scope,
+    schedules_overlap,
 )
 
 
@@ -294,3 +297,67 @@ def test_cashier_denied_create_promotion_under_enforce():
         )
 
     assert response.status_code == 403
+
+
+def test_schedules_overlap_same_window():
+    a = {
+        "days_of_week": 62,
+        "start_time": "17:00",
+        "end_time": "20:00",
+        "crosses_midnight": False,
+    }
+    b = {
+        "days_of_week": 62,
+        "start_time": "18:00",
+        "end_time": "21:00",
+        "crosses_midnight": False,
+    }
+    assert schedules_overlap(a, b) is True
+
+
+def test_schedules_overlap_disjoint_days():
+    a = {
+        "days_of_week": 1,
+        "start_time": "17:00",
+        "end_time": "20:00",
+        "crosses_midnight": False,
+    }
+    b = {
+        "days_of_week": 2,
+        "start_time": "17:00",
+        "end_time": "20:00",
+        "crosses_midnight": False,
+    }
+    assert schedules_overlap(a, b) is False
+
+
+def test_find_intra_promo_schedule_overlap():
+    schedules = [
+        type("S", (), {
+            "days_of_week": 62,
+            "start_time": "17:00",
+            "end_time": "20:00",
+            "crosses_midnight": False,
+        })(),
+        type("S", (), {
+            "days_of_week": 62,
+            "start_time": "19:00",
+            "end_time": "22:00",
+            "crosses_midnight": False,
+        })(),
+    ]
+    message = find_intra_promo_schedule_overlap(schedules)
+    assert message is not None
+    assert "horarios 1 y 2" in message
+
+
+def test_campaign_dates_overlap_open_ended():
+    start = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    end = datetime(2026, 6, 30, tzinfo=timezone.utc)
+    assert campaign_dates_overlap(start, end, None, None) is True
+    assert campaign_dates_overlap(
+        start,
+        end,
+        datetime(2026, 7, 1, tzinfo=timezone.utc),
+        None,
+    ) is False


### PR DESCRIPTION
## Summary
- Detect cross-promo overlaps (expanded SKU scope, recurring schedules, campaign dates) against other active promos on create/update.
- Return `overlap_warnings` and `requires_acknowledgment` without 409; block persist only when priority-0 tie needs ack.
- Reject intra-promo schedule overlap with HTTP 400 (parity with front).

Companion: uno0uno/warocol.com PR (front warning panel).

Closes uno0uno/warocol.com#1014

## Test plan
- [ ] Create two active promos on overlapping products/schedules/dates — second returns warnings
- [ ] Same priority 0 tie returns `requires_acknowledgment: true` until ack or priority > 0
- [ ] Intra-promo overlapping schedule rows return 400
- [ ] `pytest tests/test_promotions_crud.py -v -k overlap`

## wr-context
See `.wr/1014.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)