### PR TITLE
fix(ventas): customer detail 404 after creating client without orders

### DIFF
--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -1265,7 +1265,8 @@ async def get_customer_detail(
 ) -> dict:
     """
     Get a single customer's aggregate stats plus their paginated POS order history.
-    Returns 404 if the customer has no POS orders for this tenant.
+    Returns 404 if the customer is not linked to the tenant.
+    Profiles without POS orders return zeroed stats and empty order history.
     """
     try:
         session_context = require_valid_session(request)
@@ -1299,7 +1300,35 @@ async def get_customer_detail(
             )
 
             if not customer_row:
-                raise APIError("Customer not found", status_code=404)
+                profile_row = await conn.fetchrow(
+                    """
+                    SELECT
+                        p.id                                 AS customer_id,
+                        COALESCE(p.name, 'Sin identificar') AS name,
+                        p.phone_number                       AS phone,
+                        p.email                              AS email
+                    FROM profile p
+                    JOIN tenant_members tm ON tm.user_id = p.id
+                    WHERE p.id = $1
+                      AND tm.tenant_id = $2
+                      AND tm.role = 'customer'
+                    LIMIT 1
+                    """,
+                    customer_id,
+                    tenant_id,
+                )
+                if not profile_row:
+                    raise APIError("Customer not found", status_code=404)
+                customer_row = {
+                    "customer_id": profile_row["customer_id"],
+                    "name": profile_row["name"],
+                    "phone": profile_row["phone"],
+                    "email": profile_row["email"],
+                    "total_orders": 0,
+                    "total_spent": 0,
+                    "first_purchase": None,
+                    "last_purchase": None,
+                }
 
             # --- Paginated order history ---
             where_conditions = [
@@ -1443,8 +1472,14 @@ async def get_customer_detail(
                     "email": customer_row['email'],
                     "total_orders": int(customer_row['total_orders']),
                     "total_spent": float(customer_row['total_spent']),
-                    "first_purchase": customer_row['first_purchase'].date().isoformat(),
-                    "last_purchase": customer_row['last_purchase'].date().isoformat(),
+                    "first_purchase": (
+                        customer_row['first_purchase'].date().isoformat()
+                        if customer_row['first_purchase'] else None
+                    ),
+                    "last_purchase": (
+                        customer_row['last_purchase'].date().isoformat()
+                        if customer_row['last_purchase'] else None
+                    ),
                 },
                 "orders": {
                     "items": orders,

--- a/tests/test_customer_detail.py
+++ b/tests/test_customer_detail.py
@@ -1,0 +1,107 @@
+"""Tests for GET /orders/customers/{customer_id} — profile without POS orders (#377)."""
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import Request
+
+from app.core.exceptions import APIError
+from app.services import orders_service
+
+_TENANT_ID = UUID('93b3e582-34fa-44a6-8d0f-bf82a3608727')
+_CUSTOMER_ID = uuid4()
+
+
+class _SeqConnCtx:
+    def __init__(self, fetchrow_responses, fetch_responses=None):
+        self._frows = iter(fetchrow_responses)
+        self._fetch = iter(fetch_responses or [])
+
+    async def __aenter__(self):
+        conn = MagicMock()
+        conn.fetchrow = AsyncMock(side_effect=lambda *a, **k: next(self._frows))
+        conn.fetch = AsyncMock(side_effect=lambda *a, **k: next(self._fetch))
+        return conn
+
+    async def __aexit__(self, *_):
+        return False
+
+
+def _patch_session():
+    fake = MagicMock()
+    fake.tenant_id = _TENANT_ID
+    return patch(
+        'app.services.orders_service.require_valid_session',
+        return_value=fake,
+    )
+
+
+def _patch_conn(fetchrow_responses, fetch_responses=None):
+    return patch(
+        'app.services.orders_service.get_db_connection',
+        return_value=_SeqConnCtx(fetchrow_responses, fetch_responses),
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_customer_detail_profile_without_orders_returns_zeroed_stats():
+    """Newly created tenant customer with no POS orders should return 200."""
+    profile_row = {
+        'customer_id': _CUSTOMER_ID,
+        'name': 'Test Customer',
+        'phone': '3001234567',
+        'email': '3001234567@customer.temp',
+    }
+
+    with _patch_session(), _patch_conn([None, profile_row, None], [[], []]):
+        result = await orders_service.get_customer_detail(
+            Request({'type': 'http'}),
+            customer_id=_CUSTOMER_ID,
+        )
+
+    assert result['success'] is True
+    assert result['customer']['customer_id'] == str(_CUSTOMER_ID)
+    assert result['customer']['total_orders'] == 0
+    assert result['customer']['total_spent'] == 0.0
+    assert result['customer']['first_purchase'] is None
+    assert result['customer']['last_purchase'] is None
+    assert result['orders']['items'] == []
+    assert result['orders']['total'] == 0
+
+
+@pytest.mark.asyncio
+async def test_get_customer_detail_unknown_profile_returns_404():
+    with _patch_session(), _patch_conn([None, None]):
+        with pytest.raises(APIError) as exc:
+            await orders_service.get_customer_detail(
+                Request({'type': 'http'}),
+                customer_id=_CUSTOMER_ID,
+            )
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_customer_detail_with_orders_unchanged():
+    """Existing aggregate path still returns order stats and dates."""
+    order_agg = {
+        'customer_id': _CUSTOMER_ID,
+        'name': 'Returning Customer',
+        'phone': '3009876543',
+        'email': 'buyer@example.com',
+        'total_orders': 2,
+        'total_spent': 50000.0,
+        'first_purchase': datetime(2026, 1, 10, tzinfo=timezone.utc),
+        'last_purchase': datetime(2026, 5, 1, tzinfo=timezone.utc),
+    }
+
+    with _patch_session(), _patch_conn([order_agg, None], [[], []]):
+        result = await orders_service.get_customer_detail(
+            Request({'type': 'http'}),
+            customer_id=_CUSTOMER_ID,
+        )
+
+    assert result['customer']['total_orders'] == 2
+    assert result['customer']['total_spent'] == 50000.0
+    assert result['customer']['first_purchase'] == '2026-01-10'
+    assert result['customer']['last_purchase'] == '2026-05-01'


### PR DESCRIPTION
## Summary
- Fallback in `get_customer_detail` to resolve tenant-linked profiles via `tenant_members` when no POS orders exist yet
- Return zeroed stats, null purchase dates, and empty order history instead of 404
- Add regression tests for the no-orders and unknown-profile paths

Closes #377

## Test plan
- [x] `pytest tests/test_customer_detail.py -v`
- [ ] Create client in Analítica → Clientes → open detail page (no "Cliente no encontrado")
- [ ] Existing customer with orders still loads normally

## wr-context
Local contract: `.wr/377.yaml` (gitignored — see issue #377 body for AC).

Made with [Cursor](https://cursor.com)