### PR TITLE
test(payments): Wompi router dispatch tests (WT-* vs Colombia)

### DIFF
--- a/.wr/355.yaml
+++ b/.wr/355.yaml
@@ -1,0 +1,24 @@
+issue: 355
+title: "test(payments): Router dispatches WT-* vs billing payment_link_id correctly"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-355-wompi-router-dispatch-tests
+epic: 351
+
+paths:
+  - tests/test_wompi_webhook_router.py
+
+ac:
+  - WT reference → forward_to_tickets; Colombia not called
+  - payment_link_id + gateway_reference → Colombia handler
+  - redirect_url warocol.com/billing → Colombia handler
+  - unknown → no downstream; classification unknown in response
+  - invalid signature → 401
+
+hints:
+  tests: pytest tests/test_wompi_webhook_router.py -v
+
+skip:
+  audits: [ux, color, typography]

--- a/tests/test_wompi_webhook_router.py
+++ b/tests/test_wompi_webhook_router.py
@@ -1,12 +1,30 @@
-"""Wompi central ingress classification (#353)."""
+"""Wompi central ingress classification and dispatch (#353, #355)."""
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastapi import BackgroundTasks, FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
+from app.routers.payments_webhook import router as payments_webhook_router
 from app.services.wompi_webhook_router_service import (
     WompiRoute,
     classify_transaction_updated,
+    dispatch_verified_event,
 )
+
+TX_UPDATED = "transaction.updated"
+
+
+def _transaction_body(**tx_fields):
+    return {
+        "event": TX_UPDATED,
+        "data": {"transaction": dict(tx_fields)},
+    }
+
+
+@pytest.fixture
+def background_tasks():
+    return BackgroundTasks()
 
 
 @pytest.mark.asyncio
@@ -52,3 +70,134 @@ async def test_classify_unknown_when_no_signals():
         AsyncMock(return_value=False),
     ):
         assert await classify_transaction_updated(body) == WompiRoute.UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wt_reference_forwards_tickets_not_colombia(background_tasks):
+    body = _transaction_body(reference="WT-abc-123")
+    forward = AsyncMock()
+    colombia = AsyncMock()
+    with patch(
+        "app.services.wompi_webhook_router_service.wompi_service.verify_event_signature",
+        return_value=True,
+    ), patch(
+        "app.services.wompi_webhook_router_service.forward_to_tickets",
+        forward,
+    ), patch(
+        "app.services.wompi_webhook_router_service.wompi_colombia_webhook_service.handle_transaction_updated",
+        colombia,
+    ):
+        result = await dispatch_verified_event(body, background_tasks)
+
+    assert result == {"status": "received"}
+    forward.assert_awaited_once_with(body)
+    colombia.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_gateway_reference_calls_colombia_not_tickets(background_tasks):
+    body = _transaction_body(payment_link_id="SD7wnV")
+    forward = AsyncMock()
+    colombia = AsyncMock()
+    with patch(
+        "app.services.wompi_webhook_router_service.wompi_service.verify_event_signature",
+        return_value=True,
+    ), patch(
+        "app.services.wompi_webhook_router_service._gateway_reference_exists",
+        AsyncMock(return_value=True),
+    ), patch(
+        "app.services.wompi_webhook_router_service.forward_to_tickets",
+        forward,
+    ), patch(
+        "app.services.wompi_webhook_router_service.wompi_colombia_webhook_service.handle_transaction_updated",
+        colombia,
+    ):
+        result = await dispatch_verified_event(body, background_tasks)
+
+    assert result == {"received": True}
+    colombia.assert_awaited_once_with(body, background_tasks)
+    forward.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_billing_redirect_calls_colombia_not_tickets(background_tasks):
+    body = _transaction_body(
+        redirect_url="https://warocol.com/billing/confirmacion",
+    )
+    forward = AsyncMock()
+    colombia = AsyncMock()
+    with patch(
+        "app.services.wompi_webhook_router_service.wompi_service.verify_event_signature",
+        return_value=True,
+    ), patch(
+        "app.services.wompi_webhook_router_service._gateway_reference_exists",
+        AsyncMock(return_value=False),
+    ), patch(
+        "app.services.wompi_webhook_router_service.forward_to_tickets",
+        forward,
+    ), patch(
+        "app.services.wompi_webhook_router_service.wompi_colombia_webhook_service.handle_transaction_updated",
+        colombia,
+    ):
+        result = await dispatch_verified_event(body, background_tasks)
+
+    assert result == {"received": True}
+    colombia.assert_awaited_once_with(body, background_tasks)
+    forward.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unknown_skips_downstream(background_tasks):
+    body = _transaction_body(reference="OTHER-999")
+    forward = AsyncMock()
+    colombia = AsyncMock()
+    with patch(
+        "app.services.wompi_webhook_router_service.wompi_service.verify_event_signature",
+        return_value=True,
+    ), patch(
+        "app.services.wompi_webhook_router_service._gateway_reference_exists",
+        AsyncMock(return_value=False),
+    ), patch(
+        "app.services.wompi_webhook_router_service._tenant_id_exists",
+        AsyncMock(return_value=False),
+    ), patch(
+        "app.services.wompi_webhook_router_service.forward_to_tickets",
+        forward,
+    ), patch(
+        "app.services.wompi_webhook_router_service.wompi_colombia_webhook_service.handle_transaction_updated",
+        colombia,
+    ):
+        result = await dispatch_verified_event(body, background_tasks)
+
+    assert result == {"received": True, "classification": "unknown"}
+    forward.assert_not_awaited()
+    colombia.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_invalid_signature_raises_401(background_tasks):
+    body = _transaction_body(reference="WT-abc-123")
+    with patch(
+        "app.services.wompi_webhook_router_service.wompi_service.verify_event_signature",
+        return_value=False,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await dispatch_verified_event(body, background_tasks)
+
+    assert exc_info.value.status_code == 401
+
+
+def test_central_webhook_endpoint_rejects_invalid_signature():
+    app = FastAPI()
+    app.include_router(payments_webhook_router)
+    body = _transaction_body(reference="WT-abc-123")
+
+    with patch(
+        "app.services.wompi_webhook_router_service.wompi_service.verify_event_signature",
+        return_value=False,
+    ):
+        client = TestClient(app)
+        response = client.post("/payments/webhooks/wompi", json=body)
+
+    assert response.status_code == 401
+    assert "signature" in response.json()["detail"].lower()


### PR DESCRIPTION
## Summary

Adds dispatch-level tests for the central Wompi webhook router (#353). Mocks `forward_to_tickets` and Colombia `handle_transaction_updated` so no real HTTP or DB is required.

Closes #355

## Changes

- `tests/test_wompi_webhook_router.py` — 6 new tests (dispatch + HTTP 401); keeps 4 classification tests
- `.wr/355.yaml` — ship context

## Test plan

- [x] `pytest tests/test_wompi_webhook_router.py -v` (10 passed locally)
- [ ] CI green

## Manual verification

| Scenario | Expected |
|----------|----------|
| `WT-abc-123` reference | Tickets forward called; Colombia not |
| `payment_link_id` + DB gateway ref | Colombia handler called |
| `redirect_url` with `warocol.com/billing` | Colombia handler called |
| Unknown transaction | No forward/handler; `classification: unknown` |
| Invalid signature | HTTP 401 on `POST /payments/webhooks/wompi` |

Epic #351 — batch 5 (tests only; no router code changes).

Made with [Cursor](https://cursor.com)