### PR TITLE
fix(billing): idempotent Wompi activation, payment-date period anchor (#361)

### DIFF
--- a/.wr/361.yaml
+++ b/.wr/361.yaml
@@ -1,0 +1,32 @@
+# wr-fast contract — issue #361
+issue: 361
+title: "fix(billing): Idempotent Wompi activation, payment-date period anchor, customer-only history"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-361-billing-idempotency-history
+
+paths:
+  - app/services/billing_service.py
+  - app/services/wompi_colombia_webhook_service.py
+  - app/routers/billing.py
+  - tests/test_billing_activation.py
+
+ac:
+  - Idempotency by metadata wompi_transaction_id before payment_approved (webhook + verify-payment)
+  - Period anchor from transaction finalized_at (fallback created_at), not server now()
+  - GET /billing/events returns customer-visible event types only
+  - Tests for all three
+
+out_of_scope:
+  - Wompi dashboard URL cutover
+  - Front-end filtering (API allowlist is source of truth)
+
+hints:
+  entry: billing_service.activate_tenant_subscription / activate_subscription_by_gateway_ref
+  pattern: payment_approved_exists + parse_wompi_period_anchor
+  tests: pytest tests/test_billing_activation.py -v
+
+skip:
+  audits: [ux, color, typography]

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -146,6 +146,8 @@ async def verify_payment(request: Request, transaction_id: str = Query(...)):
     internal_status = wompi_service.map_status(wompi_status)
     payment_link_id = transaction.get("payment_link_id")
 
+    period_anchor = billing_service.parse_wompi_period_anchor(transaction)
+
     async with get_db_connection() as conn:
         if internal_status == "active" and payment_link_id:
             await billing_service.activate_subscription_by_gateway_ref(
@@ -154,6 +156,7 @@ async def verify_payment(request: Request, transaction_id: str = Query(...)):
                 gateway_reference=payment_link_id,
                 wompi_transaction_id=transaction_id,
                 amount=transaction.get("amount_in_cents", 0) / 100,
+                period_anchor=period_anchor,
             )
 
     return {

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -265,6 +265,7 @@ async def list_tenant_billing_events(
     conn, tenant_id, limit: int = 20, offset: int = 0
 ) -> Dict[str, Any]:
     """Paginated billing events for the session tenant, newest first."""
+    visible_types = list(CUSTOMER_VISIBLE_BILLING_EVENT_TYPES)
     rows = await conn.fetch("""
         SELECT
             be.id, be.tenant_id, t.name AS tenant_name,
@@ -273,11 +274,18 @@ async def list_tenant_billing_events(
         FROM billing_events be
         JOIN tenants t ON t.id = be.tenant_id
         WHERE be.tenant_id = $3
+          AND be.event_type = ANY($4::text[])
         ORDER BY be.created_at DESC
         LIMIT $1 OFFSET $2
-    """, limit, offset, tenant_id)
+    """, limit, offset, tenant_id, visible_types)
     total = await conn.fetchval(
-        "SELECT COUNT(*) FROM billing_events WHERE tenant_id = $1", tenant_id
+        """
+        SELECT COUNT(*) FROM billing_events
+        WHERE tenant_id = $1
+          AND event_type = ANY($2::text[])
+        """,
+        tenant_id,
+        visible_types,
     )
     return _serialize_billing_events(rows, total, limit, offset)
 
@@ -394,6 +402,60 @@ async def subscribe_tenant(
 
 _ACTIVATABLE_STATUSES = frozenset({"pending", "past_due"})
 
+# Tenant-facing Mi Plan history (GET /billing/events) — excludes cron/ops noise.
+CUSTOMER_VISIBLE_BILLING_EVENT_TYPES = (
+    "subscribe_initiated",
+    "payment_approved",
+    "payment_rejected",
+    "payment_failed",
+    "payment_pending",
+    "subscription_cancelled",
+    "subscription_created",
+    "subscription_renewed",
+    "subscription_expired",
+    "gift_granted",
+    "plan_changed",
+)
+
+
+def parse_wompi_period_anchor(transaction: Dict[str, Any]) -> datetime:
+    """Anchor billing period to Wompi payment time, not webhook processing time."""
+    for key in ("finalized_at", "created_at"):
+        raw = transaction.get(key)
+        if not raw:
+            continue
+        text = str(raw).replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError:
+            continue
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    return datetime.now(timezone.utc)
+
+
+async def payment_approved_exists(
+    conn,
+    subscription_id: UUID,
+    wompi_transaction_id: str,
+) -> bool:
+    """True if this Wompi transaction already recorded as payment_approved."""
+    if not wompi_transaction_id:
+        return False
+    row = await conn.fetchval(
+        """
+        SELECT 1 FROM billing_events
+        WHERE subscription_id = $1
+          AND event_type = 'payment_approved'
+          AND metadata->>'wompi_transaction_id' = $2
+        LIMIT 1
+        """,
+        subscription_id,
+        wompi_transaction_id,
+    )
+    return row is not None
+
 
 async def _activate_subscription_with_period(
     conn,
@@ -404,22 +466,26 @@ async def _activate_subscription_with_period(
     amount: float,
     currency: str,
     metadata: Dict[str, Any],
+    period_anchor: Optional[datetime] = None,
 ) -> Optional[datetime]:
     """Set subscription active, extend billing period, record payment_approved."""
     # Interval literals stay in SQL — asyncpg cannot bind '1 year' strings as interval.
     cycle = billing_cycle if billing_cycle in ("monthly", "annual") else "annual"
+    anchor = period_anchor or datetime.now(timezone.utc)
+    if anchor.tzinfo is None:
+        anchor = anchor.replace(tzinfo=timezone.utc)
     updated = await conn.fetchrow("""
         UPDATE tenant_subscriptions
         SET status               = 'active',
-            current_period_start = now(),
-            current_period_end   = now() + CASE
+            current_period_start = $3,
+            current_period_end   = $3 + CASE
                 WHEN $2::text = 'monthly' THEN interval '1 month'
                 ELSE interval '1 year'
             END,
             updated_at           = now()
         WHERE id = $1
         RETURNING current_period_end
-    """, subscription_id, cycle)
+    """, subscription_id, cycle, anchor)
 
     await conn.execute("""
         INSERT INTO billing_events
@@ -438,6 +504,7 @@ async def activate_subscription_by_gateway_ref(
     gateway_reference: str,
     wompi_transaction_id: str,
     amount: float,
+    period_anchor: Optional[datetime] = None,
 ) -> None:
     """
     Activa la suscripción del tenant cuando Wompi confirma el pago (verify-payment).
@@ -467,6 +534,14 @@ async def activate_subscription_by_gateway_ref(
         )
         return
 
+    if await payment_approved_exists(conn, row["id"], wompi_transaction_id):
+        logger.info(
+            "activate_subscription: duplicate wompi_transaction_id=%s tenant=%s — skipped",
+            wompi_transaction_id,
+            tenant_id,
+        )
+        return
+
     period_end = await _activate_subscription_with_period(
         conn,
         subscription_id=row["id"],
@@ -478,6 +553,7 @@ async def activate_subscription_by_gateway_ref(
             "wompi_transaction_id": wompi_transaction_id,
             "gateway_reference": gateway_reference,
         },
+        period_anchor=period_anchor,
     )
 
     logger.info(
@@ -582,6 +658,7 @@ async def activate_tenant_subscription(
     payment_id: str = "",
     amount: float = 0,
     currency: str = "COP",
+    period_anchor: Optional[datetime] = None,
 ):
     """
     Llamado desde el webhook de Wompi cuando la transacción es APPROVED.
@@ -606,6 +683,14 @@ async def activate_tenant_subscription(
         )
         return None
 
+    if await payment_approved_exists(conn, row["id"], payment_id):
+        logger.info(
+            "activate_tenant_subscription: duplicate wompi_transaction_id=%s ref=%s — skipped",
+            payment_id,
+            gateway_reference,
+        )
+        return None
+
     billing_cycle = row["billing_cycle"]
     metadata: Dict[str, Any] = {"gateway_reference": gateway_reference}
     if payment_id:
@@ -619,6 +704,7 @@ async def activate_tenant_subscription(
         amount=amount,
         currency=currency,
         metadata=metadata,
+        period_anchor=period_anchor,
     )
     next_period_end = period_end.isoformat() if period_end else None
 

--- a/app/services/wompi_colombia_webhook_service.py
+++ b/app/services/wompi_colombia_webhook_service.py
@@ -42,6 +42,7 @@ async def handle_transaction_updated(
         return
 
     if wompi_status == "APPROVED":
+        period_anchor = billing_service.parse_wompi_period_anchor(transaction)
         async with get_db_connection() as conn:
             tenant_info = await billing_service.activate_tenant_subscription(
                 conn,
@@ -49,6 +50,7 @@ async def handle_transaction_updated(
                 payment_id=transaction_id,
                 amount=amount_cents / 100,
                 currency="COP",
+                period_anchor=period_anchor,
             )
         if tenant_info:
             background_tasks.add_task(

--- a/tests/test_billing_activation.py
+++ b/tests/test_billing_activation.py
@@ -1,4 +1,4 @@
-"""Subscription activation — verify-payment period extension (#354)."""
+"""Subscription activation — idempotency, period anchor, customer events (#361)."""
 import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
@@ -9,25 +9,41 @@ import pytest
 from app.services import billing_service
 
 
-@pytest.mark.asyncio
-async def test_activate_by_gateway_ref_past_due_extends_period():
-    tenant_id = uuid4()
-    sub_id = uuid4()
+def _conn_with_activation(
+    *,
+    sub_row,
+    duplicate: bool = False,
+    period_anchor=None,
+):
+    """MagicMock conn: fetchrow (lookup + UPDATE), fetchval (idempotency), execute (event)."""
     new_end = datetime.now(timezone.utc) + timedelta(days=365)
-
     conn = MagicMock()
 
     async def fetchrow_side_effect(query, *args):
         sql = " ".join(query.split())
         if "FROM tenant_subscriptions" in sql and "gateway_reference" in sql:
-            return {"id": sub_id, "status": "past_due", "billing_cycle": "annual"}
+            return sub_row
+        if "FROM tenant_subscriptions ts" in sql:
+            return sub_row
         if "UPDATE tenant_subscriptions" in sql:
-            assert args[1] == "annual"
+            assert args[1] in ("monthly", "annual")
+            if period_anchor is not None:
+                assert args[2] == period_anchor
             return {"current_period_end": new_end}
         return None
 
     conn.fetchrow = AsyncMock(side_effect=fetchrow_side_effect)
+    conn.fetchval = AsyncMock(return_value=1 if duplicate else None)
     conn.execute = AsyncMock()
+    return conn, new_end
+
+
+@pytest.mark.asyncio
+async def test_activate_by_gateway_ref_past_due_extends_period():
+    tenant_id = uuid4()
+    sub_id = uuid4()
+    sub_row = {"id": sub_id, "status": "past_due", "billing_cycle": "annual"}
+    conn, _ = _conn_with_activation(sub_row=sub_row)
 
     await billing_service.activate_subscription_by_gateway_ref(
         conn,
@@ -38,11 +54,46 @@ async def test_activate_by_gateway_ref_past_due_extends_period():
     )
 
     conn.execute.assert_called_once()
-    event_args = conn.execute.call_args[0]
-    assert "payment_approved" in event_args[0]
-    metadata = json.loads(event_args[5])
+    metadata = json.loads(conn.execute.call_args[0][5])
     assert metadata["wompi_transaction_id"] == "txn-123"
     assert metadata["gateway_reference"] == "SD7wnV"
+
+
+@pytest.mark.asyncio
+async def test_activate_by_gateway_ref_duplicate_skips_activation():
+    tenant_id = uuid4()
+    sub_row = {"id": uuid4(), "status": "past_due", "billing_cycle": "annual"}
+    conn, _ = _conn_with_activation(sub_row=sub_row, duplicate=True)
+
+    await billing_service.activate_subscription_by_gateway_ref(
+        conn,
+        tenant_id=tenant_id,
+        gateway_reference="SD7wnV",
+        wompi_transaction_id="txn-dup",
+        amount=99.0,
+    )
+
+    conn.execute.assert_not_called()
+    assert conn.fetchrow.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_activate_by_gateway_ref_uses_period_anchor():
+    tenant_id = uuid4()
+    anchor = datetime(2025, 5, 31, 18, 0, tzinfo=timezone.utc)
+    sub_row = {"id": uuid4(), "status": "past_due", "billing_cycle": "annual"}
+    conn, _ = _conn_with_activation(sub_row=sub_row, period_anchor=anchor)
+
+    await billing_service.activate_subscription_by_gateway_ref(
+        conn,
+        tenant_id=tenant_id,
+        gateway_reference="SD7wnV",
+        wompi_transaction_id="txn-anchor",
+        amount=99.0,
+        period_anchor=anchor,
+    )
+
+    conn.execute.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -53,6 +104,7 @@ async def test_activate_by_gateway_ref_already_active_is_noop():
         return_value={"id": uuid4(), "status": "active", "billing_cycle": "annual"},
     )
     conn.execute = AsyncMock()
+    conn.fetchval = AsyncMock()
 
     await billing_service.activate_subscription_by_gateway_ref(
         conn,
@@ -63,7 +115,7 @@ async def test_activate_by_gateway_ref_already_active_is_noop():
     )
 
     conn.execute.assert_not_called()
-    assert conn.fetchrow.call_count == 1
+    conn.fetchval.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -91,30 +143,26 @@ async def test_activate_tenant_subscription_past_due_extends_period():
     sub_id = uuid4()
     tenant_id = uuid4()
     new_end = datetime.now(timezone.utc) + timedelta(days=30)
-
-    conn = MagicMock()
-    call_count = 0
+    sub_row = {
+        "id": sub_id,
+        "tenant_id": tenant_id,
+        "billing_cycle": "monthly",
+        "tenant_name": "Natural Food",
+        "tenant_email": "nf@example.com",
+        "plan_name": "Pro",
+    }
+    conn, _ = _conn_with_activation(sub_row=sub_row)
 
     async def fetchrow_side_effect(query, *args):
-        nonlocal call_count
-        call_count += 1
         sql = " ".join(query.split())
         if "FROM tenant_subscriptions ts" in sql:
-            return {
-                "id": sub_id,
-                "tenant_id": tenant_id,
-                "billing_cycle": "monthly",
-                "tenant_name": "Natural Food",
-                "tenant_email": "nf@example.com",
-                "plan_name": "Pro",
-            }
+            return sub_row
         if "UPDATE tenant_subscriptions" in sql:
             assert args[1] == "monthly"
             return {"current_period_end": new_end}
         return None
 
     conn.fetchrow = AsyncMock(side_effect=fetchrow_side_effect)
-    conn.execute = AsyncMock()
 
     result = await billing_service.activate_tenant_subscription(
         conn,
@@ -126,9 +174,69 @@ async def test_activate_tenant_subscription_past_due_extends_period():
     assert result is not None
     assert result["next_period_end"] == new_end.isoformat()
     conn.execute.assert_called_once()
-    metadata = json.loads(conn.execute.call_args[0][5])
-    assert metadata["gateway_reference"] == "SD7wnV"
-    assert metadata["wompi_transaction_id"] == "txn-456"
+
+
+@pytest.mark.asyncio
+async def test_activate_tenant_subscription_duplicate_returns_none():
+    sub_row = {
+        "id": uuid4(),
+        "tenant_id": uuid4(),
+        "billing_cycle": "annual",
+        "tenant_name": "T",
+        "tenant_email": "t@x.com",
+        "plan_name": "Pro",
+    }
+    conn, _ = _conn_with_activation(sub_row=sub_row, duplicate=True)
+
+    async def fetchrow_side_effect(query, *args):
+        if "FROM tenant_subscriptions ts" in " ".join(query.split()):
+            return sub_row
+        return None
+
+    conn.fetchrow = AsyncMock(side_effect=fetchrow_side_effect)
+
+    result = await billing_service.activate_tenant_subscription(
+        conn,
+        gateway_reference="SD7wnV",
+        payment_id="txn-dup",
+        amount=50.0,
+    )
+
+    assert result is None
+    conn.execute.assert_not_called()
+
+
+def test_parse_wompi_period_anchor_prefers_finalized_at():
+    anchor = billing_service.parse_wompi_period_anchor({
+        "finalized_at": "2025-05-31T18:00:00.000Z",
+        "created_at": "2025-05-31T17:00:00.000Z",
+    })
+    assert anchor == datetime(2025, 5, 31, 18, 0, tzinfo=timezone.utc)
+
+
+def test_parse_wompi_period_anchor_falls_back_to_created_at():
+    anchor = billing_service.parse_wompi_period_anchor({
+        "created_at": "2025-05-31T17:00:00.000Z",
+    })
+    assert anchor == datetime(2025, 5, 31, 17, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_list_tenant_billing_events_filters_internal_types():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value=0)
+
+    await billing_service.list_tenant_billing_events(conn, tenant_id, limit=10, offset=0)
+
+    visible = list(billing_service.CUSTOMER_VISIBLE_BILLING_EVENT_TYPES)
+    fetch_args = conn.fetch.call_args[0]
+    assert fetch_args[4] == visible
+    count_args = conn.fetchval.call_args[0]
+    assert count_args[2] == visible
+    assert "grace_reminder" not in visible
+    assert "subscription_period_ended" not in visible
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Skip duplicate `payment_approved` when the same `wompi_transaction_id` was already recorded (webhook + verify-payment).
- Anchor `current_period_start` / `current_period_end` to Wompi `finalized_at` (fallback `created_at`) instead of server `now()`.
- Filter `GET /billing/events` to customer-visible event types only.

Closes #361

## Test plan
- [x] `pytest tests/test_billing_activation.py -v` (11 passed)
- [ ] After deploy: replay Natural Food webhook — expect HTTP 200, no second `payment_approved` in Mi Plan history
- [ ] Verify-payment + webhook for same txn — only one activation event

## wr-context
See `.wr/361.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)