### PR TITLE
feat(menu): modifier option types — recipe and product composition

### DIFF
--- a/app/models/modifier.py
+++ b/app/models/modifier.py
@@ -1,9 +1,12 @@
 # Modifier models for menu management
 from pydantic import BaseModel, Field
-from typing import Optional, List
+from typing import Optional, List, Literal
 from uuid import UUID
 from datetime import datetime
 from decimal import Decimal
+
+
+ModifierOptionType = Literal["INGREDIENT", "RECIPE", "PRODUCT", "NONE"]
 
 
 class ProductInfo(BaseModel):
@@ -21,6 +24,23 @@ class IngredientInfo(BaseModel):
     controla_inventario: bool = False
 
 
+class RecipeBaseInfo(BaseModel):
+    """Recipe base type linked to a RECIPE modifier option"""
+    id: UUID
+    name: str
+
+
+class ModifierRecipeLineBase(BaseModel):
+    ingredient_id: UUID
+    quantity: Decimal = Field(..., gt=0)
+    unit: str = Field(..., min_length=1, max_length=50)
+
+
+class ModifierRecipeLine(ModifierRecipeLineBase):
+    id: UUID
+    ingredient: Optional[IngredientInfo] = None
+
+
 class ModifierBase(BaseModel):
     """Base modifier fields"""
     name: str = Field(..., min_length=1, max_length=255, description="Modifier name")
@@ -29,14 +49,34 @@ class ModifierBase(BaseModel):
     is_default: bool = Field(default=False, description="Selected by default")
     is_available: bool = Field(default=True, description="Available for selection")
     sort_order: int = Field(default=0, ge=0, description="Display order")
-    # Ingredient linking for inventory deduction
+    option_type: ModifierOptionType = Field(
+        default="INGREDIENT",
+        description="INGREDIENT | RECIPE | PRODUCT | NONE",
+    )
+    # Ingredient option
     ingredient_id: Optional[UUID] = Field(None, description="Linked ingredient ID")
     ingredient_quantity: Optional[Decimal] = Field(None, description="Quantity of ingredient per modifier")
     ingredient_unit: Optional[str] = Field(None, max_length=20, description="Unit for ingredient quantity")
+    # Recipe option (recipe base and/or modifier_recipes BOM)
+    recipe_base_type_id: Optional[UUID] = Field(None, description="Recipe base type for RECIPE option")
+    recipe_base_quantity: Decimal = Field(default=1, gt=0, description="Multiplier on recipe base template")
+    recipe_lines: Optional[List[ModifierRecipeLineBase]] = Field(
+        None,
+        description="Per-modifier ingredient BOM (modifier_recipes table)",
+    )
+    # Product option
+    linked_product_id: Optional[UUID] = Field(None, description="Menu product for PRODUCT option")
+    linked_product_quantity: Decimal = Field(
+        default=1,
+        gt=0,
+        description="Multiplier on linked product composition",
+    )
+
 
 class ModifierCreate(ModifierBase):
     """Create modifier"""
     pass
+
 
 class ModifierUpdate(BaseModel):
     """Update modifier fields"""
@@ -46,10 +86,16 @@ class ModifierUpdate(BaseModel):
     is_default: Optional[bool] = None
     is_available: Optional[bool] = None
     sort_order: Optional[int] = Field(None, ge=0)
-    # Ingredient linking
+    option_type: Optional[ModifierOptionType] = None
     ingredient_id: Optional[UUID] = None
     ingredient_quantity: Optional[Decimal] = None
     ingredient_unit: Optional[str] = Field(None, max_length=20)
+    recipe_base_type_id: Optional[UUID] = None
+    recipe_base_quantity: Optional[Decimal] = Field(None, gt=0)
+    recipe_lines: Optional[List[ModifierRecipeLineBase]] = None
+    linked_product_id: Optional[UUID] = None
+    linked_product_quantity: Optional[Decimal] = Field(None, gt=0)
+
 
 class Modifier(ModifierBase):
     """Complete modifier"""
@@ -57,11 +103,18 @@ class Modifier(ModifierBase):
     modifier_group_id: UUID
     created_at: datetime
     updated_at: datetime
-    # Ingredient info for display (populated from JOIN)
     ingredient: Optional[IngredientInfo] = None
+    recipe_base: Optional[RecipeBaseInfo] = None
+    linked_product: Optional[ProductInfo] = None
+    recipe_lines: Optional[List[ModifierRecipeLine]] = None
+    unit_cost: Optional[Decimal] = Field(
+        None,
+        description="Calculated unit cost for one modifier selection (menu preview)",
+    )
 
     class Config:
         from_attributes = True
+
 
 class ModifierGroupBase(BaseModel):
     """Base modifier group fields"""
@@ -97,23 +150,25 @@ class ModifierGroup(ModifierGroupBase):
     created_at: datetime
     updated_at: datetime
 
-    # Related data - now supports multiple products
     products: List[ProductInfo] = Field(default=[], description="Associated products")
     modifiers: List[Modifier] = []
 
     class Config:
         from_attributes = True
 
+
 class ModifierGroupResponse(BaseModel):
     """Single modifier group response"""
     success: bool = True
     data: ModifierGroup
+
 
 class ModifierGroupsListResponse(BaseModel):
     """List of modifier groups response"""
     success: bool = True
     total: int
     data: List[ModifierGroup]
+
 
 class ModifierGroupStats(BaseModel):
     """Modifier groups statistics"""

--- a/app/services/menu_history_service.py
+++ b/app/services/menu_history_service.py
@@ -627,7 +627,10 @@ async def get_modifier_group_snapshot(conn, modifier_group_id: UUID, tenant_id: 
         # Modificadores
         modifiers = await conn.fetch("""
             SELECT id, name, price, is_available, is_default, sort_order,
-                   ingredient_id, ingredient_quantity, ingredient_unit
+                   option_type,
+                   ingredient_id, ingredient_quantity, ingredient_unit,
+                   recipe_base_type_id, recipe_base_quantity,
+                   linked_product_id, linked_product_quantity
             FROM modifiers WHERE modifier_group_id = $1
         """, modifier_group_id)
         snapshot['modifiers'] = [dict(m) for m in modifiers]

--- a/app/services/modifier_option_service.py
+++ b/app/services/modifier_option_service.py
@@ -1,0 +1,294 @@
+"""
+Resolve modifier option composition (ingredient / recipe / product) for cost and inventory.
+
+Issue warocol.com#1121.
+"""
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from app.services.cost_resolution_service import calculated_product_cost_real
+from app.services.ingredient_purchase_units_service import resolve_recipe_quantity_to_base_unit
+
+
+OPTION_TYPES = frozenset({"INGREDIENT", "RECIPE", "PRODUCT", "NONE"})
+
+
+async def fetch_modifier_option_row(conn, modifier_id: UUID) -> Optional[Dict[str, Any]]:
+    return await conn.fetchrow(
+        """
+        SELECT
+            m.id,
+            m.option_type,
+            m.ingredient_id,
+            m.ingredient_quantity,
+            m.ingredient_unit,
+            m.recipe_base_type_id,
+            m.recipe_base_quantity,
+            m.linked_product_id,
+            m.linked_product_quantity,
+            i.name AS ingredient_name,
+            i.controla_inventario
+        FROM modifiers m
+        LEFT JOIN ingredients i ON m.ingredient_id = i.id
+        WHERE m.id = $1
+        """,
+        modifier_id,
+    )
+
+
+async def resolve_modifier_ingredient_lines(
+    conn,
+    modifier_id: UUID,
+    tenant_id: UUID,
+) -> List[Dict[str, Any]]:
+    """
+    Ingredient consumption per one modifier selection (before order line qty multipliers).
+    Each row: ingredient_id, quantity, unit, ingredient_name, controla_inventario.
+    """
+    row = await fetch_modifier_option_row(conn, modifier_id)
+    if not row:
+        return []
+
+    option_type = (row["option_type"] or "INGREDIENT").upper()
+
+    if option_type == "NONE":
+        return []
+
+    if option_type == "INGREDIENT":
+        if not row["ingredient_id"] or not row["ingredient_quantity"]:
+            return []
+        resolved_qty = await resolve_recipe_quantity_to_base_unit(
+            conn,
+            row["ingredient_id"],
+            float(row["ingredient_quantity"]),
+            row["ingredient_unit"] or "",
+        )
+        return [
+            {
+                "ingredient_id": row["ingredient_id"],
+                "quantity": resolved_qty,
+                "unit": row["ingredient_unit"] or "und",
+                "ingredient_name": row["ingredient_name"],
+                "controla_inventario": row["controla_inventario"],
+            }
+        ]
+
+    if option_type == "RECIPE":
+        lines: List[Dict[str, Any]] = []
+        base_qty = float(row["recipe_base_quantity"] or 1)
+
+        if row["recipe_base_type_id"]:
+            base_rows = await conn.fetch(
+                """
+                SELECT
+                    brt.ingredient_id,
+                    brt.base_quantity * $2 AS quantity,
+                    brt.unit,
+                    i.name AS ingredient_name,
+                    i.controla_inventario
+                FROM base_recipe_templates brt
+                JOIN ingredients i ON brt.ingredient_id = i.id
+                WHERE brt.product_base_type_id = $1
+                """,
+                row["recipe_base_type_id"],
+                base_qty,
+            )
+            for br in base_rows:
+                resolved = await resolve_recipe_quantity_to_base_unit(
+                    conn,
+                    br["ingredient_id"],
+                    float(br["quantity"]),
+                    br["unit"] or "",
+                )
+                lines.append(
+                    {
+                        "ingredient_id": br["ingredient_id"],
+                        "quantity": resolved,
+                        "unit": br["unit"] or "und",
+                        "ingredient_name": br["ingredient_name"],
+                        "controla_inventario": br["controla_inventario"],
+                    }
+                )
+
+        recipe_rows = await conn.fetch(
+            """
+            SELECT
+                mr.ingredient_id,
+                mr.quantity,
+                mr.unit,
+                i.name AS ingredient_name,
+                i.controla_inventario
+            FROM modifier_recipes mr
+            JOIN ingredients i ON mr.ingredient_id = i.id
+            WHERE mr.modifier_id = $1
+            """,
+            modifier_id,
+        )
+        for rr in recipe_rows:
+            resolved = await resolve_recipe_quantity_to_base_unit(
+                conn,
+                rr["ingredient_id"],
+                float(rr["quantity"]),
+                rr["unit"] or "",
+            )
+            lines.append(
+                {
+                    "ingredient_id": rr["ingredient_id"],
+                    "quantity": resolved,
+                    "unit": rr["unit"] or "und",
+                    "ingredient_name": rr["ingredient_name"],
+                    "controla_inventario": rr["controla_inventario"],
+                }
+            )
+        return _merge_ingredient_lines(lines)
+
+    if option_type == "PRODUCT":
+        product_id = row["linked_product_id"]
+        if not product_id:
+            return []
+        mult = float(row["linked_product_quantity"] or 1)
+        product_rows = await conn.fetch(
+            """
+            SELECT
+                pr.ingredient_id,
+                pr.quantity * $2 AS quantity,
+                pr.unit,
+                i.name AS ingredient_name,
+                i.controla_inventario
+            FROM product_recipes pr
+            JOIN ingredients i ON pr.ingredient_id = i.id
+            WHERE pr.product_id = $1
+
+            UNION ALL
+
+            SELECT
+                brt.ingredient_id,
+                brt.base_quantity * pbr.quantity * $2 AS quantity,
+                brt.unit,
+                i.name AS ingredient_name,
+                i.controla_inventario
+            FROM product_base_recipes pbr
+            JOIN base_recipe_templates brt ON pbr.product_base_type_id = brt.product_base_type_id
+            JOIN ingredients i ON brt.ingredient_id = i.id
+            WHERE pbr.product_id = $1
+            """,
+            product_id,
+            mult,
+        )
+        lines = []
+        for pr in product_rows:
+            resolved = await resolve_recipe_quantity_to_base_unit(
+                conn,
+                pr["ingredient_id"],
+                float(pr["quantity"]),
+                pr["unit"] or "",
+            )
+            lines.append(
+                {
+                    "ingredient_id": pr["ingredient_id"],
+                    "quantity": resolved,
+                    "unit": pr["unit"] or "und",
+                    "ingredient_name": pr["ingredient_name"],
+                    "controla_inventario": pr["controla_inventario"],
+                }
+            )
+        return _merge_ingredient_lines(lines)
+
+    return []
+
+
+def _merge_ingredient_lines(lines: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Sum quantities when the same ingredient appears from multiple recipe sources."""
+    merged: Dict[Any, Dict[str, Any]] = {}
+    for line in lines:
+        ing_id = line["ingredient_id"]
+        if ing_id in merged:
+            merged[ing_id]["quantity"] = float(merged[ing_id]["quantity"]) + float(line["quantity"])
+        else:
+            merged[ing_id] = dict(line)
+    return list(merged.values())
+
+
+async def calculated_modifier_option_unit_cost(
+    conn,
+    modifier_id: UUID,
+    tenant_id: UUID,
+) -> Decimal:
+    """Unit cost for one modifier selection (menu preview / API embedded field)."""
+    lines = await resolve_modifier_ingredient_lines(conn, modifier_id, tenant_id)
+    if not lines:
+        row = await fetch_modifier_option_row(conn, modifier_id)
+        if row and (row["option_type"] or "").upper() == "PRODUCT" and row["linked_product_id"]:
+            total = await calculated_product_cost_real(
+                row["linked_product_id"],
+                tenant_id,
+                conn,
+            )
+            mult = Decimal(str(row["linked_product_quantity"] or 1))
+            return total * mult
+        return Decimal("0")
+
+    ingredient_ids = [str(line["ingredient_id"]) for line in lines]
+    prices = await _get_ingredient_unit_costs(conn, ingredient_ids, tenant_id)
+    total = Decimal("0")
+    for line in lines:
+        unit_cost = prices.get(str(line["ingredient_id"]), Decimal("0"))
+        total += Decimal(str(line["quantity"])) * unit_cost
+    return total
+
+
+async def _get_ingredient_unit_costs(
+    conn,
+    ingredient_ids: List[str],
+    tenant_id: UUID,
+) -> Dict[str, Decimal]:
+    if not ingredient_ids:
+        return {}
+    rows = await conn.fetch(
+        """
+        WITH latest_purchase_costs AS (
+            SELECT DISTINCT ON (pi.ingredient_id)
+                pi.ingredient_id,
+                pi.unit_cost
+            FROM tenant_purchase_items pi
+            JOIN tenant_purchases tp ON pi.purchase_id = tp.id
+            WHERE tp.tenant_id = $1
+              AND pi.ingredient_id = ANY($2::uuid[])
+              AND pi.unit_cost IS NOT NULL
+              AND pi.unit_cost > 0
+            ORDER BY pi.ingredient_id, tp.purchase_date DESC
+        )
+        SELECT i.id AS ingredient_id,
+               COALESCE(lpc.unit_cost, i.costo_unitario, 0) AS unit_cost
+        FROM ingredients i
+        LEFT JOIN latest_purchase_costs lpc ON i.id = lpc.ingredient_id
+        WHERE i.id = ANY($2::uuid[])
+        """,
+        tenant_id,
+        ingredient_ids,
+    )
+    return {str(r["ingredient_id"]): Decimal(str(r["unit_cost"])) for r in rows}
+
+
+def validate_modifier_option_fields(modifier_data) -> None:
+    """Raise ValueError when option_type and FKs are inconsistent."""
+    option_type = (getattr(modifier_data, "option_type", None) or "INGREDIENT").upper()
+    if option_type not in OPTION_TYPES:
+        raise ValueError(f"Invalid option_type: {option_type}")
+
+    ingredient_id = getattr(modifier_data, "ingredient_id", None)
+    recipe_base_type_id = getattr(modifier_data, "recipe_base_type_id", None)
+    recipe_lines = getattr(modifier_data, "recipe_lines", None) or []
+    linked_product_id = getattr(modifier_data, "linked_product_id", None)
+
+    if option_type == "INGREDIENT" and not ingredient_id:
+        raise ValueError("INGREDIENT option requires ingredient_id")
+    if option_type == "RECIPE" and not recipe_base_type_id and not recipe_lines:
+        raise ValueError("RECIPE option requires recipe_base_type_id or recipe_lines")
+    if option_type == "PRODUCT" and not linked_product_id:
+        raise ValueError("PRODUCT option requires linked_product_id")
+    if option_type == "NONE" and any(
+        [ingredient_id, recipe_base_type_id, linked_product_id, recipe_lines]
+    ):
+        raise ValueError("NONE option must not set composition FKs")

--- a/app/services/modifiers_service.py
+++ b/app/services/modifiers_service.py
@@ -7,13 +7,206 @@ from app.core.exceptions import AuthenticationError, APIError
 from app.models.modifier import (
     ModifierGroup, ModifierGroupCreate, ModifierGroupUpdate,
     ModifierGroupsListResponse, ModifierGroupResponse, ModifierGroupStats,
-    Modifier, ProductInfo, IngredientInfo
+    Modifier, ProductInfo, IngredientInfo, RecipeBaseInfo,
+    ModifierRecipeLine, ModifierRecipeLineBase,
 )
 from app.services import menu_history_service
 from app.services.ingredient_purchase_units_service import resolve_to_base_unit
+from app.services.modifier_option_service import (
+    calculated_modifier_option_unit_cost,
+    validate_modifier_option_fields,
+)
 import logging
 
 logger = logging.getLogger(__name__)
+
+_MODIFIER_SELECT_COLS = """
+    m.id,
+    m.modifier_group_id,
+    m.name,
+    m.price,
+    m.max_limit,
+    m.is_default,
+    m.is_available,
+    m.sort_order,
+    m.created_at,
+    m.updated_at,
+    m.option_type,
+    m.ingredient_id,
+    m.ingredient_quantity,
+    m.ingredient_unit,
+    m.recipe_base_type_id,
+    m.recipe_base_quantity,
+    m.linked_product_id,
+    m.linked_product_quantity,
+    i.name as ingredient_name,
+    i.unit as ingredient_base_unit,
+    i.costo_unitario,
+    i.controla_inventario,
+    pbt.name as recipe_base_name,
+    lp.name as linked_product_name
+"""
+
+
+async def _replace_modifier_recipes(
+    conn,
+    modifier_id: UUID,
+    recipe_lines: Optional[List[ModifierRecipeLineBase]],
+) -> None:
+    await conn.execute("DELETE FROM modifier_recipes WHERE modifier_id = $1", modifier_id)
+    if not recipe_lines:
+        return
+    for line in recipe_lines:
+        qty, unit = await resolve_to_base_unit(
+            conn,
+            line.ingredient_id,
+            float(line.quantity),
+            line.unit,
+        )
+        await conn.execute(
+            """
+            INSERT INTO modifier_recipes (modifier_id, ingredient_id, quantity, unit)
+            VALUES ($1, $2, $3, $4)
+            """,
+            modifier_id,
+            line.ingredient_id,
+            qty,
+            unit,
+        )
+
+
+async def _fetch_modifier_recipe_lines(conn, modifier_id: UUID) -> List[ModifierRecipeLine]:
+    rows = await conn.fetch(
+        """
+        SELECT mr.id, mr.ingredient_id, mr.quantity, mr.unit,
+               i.name as ingredient_name, i.unit as ingredient_base_unit,
+               i.costo_unitario, i.controla_inventario
+        FROM modifier_recipes mr
+        JOIN ingredients i ON mr.ingredient_id = i.id
+        WHERE mr.modifier_id = $1
+        ORDER BY mr.created_at
+        """,
+        modifier_id,
+    )
+    lines = []
+    for r in rows:
+        ing = IngredientInfo(
+            id=r["ingredient_id"],
+            name=r["ingredient_name"],
+            unit=r["ingredient_base_unit"],
+            costo_unitario=r["costo_unitario"],
+            controla_inventario=r["controla_inventario"] or False,
+        )
+        lines.append(
+            ModifierRecipeLine(
+                id=r["id"],
+                ingredient_id=r["ingredient_id"],
+                quantity=r["quantity"],
+                unit=r["unit"],
+                ingredient=ing,
+            )
+        )
+    return lines
+
+
+async def _build_modifier(
+    conn,
+    row,
+    tenant_id: UUID,
+) -> Modifier:
+    recipe_lines = await _fetch_modifier_recipe_lines(conn, row["id"])
+    mod_dict = {
+        "id": row["id"],
+        "modifier_group_id": row["modifier_group_id"],
+        "name": row["name"],
+        "price": row["price"],
+        "max_limit": row["max_limit"],
+        "is_default": row["is_default"],
+        "is_available": row["is_available"],
+        "sort_order": row["sort_order"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+        "option_type": row["option_type"] or "INGREDIENT",
+        "ingredient_id": row["ingredient_id"],
+        "ingredient_quantity": row["ingredient_quantity"],
+        "ingredient_unit": row["ingredient_unit"],
+        "recipe_base_type_id": row["recipe_base_type_id"],
+        "recipe_base_quantity": row["recipe_base_quantity"] or 1,
+        "linked_product_id": row["linked_product_id"],
+        "linked_product_quantity": row["linked_product_quantity"] or 1,
+        "recipe_lines": recipe_lines or None,
+    }
+    if row["ingredient_id"]:
+        mod_dict["ingredient"] = IngredientInfo(
+            id=row["ingredient_id"],
+            name=row["ingredient_name"],
+            unit=row["ingredient_base_unit"],
+            costo_unitario=row["costo_unitario"],
+            controla_inventario=row["controla_inventario"] or False,
+        )
+    if row["recipe_base_type_id"] and row.get("recipe_base_name"):
+        mod_dict["recipe_base"] = RecipeBaseInfo(
+            id=row["recipe_base_type_id"],
+            name=row["recipe_base_name"],
+        )
+    if row["linked_product_id"] and row.get("linked_product_name"):
+        mod_dict["linked_product"] = ProductInfo(
+            id=row["linked_product_id"],
+            name=row["linked_product_name"],
+        )
+    mod_dict["unit_cost"] = await calculated_modifier_option_unit_cost(
+        conn, row["id"], tenant_id
+    )
+    return Modifier(**mod_dict)
+
+
+async def _insert_modifier(conn, group_id: UUID, modifier) -> UUID:
+    validate_modifier_option_fields(modifier)
+    option_type = (modifier.option_type or "INGREDIENT").upper()
+
+    ing_qty = modifier.ingredient_quantity
+    ing_unit = modifier.ingredient_unit
+    if modifier.ingredient_id and ing_qty is not None and ing_unit:
+        ing_qty, ing_unit = await resolve_to_base_unit(
+            conn,
+            modifier.ingredient_id,
+            float(ing_qty),
+            ing_unit,
+        )
+
+    row = await conn.fetchrow(
+        """
+        INSERT INTO modifiers (
+            modifier_group_id, name, price, max_limit,
+            is_default, is_available, sort_order,
+            option_type,
+            ingredient_id, ingredient_quantity, ingredient_unit,
+            recipe_base_type_id, recipe_base_quantity,
+            linked_product_id, linked_product_quantity
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+        RETURNING id
+        """,
+        group_id,
+        modifier.name,
+        modifier.price,
+        modifier.max_limit,
+        modifier.is_default,
+        modifier.is_available,
+        modifier.sort_order,
+        option_type,
+        modifier.ingredient_id if option_type == "INGREDIENT" else None,
+        ing_qty if option_type == "INGREDIENT" else None,
+        ing_unit if option_type == "INGREDIENT" else None,
+        modifier.recipe_base_type_id if option_type == "RECIPE" else None,
+        modifier.recipe_base_quantity if option_type == "RECIPE" else 1,
+        modifier.linked_product_id if option_type == "PRODUCT" else None,
+        modifier.linked_product_quantity if option_type == "PRODUCT" else 1,
+    )
+    modifier_id = row["id"]
+    if option_type == "RECIPE" and modifier.recipe_lines:
+        await _replace_modifier_recipes(conn, modifier_id, modifier.recipe_lines)
+    return modifier_id
 
 async def create_modifier_group(
     request: Request,
@@ -68,40 +261,10 @@ async def create_modifier_group(
                         tenant_id
                     )
 
-                # 3. Insert modifiers (with ingredient linking)
+                # 3. Insert modifiers (option types + optional modifier_recipes)
                 if group_data.modifiers:
-                    modifier_query = """
-                        INSERT INTO modifiers (
-                            modifier_group_id, name, price, max_limit,
-                            is_default, is_available, sort_order,
-                            ingredient_id, ingredient_quantity, ingredient_unit
-                        )
-                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-                    """
-
                     for modifier in group_data.modifiers:
-                        ing_qty = modifier.ingredient_quantity
-                        ing_unit = modifier.ingredient_unit
-                        if modifier.ingredient_id and ing_qty is not None and ing_unit:
-                            ing_qty, ing_unit = await resolve_to_base_unit(
-                                conn,
-                                modifier.ingredient_id,
-                                float(ing_qty),
-                                ing_unit
-                            )
-                        await conn.execute(
-                            modifier_query,
-                            group_id,
-                            modifier.name,
-                            modifier.price,
-                            modifier.max_limit,
-                            modifier.is_default,
-                            modifier.is_available,
-                            modifier.sort_order,
-                            modifier.ingredient_id,
-                            ing_qty,
-                            ing_unit
-                        )
+                        await _insert_modifier(conn, group_id, modifier)
 
                 # 4. Registrar en historial
                 user_id = session_context.user_id if hasattr(session_context, 'user_id') else None
@@ -117,6 +280,8 @@ async def create_modifier_group(
 
     except AuthenticationError as e:
         raise e
+    except ValueError as e:
+        raise APIError(str(e), status_code=400)
     except Exception as e:
         logger.error(f"Error creating modifier group: {str(e)}")
         raise APIError(f"Error creating modifier group: {str(e)}", status_code=500)
@@ -167,66 +332,24 @@ async def get_modifier_group_by_id(
             """
             products_rows = await connection.fetch(products_query, group_id)
 
-            # Get modifiers with ingredient info
-            modifiers_query = """
-                SELECT
-                    m.id,
-                    m.modifier_group_id,
-                    m.name,
-                    m.price,
-                    m.max_limit,
-                    m.is_default,
-                    m.is_available,
-                    m.sort_order,
-                    m.created_at,
-                    m.updated_at,
-                    m.ingredient_id,
-                    m.ingredient_quantity,
-                    m.ingredient_unit,
-                    i.name as ingredient_name,
-                    i.unit as ingredient_base_unit,
-                    i.costo_unitario,
-                    i.controla_inventario
+            modifiers_query = f"""
+                SELECT {_MODIFIER_SELECT_COLS}
                 FROM modifiers m
                 LEFT JOIN ingredients i ON m.ingredient_id = i.id
+                LEFT JOIN product_base_types pbt ON m.recipe_base_type_id = pbt.id
+                LEFT JOIN product lp ON m.linked_product_id = lp.id
                 WHERE m.modifier_group_id = $1
                 ORDER BY m.sort_order, m.name
             """
 
             modifier_rows = await connection.fetch(modifiers_query, group_id)
 
-            # Build group dict
             group_dict = dict(group_row)
             group_dict['products'] = [ProductInfo(id=row['id'], name=row['name']) for row in products_rows]
 
-            # Build modifiers with ingredient info
             modifiers = []
             for row in modifier_rows:
-                mod_dict = {
-                    'id': row['id'],
-                    'modifier_group_id': row['modifier_group_id'],
-                    'name': row['name'],
-                    'price': row['price'],
-                    'max_limit': row['max_limit'],
-                    'is_default': row['is_default'],
-                    'is_available': row['is_available'],
-                    'sort_order': row['sort_order'],
-                    'created_at': row['created_at'],
-                    'updated_at': row['updated_at'],
-                    'ingredient_id': row['ingredient_id'],
-                    'ingredient_quantity': row['ingredient_quantity'],
-                    'ingredient_unit': row['ingredient_unit'],
-                }
-                # Add ingredient info if linked
-                if row['ingredient_id']:
-                    mod_dict['ingredient'] = IngredientInfo(
-                        id=row['ingredient_id'],
-                        name=row['ingredient_name'],
-                        unit=row['ingredient_base_unit'],
-                        costo_unitario=row['costo_unitario'],
-                        controla_inventario=row['controla_inventario'] or False
-                    )
-                modifiers.append(Modifier(**mod_dict))
+                modifiers.append(await _build_modifier(connection, row, tenant_id))
 
             group_dict['modifiers'] = modifiers
 
@@ -332,60 +455,20 @@ async def get_modifier_groups_list(
                 products_rows = await conn.fetch(products_query, row['id'])
                 group_dict['products'] = [ProductInfo(id=r['id'], name=r['name']) for r in products_rows]
 
-                # Fetch modifiers for each group with ingredient info
-                modifiers_query = """
-                    SELECT
-                        m.id,
-                        m.modifier_group_id,
-                        m.name,
-                        m.price,
-                        m.max_limit,
-                        m.is_default,
-                        m.is_available,
-                        m.sort_order,
-                        m.created_at,
-                        m.updated_at,
-                        m.ingredient_id,
-                        m.ingredient_quantity,
-                        m.ingredient_unit,
-                        i.name as ingredient_name,
-                        i.unit as ingredient_base_unit,
-                        i.costo_unitario,
-                        i.controla_inventario
+                modifiers_query = f"""
+                    SELECT {_MODIFIER_SELECT_COLS}
                     FROM modifiers m
                     LEFT JOIN ingredients i ON m.ingredient_id = i.id
+                    LEFT JOIN product_base_types pbt ON m.recipe_base_type_id = pbt.id
+                    LEFT JOIN product lp ON m.linked_product_id = lp.id
                     WHERE m.modifier_group_id = $1
                     ORDER BY m.sort_order, m.name
                 """
                 modifier_rows = await conn.fetch(modifiers_query, row['id'])
 
-                # Build modifiers with ingredient info
                 modifiers = []
                 for r in modifier_rows:
-                    mod_dict = {
-                        'id': r['id'],
-                        'modifier_group_id': r['modifier_group_id'],
-                        'name': r['name'],
-                        'price': r['price'],
-                        'max_limit': r['max_limit'],
-                        'is_default': r['is_default'],
-                        'is_available': r['is_available'],
-                        'sort_order': r['sort_order'],
-                        'created_at': r['created_at'],
-                        'updated_at': r['updated_at'],
-                        'ingredient_id': r['ingredient_id'],
-                        'ingredient_quantity': r['ingredient_quantity'],
-                        'ingredient_unit': r['ingredient_unit'],
-                    }
-                    if r['ingredient_id']:
-                        mod_dict['ingredient'] = IngredientInfo(
-                            id=r['ingredient_id'],
-                            name=r['ingredient_name'],
-                            unit=r['ingredient_base_unit'],
-                            costo_unitario=r['costo_unitario'],
-                            controla_inventario=r['controla_inventario'] or False
-                        )
-                    modifiers.append(Modifier(**mod_dict))
+                    modifiers.append(await _build_modifier(conn, r, tenant_id))
 
                 group_dict['modifiers'] = modifiers
 
@@ -512,6 +595,9 @@ async def update_modifier_group(
                     modifiers_to_keep = set()
 
                     for modifier in group_data.modifiers:
+                        validate_modifier_option_fields(modifier)
+                        option_type = (modifier.option_type or "INGREDIENT").upper()
+
                         ing_qty = modifier.ingredient_quantity
                         ing_unit = modifier.ingredient_unit
                         if modifier.ingredient_id and ing_qty is not None and ing_unit:
@@ -519,11 +605,10 @@ async def update_modifier_group(
                                 conn,
                                 modifier.ingredient_id,
                                 float(ing_qty),
-                                ing_unit
+                                ing_unit,
                             )
 
                         if modifier.name in existing_names:
-                            # UPDATE existing modifier (including ingredient fields)
                             mod_id = existing_names[modifier.name]
                             modifiers_to_keep.add(mod_id)
                             await conn.execute(
@@ -531,7 +616,10 @@ async def update_modifier_group(
                                 UPDATE modifiers SET
                                     price = $2, max_limit = $3, is_default = $4,
                                     is_available = $5, sort_order = $6,
-                                    ingredient_id = $7, ingredient_quantity = $8, ingredient_unit = $9
+                                    option_type = $7,
+                                    ingredient_id = $8, ingredient_quantity = $9, ingredient_unit = $10,
+                                    recipe_base_type_id = $11, recipe_base_quantity = $12,
+                                    linked_product_id = $13, linked_product_quantity = $14
                                 WHERE id = $1
                                 """,
                                 mod_id,
@@ -540,32 +628,26 @@ async def update_modifier_group(
                                 modifier.is_default,
                                 modifier.is_available,
                                 modifier.sort_order,
-                                modifier.ingredient_id,
-                                ing_qty,
-                                ing_unit
+                                option_type,
+                                modifier.ingredient_id if option_type == "INGREDIENT" else None,
+                                ing_qty if option_type == "INGREDIENT" else None,
+                                ing_unit if option_type == "INGREDIENT" else None,
+                                modifier.recipe_base_type_id if option_type == "RECIPE" else None,
+                                modifier.recipe_base_quantity if option_type == "RECIPE" else 1,
+                                modifier.linked_product_id if option_type == "PRODUCT" else None,
+                                modifier.linked_product_quantity if option_type == "PRODUCT" else 1,
                             )
-                        else:
-                            # INSERT new modifier (with ingredient fields)
-                            await conn.execute(
-                                """
-                                INSERT INTO modifiers (
-                                    modifier_group_id, name, price, max_limit,
-                                    is_default, is_available, sort_order,
-                                    ingredient_id, ingredient_quantity, ingredient_unit
+                            if option_type == "RECIPE":
+                                await _replace_modifier_recipes(
+                                    conn, mod_id, modifier.recipe_lines
                                 )
-                                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-                                """,
-                                group_id,
-                                modifier.name,
-                                modifier.price,
-                                modifier.max_limit,
-                                modifier.is_default,
-                                modifier.is_available,
-                                modifier.sort_order,
-                                modifier.ingredient_id,
-                                ing_qty,
-                                ing_unit
-                            )
+                            else:
+                                await conn.execute(
+                                    "DELETE FROM modifier_recipes WHERE modifier_id = $1",
+                                    mod_id,
+                                )
+                        else:
+                            await _insert_modifier(conn, group_id, modifier)
 
                     # Soft-delete removed modifiers (preserve order history)
                     modifiers_to_disable = existing_ids - modifiers_to_keep
@@ -591,6 +673,8 @@ async def update_modifier_group(
         raise
     except AuthenticationError as e:
         raise e
+    except ValueError as e:
+        raise APIError(str(e), status_code=400)
     except Exception as e:
         logger.error(f"Error updating modifier group: {str(e)}")
         raise APIError(f"Error updating modifier group: {str(e)}", status_code=500)

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -2364,6 +2364,29 @@ async def _get_last_purchase_prices(conn, ingredient_ids: List[str], tenant_id: 
     )
     return {r["ingredient_id"]: float(r["unit_cost"]) for r in rows}
 
+# Aggregate qty/cost when product recipe and modifier share an ingredient; replace on
+# same-source retry so re-running capture for one source does not double-count.
+_ORDER_ITEM_INGREDIENT_UPSERT = """
+ON CONFLICT (order_item_id, ingredient_id) DO UPDATE SET
+  quantity = CASE
+    WHEN order_item_ingredients.source_type IS NOT DISTINCT FROM EXCLUDED.source_type
+     AND order_item_ingredients.source_id IS NOT DISTINCT FROM EXCLUDED.source_id
+    THEN EXCLUDED.quantity
+    ELSE order_item_ingredients.quantity + EXCLUDED.quantity
+  END,
+  unit_cost = COALESCE(order_item_ingredients.unit_cost, EXCLUDED.unit_cost),
+  total_cost = CASE
+    WHEN COALESCE(EXCLUDED.unit_cost, order_item_ingredients.unit_cost) IS NOT NULL THEN
+      (CASE
+        WHEN order_item_ingredients.source_type IS NOT DISTINCT FROM EXCLUDED.source_type
+         AND order_item_ingredients.source_id IS NOT DISTINCT FROM EXCLUDED.source_id
+        THEN EXCLUDED.quantity
+        ELSE order_item_ingredients.quantity + EXCLUDED.quantity
+      END) * COALESCE(EXCLUDED.unit_cost, order_item_ingredients.unit_cost)
+    ELSE NULL
+  END
+"""
+
 
 async def _capture_order_item_ingredients(
     conn,
@@ -2379,7 +2402,7 @@ async def _capture_order_item_ingredients(
     - product_recipes (source_type = 'product_recipe')
     - product_base_recipes → base_recipe_templates (source_type = 'base_recipe')
 
-    Idempotent via ON CONFLICT (order_item_id, ingredient_id) DO NOTHING.
+    Idempotent per source on conflict; aggregates qty/cost across product + modifier.
     """
     rows = await conn.fetch(
         """
@@ -2436,8 +2459,8 @@ async def _capture_order_item_ingredients(
                 quantity, unit, unit_cost, total_cost,
                 source_type, source_id, created_at
             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::uuid, NOW())
-            ON CONFLICT (order_item_id, ingredient_id) DO NOTHING
-            """,
+            """
+            + _ORDER_ITEM_INGREDIENT_UPSERT,
             order_item_id,
             r["ingredient_id"],
             r["ingredient_name"],
@@ -2462,113 +2485,139 @@ async def _deduct_modifier_inventory_for_order_item(
     modifier: dict,
     modifier_qty: float = 1,
 ) -> None:
-    """Deduct linked-ingredient inventory for one order line modifier (POS + mesa tab)."""
+    """Deduct inventory for one order line modifier (all option types). Issue #1121."""
+    from app.services.modifier_option_service import resolve_modifier_ingredient_lines
+
     modifier_id = modifier.get("id")
     modifier_name = modifier.get("name", "Modificador")
     if not modifier_id:
         return
 
-    modifier_ingredient = await conn.fetchrow(
-        """
-        SELECT
-            m.ingredient_id,
-            m.ingredient_quantity,
-            m.ingredient_unit,
-            i.name as ingredient_name,
-            i.controla_inventario
-        FROM modifiers m
-        LEFT JOIN ingredients i ON m.ingredient_id = i.id
-        WHERE m.id = $1 AND m.ingredient_id IS NOT NULL
-        """,
-        modifier_id,
+    ingredient_lines = await resolve_modifier_ingredient_lines(
+        conn, modifier_id, tenant_id
     )
-
-    if (
-        not modifier_ingredient
-        or not modifier_ingredient["ingredient_id"]
-        or not modifier_ingredient["ingredient_quantity"]
-    ):
+    if not ingredient_lines:
         return
 
-    resolved_mod_qty = await resolve_recipe_quantity_to_base_unit(
-        conn,
-        modifier_ingredient["ingredient_id"],
-        float(modifier_ingredient["ingredient_quantity"]),
-        modifier_ingredient["ingredient_unit"] or "",
-    )
-    total_deduction = float(item_quantity) * float(modifier_qty) * resolved_mod_qty
-
-    stock_row = await conn.fetchrow(
-        """
-        SELECT current_stock FROM tenant_inventory
-        WHERE ingredient_id = $1 AND tenant_id = $2
-        """,
-        modifier_ingredient["ingredient_id"],
-        tenant_id,
-    )
-
-    previous_stock = float(stock_row["current_stock"]) if stock_row else 0.0
-    new_stock = previous_stock - total_deduction
-
-    if stock_row:
-        await conn.execute(
-            """
-            UPDATE tenant_inventory
-            SET current_stock = $1, last_updated = NOW()
-            WHERE ingredient_id = $2 AND tenant_id = $3
-            """,
-            new_stock,
-            modifier_ingredient["ingredient_id"],
-            tenant_id,
+    for line in ingredient_lines:
+        total_deduction = (
+            float(item_quantity) * float(modifier_qty) * float(line["quantity"])
         )
-    else:
-        await conn.execute(
-            """
-            INSERT INTO tenant_inventory (
-                tenant_id, ingredient_id, current_stock, minimum_stock, last_updated
+
+        if line.get("controla_inventario") is not False:
+            stock_row = await conn.fetchrow(
+                """
+                SELECT current_stock FROM tenant_inventory
+                WHERE ingredient_id = $1 AND tenant_id = $2
+                """,
+                line["ingredient_id"],
+                tenant_id,
             )
-            VALUES ($1, $2, $3, 0, NOW())
-            """,
-            tenant_id,
-            modifier_ingredient["ingredient_id"],
-            -total_deduction,
+
+            previous_stock = float(stock_row["current_stock"]) if stock_row else 0.0
+            new_stock = previous_stock - total_deduction
+
+            if stock_row:
+                await conn.execute(
+                    """
+                    UPDATE tenant_inventory
+                    SET current_stock = $1, last_updated = NOW()
+                    WHERE ingredient_id = $2 AND tenant_id = $3
+                    """,
+                    new_stock,
+                    line["ingredient_id"],
+                    tenant_id,
+                )
+            else:
+                await conn.execute(
+                    """
+                    INSERT INTO tenant_inventory (
+                        tenant_id, ingredient_id, current_stock, minimum_stock, last_updated
+                    )
+                    VALUES ($1, $2, $3, 0, NOW())
+                    """,
+                    tenant_id,
+                    line["ingredient_id"],
+                    -total_deduction,
+                )
+
+            await conn.execute(
+                """
+                INSERT INTO tenant_ingredient_movements (
+                    tenant_id, ingredient_id, movement_type,
+                    quantity_change, unit, previous_stock, new_stock,
+                    reference_table, reference_id, reason, created_by, created_at
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW())
+                """,
+                tenant_id,
+                line["ingredient_id"],
+                "consumption",
+                -total_deduction,
+                line["unit"] or "und",
+                previous_stock,
+                new_stock,
+                "orders",
+                order_id,
+                f"Modificador {modifier_name} ({modifier_qty}x) - Orden #{order_number}",
+                user_id,
+            )
+
+            logger.info(
+                f"Modifier inventory deducted: {line['ingredient_name']} "
+                f"-{total_deduction}{line['unit']} "
+                f"(Modifier: {modifier_name}, Order #{order_number})"
+            )
+
+        await _capture_modifier_ingredient_line_snapshot(
+            conn,
+            order_item_id,
+            line,
+            modifier_id,
+            item_quantity,
+            float(modifier_qty),
+            str(tenant_id),
         )
+
+
+async def _capture_modifier_ingredient_line_snapshot(
+    conn,
+    order_item_id,
+    line: dict,
+    modifier_id,
+    item_quantity: float,
+    modifier_qty: float,
+    tenant_id: str,
+) -> None:
+    """
+    COGS snapshot for one exploded modifier ingredient line.
+    source_type = 'MODIFIER_RECIPE', source_id = modifier_id.
+    """
+    ingredient_id = line["ingredient_id"]
+    ingredient_id_str = str(ingredient_id)
+    prices = await _get_last_purchase_prices(conn, [ingredient_id_str], tenant_id)
+
+    quantity = float(line["quantity"]) * item_quantity * modifier_qty
+    unit_cost = prices.get(ingredient_id_str)
+    total_cost = quantity * unit_cost if unit_cost is not None else None
 
     await conn.execute(
         """
-        INSERT INTO tenant_ingredient_movements (
-            tenant_id, ingredient_id, movement_type,
-            quantity_change, unit, previous_stock, new_stock,
-            reference_table, reference_id, reason, created_by, created_at
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW())
-        """,
-        tenant_id,
-        modifier_ingredient["ingredient_id"],
-        "consumption",
-        -total_deduction,
-        modifier_ingredient["ingredient_unit"] or "und",
-        previous_stock,
-        new_stock,
-        "orders",
-        order_id,
-        f"Modificador {modifier_name} ({modifier_qty}x) - Orden #{order_number}",
-        user_id,
-    )
-
-    logger.info(
-        f"Modifier inventory deducted: {modifier_ingredient['ingredient_name']} "
-        f"-{total_deduction}{modifier_ingredient['ingredient_unit']} "
-        f"(Modifier: {modifier_name}, Order #{order_number})"
-    )
-
-    await _capture_modifier_ingredient_snapshot(
-        conn,
+        INSERT INTO order_item_ingredients (
+            order_item_id, ingredient_id, ingredient_name,
+            quantity, unit, unit_cost, total_cost,
+            source_type, source_id, created_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::uuid, NOW())
+        """
+        + _ORDER_ITEM_INGREDIENT_UPSERT,
         order_item_id,
-        modifier_ingredient,
-        modifier_id,
-        item_quantity,
-        float(modifier_qty),
-        str(tenant_id),
+        ingredient_id,
+        line["ingredient_name"],
+        quantity,
+        line.get("unit") or "und",
+        unit_cost,
+        total_cost,
+        "MODIFIER_RECIPE",
+        str(modifier_id),
     )
 
 
@@ -2581,47 +2630,30 @@ async def _capture_modifier_ingredient_snapshot(
     modifier_qty: float,
     tenant_id: str,
 ) -> None:
-    """
-    Insert a single ingredient snapshot for a modifier that has ingredient_id set.
-    source_type = 'MODIFIER_RECIPE', source_id = modifier_id.
-    Idempotent via ON CONFLICT (order_item_id, ingredient_id) DO NOTHING.
-    """
+    """Backward-compatible wrapper for single-ingredient modifier rows (tests)."""
     ing_qty = modifier_ingredient.get("ingredient_quantity")
     if not ing_qty:
         return
 
-    ingredient_id = modifier_ingredient["ingredient_id"]
-    ingredient_id_str = str(ingredient_id)
-    prices = await _get_last_purchase_prices(conn, [ingredient_id_str], tenant_id)
-
     resolved_ing_qty = await resolve_recipe_quantity_to_base_unit(
         conn,
-        ingredient_id,
+        modifier_ingredient["ingredient_id"],
         float(ing_qty),
         modifier_ingredient.get("ingredient_unit") or "",
     )
-    quantity = resolved_ing_qty * item_quantity * modifier_qty
-    unit_cost = prices.get(ingredient_id_str)
-    total_cost = quantity * unit_cost if unit_cost is not None else None
-
-    await conn.execute(
-        """
-        INSERT INTO order_item_ingredients (
-            order_item_id, ingredient_id, ingredient_name,
-            quantity, unit, unit_cost, total_cost,
-            source_type, source_id, created_at
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::uuid, NOW())
-        ON CONFLICT (order_item_id, ingredient_id) DO NOTHING
-        """,
+    await _capture_modifier_ingredient_line_snapshot(
+        conn,
         order_item_id,
-        ingredient_id,
-        modifier_ingredient["ingredient_name"],
-        quantity,
-        modifier_ingredient["ingredient_unit"] or "und",
-        unit_cost,
-        total_cost,
-        "MODIFIER_RECIPE",
-        str(modifier_id),
+        {
+            "ingredient_id": modifier_ingredient["ingredient_id"],
+            "quantity": resolved_ing_qty,
+            "unit": modifier_ingredient.get("ingredient_unit") or "und",
+            "ingredient_name": modifier_ingredient["ingredient_name"],
+        },
+        modifier_id,
+        item_quantity,
+        modifier_qty,
+        tenant_id,
     )
 
 

--- a/app/services/products_service.py
+++ b/app/services/products_service.py
@@ -491,28 +491,27 @@ async def get_product_by_id(
                         m.is_available,
                         m.is_default,
                         m.max_limit,
-                        m.sort_order
+                        m.sort_order,
+                        m.option_type,
+                        m.ingredient_id,
+                        m.ingredient_quantity,
+                        m.ingredient_unit,
+                        m.recipe_base_type_id,
+                        m.recipe_base_quantity,
+                        m.linked_product_id,
+                        m.linked_product_quantity
                     FROM modifiers m
                     WHERE m.modifier_group_id = ANY($1::uuid[])
                     ORDER BY m.sort_order, m.name
                 """
                 modifiers_rows = await connection.fetch(modifiers_query, group_ids)
 
-                # Group modifiers by modifier_group_id
                 modifiers_by_group = {}
                 for mod in modifiers_rows:
                     group_id = mod['modifier_group_id']
                     if group_id not in modifiers_by_group:
                         modifiers_by_group[group_id] = []
-                    modifiers_by_group[group_id].append({
-                        'id': mod['id'],
-                        'name': mod['name'],
-                        'price': mod['price'],
-                        'is_available': mod['is_available'],
-                        'is_default': mod['is_default'],
-                        'max_limit': mod['max_limit'],
-                        'sort_order': mod['sort_order']
-                    })
+                    modifiers_by_group[group_id].append(dict(mod))
 
                 # Build modifier groups with their modifiers
                 modifier_groups = []

--- a/migrations/083_modifier_option_types.sql
+++ b/migrations/083_modifier_option_types.sql
@@ -1,0 +1,22 @@
+-- Issue warocol.com#1121: Modifier option types (ingredient | recipe | product | none).
+--
+-- Existing rows with ingredient_id stay INGREDIENT; price-only rows become NONE.
+-- RECIPE uses recipe_base_type_id and/or modifier_recipes; PRODUCT uses linked_product_id.
+
+ALTER TABLE modifiers
+    ADD COLUMN IF NOT EXISTS option_type VARCHAR(20) NOT NULL DEFAULT 'INGREDIENT',
+    ADD COLUMN IF NOT EXISTS recipe_base_type_id UUID REFERENCES product_base_types(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS recipe_base_quantity NUMERIC(10, 4) NOT NULL DEFAULT 1,
+    ADD COLUMN IF NOT EXISTS linked_product_id UUID REFERENCES product(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS linked_product_quantity NUMERIC(10, 4) NOT NULL DEFAULT 1;
+
+ALTER TABLE modifiers DROP CONSTRAINT IF EXISTS check_modifier_option_type;
+ALTER TABLE modifiers ADD CONSTRAINT check_modifier_option_type
+    CHECK (option_type IN ('INGREDIENT', 'RECIPE', 'PRODUCT', 'NONE'));
+
+UPDATE modifiers
+SET option_type = 'NONE'
+WHERE ingredient_id IS NULL;
+
+COMMENT ON COLUMN modifiers.option_type IS
+    'INGREDIENT: ingredient_id/qty; RECIPE: recipe_base_type_id and/or modifier_recipes; PRODUCT: linked_product composition; NONE: price-only';

--- a/tests/test_modifier_option_types.py
+++ b/tests/test_modifier_option_types.py
@@ -1,0 +1,123 @@
+"""Modifier option types — validation and ingredient line resolution (#1121)."""
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.models.modifier import ModifierCreate, ModifierRecipeLineBase
+from app.services.modifier_option_service import (
+    validate_modifier_option_fields,
+    _merge_ingredient_lines,
+    calculated_modifier_option_unit_cost,
+    resolve_modifier_ingredient_lines,
+)
+
+
+def test_validate_ingredient_requires_ingredient_id():
+    mod = ModifierCreate(name="Extra", price=0, option_type="INGREDIENT")
+    with pytest.raises(ValueError, match="ingredient_id"):
+        validate_modifier_option_fields(mod)
+
+
+def test_validate_recipe_requires_composition():
+    mod = ModifierCreate(name="Salsa", price=0, option_type="RECIPE")
+    with pytest.raises(ValueError, match="recipe_base_type_id"):
+        validate_modifier_option_fields(mod)
+
+
+def test_validate_recipe_with_lines_ok():
+    mod = ModifierCreate(
+        name="Salsa",
+        price=0,
+        option_type="RECIPE",
+        recipe_lines=[
+            ModifierRecipeLineBase(
+                ingredient_id=uuid4(),
+                quantity=Decimal("10"),
+                unit="gr",
+            )
+        ],
+    )
+    validate_modifier_option_fields(mod)
+
+
+def test_validate_none_rejects_fks():
+    mod = ModifierCreate(
+        name="Sin inventario",
+        price=1000,
+        option_type="NONE",
+        ingredient_id=uuid4(),
+    )
+    with pytest.raises(ValueError, match="NONE"):
+        validate_modifier_option_fields(mod)
+
+
+def test_merge_ingredient_lines_sums_same_ingredient():
+    ing = uuid4()
+    merged = _merge_ingredient_lines(
+        [
+            {"ingredient_id": ing, "quantity": 10.0, "unit": "gr"},
+            {"ingredient_id": ing, "quantity": 5.0, "unit": "gr"},
+        ]
+    )
+    assert len(merged) == 1
+    assert merged[0]["quantity"] == 15.0
+
+
+@pytest.mark.asyncio
+async def test_resolve_ingredient_option_single_line():
+    modifier_id = uuid4()
+    tenant_id = uuid4()
+    ing_id = uuid4()
+
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(
+        return_value={
+            "id": modifier_id,
+            "option_type": "INGREDIENT",
+            "ingredient_id": ing_id,
+            "ingredient_quantity": Decimal("2"),
+            "ingredient_unit": "und",
+            "recipe_base_type_id": None,
+            "recipe_base_quantity": 1,
+            "linked_product_id": None,
+            "linked_product_quantity": 1,
+            "ingredient_name": "Queso",
+            "controla_inventario": True,
+        }
+    )
+    conn.fetch = AsyncMock(return_value=[])
+
+    with patch(
+        "app.services.modifier_option_service.resolve_recipe_quantity_to_base_unit",
+        new=AsyncMock(return_value=2.0),
+    ):
+        lines = await resolve_modifier_ingredient_lines(conn, modifier_id, tenant_id)
+
+    assert len(lines) == 1
+    assert lines[0]["ingredient_id"] == ing_id
+    assert lines[0]["quantity"] == 2.0
+
+
+@pytest.mark.asyncio
+async def test_calculated_cost_sums_line_costs():
+    modifier_id = uuid4()
+    tenant_id = uuid4()
+    ing_id = uuid4()
+
+    conn = AsyncMock()
+
+    async def fake_resolve(*_a, **_k):
+        return [{"ingredient_id": ing_id, "quantity": 3.0, "unit": "und", "ingredient_name": "X"}]
+
+    with patch(
+        "app.services.modifier_option_service.resolve_modifier_ingredient_lines",
+        new=fake_resolve,
+    ), patch(
+        "app.services.modifier_option_service._get_ingredient_unit_costs",
+        new=AsyncMock(return_value={str(ing_id): Decimal("10")}),
+    ):
+        cost = await calculated_modifier_option_unit_cost(conn, modifier_id, tenant_id)
+
+    assert cost == Decimal("30")


### PR DESCRIPTION
## Summary

- Adds `option_type` on modifiers (`INGREDIENT`, `RECIPE`, `PRODUCT`, `NONE`) with migration `083_modifier_option_types.sql`
- Extends `/menu/modifier-groups` CRUD to persist recipe base, `modifier_recipes` BOM, linked product, and embedded `unit_cost`
- Checkout uses `resolve_modifier_ingredient_lines` for multi-ingredient inventory + COGS snapshots (aggregates with product lines)

Closes uno0uno/warocol.com#1121

## Test plan

- [ ] Apply migration `083_modifier_option_types.sql` on staging
- [ ] `POST /menu/modifier-groups` with mixed option types (ingredient + recipe BOM + product)
- [ ] `GET /menu/modifier-groups/{id}` returns `option_type`, `unit_cost`, `recipe_lines`
- [ ] POS checkout with RECIPE modifier → multiple `order_item_ingredients` rows + inventory movements
- [ ] Existing ingredient-only modifiers unchanged (`option_type=INGREDIENT`)
- [x] `pytest tests/test_modifier_option_types.py tests/test_order_item_ingredient_snapshots.py`


Made with [Cursor](https://cursor.com)