### PR TITLE
feat(waros): hybrid redemption engine at checkout (B1/B2/B3)

### DIFF
--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -221,6 +221,8 @@ class CompleteOrderRequest(BaseModel):
     tip_amount: float = Field(0, ge=0, description="Issue warocol.com#637 — tip amount in COP. Strictly separate from total_amount. Rejected when tip_enabled=false for the tenant. Allowed with split_mode (settlement is total + tip). For cash payments, cash_received must cover total + tip on single-pay close.")
     tip_source: Literal['preset', 'custom', 'none'] = Field('none', description="Issue warocol.com#637 — how the customer chose the tip. Must agree with tip_amount: (0,'none') or (>0,'preset'|'custom').")
     tip_taxable: bool = Field(False, description="warocol.com#740 — when true, standard consumption tax is applied to tip_amount (gravada).")
+    waros_to_redeem: Optional[int] = Field(None, ge=0, description="B1 WaRos points to redeem for COP discount (api#370)")
+    waro_reward_id: Optional[UUID] = Field(None, description="B2 catalog reward UUID (api#370)")
 
 
 @router.post("/{cart_id}/complete", dependencies=[Depends(require_module(Module.POS))])
@@ -259,6 +261,8 @@ async def complete_order(
         tip_amount=order_data.tip_amount,
         tip_source=order_data.tip_source,
         tip_taxable=order_data.tip_taxable,
+        waros_to_redeem=order_data.waros_to_redeem,
+        waro_reward_id=order_data.waro_reward_id,
     )
 
 

--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -185,6 +185,8 @@ class CloseSessionRequest(BaseModel):
         None,
         description="Motivo de liberación — required when closing without payment and pending tab lines exist",
     )
+    waros_to_redeem: Optional[int] = Field(None, ge=0, description="B1 WaRos to redeem (api#370)")
+    waro_reward_id: Optional[UUID] = Field(None, description="B2 reward UUID (api#370)")
 
 
 class AddSessionPaymentRequest(BaseModel):
@@ -225,6 +227,8 @@ async def close_session(request: Request, table_id: UUID, body: CloseSessionRequ
         tip_taxable=body.tip_taxable,
         served_by_member_id=body.served_by_member_id,
         reason=body.reason,
+        waros_to_redeem=body.waros_to_redeem,
+        waro_reward_id=body.waro_reward_id,
     )
 
 

--- a/app/routers/waros.py
+++ b/app/routers/waros.py
@@ -3,11 +3,12 @@ Waros Points System Router
 Endpoints for configuring earning rules and global system toggle.
 All endpoints require a valid tenant session.
 """
+import json
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.core.permissions import Module, require_module
 from app.services import waros_service
@@ -15,6 +16,7 @@ from app.services import waros_service
 router = APIRouter(prefix="/admin/waros", tags=["Waros"])
 
 VALID_RULE_TYPES = {"ticket_value", "purchase_count", "frequency", "per_ticket_qty"}
+VALID_REWARD_TYPES = {"fixed_cop_off", "free_product"}
 
 
 # ── Pydantic models ──────────────────────────────────────────────────────────
@@ -29,6 +31,34 @@ class RuleBody(BaseModel):
 class GlobalConfigBody(BaseModel):
     """Body for PATCH /admin/waros/config"""
     is_enabled: bool
+
+
+class RedemptionConfigBody(BaseModel):
+    """Body for PATCH /admin/waros/redemption-config"""
+    is_enabled: Optional[bool] = None
+    redemption_enabled: Optional[bool] = None
+    waros_per_1000_cop: Optional[int] = Field(None, ge=1)
+    max_redeem_percent_per_order: Optional[float] = Field(None, ge=0, le=100)
+    min_waros_to_redeem: Optional[int] = Field(None, ge=1)
+    earn_on_wallet_payment: Optional[bool] = None
+    earn_base_excludes_waro_redemption: Optional[bool] = None
+
+
+class WaroRewardBody(BaseModel):
+    name: str
+    reward_type: str
+    waros_cost: int = Field(..., ge=1)
+    fixed_cop_off: Optional[float] = None
+    product_id: Optional[UUID] = None
+    is_active: bool = True
+
+
+class WaroRewardUpdateBody(BaseModel):
+    name: Optional[str] = None
+    waros_cost: Optional[int] = Field(None, ge=1)
+    fixed_cop_off: Optional[float] = None
+    product_id: Optional[UUID] = None
+    is_active: Optional[bool] = None
 
 
 class AssignBody(BaseModel):
@@ -165,3 +195,108 @@ async def assign_waros(body: AssignBody, request: Request):
         waros_amount=body.waros_amount,
         reason=body.reason,
     )
+
+
+@router.get("/redemption-config", dependencies=[Depends(require_module(Module.POS))])
+async def get_redemption_config(request: Request):
+    """Redemption + earn flags from gamification_config (api#370)."""
+    return await waros_service.get_redemption_config(request)
+
+
+@router.patch("/redemption-config", dependencies=[Depends(require_module(Module.POS))])
+async def patch_redemption_config(body: RedemptionConfigBody, request: Request):
+    return await waros_service.update_redemption_config(
+        request,
+        redemption_enabled=body.redemption_enabled,
+        waros_per_1000_cop=body.waros_per_1000_cop,
+        max_redeem_percent_per_order=body.max_redeem_percent_per_order,
+        min_waros_to_redeem=body.min_waros_to_redeem,
+        earn_on_wallet_payment=body.earn_on_wallet_payment,
+        earn_base_excludes_waro_redemption=body.earn_base_excludes_waro_redemption,
+        is_enabled=body.is_enabled,
+    )
+
+
+@router.get("/preview-redemption", dependencies=[Depends(require_module(Module.POS))])
+async def preview_redemption(
+    request: Request,
+    lines: str = Query(..., description="JSON array of cart line objects for promo evaluation"),
+    customer_id: Optional[str] = Query(None),
+    manual_discount_amount: float = Query(0, ge=0),
+    discount_type: Optional[str] = Query(None),
+    discount_value: Optional[float] = Query(None),
+    waros_to_redeem: Optional[int] = Query(None, ge=0),
+    waro_reward_id: Optional[str] = Query(None),
+):
+    try:
+        parsed_lines = json.loads(lines)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=422, detail="lines debe ser JSON válido")
+    if not isinstance(parsed_lines, list):
+        raise HTTPException(status_code=422, detail="lines debe ser un array JSON")
+
+    parsed_customer: Optional[UUID] = None
+    if customer_id:
+        try:
+            parsed_customer = UUID(customer_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="customer_id no es un UUID válido")
+
+    parsed_reward: Optional[UUID] = None
+    if waro_reward_id:
+        try:
+            parsed_reward = UUID(waro_reward_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="waro_reward_id no es un UUID válido")
+
+    return await waros_service.preview_redemption(
+        request,
+        parsed_lines,
+        customer_id=parsed_customer,
+        manual_discount_amount=manual_discount_amount,
+        discount_type=discount_type,
+        discount_value=discount_value,
+        waros_to_redeem=waros_to_redeem,
+        waro_reward_id=parsed_reward,
+    )
+
+
+@router.get("/rewards", dependencies=[Depends(require_module(Module.POS))])
+async def list_rewards(request: Request):
+    return await waros_service.list_waro_rewards(request)
+
+
+@router.post("/rewards", dependencies=[Depends(require_module(Module.POS))])
+async def create_reward(body: WaroRewardBody, request: Request):
+    if body.reward_type not in VALID_REWARD_TYPES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"reward_type inválido. Valores: {sorted(VALID_REWARD_TYPES)}",
+        )
+    return await waros_service.create_waro_reward(
+        request,
+        name=body.name,
+        reward_type=body.reward_type,
+        waros_cost=body.waros_cost,
+        fixed_cop_off=body.fixed_cop_off,
+        product_id=body.product_id,
+        is_active=body.is_active,
+    )
+
+
+@router.put("/rewards/{reward_id}", dependencies=[Depends(require_module(Module.POS))])
+async def update_reward(reward_id: UUID, body: WaroRewardUpdateBody, request: Request):
+    return await waros_service.update_waro_reward(
+        request,
+        reward_id,
+        name=body.name,
+        waros_cost=body.waros_cost,
+        fixed_cop_off=body.fixed_cop_off,
+        product_id=body.product_id,
+        is_active=body.is_active,
+    )
+
+
+@router.delete("/rewards/{reward_id}", dependencies=[Depends(require_module(Module.POS))])
+async def delete_reward(reward_id: UUID, request: Request):
+    return await waros_service.delete_waro_reward(request, reward_id)

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -1109,6 +1109,7 @@ async def add_order_payment(
         remaining = 0.0
         is_complete = False
         order_id = None
+        award_customer_id = None
 
         async with get_db_connection() as conn:
             async with conn.transaction():
@@ -1253,6 +1254,10 @@ async def add_order_payment(
 
                 # 5. Update order status
                 if is_complete:
+                    award_customer_id = await conn.fetchval(
+                        "SELECT customer_id FROM orders WHERE id = $1",
+                        order_id,
+                    )
                     await conn.execute(
                         """
                         UPDATE orders
@@ -1313,9 +1318,11 @@ async def add_order_payment(
                         )
 
         # 6. Fire-and-forget side effects OUTSIDE transaction (only on completion)
-        if is_complete:
+        if is_complete and award_customer_id:
             try:
-                asyncio.create_task(evaluate_and_award(order_id, tenant_id))
+                asyncio.create_task(
+                    evaluate_and_award(order_id, award_customer_id, tenant_id)
+                )
             except Exception as _w_err:
                 logger.warning(f"Could not schedule waros for order {order_id}: {_w_err}")
 
@@ -1525,6 +1532,8 @@ async def complete_pos_order(
     tip_amount: float = 0,
     tip_source: str = 'none',
     tip_taxable: bool = False,
+    waros_to_redeem: Optional[int] = None,
+    waro_reward_id: Optional[UUID] = None,
 ) -> dict:
     """
     Complete a POS order:
@@ -1675,6 +1684,27 @@ async def complete_pos_order(
                     discount_type=discount_type,
                     discount_value=discount_value,
                 )
+
+                from app.services.waros_service import (
+                    apply_checkout_waro_redemption,
+                    settle_waro_redemption,
+                )
+                from fastapi import HTTPException as FastAPIHTTPException
+
+                try:
+                    checkout_eval = await apply_checkout_waro_redemption(
+                        conn,
+                        tenant_id,
+                        customer_id,
+                        checkout_eval,
+                        waros_to_redeem=waros_to_redeem,
+                        waro_reward_id=waro_reward_id,
+                    )
+                except FastAPIHTTPException as waro_exc:
+                    raise APIError(waro_exc.detail, status_code=waro_exc.status_code)
+
+                _waro_preview = checkout_eval.pop("_waro_redemption_preview", None)
+
                 cart_subtotal = float(checkout_eval["subtotal"])
                 _promo_savings = float(checkout_eval["promo_savings"])
                 _subtotal_after_promos = float(checkout_eval["subtotal_after_promos"])
@@ -1749,6 +1779,18 @@ async def complete_pos_order(
                 )
                 order_id = order_row['id']
                 order_number = order_row['order_number']
+
+                if _waro_preview:
+                    try:
+                        await settle_waro_redemption(
+                            conn,
+                            tenant_id,
+                            customer_id,
+                            order_id,
+                            _waro_preview,
+                        )
+                    except FastAPIHTTPException as waro_exc:
+                        raise APIError(waro_exc.detail, status_code=waro_exc.status_code)
 
                 logger.info(f"Created order #{order_number} from cart {cart_id}")
 

--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -1452,6 +1452,45 @@ def apply_manual_discount_to_evaluated_lines(
     }
 
 
+def apply_waro_redemption_to_evaluated_lines(
+    evaluated: Dict[str, Any],
+    waro_discount_cop: float,
+) -> Dict[str, Any]:
+    """Apply WaRo COP discount on promo+manual-adjusted subtotals (checkout layer 4)."""
+    waro_discount = max(0.0, float(waro_discount_cop or 0))
+    lines = evaluated["lines"]
+    base_total = float(evaluated["total_amount"])
+    if waro_discount <= 0 or base_total <= 0:
+        for line in lines:
+            line["waro_discount_allocated"] = 0
+        return {
+            **evaluated,
+            "waro_redemption_amount_cop": 0,
+            "total_amount": round(base_total),
+        }
+
+    waro_discount = min(round(waro_discount), round(base_total))
+    dist_input = [
+        {"subtotal": float(line["net_total"]), "_idx": idx}
+        for idx, line in enumerate(lines)
+    ]
+    dist = _distribute_discount_from_promotions(dist_input, waro_discount)
+    for idx, line in enumerate(lines):
+        waro_alloc = dist[idx]["discount_allocated"]
+        line["waro_discount_allocated"] = waro_alloc
+        line["total_discount_allocated"] = (
+            float(line.get("total_discount_allocated") or line.get("promo_savings") or 0)
+            + waro_alloc
+        )
+        line["net_total"] = float(line["subtotal"]) - line["total_discount_allocated"]
+
+    return {
+        **evaluated,
+        "waro_redemption_amount_cop": waro_discount,
+        "total_amount": round(base_total - waro_discount),
+    }
+
+
 def _distribute_discount_from_promotions(items: List[dict], discount_amount: float) -> List[dict]:
     """Same proportional allocation as pos_cart_service._distribute_discount."""
     total_subtotal = sum(float(item["subtotal"]) for item in items)

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -821,7 +821,7 @@ async def open_session(
         raise APIError(f"Error opening session: {e}", status_code=500)
 
 
-async def close_session(request: Request, table_id: UUID, payment_method: Optional[str] = None, customer_id: Optional[str] = None, credit_due_date: Optional[date] = None, payment_method_id: Optional[UUID] = None, discount_type: Optional[str] = None, discount_value: Optional[float] = None, split_mode: bool = False, split_first_amount: float = 0.0, *, split_first_cash_received: Optional[float] = None, cash_received: Optional[float] = None, tip_amount: float = 0, tip_source: str = 'none', tip_taxable: bool = False, served_by_member_id: Optional[UUID] = None, reason: Optional[str] = None) -> dict:
+async def close_session(request: Request, table_id: UUID, payment_method: Optional[str] = None, customer_id: Optional[str] = None, credit_due_date: Optional[date] = None, payment_method_id: Optional[UUID] = None, discount_type: Optional[str] = None, discount_value: Optional[float] = None, split_mode: bool = False, split_first_amount: float = 0.0, *, split_first_cash_received: Optional[float] = None, cash_received: Optional[float] = None, tip_amount: float = 0, tip_source: str = 'none', tip_taxable: bool = False, served_by_member_id: Optional[UUID] = None, reason: Optional[str] = None, waros_to_redeem: Optional[int] = None, waro_reward_id: Optional[UUID] = None) -> dict:
     """
     Close the active session for a table.
     If payment_method is provided, marks all pending orders as completed with that payment method.
@@ -960,6 +960,33 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                         discount_type=discount_type,
                         discount_value=discount_value,
                     )
+                    from app.services.waros_service import (
+                        apply_checkout_waro_redemption,
+                        settle_waro_redemption,
+                    )
+                    from fastapi import HTTPException as FastAPIHTTPException
+
+                    _mesa_customer_uuid: Optional[UUID] = None
+                    if customer_id:
+                        try:
+                            _mesa_customer_uuid = UUID(str(customer_id))
+                        except ValueError:
+                            raise APIError("customer_id no es un UUID válido", status_code=422)
+
+                    try:
+                        checkout_eval = await apply_checkout_waro_redemption(
+                            conn,
+                            tenant_id,
+                            _mesa_customer_uuid,
+                            checkout_eval,
+                            waros_to_redeem=waros_to_redeem,
+                            waro_reward_id=waro_reward_id,
+                        )
+                    except FastAPIHTTPException as waro_exc:
+                        raise APIError(waro_exc.detail, status_code=waro_exc.status_code)
+
+                    _waro_preview = checkout_eval.pop("_waro_redemption_preview", None)
+
                     _promo_savings = float(checkout_eval.get("promo_savings") or 0)
                     _promo_breakdown = checkout_eval.get("promo_breakdown") or []
                     _discount_amount = checkout_eval.get("manual_discount_amount") or None
@@ -970,6 +997,28 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
 
                     await apply_promo_eval_to_order_items(conn, item_rows, checkout_eval)
                     await recalc_pending_session_order_totals(conn, session_row["id"])
+
+                    if _waro_preview and _mesa_customer_uuid:
+                        _first_pending_order = await conn.fetchval(
+                            """
+                            SELECT id FROM orders
+                            WHERE table_session_id = $1 AND status = 'pending'
+                            ORDER BY created_at LIMIT 1
+                            """,
+                            session_row["id"],
+                        )
+                        if _first_pending_order:
+                            try:
+                                await settle_waro_redemption(
+                                    conn,
+                                    tenant_id,
+                                    _mesa_customer_uuid,
+                                    _first_pending_order,
+                                    _waro_preview,
+                                )
+                            except FastAPIHTTPException as waro_exc:
+                                raise APIError(waro_exc.detail, status_code=waro_exc.status_code)
+                            await recalc_pending_session_order_totals(conn, session_row["id"])
 
                     completed_count = await conn.fetchval(
                         "SELECT COUNT(*) FROM orders WHERE table_session_id = $1 AND status = 'pending'",

--- a/app/services/waros_service.py
+++ b/app/services/waros_service.py
@@ -499,6 +499,589 @@ async def assign_manual_waros(
         raise HTTPException(status_code=500, detail="Error al asignar Waros")
 
 
+# ── Redemption (checkout B1/B2/B3) — api#370 ─────────────────────────────────
+
+REWARD_TYPES = {"fixed_cop_off", "free_product"}
+
+
+async def _fetch_redemption_config_row(
+    conn: Any,
+    tenant_id: Any,
+) -> Optional[Any]:
+    return await conn.fetchrow(
+        """
+        SELECT is_enabled, redemption_enabled, waros_per_1000_cop,
+               max_redeem_percent_per_order, min_waros_to_redeem,
+               earn_on_wallet_payment, earn_base_excludes_waro_redemption
+        FROM gamification_config
+        WHERE tenant_id = $1
+        """,
+        tenant_id,
+    )
+
+
+def _b1_cop_from_waros(waros_amount: int, waros_per_1000_cop: int) -> int:
+    if waros_amount <= 0 or waros_per_1000_cop <= 0:
+        return 0
+    return int(waros_amount * 1000 / waros_per_1000_cop)
+
+
+async def _fetch_waro_reward_row(
+    conn: Any,
+    tenant_id: Any,
+    reward_id: UUID,
+) -> Optional[Any]:
+    return await conn.fetchrow(
+        """
+        SELECT id, name, reward_type, waros_cost, fixed_cop_off, product_id, is_active
+        FROM waro_rewards
+        WHERE id = $1 AND tenant_id = $2
+        """,
+        reward_id,
+        tenant_id,
+    )
+
+
+async def compute_redemption_preview(
+    conn: Any,
+    tenant_id: Any,
+    customer_id: Optional[UUID],
+    checkout_eval: Dict[str, Any],
+    waros_to_redeem: Optional[int] = None,
+    waro_reward_id: Optional[UUID] = None,
+) -> Dict[str, Any]:
+    """
+    Read-only redemption math for preview and settlement validation.
+    Layer: promos → manual → WaRo (this function).
+    """
+    from app.services.promotions_service import apply_waro_redemption_to_evaluated_lines
+
+    config_row = await _fetch_redemption_config_row(conn, tenant_id)
+    redemption_enabled = bool(config_row and config_row["redemption_enabled"])
+    system_enabled = bool(config_row and config_row["is_enabled"])
+
+    subtotal_after_promos = float(checkout_eval.get("subtotal_after_promos") or 0)
+    manual_discount = float(checkout_eval.get("manual_discount_amount") or 0)
+    base_after_manual = max(0.0, subtotal_after_promos - manual_discount)
+
+    waros_per_1000 = int(config_row["waros_per_1000_cop"] or 100) if config_row else 100
+    max_percent = float(config_row["max_redeem_percent_per_order"] or 50) if config_row else 50.0
+    min_waros = int(config_row["min_waros_to_redeem"] or 1) if config_row else 1
+
+    b1_waros = max(0, int(waros_to_redeem or 0))
+    b2_waros = 0
+    reward_fixed_off = 0.0
+    free_product_id: Optional[UUID] = None
+    reward_name: Optional[str] = None
+    reward_type: Optional[str] = None
+
+    if waro_reward_id:
+        reward_row = await _fetch_waro_reward_row(conn, tenant_id, waro_reward_id)
+        if not reward_row or not reward_row["is_active"]:
+            raise HTTPException(status_code=422, detail="Recompensa WaRo no encontrada o inactiva")
+        b2_waros = int(reward_row["waros_cost"])
+        reward_name = reward_row["name"]
+        reward_type = reward_row["reward_type"]
+        if reward_type == "fixed_cop_off":
+            reward_fixed_off = float(reward_row["fixed_cop_off"] or 0)
+        elif reward_type == "free_product":
+            free_product_id = reward_row["product_id"]
+
+    base_canje = max(0.0, base_after_manual - reward_fixed_off)
+
+    b1_cop_raw = 0
+    b1_cop = 0
+    if b1_waros > 0:
+        if not redemption_enabled or not system_enabled:
+            raise HTTPException(status_code=422, detail="Canje de WaRos no está habilitado")
+        if b1_waros < min_waros:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Mínimo {min_waros} WaRos para canjear en esta orden",
+            )
+        b1_cop_raw = _b1_cop_from_waros(b1_waros, waros_per_1000)
+        max_b1_cop = int(base_canje * max_percent / 100)
+        b1_cop = min(b1_cop_raw, max_b1_cop, int(base_canje))
+
+    if b2_waros > 0 and (not redemption_enabled or not system_enabled):
+        raise HTTPException(status_code=422, detail="Canje de WaRos no está habilitado")
+
+    total_waro_discount_cop = b1_cop + reward_fixed_off
+    total_waros_cost = b1_waros + b2_waros
+
+    wallet_balance = 0
+    if customer_id and total_waros_cost > 0:
+        bal_row = await conn.fetchrow(
+            """
+            SELECT current_balance FROM waros_wallets
+            WHERE profile_id = $1 AND tenant_id = $2
+            """,
+            customer_id,
+            tenant_id,
+        )
+        wallet_balance = int(bal_row["current_balance"]) if bal_row else 0
+        if wallet_balance < total_waros_cost:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Saldo WaRo insuficiente. Disponible: {wallet_balance}, "
+                    f"requerido: {total_waros_cost}"
+                ),
+            )
+
+    updated_eval = apply_waro_redemption_to_evaluated_lines(checkout_eval, total_waro_discount_cop)
+
+    return {
+        "redemption_enabled": redemption_enabled and system_enabled,
+        "subtotal_after_promos": round(subtotal_after_promos),
+        "manual_discount_amount": round(manual_discount),
+        "base_after_manual": round(base_after_manual),
+        "base_canje": round(base_canje),
+        "b1_waros": b1_waros,
+        "b1_cop": b1_cop,
+        "b1_cop_raw": b1_cop_raw,
+        "b2_waros": b2_waros,
+        "reward_fixed_off": round(reward_fixed_off),
+        "reward_type": reward_type,
+        "reward_name": reward_name,
+        "free_product_id": str(free_product_id) if free_product_id else None,
+        "waro_reward_id": str(waro_reward_id) if waro_reward_id else None,
+        "total_waro_discount_cop": round(total_waro_discount_cop),
+        "total_waros_cost": total_waros_cost,
+        "max_redeem_percent": max_percent,
+        "max_b1_cop_cap": int(base_canje * max_percent / 100),
+        "wallet_balance": wallet_balance,
+        "total_after_redemption": updated_eval["total_amount"],
+        "checkout_eval": updated_eval,
+    }
+
+
+async def settle_waro_redemption(
+    conn: Any,
+    tenant_id: Any,
+    customer_id: UUID,
+    order_id: Any,
+    preview: Dict[str, Any],
+) -> None:
+    """Atomic WaRo wallet debit + detail rows inside caller transaction."""
+    total_waros = int(preview.get("total_waros_cost") or 0)
+    if total_waros <= 0:
+        return
+
+    total_cop = float(preview.get("total_waro_discount_cop") or 0)
+
+    wallet_row = await conn.fetchrow(
+        """
+        SELECT current_balance
+        FROM waros_wallets
+        WHERE profile_id = $1 AND tenant_id = $2
+        FOR UPDATE
+        """,
+        customer_id,
+        tenant_id,
+    )
+    current_balance = int(wallet_row["current_balance"]) if wallet_row else 0
+    if current_balance < total_waros:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Saldo WaRo insuficiente ({current_balance} < {total_waros})",
+        )
+
+    if wallet_row:
+        await conn.execute(
+            """
+            UPDATE waros_wallets SET
+                current_balance = current_balance - $3,
+                lifetime_spent = lifetime_spent + $3,
+                last_activity_date = CURRENT_DATE,
+                updated_at = now()
+            WHERE profile_id = $1 AND tenant_id = $2
+            """,
+            customer_id,
+            tenant_id,
+            total_waros,
+        )
+        new_balance = current_balance - total_waros
+    else:
+        raise HTTPException(status_code=422, detail="Cliente sin billetera WaRo")
+
+    await conn.execute(
+        """
+        INSERT INTO waros_transactions (
+            profile_id, tenant_id, transaction_type, waros_amount,
+            balance_after, description, related_entity_type, related_entity_id
+        )
+        VALUES ($1, $2, 'redeemed', $3, $4, $5, 'order', $6)
+        """,
+        customer_id,
+        tenant_id,
+        -total_waros,
+        new_balance,
+        f"WaRos canjeados en orden ({total_waros} pts, -${int(total_cop)} COP)",
+        str(order_id),
+    )
+
+    await conn.execute(
+        """
+        UPDATE orders
+        SET waros_redeemed = $2, waro_redeemed_amount_cop = $3
+        WHERE id = $1
+        """,
+        order_id,
+        total_waros,
+        total_cop,
+    )
+
+    b1_waros = int(preview.get("b1_waros") or 0)
+    b1_cop = float(preview.get("b1_cop") or 0)
+    if b1_waros > 0:
+        await conn.execute(
+            """
+            INSERT INTO order_waro_redemptions (
+                order_id, tenant_id, redemption_type, waros_spent, cop_discount
+            )
+            VALUES ($1, $2, 'points_cop', $3, $4)
+            """,
+            order_id,
+            tenant_id,
+            b1_waros,
+            b1_cop,
+        )
+
+    b2_waros = int(preview.get("b2_waros") or 0)
+    reward_type = preview.get("reward_type")
+    waro_reward_id = preview.get("waro_reward_id")
+    reward_uuid = UUID(waro_reward_id) if waro_reward_id else None
+
+    if b2_waros > 0 and reward_type == "fixed_cop_off":
+        await conn.execute(
+            """
+            INSERT INTO order_waro_redemptions (
+                order_id, tenant_id, redemption_type, waros_spent, cop_discount, waro_reward_id
+            )
+            VALUES ($1, $2, 'reward_fixed_cop', $3, $4, $5)
+            """,
+            order_id,
+            tenant_id,
+            b2_waros,
+            float(preview.get("reward_fixed_off") or 0),
+            reward_uuid,
+        )
+    elif b2_waros > 0 and reward_type == "free_product":
+        free_product_id = preview.get("free_product_id")
+        order_item_id = None
+        if free_product_id:
+            item_row = await conn.fetchrow(
+                """
+                INSERT INTO order_items (
+                    order_id, product_id, quantity, price_at_purchase, subtotal,
+                    discount_allocated, net_total, promo_opt_out, line_source
+                )
+                VALUES ($1, $2::uuid, 1, 0, 0, 0, 0, true, 'waro_reward')
+                RETURNING id
+                """,
+                order_id,
+                free_product_id,
+            )
+            order_item_id = item_row["id"] if item_row else None
+        await conn.execute(
+            """
+            INSERT INTO order_waro_redemptions (
+                order_id, tenant_id, redemption_type, waros_spent, cop_discount,
+                waro_reward_id, order_item_id
+            )
+            VALUES ($1, $2, 'reward_free_product', $3, 0, $4, $5)
+            """,
+            order_id,
+            tenant_id,
+            b2_waros,
+            reward_uuid,
+            order_item_id,
+        )
+
+
+async def apply_checkout_waro_redemption(
+    conn: Any,
+    tenant_id: Any,
+    customer_id: Optional[UUID],
+    checkout_eval: Dict[str, Any],
+    waros_to_redeem: Optional[int] = None,
+    waro_reward_id: Optional[UUID] = None,
+) -> Dict[str, Any]:
+    """Preview + apply layer 4 to checkout_eval. No wallet write."""
+    if not waros_to_redeem and not waro_reward_id:
+        return checkout_eval
+    if not customer_id:
+        raise HTTPException(
+            status_code=422,
+            detail="Canje WaRo requiere un cliente identificado",
+        )
+    preview = await compute_redemption_preview(
+        conn,
+        tenant_id,
+        customer_id,
+        checkout_eval,
+        waros_to_redeem=waros_to_redeem,
+        waro_reward_id=waro_reward_id,
+    )
+    checkout_eval["_waro_redemption_preview"] = preview
+    return preview["checkout_eval"]
+
+
+async def preview_redemption(
+    request: Request,
+    lines: List[Dict[str, Any]],
+    customer_id: Optional[UUID] = None,
+    manual_discount_amount: float = 0,
+    discount_type: Optional[str] = None,
+    discount_value: Optional[float] = None,
+    waros_to_redeem: Optional[int] = None,
+    waro_reward_id: Optional[UUID] = None,
+) -> Dict[str, Any]:
+    """GET /admin/waros/preview-redemption service entry."""
+    from app.services.promotions_service import evaluate_checkout_promotions
+
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+
+    async with get_db_connection(use_transaction=False) as conn:
+        checkout_eval = await evaluate_checkout_promotions(
+            conn,
+            UUID(str(tenant_id)),
+            lines,
+            manual_discount_amount=manual_discount_amount,
+            discount_type=discount_type,
+            discount_value=discount_value,
+        )
+        preview = await compute_redemption_preview(
+            conn,
+            tenant_id,
+            customer_id,
+            checkout_eval,
+            waros_to_redeem=waros_to_redeem,
+            waro_reward_id=waro_reward_id,
+        )
+    preview.pop("checkout_eval", None)
+    return preview
+
+
+async def list_waro_rewards(request: Request) -> Dict[str, Any]:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    async with get_db_connection(use_transaction=False) as conn:
+        rows = await conn.fetch(
+            """
+            SELECT id, name, reward_type, waros_cost, fixed_cop_off, product_id, is_active,
+                   created_at, updated_at
+            FROM waro_rewards
+            WHERE tenant_id = $1
+            ORDER BY name
+            """,
+            tenant_id,
+        )
+    rewards = [
+        {
+            "id": str(r["id"]),
+            "name": r["name"],
+            "reward_type": r["reward_type"],
+            "waros_cost": int(r["waros_cost"]),
+            "fixed_cop_off": float(r["fixed_cop_off"]) if r["fixed_cop_off"] is not None else None,
+            "product_id": str(r["product_id"]) if r["product_id"] else None,
+            "is_active": r["is_active"],
+            "created_at": r["created_at"].isoformat(),
+            "updated_at": r["updated_at"].isoformat(),
+        }
+        for r in rows
+    ]
+    return {"rewards": rewards}
+
+
+async def create_waro_reward(
+    request: Request,
+    name: str,
+    reward_type: str,
+    waros_cost: int,
+    fixed_cop_off: Optional[float] = None,
+    product_id: Optional[UUID] = None,
+    is_active: bool = True,
+) -> Dict[str, Any]:
+    if reward_type not in REWARD_TYPES:
+        raise HTTPException(status_code=422, detail=f"reward_type inválido: {sorted(REWARD_TYPES)}")
+    if waros_cost <= 0:
+        raise HTTPException(status_code=422, detail="waros_cost debe ser positivo")
+    if reward_type == "fixed_cop_off" and (fixed_cop_off is None or fixed_cop_off <= 0):
+        raise HTTPException(status_code=422, detail="fixed_cop_off requerido para fixed_cop_off")
+    if reward_type == "free_product" and product_id is None:
+        raise HTTPException(status_code=422, detail="product_id requerido para free_product")
+
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    async with get_db_connection() as conn:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO waro_rewards (
+                tenant_id, name, reward_type, waros_cost, fixed_cop_off, product_id, is_active
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            RETURNING id, name, reward_type, waros_cost, fixed_cop_off, product_id, is_active
+            """,
+            tenant_id,
+            name,
+            reward_type,
+            waros_cost,
+            fixed_cop_off,
+            product_id,
+            is_active,
+        )
+    return {"reward": dict(row)}
+
+
+async def update_waro_reward(
+    request: Request,
+    reward_id: UUID,
+    name: Optional[str] = None,
+    waros_cost: Optional[int] = None,
+    fixed_cop_off: Optional[float] = None,
+    product_id: Optional[UUID] = None,
+    is_active: Optional[bool] = None,
+) -> Dict[str, Any]:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    async with get_db_connection() as conn:
+        existing = await _fetch_waro_reward_row(conn, tenant_id, reward_id)
+        if not existing:
+            raise HTTPException(status_code=404, detail="Recompensa no encontrada")
+        row = await conn.fetchrow(
+            """
+            UPDATE waro_rewards SET
+                name = COALESCE($3, name),
+                waros_cost = COALESCE($4, waros_cost),
+                fixed_cop_off = COALESCE($5, fixed_cop_off),
+                product_id = COALESCE($6, product_id),
+                is_active = COALESCE($7, is_active),
+                updated_at = now()
+            WHERE id = $1 AND tenant_id = $2
+            RETURNING id, name, reward_type, waros_cost, fixed_cop_off, product_id, is_active
+            """,
+            reward_id,
+            tenant_id,
+            name,
+            waros_cost,
+            fixed_cop_off,
+            product_id,
+            is_active,
+        )
+    return {"reward": dict(row)}
+
+
+async def delete_waro_reward(request: Request, reward_id: UUID) -> Dict[str, Any]:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    async with get_db_connection() as conn:
+        result = await conn.execute(
+            "DELETE FROM waro_rewards WHERE id = $1 AND tenant_id = $2",
+            reward_id,
+            tenant_id,
+        )
+        if result == "DELETE 0":
+            raise HTTPException(status_code=404, detail="Recompensa no encontrada")
+    return {"deleted": True, "id": str(reward_id)}
+
+
+async def update_redemption_config(
+    request: Request,
+    redemption_enabled: Optional[bool] = None,
+    waros_per_1000_cop: Optional[int] = None,
+    max_redeem_percent_per_order: Optional[float] = None,
+    min_waros_to_redeem: Optional[int] = None,
+    earn_on_wallet_payment: Optional[bool] = None,
+    earn_base_excludes_waro_redemption: Optional[bool] = None,
+    is_enabled: Optional[bool] = None,
+) -> Dict[str, Any]:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    async with get_db_connection() as conn:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO gamification_config (
+                tenant_id, is_enabled, redemption_enabled, waros_per_1000_cop,
+                max_redeem_percent_per_order, min_waros_to_redeem,
+                earn_on_wallet_payment, earn_base_excludes_waro_redemption
+            )
+            VALUES (
+                $1,
+                COALESCE($8, true),
+                COALESCE($2, false),
+                COALESCE($3, 100),
+                COALESCE($4, 50),
+                COALESCE($5, 1),
+                COALESCE($6, false),
+                COALESCE($7, true)
+            )
+            ON CONFLICT (tenant_id) DO UPDATE SET
+                is_enabled = COALESCE($8, gamification_config.is_enabled),
+                redemption_enabled = COALESCE($2, gamification_config.redemption_enabled),
+                waros_per_1000_cop = COALESCE($3, gamification_config.waros_per_1000_cop),
+                max_redeem_percent_per_order = COALESCE(
+                    $4, gamification_config.max_redeem_percent_per_order
+                ),
+                min_waros_to_redeem = COALESCE($5, gamification_config.min_waros_to_redeem),
+                earn_on_wallet_payment = COALESCE($6, gamification_config.earn_on_wallet_payment),
+                earn_base_excludes_waro_redemption = COALESCE(
+                    $7, gamification_config.earn_base_excludes_waro_redemption
+                ),
+                updated_at = now()
+            RETURNING tenant_id, is_enabled, redemption_enabled, waros_per_1000_cop,
+                      max_redeem_percent_per_order, min_waros_to_redeem,
+                      earn_on_wallet_payment, earn_base_excludes_waro_redemption
+            """,
+            tenant_id,
+            redemption_enabled,
+            waros_per_1000_cop,
+            max_redeem_percent_per_order,
+            min_waros_to_redeem,
+            earn_on_wallet_payment,
+            earn_base_excludes_waro_redemption,
+            is_enabled,
+        )
+    return {
+        "tenant_id": str(row["tenant_id"]),
+        "is_enabled": row["is_enabled"],
+        "redemption_enabled": row["redemption_enabled"],
+        "waros_per_1000_cop": int(row["waros_per_1000_cop"]),
+        "max_redeem_percent_per_order": float(row["max_redeem_percent_per_order"]),
+        "min_waros_to_redeem": int(row["min_waros_to_redeem"]),
+        "earn_on_wallet_payment": row["earn_on_wallet_payment"],
+        "earn_base_excludes_waro_redemption": row["earn_base_excludes_waro_redemption"],
+    }
+
+
+async def get_redemption_config(request: Request) -> Dict[str, Any]:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    async with get_db_connection(use_transaction=False) as conn:
+        row = await _fetch_redemption_config_row(conn, tenant_id)
+    if not row:
+        return {
+            "is_enabled": False,
+            "redemption_enabled": False,
+            "waros_per_1000_cop": 100,
+            "max_redeem_percent_per_order": 50.0,
+            "min_waros_to_redeem": 1,
+            "earn_on_wallet_payment": False,
+            "earn_base_excludes_waro_redemption": True,
+        }
+    return {
+        "is_enabled": row["is_enabled"],
+        "redemption_enabled": row["redemption_enabled"],
+        "waros_per_1000_cop": int(row["waros_per_1000_cop"]),
+        "max_redeem_percent_per_order": float(row["max_redeem_percent_per_order"]),
+        "min_waros_to_redeem": int(row["min_waros_to_redeem"]),
+        "earn_on_wallet_payment": row["earn_on_wallet_payment"],
+        "earn_base_excludes_waro_redemption": row["earn_base_excludes_waro_redemption"],
+    }
+
+
 # ── Estimate (read-only) ─────────────────────────────────────────────────────
 
 async def _estimate_waros_for_tenant(
@@ -747,7 +1330,8 @@ async def evaluate_and_award(
             # 1. Check system enabled + daily cap
             config_row = await conn.fetchrow(
                 """
-                SELECT is_enabled, max_daily_waros
+                SELECT is_enabled, max_daily_waros,
+                       earn_on_wallet_payment, earn_base_excludes_waro_redemption
                 FROM gamification_config
                 WHERE tenant_id = $1
                 """,
@@ -757,11 +1341,13 @@ async def evaluate_and_award(
                 return 0
 
             max_daily = int(config_row["max_daily_waros"] or 0)
+            earn_on_wallet = bool(config_row["earn_on_wallet_payment"])
+            exclude_waro_redemption = bool(config_row["earn_base_excludes_waro_redemption"])
 
-            # 2. Fetch order total
+            # 2. Fetch order totals for eligible earn base
             order_row = await conn.fetchrow(
                 """
-                SELECT total_amount
+                SELECT total_amount, waro_redeemed_amount_cop, payment_method
                 FROM orders
                 WHERE id = $1 AND tenant_id = $2
                 """,
@@ -773,6 +1359,29 @@ async def evaluate_and_award(
                 return 0
 
             total_amount = float(order_row["total_amount"])
+            waro_redeemed_cop = float(order_row["waro_redeemed_amount_cop"] or 0)
+
+            eligible_amount = total_amount
+            if exclude_waro_redemption and waro_redeemed_cop > 0:
+                eligible_amount += waro_redeemed_cop
+
+            if not earn_on_wallet and order_row["payment_method"] == "customer_wallet":
+                eligible_amount = 0.0
+            elif not earn_on_wallet:
+                wallet_paid = await conn.fetchval(
+                    """
+                    SELECT COALESCE(SUM(amount), 0)
+                    FROM order_payments
+                    WHERE order_id = $1 AND payment_method = 'customer_wallet'
+                    """,
+                    order_id,
+                )
+                if wallet_paid:
+                    eligible_amount = max(0.0, eligible_amount - float(wallet_paid))
+
+            total_amount = eligible_amount
+            if total_amount <= 0:
+                return 0
 
             # 3. Fetch active rules
             rule_rows = await conn.fetch(

--- a/dbdoc/public.gamification_config.md
+++ b/dbdoc/public.gamification_config.md
@@ -16,6 +16,12 @@
 | level_multiplier | numeric(3,2) | 1.5 | true |  |  |  |
 | created_at | timestamp with time zone | now() | true |  |  |  |
 | updated_at | timestamp with time zone | now() | true |  |  |  |
+| redemption_enabled | boolean | false | false |  |  | api#370 — checkout redemption master toggle |
+| waros_per_1000_cop | integer | 100 | false |  |  | WaRos required per 1000 COP B1 discount |
+| max_redeem_percent_per_order | numeric(5,2) | 50.00 | false |  |  | Max B1 % of base_canje |
+| min_waros_to_redeem | integer | 1 | false |  |  | Minimum B1 waros per order |
+| earn_on_wallet_payment | boolean | false | false |  |  | Earn on wallet-paid portion |
+| earn_base_excludes_waro_redemption | boolean | true | false |  |  | Add back waro discount for earn base |
 
 ## Constraints
 

--- a/dbdoc/public.order_waro_redemptions.md
+++ b/dbdoc/public.order_waro_redemptions.md
@@ -1,0 +1,18 @@
+# public.order_waro_redemptions
+
+## Columns
+
+| Name | Type | Default | Nullable | Children | Parents | Comment |
+| ---- | ---- | ------- | -------- | -------- | ------- | ------- |
+| id | uuid | gen_random_uuid() | false |  |  |  |
+| order_id | uuid |  | false |  | [public.orders](public.orders.md) |  |
+| tenant_id | uuid |  | false |  | [public.tenants](public.tenants.md) |  |
+| redemption_type | varchar(20) |  | false |  |  | points_cop \| reward_fixed_cop \| reward_free_product |
+| waros_spent | integer |  | false |  |  |  |
+| cop_discount | numeric(12,2) | 0 | false |  |  |  |
+| waro_reward_id | uuid |  | true |  | [public.waro_rewards](public.waro_rewards.md) |  |
+| order_item_id | uuid |  | true |  | [public.order_items](public.order_items.md) | B2 free product line |
+| created_at | timestamptz | now() | false |  |  |  |
+
+---
+> api-warolabs#370

--- a/dbdoc/public.orders.md
+++ b/dbdoc/public.orders.md
@@ -47,6 +47,8 @@
 | tip_source | varchar(20) | 'none'::character varying | false |  |  | How the tip was selected (warocol.com#635): preset (chip from tenant config), custom (free input), or none. Used for analytics. Must agree with tip_amount via chk_orders_tip_source_consistency. |
 | tip_taxable | boolean | false | false |  |  | warocol.com#740 — whether IVA/INC was applied to tip_amount for this sale |
 | tip_tax_amount | numeric(12,2) | 0 | false |  |  | warocol.com#740 — tax on tip_amount when tip_taxable=true; separate from total_amount |
+| waros_redeemed | integer | 0 | false |  |  | api#370 — total WaRos spent |
+| waro_redeemed_amount_cop | numeric(12,2) | 0 | false |  |  | api#370 — total COP discount from WaRo |
 
 ## Constraints
 

--- a/dbdoc/public.waro_rewards.md
+++ b/dbdoc/public.waro_rewards.md
@@ -1,0 +1,19 @@
+# public.waro_rewards
+
+## Columns
+
+| Name | Type | Default | Nullable | Children | Parents | Comment |
+| ---- | ---- | ------- | -------- | -------- | ------- | ------- |
+| id | uuid | gen_random_uuid() | false | [public.order_waro_redemptions](public.order_waro_redemptions.md) |  |  |
+| tenant_id | uuid |  | false |  | [public.tenants](public.tenants.md) |  |
+| name | varchar(120) |  | false |  |  |  |
+| reward_type | varchar(20) |  | false |  |  | fixed_cop_off \| free_product |
+| waros_cost | integer |  | false |  |  |  |
+| fixed_cop_off | numeric(12,2) |  | true |  |  |  |
+| product_id | uuid |  | true |  | [public.product](public.product.md) |  |
+| is_active | boolean | true | false |  |  |  |
+| created_at | timestamptz | now() | false |  |  |  |
+| updated_at | timestamptz | now() | false |  |  |  |
+
+---
+> api-warolabs#370

--- a/sql/20260601_waro_redemption.sql
+++ b/sql/20260601_waro_redemption.sql
@@ -1,0 +1,105 @@
+-- 084_waro_redemption.sql
+-- Issue api-warolabs#370 — WaRos hybrid redemption (B1/B2/B3) at checkout
+-- Epic warocol.com#1061 batch 2
+
+-- ─────────────────────────────────────────────
+-- gamification_config — redemption + earn flags
+-- ─────────────────────────────────────────────
+
+ALTER TABLE gamification_config
+    ADD COLUMN IF NOT EXISTS redemption_enabled boolean NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS waros_per_1000_cop integer NOT NULL DEFAULT 100,
+    ADD COLUMN IF NOT EXISTS max_redeem_percent_per_order numeric(5,2) NOT NULL DEFAULT 50.00,
+    ADD COLUMN IF NOT EXISTS min_waros_to_redeem integer NOT NULL DEFAULT 1,
+    ADD COLUMN IF NOT EXISTS earn_on_wallet_payment boolean NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS earn_base_excludes_waro_redemption boolean NOT NULL DEFAULT true;
+
+COMMENT ON COLUMN gamification_config.redemption_enabled IS
+    'When true, customers may redeem WaRos at checkout (api#370).';
+COMMENT ON COLUMN gamification_config.waros_per_1000_cop IS
+    'WaRos required to redeem 1000 COP (B1 points→COP rate).';
+COMMENT ON COLUMN gamification_config.max_redeem_percent_per_order IS
+    'Max B1 COP discount as percent of base_canje after manual + B2 fixed off.';
+COMMENT ON COLUMN gamification_config.min_waros_to_redeem IS
+    'Minimum WaRos for B1 redemption on a single order.';
+COMMENT ON COLUMN gamification_config.earn_on_wallet_payment IS
+    'When false, wallet-paid portion excluded from earn base (api#370).';
+COMMENT ON COLUMN gamification_config.earn_base_excludes_waro_redemption IS
+    'When true, waro_redeemed_amount_cop added back to earn eligible subtotal.';
+
+-- ─────────────────────────────────────────────
+-- waro_rewards — B2 catalog
+-- ─────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS waro_rewards (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id           UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    name                VARCHAR(120) NOT NULL,
+    reward_type         VARCHAR(20) NOT NULL,
+    waros_cost          integer NOT NULL,
+    fixed_cop_off       numeric(12,2),
+    product_id          UUID REFERENCES product(id) ON DELETE SET NULL,
+    is_active           boolean NOT NULL DEFAULT true,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT chk_waro_rewards_type CHECK (
+        reward_type IN ('fixed_cop_off', 'free_product')
+    ),
+    CONSTRAINT chk_waro_rewards_cost_positive CHECK (waros_cost > 0),
+    CONSTRAINT chk_waro_rewards_fixed_cop CHECK (
+        (reward_type = 'fixed_cop_off' AND fixed_cop_off IS NOT NULL AND fixed_cop_off > 0)
+        OR (reward_type = 'free_product' AND product_id IS NOT NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_waro_rewards_tenant_active
+    ON waro_rewards (tenant_id, is_active);
+
+COMMENT ON TABLE waro_rewards IS
+    'WaRos catalog rewards redeemable at checkout (api#370 B2).';
+
+-- ─────────────────────────────────────────────
+-- orders — redemption summary columns
+-- ─────────────────────────────────────────────
+
+ALTER TABLE orders
+    ADD COLUMN IF NOT EXISTS waros_redeemed integer NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS waro_redeemed_amount_cop numeric(12,2) NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN orders.waros_redeemed IS
+    'Total WaRos spent on this order (B1 + B2).';
+COMMENT ON COLUMN orders.waro_redeemed_amount_cop IS
+    'Total COP discount from WaRo redemption (B1 COP + B2 fixed off).';
+
+-- ─────────────────────────────────────────────
+-- order_waro_redemptions — detail rows
+-- ─────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS order_waro_redemptions (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    order_id            UUID NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+    tenant_id           UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    redemption_type     VARCHAR(20) NOT NULL,
+    waros_spent         integer NOT NULL,
+    cop_discount        numeric(12,2) NOT NULL DEFAULT 0,
+    waro_reward_id      UUID REFERENCES waro_rewards(id) ON DELETE SET NULL,
+    order_item_id       UUID REFERENCES order_items(id) ON DELETE SET NULL,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT chk_order_waro_redemptions_type CHECK (
+        redemption_type IN ('points_cop', 'reward_fixed_cop', 'reward_free_product')
+    ),
+    CONSTRAINT chk_order_waro_redemptions_waros CHECK (waros_spent >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_order_waro_redemptions_order
+    ON order_waro_redemptions (order_id);
+
+-- ─────────────────────────────────────────────
+-- order_items — B2 free product source tag
+-- ─────────────────────────────────────────────
+
+ALTER TABLE order_items
+    ADD COLUMN IF NOT EXISTS line_source varchar(30);
+
+COMMENT ON COLUMN order_items.line_source IS
+    'Origin tag for special lines (e.g. waro_reward for B2 free product).';


### PR DESCRIPTION
## Summary
- WaRos checkout redemption layer 4 (B1 points→COP, B2 catalog rewards, B3 combined) after promos + manual discount
- Migration: `gamification_config` redemption flags, `waro_rewards`, `order_waro_redemptions`, order columns
- APIs: preview-redemption, rewards CRUD, redemption-config
- Settlement on `complete_pos_order` and `close_session`; eligible earn base in `evaluate_and_award`

## Test plan
- [ ] Run `sql/20260601_waro_redemption.sql`
- [ ] `PATCH /admin/waros/redemption-config` — enable redemption
- [ ] `POST /admin/waros/rewards` — fixed_cop_off + free_product
- [ ] `GET /admin/waros/preview-redemption` with cart lines + B1/B2
- [ ] `POST /pos/carts/{id}/complete` with redemption → `orders.waros_redeemed`, `waros_transactions.redeemed`
- [ ] `POST /tables/{id}/close` with redemption on mesa
- [ ] Wallet recharge does not award WaRos

Closes #370

Made with [Cursor](https://cursor.com)