### PR TITLE
feat(comandas): split BOGO bundle lines on fire to KDS

### DIFF
--- a/.wr/1021.yaml
+++ b/.wr/1021.yaml
@@ -1,0 +1,25 @@
+issue: 1021
+title: "feat(api): align comanda firing with BOGO bundle quantities"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-1021-comanda-bogo-bundles
+
+paths:
+  - app/services/comandas_service.py
+  - app/models/comanda.py
+  - tests/test_comanda_bogo_fire.py
+
+ac:
+  - Fire qty=3 under 3×1 (buy 2 get 1) → comanda payload exposes 3 kitchen units with correct product + modifiers
+  - Free bundle units identifiable on ticket (notes annotation or response flag) without breaking KDS flow
+  - Partial bundles (qty below buy_qty+get_qty) fire full kitchen qty with no promo/free labeling
+  - Test covers tab-line promo persist (#1020) → fire_comandas → comanda items match bundle qty
+
+hints:
+  entry: "_fire_with_conn — comandas_service.py"
+  tests: "pytest tests/test_comanda_bogo_fire.py tests/test_comanda_item_notes.py -v"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/models/comanda.py
+++ b/app/models/comanda.py
@@ -20,6 +20,7 @@ class ComandaItem(BaseModel):
     quantity: Decimal
     notes: Optional[str] = None
     modifiers_snapshot: Optional[List[Dict[str, Any]]] = None
+    is_promo_free: Optional[bool] = False
     status: str
     ready_at: Optional[datetime] = None
     created_at: datetime

--- a/app/services/comandas_service.py
+++ b/app/services/comandas_service.py
@@ -24,7 +24,7 @@ from fastapi import Request
 logger = logging.getLogger(__name__)
 
 
-def _parse_item_row(ir: Any) -> Dict[str, Any]:
+def _parse_item_row(ir: Any, *, is_promo_free: bool = False) -> Dict[str, Any]:
     """Convert an asyncpg comanda_items row to a serializable dict.
     asyncpg returns JSONB columns as raw strings — parse modifiers_snapshot
     so the frontend receives a proper array, not a JSON-encoded string.
@@ -36,7 +36,97 @@ def _parse_item_row(ir: Any) -> Dict[str, Any]:
             d['modifiers_snapshot'] = json.loads(snap)
         except (ValueError, TypeError):
             d['modifiers_snapshot'] = None
+    d['is_promo_free'] = is_promo_free
     return d
+
+
+def _parse_promotion_value_json(raw: Any) -> Dict[str, Any]:
+    if raw is None:
+        return {}
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+            return parsed if isinstance(parsed, dict) else {}
+        except (ValueError, TypeError):
+            return {}
+    if isinstance(raw, dict):
+        return raw
+    return {}
+
+
+def _bogo_comanda_kitchen_lines(
+    quantity: float,
+    *,
+    buy_qty: int,
+    get_qty: int,
+    promotion_name: str,
+    base_notes: Optional[str],
+) -> List[Dict[str, Any]]:
+    """Split a BOGO order line into paid + free comanda rows (warocol.com#1021)."""
+    qty = int(quantity)
+    if qty <= 0:
+        return []
+
+    bundle = buy_qty + get_qty
+    sets = qty // bundle if buy_qty >= 1 and get_qty >= 1 and bundle > 0 else 0
+    if sets <= 0:
+        return [{"quantity": qty, "notes": base_notes, "is_promo_free": False}]
+
+    free_units = sets * get_qty
+    paid_units = qty - free_units
+    promo_label = (promotion_name or "BOGO").strip()
+    lines: List[Dict[str, Any]] = []
+
+    if paid_units > 0:
+        lines.append({"quantity": paid_units, "notes": base_notes, "is_promo_free": False})
+    if free_units > 0:
+        gratis_note = f"GRATIS ({promo_label})"
+        free_notes = f"{base_notes} — {gratis_note}" if base_notes else gratis_note
+        lines.append({"quantity": free_units, "notes": free_notes, "is_promo_free": True})
+    return lines
+
+
+def _comanda_kitchen_lines_for_order_item(item: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Map one order_item row → one or more comanda kitchen lines."""
+    base_notes = (item.get("notes") or "").strip() or None
+    qty = float(item.get("quantity") or 0)
+    if qty <= 0:
+        return []
+
+    if item.get("promo_type") != "bogo" or not item.get("applied_promotion_id"):
+        return [{"quantity": qty, "notes": base_notes, "is_promo_free": False}]
+
+    value_json = _parse_promotion_value_json(item.get("promotion_value_json"))
+    buy_qty = int(value_json.get("buy_qty") or 0)
+    get_qty = int(value_json.get("get_qty") or 0)
+    if buy_qty < 1 or get_qty < 1:
+        return [{"quantity": qty, "notes": base_notes, "is_promo_free": False}]
+
+    return _bogo_comanda_kitchen_lines(
+        qty,
+        buy_qty=buy_qty,
+        get_qty=get_qty,
+        promotion_name=item.get("promotion_name") or "",
+        base_notes=base_notes,
+    )
+
+
+_UNFIRED_ORDER_ITEMS_SELECT = """
+    SELECT
+        oi.id,
+        oi.quantity,
+        oi.product_id,
+        oi.notes,
+        oi.applied_promotion_id,
+        oi.promo_savings_allocated,
+        tp.promo_type,
+        tp.name AS promotion_name,
+        tp.value_json AS promotion_value_json,
+        COALESCE(p.kitchen_name, p.name) AS kitchen_name
+    FROM order_items oi
+    JOIN product p ON oi.product_id = p.id
+    LEFT JOIN tenant_promotions tp ON tp.id = oi.applied_promotion_id
+"""
 
 # Allowed status transitions — any move not in this map is rejected with 422.
 # 'recall' (delivered → ready) is handled by recall_comanda() separately.
@@ -142,15 +232,8 @@ async def _fire_with_conn(
     # ─── Step 1: Load unfired items ─────────────────────────────────────────
     if item_ids:
         rows = await conn.fetch(
-            """
-            SELECT
-                oi.id,
-                oi.quantity,
-                oi.product_id,
-                oi.notes,
-                COALESCE(p.kitchen_name, p.name) AS kitchen_name
-            FROM order_items oi
-            JOIN product p ON oi.product_id = p.id
+            f"""
+            {_UNFIRED_ORDER_ITEMS_SELECT}
             WHERE oi.order_id = $1
               AND oi.fulfillment_status = 'new'
               AND oi.id = ANY($2::uuid[])
@@ -160,15 +243,8 @@ async def _fire_with_conn(
         )
     else:
         rows = await conn.fetch(
-            """
-            SELECT
-                oi.id,
-                oi.quantity,
-                oi.product_id,
-                oi.notes,
-                COALESCE(p.kitchen_name, p.name) AS kitchen_name
-            FROM order_items oi
-            JOIN product p ON oi.product_id = p.id
+            f"""
+            {_UNFIRED_ORDER_ITEMS_SELECT}
             WHERE oi.order_id = $1
               AND oi.fulfillment_status = 'new'
             ORDER BY oi.created_at
@@ -232,7 +308,7 @@ async def _fire_with_conn(
         )
         comanda_id = comanda_row['id']
 
-        # 3c. INSERT comanda_items — one per order_item in this station's group
+        # 3c. INSERT comanda_items — BOGO lines may split paid vs free units (#1021)
         inserted_items: List[Dict[str, Any]] = []
         item_ids_in_group: List[UUID] = []
 
@@ -240,7 +316,6 @@ async def _fire_with_conn(
             order_item_id = item['id']
             item_ids_in_group.append(order_item_id)
 
-            # Build modifiers_snapshot from order_item_modifiers
             mod_rows = await conn.fetch(
                 """
                 SELECT modifier_name, price_at_purchase, quantity
@@ -258,26 +333,30 @@ async def _fire_with_conn(
                 }
                 for m in mod_rows
             ] if mod_rows else None
+            modifiers_json = json.dumps(modifiers_snapshot) if modifiers_snapshot else None
 
-            item_notes = (item.get('notes') or '').strip() or None
-            ci_row = await conn.fetchrow(
-                """
-                INSERT INTO comanda_items (
-                    comanda_id, order_item_id, kitchen_name,
-                    quantity, modifiers_snapshot, notes
+            kitchen_lines = _comanda_kitchen_lines_for_order_item(dict(item))
+            for kitchen_line in kitchen_lines:
+                ci_row = await conn.fetchrow(
+                    """
+                    INSERT INTO comanda_items (
+                        comanda_id, order_item_id, kitchen_name,
+                        quantity, modifiers_snapshot, notes
+                    )
+                    VALUES ($1, $2, $3, $4, $5, $6)
+                    RETURNING id, order_item_id, kitchen_name, quantity,
+                              notes, modifiers_snapshot, status, ready_at, created_at
+                    """,
+                    comanda_id,
+                    order_item_id,
+                    item['kitchen_name'],
+                    kitchen_line['quantity'],
+                    modifiers_json,
+                    kitchen_line['notes'],
                 )
-                VALUES ($1, $2, $3, $4, $5, $6)
-                RETURNING id, order_item_id, kitchen_name, quantity,
-                          notes, modifiers_snapshot, status, ready_at, created_at
-                """,
-                comanda_id,
-                order_item_id,
-                item['kitchen_name'],
-                item['quantity'],
-                json.dumps(modifiers_snapshot) if modifiers_snapshot else None,
-                item_notes,
-            )
-            inserted_items.append(_parse_item_row(ci_row))
+                inserted_items.append(
+                    _parse_item_row(ci_row, is_promo_free=kitchen_line['is_promo_free'])
+                )
 
         # 3d. Mark fired items as 'sent'
         await conn.execute(

--- a/tests/test_comanda_bogo_fire.py
+++ b/tests/test_comanda_bogo_fire.py
@@ -1,0 +1,156 @@
+"""BOGO bundle semantics when firing comandas (warocol.com#1021)."""
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services.comandas_service import (
+    _bogo_comanda_kitchen_lines,
+    _comanda_kitchen_lines_for_order_item,
+    _fire_with_conn,
+)
+
+
+def test_bogo_3x1_splits_paid_and_free_units():
+    lines = _bogo_comanda_kitchen_lines(
+        3,
+        buy_qty=2,
+        get_qty=1,
+        promotion_name="3×1 Pizza",
+        base_notes=None,
+    )
+    assert len(lines) == 2
+    assert lines[0] == {"quantity": 2, "notes": None, "is_promo_free": False}
+    assert lines[1]["quantity"] == 1
+    assert lines[1]["is_promo_free"] is True
+    assert "GRATIS (3×1 Pizza)" in lines[1]["notes"]
+    assert sum(line["quantity"] for line in lines) == 3
+
+
+def test_bogo_partial_bundle_keeps_single_row_without_gratis():
+    lines = _bogo_comanda_kitchen_lines(
+        2,
+        buy_qty=2,
+        get_qty=1,
+        promotion_name="3×1",
+        base_notes="Extra queso",
+    )
+    assert lines == [{"quantity": 2, "notes": "Extra queso", "is_promo_free": False}]
+
+
+def test_comanda_kitchen_lines_non_bogo_unchanged():
+    item = {
+        "quantity": 2,
+        "notes": "Sin cebolla",
+        "promo_type": "percent_off",
+        "applied_promotion_id": uuid4(),
+    }
+    assert _comanda_kitchen_lines_for_order_item(item) == [
+        {"quantity": 2.0, "notes": "Sin cebolla", "is_promo_free": False},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fire_comandas_bogo_emits_paid_and_free_comanda_items():
+    tenant_id = uuid4()
+    order_id = uuid4()
+    order_item_id = uuid4()
+    product_id = uuid4()
+    station_id = uuid4()
+    comanda_id = uuid4()
+    promo_id = uuid4()
+
+    order_rows = [
+        {
+            "id": order_item_id,
+            "quantity": 3,
+            "product_id": product_id,
+            "notes": None,
+            "applied_promotion_id": promo_id,
+            "promo_savings_allocated": 10000,
+            "promo_type": "bogo",
+            "promotion_name": "3×1 Promo",
+            "promotion_value_json": {"buy_qty": 2, "get_qty": 1},
+            "kitchen_name": "Pizza Especial",
+        },
+    ]
+
+    mock_conn = AsyncMock()
+
+    async def fetch_side_effect(query, *args):
+        if "order_item_modifiers" in query:
+            return [
+                {
+                    "modifier_name": "Borde queso",
+                    "price_at_purchase": 2000,
+                    "quantity": 1,
+                },
+            ]
+        return order_rows
+
+    mock_conn.fetch = AsyncMock(side_effect=fetch_side_effect)
+
+    insert_calls = []
+
+    async def fetchrow_side_effect(query, *args):
+        q = " ".join(query.split())
+        if "INSERT INTO comandas" in q:
+            return {
+                "id": comanda_id,
+                "comanda_number": 1,
+                "comanda_index": 1,
+                "station_id": station_id,
+                "status": "pending",
+                "source_type": "table",
+                "table_display_name": "Mesa 1",
+                "notes": None,
+                "fired_at": None,
+                "ready_at": None,
+                "created_at": None,
+            }
+        if "INSERT INTO comanda_items" in q:
+            insert_calls.append(args)
+            return {
+                "id": uuid4(),
+                "order_item_id": order_item_id,
+                "kitchen_name": "Pizza Especial",
+                "quantity": args[3],
+                "notes": args[5] if len(args) > 5 else None,
+                "modifiers_snapshot": args[4] if len(args) > 4 else None,
+                "status": "pending",
+                "ready_at": None,
+                "created_at": None,
+            }
+        return None
+
+    mock_conn.fetchrow = AsyncMock(side_effect=fetchrow_side_effect)
+    mock_conn.fetchval = AsyncMock(side_effect=lambda q, *a: 42 if "order_number" in q else 1)
+    mock_conn.execute = AsyncMock()
+
+    with patch(
+        "app.services.comandas_service.get_effective_station",
+        new_callable=AsyncMock,
+        return_value=station_id,
+    ):
+        result = await _fire_with_conn(
+            mock_conn,
+            order_id,
+            tenant_id,
+            "table",
+            "Mesa 1",
+            None,
+        )
+
+    assert len(result) == 1
+    items = result[0]["items"]
+    assert len(items) == 2
+    assert sum(int(i["quantity"]) for i in items) == 3
+    assert items[0]["is_promo_free"] is False
+    assert items[1]["is_promo_free"] is True
+    assert "GRATIS (3×1 Promo)" in items[1]["notes"]
+    assert all(i["modifiers_snapshot"][0]["name"] == "Borde queso" for i in items)
+
+    assert len(insert_calls) == 2
+    assert insert_calls[0][3] == 2
+    assert insert_calls[1][3] == 1
+    assert "GRATIS (3×1 Promo)" in insert_calls[1][5]


### PR DESCRIPTION
## Summary
- `fire_comandas` loads persisted BOGO promo metadata from `order_items` + `tenant_promotions` and splits kitchen rows into paid vs free units.
- Free units get `GRATIS (promo name)` in `comanda_items.notes` and `is_promo_free: true` in the fire response; partial bundles stay a single row with full qty.
- Unit tests cover 3×1 split, partial bundle, and non-BOGO unchanged behavior.

Closes uno0uno/warocol.com#1021

## Test plan
- [x] `pytest tests/test_comanda_bogo_fire.py tests/test_comanda_item_notes.py -v`
- [ ] Mesa tab: add 3×1 promo line qty=3 → fire → KDS shows 2 paid + 1 GRATIS row, modifiers on both

## wr-context
See `.wr/1021.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)