### PR TITLE
fix(billing): exempt internal tenants from grace-period IA block

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,7 @@ MP_ENVIRONMENT=sandbox
 
 # Cron secret — grace period reminders (issue #62)
 CRON_SECRET=your_cron_secret
+
+# Internal/dogfood tenants — skip grace-period IA blocks (issue #1057)
+# Waro Colombia: 93b3e582-34fa-44a6-8d0f-bf82a3608727
+BILLING_EXEMPT_TENANT_IDS=

--- a/app/config.py
+++ b/app/config.py
@@ -85,6 +85,10 @@ class Settings(BaseSettings):
     # Cron secret — grace period reminders (issue #62)
     cron_secret: Optional[str] = Field(default=None, alias='CRON_SECRET')
 
+    # Comma-separated tenant UUIDs that bypass grace-period downgrades (issue #1057).
+    # Internal/dogfood tenants keep full IA scanner access even when past_due.
+    billing_exempt_tenant_ids: str = Field(default="", alias='BILLING_EXEMPT_TENANT_IDS')
+
     # Outgoing webhook fired on subscription payment approval (issue #156).
     # Empty / None → no-op. Set to any URL (Discord, n8n, Slack, custom) to
     # receive a JSON payload describing each successful renewal.

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -16,7 +16,22 @@ from uuid import UUID
 
 from fastapi import HTTPException
 
+from app.config import settings
+
 logger = logging.getLogger(__name__)
+
+
+def _billing_exempt_tenant_ids() -> set[UUID]:
+    """Tenant UUIDs that skip grace-period downgrades (internal/dogfood)."""
+    raw = settings.billing_exempt_tenant_ids.strip()
+    if not raw:
+        return set()
+    result: set[UUID] = set()
+    for part in raw.split(","):
+        part = part.strip()
+        if part:
+            result.add(UUID(part))
+    return result
 
 
 async def check_scan_quota(tenant_id: UUID, conn) -> None:
@@ -612,6 +627,15 @@ async def get_subscription_access(tenant_id: UUID, conn) -> SubscriptionAccess:
 
     Uses timezone.utc (Python 3.9 safe — NOT datetime.UTC which requires 3.11+).
     """
+    if tenant_id in _billing_exempt_tenant_ids():
+        return SubscriptionAccess(
+            level="full",
+            grace_days_remaining=0,
+            subscription_status="active",
+            next_payment_date=None,
+            message="Acceso completo.",
+        )
+
     sub = await conn.fetchrow("""
         SELECT status, current_period_end, plan_id
         FROM tenant_subscriptions

--- a/tests/test_billing_exempt_tenants.py
+++ b/tests/test_billing_exempt_tenants.py
@@ -1,0 +1,39 @@
+"""Billing exempt tenant IDs — issue #1057."""
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
+
+import pytest
+
+from app.services import billing_service
+
+
+WAROCOLOMBIA_ID = UUID("93b3e582-34fa-44a6-8d0f-bf82a3608727")
+OTHER_ID = UUID("11111111-1111-1111-1111-111111111111")
+
+
+@pytest.mark.asyncio
+async def test_exempt_tenant_returns_full_access(monkeypatch):
+    monkeypatch.setattr(
+        billing_service.settings,
+        "billing_exempt_tenant_ids",
+        str(WAROCOLOMBIA_ID),
+    )
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={"status": "past_due", "current_period_end": None, "plan_id": None})
+
+    access = await billing_service.get_subscription_access(WAROCOLOMBIA_ID, conn)
+
+    assert access.level == "full"
+    conn.fetchrow.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_exempt_tenant_still_queries_subscription(monkeypatch):
+    monkeypatch.setattr(billing_service.settings, "billing_exempt_tenant_ids", "")
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+
+    access = await billing_service.get_subscription_access(OTHER_ID, conn)
+
+    assert access.level == "free"
+    conn.fetchrow.assert_called_once()


### PR DESCRIPTION
## Summary
- Adds `BILLING_EXEMPT_TENANT_IDS` env var so internal/dogfood tenants keep `full` access even when subscription is `past_due`.
- Waro Colombia (`93b3e582-34fa-44a6-8d0f-bf82a3608727`) was `read_only` (~4 days overdue) while scan quota still showed 4/1000.

Companion to [warocol.com#1057](https://github.com/uno0uno/warocol.com/issues/1057)

## Test plan
- [ ] Set `BILLING_EXEMPT_TENANT_IDS=93b3e582-34fa-44a6-8d0f-bf82a3608727` on API
- [ ] `GET /billing/access-status` returns `full` for Waro Colombia
- [ ] `pytest tests/test_billing_exempt_tenants.py -v`

## wr-context
See `.wr/1057.yaml` on warocol.com branch (LLM contract).

Made with [Cursor](https://cursor.com)