### PR TITLE
feat(analytics): data quality monitoring — close #46 gaps

### DIFF
--- a/.wr/46.yaml
+++ b/.wr/46.yaml
@@ -1,0 +1,27 @@
+issue: 46
+title: "[Feature] Data Quality Monitoring — Detección automática de anomalías en compras"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-46-data-quality-monitoring
+
+paths:
+  - app/services/analytics_service.py
+  - app/routers/purchases.py
+  - sql/20260601_data_quality_alerts.sql
+  - tests/test_data_quality.py
+
+ac:
+  - GET /analytics/data-quality scans 30d history then returns alerts
+  - POST/PUT /suppliers/purchases/direct schedule anomaly checks
+  - Migration SQL artifact for data_quality_alerts
+  - Unit tests for _compute_anomaly and _check_unit_mismatch
+
+hints:
+  entry: backfill_anomaly_checks_for_tenant — analytics_service.py
+  pattern: run_anomaly_checks_for_purchase — same file
+  tests: pytest tests/test_data_quality.py -v
+
+skip:
+  audits: [ux, color, typography]

--- a/app/routers/purchases.py
+++ b/app/routers/purchases.py
@@ -282,16 +282,14 @@ async def update_direct_purchase_endpoint(
     purchase_id: UUID,
     purchase_data: DirectPurchaseUpdate,
     request: Request,
-    response: Response
+    response: Response,
+    background_tasks: BackgroundTasks,
 ):
     """
     Update a direct purchase (Compra Directa) - JSON payload
     Updates purchase items and metadata. Use separate endpoints for file uploads.
     """
-    # Import locally to avoid circular imports if any, keeping with existing pattern
-    
-    # Map Pydantic model to function arguments
-    return await update_direct_purchase(
+    result = await update_direct_purchase(
         request=request,
         response=response,
         purchase_id=purchase_id,
@@ -304,6 +302,18 @@ async def update_direct_purchase_endpoint(
         payment_amount=purchase_data.payment_amount,
         payment_date=purchase_data.payment_date
     )
+
+    try:
+        if result.get("success"):
+            session_context = require_valid_session(request)
+            tenant_id = session_context.tenant_id
+            background_tasks.add_task(
+                run_anomaly_checks_for_purchase, purchase_id, tenant_id
+            )
+    except Exception:
+        pass
+
+    return result
 
 
 @router.post("/direct/{purchase_id}/attachments", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])

--- a/app/services/analytics_service.py
+++ b/app/services/analytics_service.py
@@ -871,8 +871,47 @@ def _check_unit_mismatch(
     }
 
 
+async def backfill_anomaly_checks_for_tenant(
+    tenant_id: str,
+    days: int = 30,
+) -> None:
+    """
+    Scan purchase items in the last `days` and upsert alerts (issue #46 GET contract).
+
+    Reuses run_anomaly_checks_for_purchase per purchase — idempotent via ON CONFLICT.
+    """
+    try:
+        async with get_db_connection(use_transaction=False) as conn:
+            rows = await conn.fetch(
+                """
+                SELECT DISTINCT tp.id AS purchase_id
+                FROM tenant_purchases tp
+                JOIN tenant_purchase_items tpi ON tpi.purchase_id = tp.id
+                WHERE tp.tenant_id = $1
+                  AND tp.purchase_date >= (CURRENT_DATE - $2::int)
+                  AND tpi.unit_cost IS NOT NULL
+                ORDER BY tp.purchase_date DESC
+                """,
+                tenant_id,
+                days,
+            )
+
+        tenant_uuid = UUID(str(tenant_id))
+        for row in rows:
+            await run_anomaly_checks_for_purchase(
+                UUID(str(row["purchase_id"])),
+                tenant_uuid,
+            )
+    except Exception as e:
+        logger.error(
+            f"backfill_anomaly_checks_for_tenant failed (tenant={tenant_id}): {e}"
+        )
+
+
 async def _get_data_quality_for_tenant(tenant_id: str) -> dict:
     """Auth-agnostic core for data quality. Called by session wrapper and public API."""
+    await backfill_anomaly_checks_for_tenant(tenant_id, days=30)
+
     async with get_db_connection(use_transaction=False) as conn:
         alerts_query = """
             SELECT
@@ -945,10 +984,10 @@ async def _get_data_quality_for_tenant(tenant_id: str) -> dict:
 
 async def get_data_quality(request: Request) -> dict:
     """
-    Returns existing alerts from data_quality_alerts plus a summary score.
+    Scans 30-day purchase history for anomalies, upserts alerts, returns score.
 
-    Read-only endpoint — anomaly detection and upserts happen in the background
-    task run_anomaly_checks_for_purchase(), triggered after each purchase save.
+    Also triggered incrementally via run_anomaly_checks_for_purchase() after each
+    direct purchase save (POST/PUT /suppliers/purchases/direct).
 
     Score: max(0, 100 - critical*10 - warning*2)
     """

--- a/sql/20260601_data_quality_alerts.sql
+++ b/sql/20260601_data_quality_alerts.sql
@@ -1,0 +1,36 @@
+-- api-warolabs#46 — purchase data quality alerts (price spike / unit mismatch)
+CREATE TABLE IF NOT EXISTS data_quality_alerts (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id uuid NOT NULL REFERENCES tenants(id),
+    purchase_item_id uuid REFERENCES tenant_purchase_items(id) ON DELETE SET NULL,
+    ingredient_id uuid REFERENCES ingredients(id) ON DELETE SET NULL,
+    ingredient_name varchar(255) NOT NULL,
+    alert_type varchar(50) NOT NULL,
+    severity varchar(20) NOT NULL,
+    expected_value numeric,
+    actual_value numeric,
+    deviation_pct numeric,
+    rolling_avg numeric,
+    context jsonb,
+    resolved boolean NOT NULL DEFAULT false,
+    resolved_by uuid REFERENCES profile(id) ON DELETE SET NULL,
+    resolved_at timestamptz,
+    resolution_note text,
+    original_value numeric,
+    corrected_value numeric,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT uq_dqa_item_tenant UNIQUE (purchase_item_id, tenant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dqa_tenant_resolved
+    ON data_quality_alerts (tenant_id, resolved);
+
+CREATE INDEX IF NOT EXISTS idx_dqa_severity
+    ON data_quality_alerts (severity, resolved);
+
+CREATE INDEX IF NOT EXISTS idx_dqa_purchase_item
+    ON data_quality_alerts (purchase_item_id)
+    WHERE purchase_item_id IS NOT NULL;
+
+COMMENT ON TABLE data_quality_alerts IS
+    'Anomaly alerts on purchase line items — IQR + % deviation (#46).';

--- a/tests/test_data_quality.py
+++ b/tests/test_data_quality.py
@@ -1,0 +1,59 @@
+"""Data quality anomaly detection (#46)."""
+import pytest
+
+from app.services.analytics_service import _check_unit_mismatch, _compute_anomaly
+
+
+def test_compute_anomaly_impossible_value():
+    result = _compute_anomaly([10.0, 12.0, 11.0, 10.5, 11.5], -1.0, "Test")
+    assert result is not None
+    assert result["alert_type"] == "impossible_value"
+    assert result["severity"] == "critical"
+
+
+def test_compute_anomaly_insufficient_history():
+    assert _compute_anomaly([10.0], 100.0, "Test") is None
+
+
+def test_compute_anomaly_warning_deviation():
+    history = [10.0, 10.0, 10.0, 10.0, 10.0]
+    result = _compute_anomaly(history, 13.0, "Test")
+    assert result is not None
+    assert result["severity"] == "warning"
+    assert result["alert_type"] == "price_spike"
+    assert result["deviation_pct"] == 30.0
+
+
+def test_compute_anomaly_critical_deviation():
+    history = [10.0, 10.0, 10.0, 10.0, 10.0]
+    result = _compute_anomaly(history, 16.0, "Test")
+    assert result is not None
+    assert result["severity"] == "critical"
+
+
+def test_compute_anomaly_no_flag_within_threshold():
+    history = [10.0, 10.0, 10.0, 10.0, 10.0]
+    assert _compute_anomaly(history, 11.0, "Test") is None
+
+
+def test_check_unit_mismatch_flags_implausible_unit_cost():
+    result = _check_unit_mismatch(
+        purchase_quantity=1.0,
+        base_quantity=1.0,
+        purchase_unit="ml",
+        ingredient_base_unit="ml",
+        unit_cost=7850.0,
+    )
+    assert result is not None
+    assert result["alert_type"] == "unit_mismatch"
+    assert result["severity"] == "critical"
+
+
+def test_check_unit_mismatch_skips_when_conversion_applied():
+    assert _check_unit_mismatch(
+        purchase_quantity=1.0,
+        base_quantity=3000.0,
+        purchase_unit="l",
+        ingredient_base_unit="ml",
+        unit_cost=7850.0,
+    ) is None


### PR DESCRIPTION
## Summary

Closes gaps identified in wr-research for #46. Core feature (table, detection, GET/PATCH, POST `/direct` BackgroundTask) was already in `main`; this PR wires the remaining contract items.

- **GET `/analytics/data-quality`** — runs `backfill_anomaly_checks_for_tenant` (30-day scan) before returning alerts + score
- **PUT `/suppliers/purchases/direct/{id}`** — schedules `run_anomaly_checks_for_purchase` after successful update
- **Migration artifact** — `sql/20260601_data_quality_alerts.sql` (idempotent; table already live in prod/dbdoc)
- **Tests** — `tests/test_data_quality.py` for `_compute_anomaly` and `_check_unit_mismatch`

Closes #46

## Test plan

- [ ] `pytest tests/test_data_quality.py -v`
- [ ] GET `/analytics/data-quality` as owner/admin — existing bad purchases (30d) surface alerts; score updates
- [ ] POST `/suppliers/purchases/direct` with outlier unit_cost (≥5 prior buys) — alert appears without manual GET
- [ ] PUT `/suppliers/purchases/direct/{id}` after correcting unit_cost — alert refreshes
- [ ] PATCH `/analytics/data-quality/{id}/resolve` — `valid` and `corrected` paths unchanged
- [ ] Apply `sql/20260601_data_quality_alerts.sql` on fresh DB only (should no-op on prod)

## Manual routes

| Method | Route | Expected |
|--------|-------|----------|
| GET | `/analytics/data-quality` | Scan + list alerts, score 0–100 |
| PATCH | `/analytics/data-quality/{id}/resolve` | Resolve with audit |
| POST | `/suppliers/purchases/direct` | 201 + background check |
| PUT | `/suppliers/purchases/direct/{id}` | 200 + background check |

Made with [Cursor](https://cursor.com)