### PR TITLE
feat(api): persist authoritative promo savings on tab/order lines

### DIFF
--- a/.wr/1020.yaml
+++ b/.wr/1020.yaml
@@ -1,0 +1,25 @@
+issue: 1020
+title: "feat(api): persist authoritative promo savings on tab/order lines and tax-preview"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-1020-persist-promo-tab-lines
+
+paths:
+  - app/services/promotions_service.py
+  - app/services/tables_service.py
+  - tests/test_tables_tab_promo_persist.py
+
+ac:
+  - Tab add and tables/current tab_items include promo_savings, promotion_id, and breakdown when a promo wins
+  - GET /pos/cart/{id}/tax-preview and mesa session payloads match checkout promo totals
+  - BOGO (2×1, 3×1, custom buy/get) evaluates on persisted tab lines, not preview-only
+  - Unit tests cover BOGO + percent conflict and multi-qty bundles on tab lines
+
+hints:
+  entry: "persist_session_tab_promos — promotions_service.py"
+  tests: "pytest tests/test_tables_tab_promo_persist.py tests/test_promo_cart_evaluation.py -v"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -1469,3 +1469,107 @@ def promo_persist_fields_from_eval_line(
     if promo_id_raw:
         promo_uuid = promo_id_raw if isinstance(promo_id_raw, UUID) else UUID(str(promo_id_raw))
     return promo_uuid, promo_savings
+
+
+_SESSION_PENDING_PROMO_ITEMS_SQL = """
+    SELECT oi.id, oi.subtotal, oi.quantity, oi.product_id, oi.promo_opt_out,
+           p.category_id,
+           COALESCE(p.tax_category, 'standard') AS tax_category
+    FROM order_items oi
+    JOIN orders o ON o.id = oi.order_id
+    JOIN product p ON p.id = oi.product_id
+    WHERE o.table_session_id = $1 AND o.status = 'pending'
+"""
+
+
+def item_rows_to_promo_lines(item_rows: Sequence[Any]) -> List[Dict[str, Any]]:
+    """Map pending order_item rows → evaluate_checkout_promotions input."""
+    return [
+        {
+            "id": str(row["id"]),
+            "product_id": str(row["product_id"]),
+            "category_id": str(row["category_id"]) if row["category_id"] else None,
+            "quantity": int(row["quantity"]),
+            "subtotal": float(row["subtotal"]),
+            "tax_category": row["tax_category"] or "standard",
+            "promo_opt_out": bool(row.get("promo_opt_out")),
+        }
+        for row in item_rows
+    ]
+
+
+async def apply_promo_eval_to_order_items(
+    conn: asyncpg.Connection,
+    item_rows: Sequence[Any],
+    checkout_eval: Dict[str, Any],
+) -> None:
+    """Persist evaluate_checkout_promotions line results on order_items (warocol.com#1020)."""
+    eval_by_id = {line["id"]: line for line in checkout_eval["lines"]}
+    for row in item_rows:
+        eval_line = eval_by_id.get(str(row["id"]), {})
+        total_alloc = eval_line.get("total_discount_allocated")
+        net_total = eval_line.get("net_total")
+        promo_id, promo_savings = promo_persist_fields_from_eval_line(eval_line)
+        if total_alloc or net_total is not None or promo_id or promo_savings:
+            await conn.execute(
+                """
+                UPDATE order_items
+                SET discount_allocated = $2, net_total = $3,
+                    applied_promotion_id = $4, promo_savings_allocated = $5
+                WHERE id = $1::uuid
+                """,
+                row["id"],
+                total_alloc,
+                net_total,
+                promo_id,
+                promo_savings,
+            )
+
+
+async def recalc_pending_session_order_totals(
+    conn: asyncpg.Connection,
+    session_id: UUID,
+) -> None:
+    """Set pending orders.total_amount from net line totals after promo persist."""
+    await conn.execute(
+        """
+        UPDATE orders o
+        SET total_amount = sub.sum_net
+        FROM (
+            SELECT oi.order_id, COALESCE(SUM(COALESCE(oi.net_total, oi.subtotal)), 0) AS sum_net
+            FROM order_items oi
+            JOIN orders ord ON ord.id = oi.order_id
+            WHERE ord.table_session_id = $1 AND ord.status = 'pending'
+            GROUP BY oi.order_id
+        ) sub
+        WHERE o.id = sub.order_id
+          AND o.table_session_id = $1
+          AND o.status = 'pending'
+        """,
+        session_id,
+    )
+
+
+async def persist_session_tab_promos(
+    conn: asyncpg.Connection,
+    tenant_id: UUID,
+    session_id: UUID,
+) -> Dict[str, Any]:
+    """Evaluate and persist promo fields for all pending tab lines in a session."""
+    item_rows = await conn.fetch(_SESSION_PENDING_PROMO_ITEMS_SQL, session_id)
+    if not item_rows:
+        return {
+            "lines": [],
+            "promo_savings": 0,
+            "subtotal_after_promos": 0,
+            "promo_breakdown": [],
+        }
+
+    checkout_eval = await evaluate_checkout_promotions(
+        conn,
+        tenant_id,
+        item_rows_to_promo_lines(item_rows),
+    )
+    await apply_promo_eval_to_order_items(conn, item_rows, checkout_eval)
+    await recalc_pending_session_order_totals(conn, session_id)
+    return checkout_eval

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -958,47 +958,13 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                     _promo_savings = float(checkout_eval.get("promo_savings") or 0)
                     _promo_breakdown = checkout_eval.get("promo_breakdown") or []
                     _discount_amount = checkout_eval.get("manual_discount_amount") or None
-                    from app.services.promotions_service import promo_persist_fields_from_eval_line
-
-                    eval_by_id = {line["id"]: line for line in checkout_eval["lines"]}
-                    for row in item_rows:
-                        eval_line = eval_by_id.get(str(row["id"]), {})
-                        total_alloc = eval_line.get("total_discount_allocated")
-                        net_total = eval_line.get("net_total")
-                        _promo_id, _promo_savings = promo_persist_fields_from_eval_line(eval_line)
-                        if total_alloc or net_total is not None or _promo_id or _promo_savings:
-                            await conn.execute(
-                                """
-                                UPDATE order_items
-                                SET discount_allocated = $2, net_total = $3,
-                                    applied_promotion_id = $4, promo_savings_allocated = $5
-                                WHERE id = $1::uuid
-                                """,
-                                row["id"],
-                                total_alloc,
-                                net_total,
-                                _promo_id,
-                                _promo_savings,
-                            )
-
-                    # Recalculate pending order totals from net line amounts
-                    await conn.execute(
-                        """
-                        UPDATE orders o
-                        SET total_amount = sub.sum_net
-                        FROM (
-                            SELECT oi.order_id, COALESCE(SUM(COALESCE(oi.net_total, oi.subtotal)), 0) AS sum_net
-                            FROM order_items oi
-                            JOIN orders ord ON ord.id = oi.order_id
-                            WHERE ord.table_session_id = $1 AND ord.status = 'pending'
-                            GROUP BY oi.order_id
-                        ) sub
-                        WHERE o.id = sub.order_id
-                          AND o.table_session_id = $1
-                          AND o.status = 'pending'
-                        """,
-                        session_row["id"],
+                    from app.services.promotions_service import (
+                        apply_promo_eval_to_order_items,
+                        recalc_pending_session_order_totals,
                     )
+
+                    await apply_promo_eval_to_order_items(conn, item_rows, checkout_eval)
+                    await recalc_pending_session_order_totals(conn, session_row["id"])
 
                     completed_count = await conn.fetchval(
                         "SELECT COUNT(*) FROM orders WHERE table_session_id = $1 AND status = 'pending'",
@@ -1998,6 +1964,7 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                         "unitPrice": float(r["price_at_purchase"]),
                         "subtotal": float(r["subtotal"]),
                         "promoSavings": int(_promo_lines_by_id.get(str(r["order_item_id"]), {}).get("promo_savings") or 0),
+                        "promotionId": _promo_lines_by_id.get(str(r["order_item_id"]), {}).get("promotion_id"),
                         "promotionName": _promo_lines_by_id.get(str(r["order_item_id"]), {}).get("promotion_name"),
                         "promoType": _promo_lines_by_id.get(str(r["order_item_id"]), {}).get("promo_type"),
                         "promoOptOut": bool(r.get("promo_opt_out")),
@@ -2599,7 +2566,7 @@ async def update_tab_item_promo_opt_out(
 
             row = await conn.fetchrow(
                 """
-                SELECT oi.id
+                SELECT oi.id, ts.id AS session_id
                 FROM order_items oi
                 JOIN orders o ON o.id = oi.order_id
                 JOIN table_sessions ts ON ts.id = o.table_session_id
@@ -2621,6 +2588,10 @@ async def update_tab_item_promo_opt_out(
                 promo_opt_out,
                 order_item_id,
             )
+
+            from app.services.promotions_service import persist_session_tab_promos
+
+            await persist_session_tab_promos(conn, UUID(str(tenant_id)), row["session_id"])
 
         return {
             "success": True,
@@ -2889,12 +2860,25 @@ async def _add_tab_items_core(
         except Exception as _inv_exc:
             logger.error(f"[tab] inventory deduction failed for item {order_item_id}: {_inv_exc}")
 
+    from app.services.promotions_service import persist_session_tab_promos
+
+    promo_eval = await persist_session_tab_promos(conn, tenant_id, session_id)
+    refreshed_order = await conn.fetchrow(
+        "SELECT total_amount FROM orders WHERE id = $1",
+        order_id,
+    )
+    if refreshed_order:
+        order_total = float(refreshed_order["total_amount"])
+
     return {
         "order_id": order_id,
         "order_number": order_number,
         "total_amount": order_total,
         "session_id": session_id,
         "items_count": len(items),
+        "promo_savings": float(promo_eval.get("promo_savings") or 0),
+        "promo_breakdown": promo_eval.get("promo_breakdown") or [],
+        "promo_lines": promo_eval.get("lines") or [],
     }
 
 
@@ -2924,6 +2908,9 @@ async def add_tab_items(
         order_id = tab_result["order_id"]
         order_number = tab_result["order_number"]
         order_total = tab_result["total_amount"]
+        promo_savings = tab_result.get("promo_savings", 0)
+        promo_breakdown = tab_result.get("promo_breakdown") or []
+        promo_lines = tab_result.get("promo_lines") or []
 
         # Auto-fire comandas if enabled (#753 — return comandas for POS print)
         fired_comandas: List[dict] = []
@@ -2947,6 +2934,9 @@ async def add_tab_items(
                 "order_number": order_number,
                 "items_count": len(items),
                 "total_amount": order_total,
+                "promo_savings": promo_savings,
+                "promo_breakdown": promo_breakdown,
+                "lines": promo_lines,
                 "comandas": fired_comandas,
                 "fired_items_count": fired_items_count,
             },

--- a/tests/test_tables_tab_promo_persist.py
+++ b/tests/test_tables_tab_promo_persist.py
@@ -1,0 +1,256 @@
+"""Persist promo evaluation on mesa tab lines (warocol.com#1020)."""
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services import tables_service
+from app.services.promotions_service import (
+    apply_promo_eval_to_order_items,
+    evaluate_cart_promotions,
+    item_rows_to_promo_lines,
+    persist_session_tab_promos,
+    promo_persist_fields_from_eval_line,
+)
+
+
+def _promo(*, promo_type: str, value_json: dict, name: str = "Tab promo"):
+    return {
+        "id": uuid4(),
+        "name": name,
+        "promo_type": promo_type,
+        "value_json": value_json,
+        "scope_type": "all_products",
+        "priority": 10,
+        "stackable": False,
+        "category_ids": set(),
+        "product_ids": set(),
+    }
+
+
+def test_item_rows_to_promo_lines_maps_pending_rows():
+    product_id = uuid4()
+    item_id = uuid4()
+    rows = [{
+        "id": item_id,
+        "product_id": product_id,
+        "category_id": None,
+        "quantity": 3,
+        "subtotal": 30000.0,
+        "tax_category": "standard",
+        "promo_opt_out": False,
+    }]
+    lines = item_rows_to_promo_lines(rows)
+    assert lines[0]["id"] == str(item_id)
+    assert lines[0]["quantity"] == 3
+    assert lines[0]["subtotal"] == 30000.0
+
+
+def test_bogo_3x1_on_tab_line_quantity():
+    product_id = uuid4()
+    lines = [{
+        "id": str(uuid4()),
+        "product_id": str(product_id),
+        "category_id": None,
+        "quantity": 3,
+        "subtotal": 30000,
+    }]
+    promos = [_promo(promo_type="bogo", value_json={"buy_qty": 2, "get_qty": 1}, name="3x1")]
+    result = evaluate_cart_promotions(lines, promos)
+    assert result["promo_savings"] == 10000
+    assert result["lines"][0]["promotion_id"] == str(promos[0]["id"])
+
+
+def test_bogo_custom_buy_get_on_tab_line():
+    product_id = uuid4()
+    lines = [{
+        "id": str(uuid4()),
+        "product_id": str(product_id),
+        "category_id": None,
+        "quantity": 5,
+        "subtotal": 50000,
+    }]
+    promos = [_promo(promo_type="bogo", value_json={"buy_qty": 3, "get_qty": 2}, name="5x3 bundle")]
+    result = evaluate_cart_promotions(lines, promos)
+    assert result["promo_savings"] == 20000
+    assert result["lines"][0]["promotion_name"] == "5x3 bundle"
+
+
+def test_bogo_wins_over_percent_on_tab_line():
+    product_id = uuid4()
+    lines = [{
+        "id": str(uuid4()),
+        "product_id": str(product_id),
+        "category_id": None,
+        "quantity": 2,
+        "subtotal": 20000,
+    }]
+    bogo = _promo(
+        promo_type="bogo",
+        value_json={"buy_qty": 1, "get_qty": 1},
+        name="BOGO",
+    )
+    percent = _promo(
+        promo_type="percent_off",
+        value_json={"percent": 50},
+        name="Half off",
+    )
+    block_map = {"bogo": ["percent_off", "fixed_off"]}
+    result = evaluate_cart_promotions(lines, [percent, bogo], promo_type_block_map=block_map)
+    assert result["lines"][0]["promotion_name"] == "BOGO"
+    assert result["promo_savings"] == 10000
+
+
+@pytest.mark.asyncio
+async def test_apply_promo_eval_to_order_items_updates_rows():
+    item_id = uuid4()
+    promo_id = uuid4()
+    item_rows = [{"id": item_id}]
+    checkout_eval = {
+        "lines": [{
+            "id": str(item_id),
+            "promotion_id": str(promo_id),
+            "promo_savings": 1500,
+            "total_discount_allocated": 1500,
+            "net_total": 8500,
+        }],
+    }
+    mock_conn = AsyncMock()
+    await apply_promo_eval_to_order_items(mock_conn, item_rows, checkout_eval)
+    mock_conn.execute.assert_called_once()
+    args = mock_conn.execute.call_args.args
+    assert args[1] == item_id
+    assert args[4] == promo_id
+    assert args[5] == 1500
+
+
+@pytest.mark.asyncio
+async def test_persist_session_tab_promos_evaluates_and_recalcs():
+    tenant_id = uuid4()
+    session_id = uuid4()
+    item_id = uuid4()
+    product_id = uuid4()
+    item_rows = [{
+        "id": item_id,
+        "product_id": product_id,
+        "category_id": None,
+        "quantity": 2,
+        "subtotal": 20000.0,
+        "tax_category": "standard",
+        "promo_opt_out": False,
+    }]
+    checkout_eval = {
+        "lines": [{
+            "id": str(item_id),
+            "promotion_id": str(uuid4()),
+            "promo_savings": 10000,
+            "total_discount_allocated": 10000,
+            "net_total": 10000,
+        }],
+        "promo_savings": 10000,
+        "subtotal_after_promos": 10000,
+        "promo_breakdown": [],
+    }
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(return_value=item_rows)
+
+    with patch(
+        "app.services.promotions_service.evaluate_checkout_promotions",
+        new=AsyncMock(return_value=checkout_eval),
+    ) as eval_mock, patch(
+        "app.services.promotions_service.apply_promo_eval_to_order_items",
+        new=AsyncMock(),
+    ) as apply_mock, patch(
+        "app.services.promotions_service.recalc_pending_session_order_totals",
+        new=AsyncMock(),
+    ) as recalc_mock:
+        result = await persist_session_tab_promos(mock_conn, tenant_id, session_id)
+
+    eval_mock.assert_awaited_once()
+    apply_mock.assert_awaited_once()
+    recalc_mock.assert_awaited_once()
+    assert result["promo_savings"] == 10000
+
+
+@pytest.mark.asyncio
+async def test_add_tab_items_core_persists_promos_after_insert():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    session_id = uuid4()
+    order_id = uuid4()
+    product_id = uuid4()
+    order_item_id = uuid4()
+
+    session_row = {
+        "session_id": session_id,
+        "table_name": "Mesa 1",
+        "is_bar": False,
+        "effective_waiter_member_id": None,
+    }
+    promo_eval = {
+        "lines": [{
+            "id": str(order_item_id),
+            "promotion_id": str(uuid4()),
+            "promo_savings": 5000,
+            "promotion_name": "BOGO",
+            "promo_type": "bogo",
+        }],
+        "promo_savings": 5000,
+        "promo_breakdown": [{"promotion_name": "BOGO", "savings": 5000}],
+    }
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(side_effect=[
+        session_row,
+        None,
+        {"id": order_id, "order_number": 7, "total_amount": 20000.0},
+        {"id": order_item_id},
+        {"total_amount": 15000.0},
+    ])
+    mock_conn.fetch = AsyncMock(return_value=[])
+    mock_conn.execute = AsyncMock()
+
+    items = [{
+        "product_id": product_id,
+        "quantity": 2,
+        "unit_price": 10000.0,
+        "modifiers": [],
+    }]
+    pricing_map = {str(product_id): {"price": 10000, "open_priced": False}}
+    persist_mock = AsyncMock(return_value=promo_eval)
+
+    with patch(
+        "app.services.tables_service._record_tab_operation_event",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.tables_service._prefetch_product_names",
+        new=AsyncMock(return_value={str(product_id): "Pizza"}),
+    ), patch(
+        "app.services.tables_service.fetch_product_pricing_map",
+        new=AsyncMock(return_value=pricing_map),
+    ), patch(
+        "app.services.tables_service._capture_order_item_ingredients",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.promotions_service.persist_session_tab_promos",
+        persist_mock,
+    ):
+        result = await tables_service._add_tab_items_core(
+            mock_conn, tenant_id, user_id, table_id, items,
+        )
+
+    persist_mock.assert_awaited_once_with(mock_conn, tenant_id, session_id)
+    assert result["promo_savings"] == 5000
+    assert result["total_amount"] == 15000.0
+    assert result["promo_breakdown"][0]["promotion_name"] == "BOGO"
+
+
+def test_promo_persist_fields_roundtrip_for_tab_line():
+    promo_id = uuid4()
+    applied, savings = promo_persist_fields_from_eval_line({
+        "promotion_id": str(promo_id),
+        "promo_savings": 999.6,
+    })
+    assert applied == promo_id
+    assert savings == 1000


### PR DESCRIPTION
## Summary
- Evaluate and persist promo fields (`applied_promotion_id`, `promo_savings_allocated`, `net_total`) on pending mesa tab lines after add and promo opt-out changes.
- Add `promotionId` to `tables/current` tab_items; tab add response includes promo breakdown and evaluated lines.
- Extract shared `persist_session_tab_promos` helper; reuse in close_session path.

Closes uno0uno/warocol.com#1020

## Test plan
- [ ] Add 2× BOGO-eligible item to mesa tab — `tables/current` shows `promoSavings`, `promotionId`, session `promo_breakdown`
- [ ] `GET /pos/cart/{id}/tax-preview` totals match mesa session promo totals for same lines
- [ ] Close session — persisted promo columns match checkout eval
- [ ] `pytest tests/test_tables_tab_promo_persist.py tests/test_promo_cart_evaluation.py -v`

## wr-context
See `.wr/1020.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)