### PR TITLE
feat(ingredients): allow hr unit for service-type ingredients

### DIFF
--- a/.wr/380.yaml
+++ b/.wr/380.yaml
@@ -1,0 +1,36 @@
+# Machine contract for wr-fast / wr-ship — LLM reads once; humans use issue summary + PR.
+issue: 380
+title: "feat(api): allow hr unit for service-type ingredients"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-380-ingredients-hr-unit
+extends: uno0uno/warocol.com#1089
+
+paths:
+  - app/services/ingredients_service.py
+  - app/models/ingredient.py
+  - sql/20260601_ingredients_unit_hr.sql
+  - tests/test_ingredients.py
+
+ac:
+  - POST /suppliers/ingredients accepts unit hr when type service
+  - PATCH /suppliers/ingredients/:id accepts unit hr for service rows
+  - type service rejects non-hr units with clear 422
+  - type supply rejects non-und units with clear 422
+  - DB ingredients_unit_check includes hr (migration)
+  - Tests for service+hr create and invalid type-unit pairs
+
+out_of_scope:
+  - Front slide-over UI (warocol.com#1090)
+  - Migrating legacy service+und tenant row (1 row; grandfather OK)
+  - Adding type to TenantIngredientUpdate (type immutable after create)
+
+hints:
+  entry: "create_tenant_ingredient / update_tenant_ingredient — ingredients_service.py"
+  pattern: "_validate_unit_for_type — service→hr, supply→und, food→FOOD_UNITS"
+  tests: "pytest tests/test_ingredients.py -v -k unit_type"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/models/ingredient.py
+++ b/app/models/ingredient.py
@@ -36,7 +36,7 @@ class PurchaseUnitInput(BaseModel):
 class TenantIngredientCreate(BaseModel):
     """Request body for tenant-scoped custom ingredient creation (POST /suppliers/ingredients)."""
     name: str = Field(..., min_length=1, max_length=255)
-    unit: str = Field(..., description="Must be one of: gr, ml, kg, und, lt")
+    unit: str = Field(..., description="food: gr/ml/kg/und/lt; service: hr; supply: und")
     type: Optional[str] = Field(default="food", description="food | service | supply")
     category: Optional[str] = Field(default=None, max_length=255)
     costo_unitario: Optional[float] = Field(default=None, ge=0)
@@ -50,7 +50,7 @@ class TenantIngredientCreate(BaseModel):
 class TenantIngredientUpdate(BaseModel):
     """Request body for updating a tenant-scoped custom ingredient (PATCH /suppliers/ingredients/:id)."""
     name: Optional[str] = Field(default=None, min_length=1, max_length=255)
-    unit: Optional[str] = Field(default=None, description="Must be one of: gr, ml, kg, und, lt")
+    unit: Optional[str] = Field(default=None, description="food: gr/ml/kg/und/lt; service: hr; supply: und")
     category: Optional[str] = Field(default=None, max_length=255)
     costo_unitario: Optional[float] = Field(default=None, ge=0)
     parent_id: Optional[str] = Field(default=None, description="UUID of a global base ingredient, or empty string to clear")

--- a/app/services/ingredients_service.py
+++ b/app/services/ingredients_service.py
@@ -10,6 +10,42 @@ from app.models.ingredient import Ingredient, IngredientsListResponse, TenantIng
 
 logger = logging.getLogger(__name__)
 
+FOOD_UNITS = frozenset({"gr", "ml", "kg", "und", "lt"})
+INGREDIENT_TYPES = frozenset({"food", "service", "supply"})
+
+
+def _normalize_ingredient_type(type_val: Optional[str]) -> str:
+    ingredient_type = (type_val or "food").strip().lower()
+    if ingredient_type not in INGREDIENT_TYPES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid type '{type_val}'. Must be one of: {', '.join(sorted(INGREDIENT_TYPES))}",
+        )
+    return ingredient_type
+
+
+def _validate_unit_for_type(unit: str, ingredient_type: str) -> None:
+    if ingredient_type == "service":
+        if unit != "hr":
+            raise HTTPException(
+                status_code=422,
+                detail="Service ingredients must use unit 'hr'.",
+            )
+        return
+    if ingredient_type == "supply":
+        if unit != "und":
+            raise HTTPException(
+                status_code=422,
+                detail="Supply ingredients must use unit 'und'.",
+            )
+        return
+    if unit not in FOOD_UNITS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid unit '{unit}'. Must be one of: {', '.join(sorted(FOOD_UNITS))}",
+        )
+
+
 # Catalog of allowed purchase units. Label and conversion_factor are resolved
 # server-side — the client only sends the key. Add new units here as needed.
 PURCHASE_UNIT_CATALOG: Dict[str, Dict[str, Any]] = {
@@ -313,20 +349,15 @@ async def create_tenant_ingredient(
     Creates a custom ingredient scoped to the given tenant.
 
     - name: trimmed, unique within tenant (enforced by ingredients_name_tenant_unique index)
-    - unit: must be one of gr, ml, kg, und, lt (enforced by DB CHECK constraint)
+    - unit: food → gr/ml/kg/und/lt; service → hr; supply → und (DB CHECK includes hr)
     - parent_id (optional): must reference a global ingredient (tenant_id IS NULL)
     """
-    ALLOWED_UNITS = {"gr", "ml", "kg", "und", "lt"}
-
     name = data.name.strip()
     if not name:
         raise HTTPException(status_code=422, detail="Ingredient name cannot be empty")
 
-    if data.unit not in ALLOWED_UNITS:
-        raise HTTPException(
-            status_code=422,
-            detail=f"Invalid unit '{data.unit}'. Must be one of: {', '.join(sorted(ALLOWED_UNITS))}"
-        )
+    ingredient_type = _normalize_ingredient_type(data.type)
+    _validate_unit_for_type(data.unit, ingredient_type)
 
     if (data.is_resale or False) and data.unit != "und":
         raise HTTPException(
@@ -363,7 +394,7 @@ async def create_tenant_ingredient(
             """,
             name,
             data.unit,
-            data.type or "food",
+            ingredient_type,
             data.category,
             data.costo_unitario,
             parent_uuid,
@@ -417,10 +448,8 @@ async def update_tenant_ingredient(
     Only fields provided (non-None) are updated.
     tenant_id guard ensures tenants can only edit their own ingredients.
     """
-    ALLOWED_UNITS = {"gr", "ml", "kg", "und", "lt"}
-
     row = await conn.fetchrow(
-        "SELECT id, name, unit, category, costo_unitario, parent_id::text FROM ingredients WHERE id = $1 AND tenant_id = $2",
+        "SELECT id, name, unit, type, category, costo_unitario, parent_id::text FROM ingredients WHERE id = $1 AND tenant_id = $2",
         ingredient_id,
         tenant_id,
     )
@@ -436,11 +465,8 @@ async def update_tenant_ingredient(
         updates["name"] = name
 
     if data.unit is not None:
-        if data.unit not in ALLOWED_UNITS:
-            raise HTTPException(
-                status_code=422,
-                detail=f"Invalid unit '{data.unit}'. Must be one of: {', '.join(sorted(ALLOWED_UNITS))}"
-            )
+        effective_type = _normalize_ingredient_type(row["type"])
+        _validate_unit_for_type(data.unit, effective_type)
         updates["unit"] = data.unit
 
     if data.category is not None:

--- a/sql/20260601_ingredients_unit_hr.sql
+++ b/sql/20260601_ingredients_unit_hr.sql
@@ -1,0 +1,19 @@
+-- api-warolabs#380 — allow hr base unit for service-type ingredients
+
+ALTER TABLE ingredients
+    DROP CONSTRAINT IF EXISTS ingredients_unit_check;
+
+ALTER TABLE ingredients
+    ADD CONSTRAINT ingredients_unit_check
+    CHECK (
+        (unit)::text = ANY (
+            ARRAY[
+                ('gr'::character varying)::text,
+                ('ml'::character varying)::text,
+                ('kg'::character varying)::text,
+                ('und'::character varying)::text,
+                ('lt'::character varying)::text,
+                ('hr'::character varying)::text
+            ]
+        )
+    );

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -3,9 +3,129 @@ Tests for ingredients module endpoints.
 
 Endpoints tested:
 - GET /suppliers/ingredients
+- type×unit validation (create_tenant_ingredient)
 """
 import pytest
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+from fastapi import HTTPException
 from httpx import AsyncClient
+
+from app.models.ingredient import TenantIngredientCreate
+from app.services.ingredients_service import (
+    _validate_unit_for_type,
+    create_tenant_ingredient,
+    update_tenant_ingredient,
+)
+from app.models.ingredient import TenantIngredientUpdate
+
+
+class TestIngredientUnitTypeValidation:
+    """Unit tests for service/supply/food unit rules (api-warolabs#380)."""
+
+    def test_service_requires_hr(self):
+        _validate_unit_for_type("hr", "service")
+
+    def test_service_rejects_gr(self):
+        with pytest.raises(HTTPException) as exc:
+            _validate_unit_for_type("gr", "service")
+        assert exc.value.status_code == 422
+        assert "hr" in exc.value.detail
+
+    def test_supply_requires_und(self):
+        _validate_unit_for_type("und", "supply")
+
+    def test_supply_rejects_kg(self):
+        with pytest.raises(HTTPException) as exc:
+            _validate_unit_for_type("kg", "supply")
+        assert exc.value.status_code == 422
+        assert "und" in exc.value.detail
+
+    def test_food_allows_gr(self):
+        _validate_unit_for_type("gr", "food")
+
+    def test_food_rejects_hr(self):
+        with pytest.raises(HTTPException) as exc:
+            _validate_unit_for_type("hr", "food")
+        assert exc.value.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_create_service_ingredient_hr(self):
+        tenant_id = uuid4()
+        conn = AsyncMock()
+        conn.fetchrow = AsyncMock(
+            return_value={
+                "id": str(uuid4()),
+                "name": "Mano de obra",
+                "unit": "hr",
+                "type": "service",
+                "category": None,
+                "costo_unitario": None,
+                "parent_id": None,
+                "tenant_id": str(tenant_id),
+                "is_resale": False,
+                "unit_weight_gr": None,
+                "unit_weight_unit": "gr",
+                "created_at": None,
+            }
+        )
+        data = TenantIngredientCreate(name="Mano de obra", unit="hr", type="service")
+        result = await create_tenant_ingredient(conn, tenant_id, data)
+        assert result["unit"] == "hr"
+        assert result["type"] == "service"
+
+    @pytest.mark.asyncio
+    async def test_create_service_rejects_gr(self):
+        tenant_id = uuid4()
+        conn = AsyncMock()
+        data = TenantIngredientCreate(name="Bad service", unit="gr", type="service")
+        with pytest.raises(HTTPException) as exc:
+            await create_tenant_ingredient(conn, tenant_id, data)
+        assert exc.value.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_create_supply_rejects_kg(self):
+        tenant_id = uuid4()
+        conn = AsyncMock()
+        data = TenantIngredientCreate(name="Bad supply", unit="kg", type="supply")
+        with pytest.raises(HTTPException) as exc:
+            await create_tenant_ingredient(conn, tenant_id, data)
+        assert exc.value.status_code == 422
+        assert "und" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_patch_service_unit_to_hr(self):
+        tenant_id = uuid4()
+        ingredient_id = uuid4()
+        conn = AsyncMock()
+        conn.fetchval = AsyncMock(return_value=False)
+        conn.fetchrow = AsyncMock(
+            side_effect=[
+                {
+                    "id": ingredient_id,
+                    "name": "Legacy service",
+                    "unit": "und",
+                    "type": "service",
+                    "category": None,
+                    "costo_unitario": None,
+                    "parent_id": None,
+                },
+                {
+                    "id": str(ingredient_id),
+                    "name": "Legacy service",
+                    "unit": "hr",
+                    "category": None,
+                    "costo_unitario": None,
+                    "parent_id": None,
+                    "tenant_id": str(tenant_id),
+                    "updated_at": None,
+                },
+            ]
+        )
+        data = TenantIngredientUpdate(unit="hr")
+        result = await update_tenant_ingredient(conn, tenant_id, ingredient_id, data)
+        assert result["unit"] == "hr"
 
 
 class TestIngredientsEndpoint:


### PR DESCRIPTION
## Summary
- Add type-aware unit validation: `service` → `hr`, `supply` → `und`, `food` → existing weight/volume/piece units.
- Extend DB `ingredients_unit_check` to include `hr` via migration.
- Add unit tests for create/PATCH validation paths.

Closes #380

## Test plan
- [ ] Run `sql/20260601_ingredients_unit_hr.sql` on staging DB
- [ ] `POST /suppliers/ingredients` with `{type: service, unit: hr}` returns 201
- [ ] `POST` with `{type: service, unit: gr}` returns 422
- [ ] `POST` with `{type: supply, unit: kg}` returns 422
- [ ] `pytest tests/test_ingredients.py -v -k UnitType` passes

## wr-context
See `.wr/380.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)