### PR TITLE
fix(billing): grace only when period expired on payment failure (#365)

### DIFF
--- a/.wr/365.yaml
+++ b/.wr/365.yaml
@@ -1,0 +1,28 @@
+# wr-fast contract — issue #365
+issue: 365
+title: "fix(billing): Do not apply grace period on failed Wompi payment attempts"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-365-grace-only-when-overdue
+
+paths:
+  - app/services/billing_service.py
+  - tests/test_billing_payment_failure.py
+
+ac:
+  - No past_due when current_period_end > now or status pending with valid period
+  - past_due when period expired or already past_due
+  - payment_rejected event always recorded
+
+out_of_scope:
+  - Grace day thresholds
+  - Front-end changes
+
+hints:
+  entry: mark_subscription_past_due — billing_service.py
+  tests: pytest tests/test_billing_payment_failure.py -v
+
+skip:
+  audits: [ux, color, typography]

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -887,20 +887,19 @@ async def mark_subscription_past_due(
     conn, gateway_reference: str, event_type: str
 ) -> Optional[Dict[str, Any]]:
     """
-    Set subscription status='past_due' for a given preapproval ID.
+    Record a failed payment and set past_due only when grace applies.
 
-    Called when MP sends:
-    - subscription_preapproval → paused  (event_type='subscription_paused')
-    - payment → rejected                 (event_type='payment_rejected')
+    Grace (past_due) is allowed when the billing period has ended or the row is
+    already past_due. Failed attempts while pending or while the period is still
+    valid only append a billing event — they do not start the grace window.
 
-    Does NOT filter by current status — allows active → past_due transition.
-    Returns tenant info dict for email trigger, or None if preapproval not found.
+    Returns tenant info dict for email trigger, or None if not found.
     """
     row = await conn.fetchrow("""
-        UPDATE tenant_subscriptions ts
-        SET status = 'past_due', updated_at = now()
+        SELECT ts.id AS subscription_id, ts.tenant_id, ts.status,
+               ts.current_period_end
+        FROM tenant_subscriptions ts
         WHERE ts.gateway_reference = $1
-        RETURNING ts.id AS subscription_id, ts.tenant_id
     """, gateway_reference)
 
     if row is None:
@@ -912,6 +911,27 @@ async def mark_subscription_past_due(
 
     sub_id = row["subscription_id"]
     tenant_id = row["tenant_id"]
+    status = row["status"]
+    period_end = row["current_period_end"]
+    if period_end is not None and period_end.tzinfo is None:
+        period_end = period_end.replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    period_expired = period_end is not None and period_end < now
+    should_mark_past_due = status == "past_due" or period_expired
+
+    if should_mark_past_due:
+        await conn.execute("""
+            UPDATE tenant_subscriptions
+            SET status = 'past_due', updated_at = now()
+            WHERE id = $1
+        """, sub_id)
+    else:
+        logger.info(
+            "mark_subscription_past_due: skipped past_due status=%s period_end=%s ref=%s",
+            status,
+            period_end,
+            gateway_reference,
+        )
 
     # Fetch tenant info for email
     tenant = await conn.fetchrow(

--- a/tests/test_billing_payment_failure.py
+++ b/tests/test_billing_payment_failure.py
@@ -1,0 +1,118 @@
+"""Failed payment handling — grace only when period overdue (#365)."""
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.services import billing_service
+
+
+def _subscription_row(*, status: str, period_end: datetime):
+    return {
+        "subscription_id": uuid4(),
+        "tenant_id": uuid4(),
+        "status": status,
+        "current_period_end": period_end,
+    }
+
+
+@pytest.mark.asyncio
+async def test_declined_with_valid_period_does_not_mark_past_due():
+    row = _subscription_row(
+        status="active",
+        period_end=datetime.now(timezone.utc) + timedelta(days=20),
+    )
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        row,
+        {"name": "Test", "email": "t@example.com"},
+    ])
+    conn.execute = AsyncMock()
+
+    result = await billing_service.mark_subscription_past_due(
+        conn, "SD7wnV", "payment_rejected",
+    )
+
+    assert result is not None
+    update_calls = [
+        c for c in conn.execute.call_args_list
+        if "UPDATE tenant_subscriptions" in c[0][0]
+    ]
+    assert len(update_calls) == 0
+    event_sql = conn.execute.call_args_list[0][0][0]
+    assert "billing_events" in event_sql
+    assert conn.execute.call_args_list[0][0][3] == "payment_rejected"
+
+
+@pytest.mark.asyncio
+async def test_declined_pending_checkout_does_not_mark_past_due():
+    row = _subscription_row(
+        status="pending",
+        period_end=datetime.now(timezone.utc) + timedelta(days=30),
+    )
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        row,
+        {"name": "Test", "email": "t@example.com"},
+    ])
+    conn.execute = AsyncMock()
+
+    await billing_service.mark_subscription_past_due(
+        conn, "LINK1", "payment_rejected",
+    )
+
+    update_calls = [
+        c for c in conn.execute.call_args_list
+        if "UPDATE tenant_subscriptions" in c[0][0]
+    ]
+    assert len(update_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_declined_with_expired_period_marks_past_due():
+    row = _subscription_row(
+        status="active",
+        period_end=datetime.now(timezone.utc) - timedelta(days=3),
+    )
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        row,
+        {"name": "Test", "email": "t@example.com"},
+    ])
+    conn.execute = AsyncMock()
+
+    await billing_service.mark_subscription_past_due(
+        conn, "SD7wnV", "payment_rejected",
+    )
+
+    update_calls = [
+        c for c in conn.execute.call_args_list
+        if "UPDATE tenant_subscriptions" in c[0][0]
+    ]
+    assert len(update_calls) == 1
+    assert "past_due" in update_calls[0][0][0]
+
+
+@pytest.mark.asyncio
+async def test_declined_when_already_past_due_stays_past_due():
+    row = _subscription_row(
+        status="past_due",
+        period_end=datetime.now(timezone.utc) - timedelta(days=10),
+    )
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        row,
+        {"name": "Test", "email": "t@example.com"},
+    ])
+    conn.execute = AsyncMock()
+
+    await billing_service.mark_subscription_past_due(
+        conn, "SD7wnV", "payment_rejected",
+    )
+
+    update_calls = [
+        c for c in conn.execute.call_args_list
+        if "UPDATE tenant_subscriptions" in c[0][0]
+    ]
+    assert len(update_calls) == 1


### PR DESCRIPTION
## Summary
- `mark_subscription_past_due` only sets `past_due` when `current_period_end < now` or status is already `past_due`.
- Failed checkout (`pending`) or failed payment with a valid period records `payment_rejected` without starting grace.
- Regression tests for the four cases.

Closes #365

## Test plan
- [x] `pytest tests/test_billing_*.py -v` (23 passed)
- [ ] Declined Wompi tx with active period → no grace banner
- [ ] Declined tx after period end → `past_due` + grace as before

## wr-context
See `.wr/365.yaml` on this branch.

Made with [Cursor](https://cursor.com)