### PR TITLE
feat(payments): central Wompi webhook router (#353)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,16 @@ MP_PUBLIC_KEY=APP_USR-xxxx-xxxx-xxxx-xxxx
 MP_WEBHOOK_SECRET=your_mp_webhook_secret
 MP_ENVIRONMENT=sandbox
 
+# Wompi — Colombia billing + central router (#60, #353)
+WOMPI_PUBLIC_KEY=
+WOMPI_PRIVATE_KEY=
+WOMPI_EVENTS_SECRET=
+WOMPI_INTEGRITY_SECRET=
+WOMPI_ENVIRONMENT=sandbox
+# Central ingress → Tickets forward (api_warotickets#46)
+WAROTICKETS_API_URL=https://api.warotickets.com
+WOMPI_WEBHOOK_FORWARD_SECRET=
+
 # Cron secret — grace period reminders (issue #62)
 CRON_SECRET=your_cron_secret
 

--- a/.wr/353.yaml
+++ b/.wr/353.yaml
@@ -1,0 +1,31 @@
+issue: 353
+title: "feat(payments): Add Wompi ingress router at POST /payments/webhooks/wompi"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-353-wompi-ingress-router
+epic: 351
+
+paths:
+  - app/routers/payments_webhook.py
+  - app/services/wompi_webhook_router_service.py
+  - app/services/wompi_colombia_webhook_service.py
+  - app/routers/billing.py
+  - app/main.py
+  - app/core/middleware.py
+  - app/config.py
+
+ac:
+  - POST /payments/webhooks/wompi classifies and dispatches
+  - Legacy POST /billing/webhook unchanged behavior via shared Colombia handler
+  - Middleware skips for webhook paths
+  - Tickets forward via WAROTICKETS_API_URL + X-Wompi-Forward-Secret
+
+hints:
+  entry: payments_webhook.py — wompi_central_webhook
+  classify: wompi_webhook_router_service.classify_transaction_updated
+  tests: pytest tests/test_wompi_webhook_router.py -v
+
+skip:
+  audits: [ux, color, typography]

--- a/app/config.py
+++ b/app/config.py
@@ -82,6 +82,14 @@ class Settings(BaseSettings):
     wompi_integrity_secret: Optional[str] = Field(default=None, alias='WOMPI_INTEGRITY_SECRET')
     wompi_environment: str = Field(default='sandbox', alias='WOMPI_ENVIRONMENT')
 
+    # Central Wompi router → Tickets forward (#353 / api_warotickets#46)
+    warotickets_api_url: Optional[str] = Field(
+        default=None, alias='WAROTICKETS_API_URL'
+    )
+    wompi_webhook_forward_secret: Optional[str] = Field(
+        default=None, alias='WOMPI_WEBHOOK_FORWARD_SECRET'
+    )
+
     # Cron secret — grace period reminders (issue #62)
     cron_secret: Optional[str] = Field(default=None, alias='CRON_SECRET')
 

--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -119,6 +119,15 @@ async def tenant_detection_middleware(request: Request, call_next):
             response = await call_next(request)
             return response
 
+        # Wompi webhooks — no tenant site header (signature-verified ingress)
+        if (
+            request.url.path.startswith('/payments/webhooks')
+            or request.url.path == '/billing/webhook'
+        ):
+            request.state.tenant_context = TenantContext()
+            response = await call_next(request)
+            return response
+
         # Skip tenant detection for public restaurant endpoints (they use slug-based lookup)
         if (
             request.url.path.startswith('/public/restaurant')
@@ -430,7 +439,14 @@ async def session_validation_middleware(request: Request, call_next):
         # /api/comandas GET-only: KDS screen polls active comandas by station_id (no session, UUID-secured)
         # Only bypass when there is no session cookie — logged-in dashboard users must go through
         # normal session validation so their tenant_id is available to the service.
-        public_prefixes = ['/blog', '/supplier-portal', '/public/restaurant', '/public/table-qr']
+        public_prefixes = [
+            '/blog',
+            '/supplier-portal',
+            '/public/restaurant',
+            '/public/table-qr',
+            '/payments/webhooks',
+            '/billing/webhook',
+        ]
         has_session_cookie = bool(request.cookies.get("session-token") or "session-token=" in request.headers.get("cookie", ""))
         kds_token_param = request.query_params.get('token', '')
         kds_public = (

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, customer_portal, leads, waros, billing, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
+from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, customer_portal, leads, waros, billing, payments_webhook, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
 from app.config import settings
 from app.core.logging import setup_logging
 from app.core.exceptions import api_exception_handler, general_exception_handler, APIError
@@ -184,6 +184,7 @@ app.include_router(inventory.router)
 app.include_router(analytics.router)
 app.include_router(waros.router)
 app.include_router(billing.tenant_router)
+app.include_router(payments_webhook.router)
 app.include_router(articles.router, prefix="/blog", tags=["blog"])
 app.include_router(invitations.router, prefix="/invitations", tags=["invitations"])
 app.include_router(api_tokens.router, prefix="/api-tokens", tags=["api-tokens"])

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -24,7 +24,13 @@ from app.config import settings
 from app.core.middleware import require_valid_session
 from app.core.permissions import Module, require_module
 from app.database import get_db_connection
-from app.services import billing_service, billing_email_service, billing_webhook_service, wompi_service
+from app.services import (
+    billing_service,
+    billing_email_service,
+    billing_webhook_service,
+    wompi_service,
+    wompi_colombia_webhook_service,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -235,65 +241,9 @@ async def wompi_webhook(
     if event != "transaction.updated":
         return {"received": True}
 
-    transaction = body.get("data", {}).get("transaction", {})
-    wompi_status = transaction.get("status", "").upper()
-    payment_link_id = transaction.get("payment_link_id", "")
-    transaction_id = str(transaction.get("id", ""))
-    amount_cents = transaction.get("amount_in_cents", 0)
-
-    logger.info(
-        "Wompi transaction: link=%s status=%s tx=%s",
-        payment_link_id, wompi_status, transaction_id,
+    await wompi_colombia_webhook_service.handle_transaction_updated(
+        body, background_tasks
     )
-
-    if not payment_link_id:
-        return {"received": True}
-
-    if wompi_status == "APPROVED":
-        async with get_db_connection() as conn:
-            tenant_info = await billing_service.activate_tenant_subscription(
-                conn,
-                gateway_reference=payment_link_id,
-                payment_id=transaction_id,
-                amount=amount_cents / 100,
-                currency="COP",
-            )
-        if tenant_info:
-            background_tasks.add_task(
-                billing_email_service.send_payment_renewed_email,
-                tenant_name=tenant_info["tenant_name"],
-                tenant_email=tenant_info["tenant_email"],
-                next_period_end=tenant_info["next_period_end"],
-            )
-            # Outgoing webhook (issue #156). No-op when BILLING_WEBHOOK_URL
-            # is empty. Failures are logged but never block activation.
-            background_tasks.add_task(
-                billing_webhook_service.send_payment_approved_webhook,
-                tenant_id=tenant_info["tenant_id"],
-                subscription_id=tenant_info["subscription_id"],
-                tenant_name=tenant_info["tenant_name"],
-                tenant_email=tenant_info["tenant_email"],
-                plan_name=tenant_info["plan_name"],
-                amount=amount_cents / 100,
-                currency="COP",
-                next_period_end=tenant_info["next_period_end"],
-                gateway_reference=payment_link_id,
-                transaction_id=transaction_id,
-            )
-
-    elif wompi_status in ("DECLINED", "VOIDED", "ERROR"):
-        async with get_db_connection() as conn:
-            tenant_info = await billing_service.mark_subscription_past_due(
-                conn, payment_link_id, "payment_rejected"
-            )
-        if tenant_info:
-            background_tasks.add_task(
-                billing_email_service.send_payment_rejected_email,
-                tenant_name=tenant_info["tenant_name"],
-                tenant_email=tenant_info["tenant_email"],
-                billing_url=f"{settings.frontend_url}/gestion/billing",
-            )
-
     return {"received": True}
 
 

--- a/app/routers/payments_webhook.py
+++ b/app/routers/payments_webhook.py
@@ -1,0 +1,27 @@
+"""
+Central Wompi webhook ingress (api-warolabs #353).
+
+Public URL: POST /payments/webhooks/wompi
+Legacy Colombia URL remains: POST /billing/webhook
+"""
+from fastapi import APIRouter, BackgroundTasks, Request
+
+from app.services import wompi_webhook_router_service
+
+router = APIRouter(prefix="/payments/webhooks", tags=["Payments Webhooks"])
+
+
+@router.post("/wompi", status_code=200)
+async def wompi_central_webhook(
+    request: Request,
+    background_tasks: BackgroundTasks,
+):
+    """
+    Central Wompi merchant webhook — verify once, classify, dispatch.
+
+    See docs/payments/wompi-webhook-routing.md.
+    """
+    body = await request.json()
+    return await wompi_webhook_router_service.dispatch_verified_event(
+        body, background_tasks
+    )

--- a/app/services/wompi_colombia_webhook_service.py
+++ b/app/services/wompi_colombia_webhook_service.py
@@ -1,0 +1,85 @@
+"""
+Colombia billing — Wompi transaction.updated handler (api-warolabs #353).
+
+Extracted from billing.wompi_webhook so the central router and legacy
+POST /billing/webhook share the same activation logic.
+"""
+import logging
+from typing import Any, Dict
+
+from fastapi import BackgroundTasks
+
+from app.config import settings
+from app.database import get_db_connection
+from app.services import billing_email_service, billing_service, billing_webhook_service
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_transaction_updated(
+    body: Dict[str, Any],
+    background_tasks: BackgroundTasks,
+) -> None:
+    """
+    Process a verified Wompi transaction.updated event for Colombia billing.
+
+    Caller must verify the signature and filter non-transaction events first.
+    """
+    transaction = body.get("data", {}).get("transaction", {})
+    wompi_status = transaction.get("status", "").upper()
+    payment_link_id = transaction.get("payment_link_id", "")
+    transaction_id = str(transaction.get("id", ""))
+    amount_cents = transaction.get("amount_in_cents", 0)
+
+    logger.info(
+        "Wompi Colombia transaction: link=%s status=%s tx=%s",
+        payment_link_id,
+        wompi_status,
+        transaction_id,
+    )
+
+    if not payment_link_id:
+        return
+
+    if wompi_status == "APPROVED":
+        async with get_db_connection() as conn:
+            tenant_info = await billing_service.activate_tenant_subscription(
+                conn,
+                gateway_reference=payment_link_id,
+                payment_id=transaction_id,
+                amount=amount_cents / 100,
+                currency="COP",
+            )
+        if tenant_info:
+            background_tasks.add_task(
+                billing_email_service.send_payment_renewed_email,
+                tenant_name=tenant_info["tenant_name"],
+                tenant_email=tenant_info["tenant_email"],
+                next_period_end=tenant_info["next_period_end"],
+            )
+            background_tasks.add_task(
+                billing_webhook_service.send_payment_approved_webhook,
+                tenant_id=tenant_info["tenant_id"],
+                subscription_id=tenant_info["subscription_id"],
+                tenant_name=tenant_info["tenant_name"],
+                tenant_email=tenant_info["tenant_email"],
+                plan_name=tenant_info["plan_name"],
+                amount=amount_cents / 100,
+                currency="COP",
+                next_period_end=tenant_info["next_period_end"],
+                gateway_reference=payment_link_id,
+                transaction_id=transaction_id,
+            )
+
+    elif wompi_status in ("DECLINED", "VOIDED", "ERROR"):
+        async with get_db_connection() as conn:
+            tenant_info = await billing_service.mark_subscription_past_due(
+                conn, payment_link_id, "payment_rejected"
+            )
+        if tenant_info:
+            background_tasks.add_task(
+                billing_email_service.send_payment_rejected_email,
+                tenant_name=tenant_info["tenant_name"],
+                tenant_email=tenant_info["tenant_email"],
+                billing_url=f"{settings.frontend_url}/gestion/billing",
+            )

--- a/app/services/wompi_webhook_router_service.py
+++ b/app/services/wompi_webhook_router_service.py
@@ -1,0 +1,171 @@
+"""
+Wompi central ingress — classify transaction.updated and dispatch (#353).
+
+Routing rules: docs/payments/wompi-webhook-routing.md (#352).
+"""
+import logging
+from enum import Enum
+from typing import Any, Dict
+from uuid import UUID
+
+import httpx
+from fastapi import BackgroundTasks, HTTPException
+
+from app.config import settings
+from app.database import get_db_connection
+from app.services import wompi_colombia_webhook_service, wompi_service
+
+logger = logging.getLogger(__name__)
+
+BILLING_REDIRECT_MARKER = "warocol.com/billing"
+TICKETS_REFERENCE_PREFIX = "WT-"
+
+
+class WompiRoute(str, Enum):
+    TICKETS = "tickets"
+    COLOMBIA = "colombia"
+    UNKNOWN = "unknown"
+
+
+async def classify_transaction_updated(body: Dict[str, Any]) -> WompiRoute:
+    """Return dispatch target per routing matrix (epic #351 / doc #352)."""
+    transaction = body.get("data", {}).get("transaction", {}) or {}
+    reference = (transaction.get("reference") or "").strip()
+
+    if reference.startswith(TICKETS_REFERENCE_PREFIX):
+        return WompiRoute.TICKETS
+
+    payment_link_id = (transaction.get("payment_link_id") or "").strip()
+    if payment_link_id and await _gateway_reference_exists(payment_link_id):
+        return WompiRoute.COLOMBIA
+
+    redirect_url = (transaction.get("redirect_url") or "").lower()
+    if BILLING_REDIRECT_MARKER in redirect_url:
+        return WompiRoute.COLOMBIA
+
+    sku = (transaction.get("sku") or "").strip()
+    if sku and await _tenant_id_exists(sku):
+        return WompiRoute.COLOMBIA
+
+    return WompiRoute.UNKNOWN
+
+
+async def _gateway_reference_exists(gateway_reference: str) -> bool:
+    async with get_db_connection(use_transaction=False) as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT 1 FROM tenant_subscriptions
+            WHERE gateway_reference = $1
+            LIMIT 1
+            """,
+            gateway_reference,
+        )
+    return row is not None
+
+
+async def _tenant_id_exists(sku: str) -> bool:
+    try:
+        tenant_id = UUID(sku)
+    except ValueError:
+        return False
+    async with get_db_connection(use_transaction=False) as conn:
+        row = await conn.fetchrow(
+            "SELECT 1 FROM tenants WHERE id = $1 LIMIT 1",
+            tenant_id,
+        )
+    return row is not None
+
+
+async def forward_to_tickets(body: Dict[str, Any]) -> None:
+    """
+    HTTP-forward raw Wompi JSON to api.warotickets.
+
+    Requires api_warotickets#46 internal auth on the receiver; sends
+    X-Wompi-Forward-Secret when WOMPI_WEBHOOK_FORWARD_SECRET is set.
+    """
+    base_url = (settings.warotickets_api_url or "").rstrip()
+    if not base_url:
+        logger.error(
+            "Wompi router: WAROTICKETS_API_URL not configured — cannot forward to Tickets"
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Tickets forward URL not configured",
+        )
+
+    url = f"{base_url}/payments/webhooks/wompi"
+    headers: Dict[str, str] = {"Content-Type": "application/json"}
+    secret = settings.wompi_webhook_forward_secret
+    if secret:
+        headers["X-Wompi-Forward-Secret"] = secret
+    else:
+        logger.warning(
+            "Wompi router: WOMPI_WEBHOOK_FORWARD_SECRET unset — forwarding without internal auth"
+        )
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(url, json=body, headers=headers)
+    except httpx.RequestError as exc:
+        logger.error("Wompi router: Tickets forward failed: %s", exc)
+        raise HTTPException(
+            status_code=502,
+            detail="Failed to forward webhook to Tickets",
+        ) from exc
+
+    if response.status_code >= 400:
+        logger.error(
+            "Wompi router: Tickets returned %s — %s",
+            response.status_code,
+            response.text[:500],
+        )
+        raise HTTPException(
+            status_code=502,
+            detail="Tickets webhook handler rejected the forward",
+        )
+
+    logger.info("Wompi router: forwarded to Tickets (%s)", response.status_code)
+
+
+async def dispatch_verified_event(
+    body: Dict[str, Any],
+    background_tasks: BackgroundTasks,
+) -> Dict[str, Any]:
+    """
+    Verify signature, classify, and dispatch a Wompi event.
+
+    Returns the HTTP response body for the ingress endpoint.
+    """
+    event = body.get("event", "")
+    logger.info("Wompi ingress: event=%s", event)
+
+    if not wompi_service.verify_event_signature(body):
+        logger.warning("Wompi ingress: invalid signature")
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")
+
+    if event != "transaction.updated":
+        return {"received": True}
+
+    route = await classify_transaction_updated(body)
+    transaction = body.get("data", {}).get("transaction", {}) or {}
+
+    if route == WompiRoute.TICKETS:
+        await forward_to_tickets(body)
+        return {"status": "received"}
+
+    if route == WompiRoute.COLOMBIA:
+        await wompi_colombia_webhook_service.handle_transaction_updated(
+            body, background_tasks
+        )
+        return {"received": True}
+
+    logger.warning(
+        "Wompi ingress: unknown classification — tx=%s ref=%s link=%s redirect=%s sku=%s amount=%s",
+        transaction.get("id"),
+        transaction.get("reference"),
+        transaction.get("payment_link_id"),
+        transaction.get("redirect_url"),
+        transaction.get("sku"),
+        transaction.get("amount_in_cents"),
+    )
+    return {"received": True, "classification": "unknown"}

--- a/tests/test_wompi_webhook_router.py
+++ b/tests/test_wompi_webhook_router.py
@@ -1,0 +1,54 @@
+"""Wompi central ingress classification (#353)."""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.wompi_webhook_router_service import (
+    WompiRoute,
+    classify_transaction_updated,
+)
+
+
+@pytest.mark.asyncio
+async def test_classify_wt_reference_routes_tickets():
+    body = {"data": {"transaction": {"reference": "WT-abc12345-1717200000"}}}
+    assert await classify_transaction_updated(body) == WompiRoute.TICKETS
+
+
+@pytest.mark.asyncio
+async def test_classify_gateway_reference_routes_colombia():
+    body = {"data": {"transaction": {"payment_link_id": "SD7wnV"}}}
+    with patch(
+        "app.services.wompi_webhook_router_service._gateway_reference_exists",
+        AsyncMock(return_value=True),
+    ):
+        assert await classify_transaction_updated(body) == WompiRoute.COLOMBIA
+
+
+@pytest.mark.asyncio
+async def test_classify_billing_redirect_routes_colombia():
+    body = {
+        "data": {
+            "transaction": {
+                "redirect_url": "https://warocol.com/billing/confirmacion",
+            }
+        }
+    }
+    with patch(
+        "app.services.wompi_webhook_router_service._gateway_reference_exists",
+        AsyncMock(return_value=False),
+    ):
+        assert await classify_transaction_updated(body) == WompiRoute.COLOMBIA
+
+
+@pytest.mark.asyncio
+async def test_classify_unknown_when_no_signals():
+    body = {"data": {"transaction": {"reference": "OTHER-123"}}}
+    with patch(
+        "app.services.wompi_webhook_router_service._gateway_reference_exists",
+        AsyncMock(return_value=False),
+    ), patch(
+        "app.services.wompi_webhook_router_service._tenant_id_exists",
+        AsyncMock(return_value=False),
+    ):
+        assert await classify_transaction_updated(body) == WompiRoute.UNKNOWN


### PR DESCRIPTION
## Summary

Implements batch #353 for epic #351: central Wompi ingress at `POST /payments/webhooks/wompi`.

- Verify signature once (`wompi_service.verify_event_signature`)
- Classify per `docs/payments/wompi-webhook-routing.md` (WT- → Tickets; gateway_reference / redirect / sku → Colombia)
- Colombia: shared `wompi_colombia_webhook_service` (legacy `POST /billing/webhook` unchanged)
- Tickets: HTTP forward to `{WAROTICKETS_API_URL}/payments/webhooks/wompi` with `X-Wompi-Forward-Secret`
- Unknown: structured warning log + HTTP 200
- Middleware: skip tenant/session for `/payments/webhooks` and `/billing/webhook`

Closes #353

## Dependencies / follow-up

- **api_warotickets#46** — receiver must validate `X-Wompi-Forward-Secret` before cutover
- **#354** — merge PR #357 for `past_due` renewal via webhook
- **#355** — dispatch integration tests
- **Ops** — Wompi dashboard URL cutover only after Tickets #46 + this PR deployed

## Test plan

- [ ] `pytest tests/test_wompi_webhook_router.py -v`
- [ ] POST `/payments/webhooks/wompi` with sandbox WT-* payload → forward to Tickets (or 503 if URL unset)
- [ ] POST with Colombia `payment_link_id` in DB → `{"received": true}` + subscription activation
- [ ] POST unknown payload → 200 + log, no forward
- [ ] POST `/billing/webhook` legacy path still works
- [ ] Set `WAROTICKETS_API_URL` + `WOMPI_WEBHOOK_FORWARD_SECRET` in prod before cutover

Made with [Cursor](https://cursor.com)