### PR TITLE
chore(legal): adopt source-available proprietary terms

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+Describe the change and why it is needed.
+
+## Authorization
+
+- [ ] This change is authorized for WARO Colombia.
+- [ ] I have the right to submit this contribution.
+- [ ] This contribution does not include secrets, credentials, customer data,
+      tenant data, database dumps, production configuration, private keys,
+      certificates, or confidential third-party material.
+- [ ] I understand this repository is source-available proprietary software,
+      not open source.
+- [ ] I understand this contribution does not grant me ownership, equity,
+      royalties, revenue share, control rights, or any claim over WARO Colombia,
+      its product, repositories, or business.
+- [ ] I grant WARO Colombia the rights described in `LICENSE.md` and
+      `CONTRIBUTING.md`.
+
+## Verification
+
+Describe tests, migrations, screenshots, or manual checks performed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to WARO Colombia API
+
+Thank you for helping improve WARO Colombia.
+
+This repository is source-available proprietary software. It is not open source.
+Public access is provided for review, education, transparency, security research,
+interoperability, and authorized collaboration.
+
+## Contribution Terms
+
+By submitting any pull request, commit, patch, issue, comment, design,
+documentation, test, script, configuration, prompt, model, or other contribution,
+you agree that:
+
+- you have the legal right to submit the contribution;
+- your contribution does not include confidential information, third-party code,
+  customer data, secrets, credentials, production configuration, private keys,
+  database dumps, or materials you are not allowed to share;
+- WARO Colombia may use, modify, integrate, distribute, commercialize,
+  sublicense, relicense, and otherwise exploit your contribution in any WARO
+  Colombia product or service;
+- your contribution does not give you ownership, equity, royalties, revenue
+  share, voting rights, control rights, or any claim over WARO Colombia, the
+  product, the repositories, or the business; and
+- WARO Colombia may accept, reject, modify, remove, or relicense contributions
+  at its discretion.
+
+For material contributions, WARO Colombia may require a separate Contributor
+License Agreement, copyright assignment, contractor agreement, employment
+agreement, or confidentiality agreement before merging the work.
+
+## Pull Request Requirements
+
+Pull requests should:
+
+- describe the change and the reason for it;
+- avoid adding secrets, credentials, customer data, production configuration,
+  private business information, database dumps, or tenant data;
+- include tests or verification notes when relevant;
+- reference any related issue or authorization note; and
+- be approved and merged only by authorized WARO Colombia maintainers.
+
+## License
+
+All contributions are governed by the repository license unless a separate
+written agreement with WARO Colombia states otherwise.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,85 @@
+# WARO Colombia Source-Available Proprietary License
+
+Copyright (c) 2025-2026 WARO Colombia and its authorized owner(s).
+All rights reserved.
+
+This repository is made publicly visible for transparency, review, education,
+security research, interoperability, and authorized collaboration. Public
+visibility does not make this software open source and does not grant any
+license except the limited rights expressly stated below.
+
+## 1. Limited Permission
+
+You may:
+
+- view and read the source code;
+- clone the repository for private, non-commercial evaluation;
+- run the software locally for private review, testing, or contribution
+  preparation; and
+- submit issues, comments, and pull requests under the contribution terms in
+  this repository.
+
+## 2. Restrictions
+
+Unless WARO Colombia gives prior written permission, you may not:
+
+- use the software or any substantial part of it for commercial purposes;
+- provide, sell, rent, lease, sublicense, host, or operate the software as a
+  service for third parties;
+- deploy the software in production, publicly accessible environments, or
+  customer-facing environments;
+- copy, redistribute, publish, mirror, or package the software outside this
+  repository except for private evaluation;
+- create or distribute a competing product, fork, hosted service, or derivative
+  offering based on the software;
+- remove or alter copyright, trademark, attribution, or license notices;
+- use WARO Colombia names, brands, domains, logos, trade dress, customer data,
+  infrastructure, credentials, secrets, documentation, or reputation to imply
+  endorsement or official status; or
+- reverse engineer, extract, or reuse non-public business logic, datasets,
+  secrets, credentials, production configuration, or tenant information.
+
+## 3. Contributions
+
+By submitting a pull request, patch, commit, issue comment, design, document,
+test, configuration, prompt, model, script, or other contribution, you represent
+that you have the right to submit it and you grant WARO Colombia a perpetual,
+worldwide, irrevocable, royalty-free, sublicensable, transferable license to
+use, reproduce, modify, integrate, distribute, commercialize, sublicense,
+relicense, and otherwise exploit the contribution in any WARO Colombia product
+or service.
+
+No contribution creates employment, partnership, co-ownership, equity,
+royalties, revenue share, control rights, or any ownership interest in WARO
+Colombia, its software, its repositories, or its business unless a separate
+written agreement signed by WARO Colombia expressly says so.
+
+WARO Colombia may require a Contributor License Agreement, copyright assignment,
+work-for-hire agreement, contractor agreement, employment agreement, or
+confidentiality agreement before accepting contributions.
+
+## 4. Trademarks
+
+WARO Colombia, warocol.com, WaRo, logos, product names, domain names, and
+related brand assets are trademarks or trade identifiers of WARO Colombia or its
+authorized owner(s). This license does not grant trademark rights.
+
+## 5. Third-Party Software
+
+Third-party dependencies remain governed by their own licenses. Nothing in this
+license limits rights you may have under third-party licenses for code that is
+not owned by WARO Colombia.
+
+## 6. No Warranty
+
+The software is provided "as is", without warranty of any kind, express or
+implied, including warranties of merchantability, fitness for a particular
+purpose, title, and non-infringement. WARO Colombia is not liable for any claim,
+damage, loss, or liability arising from use, review, testing, or attempted use
+of the software.
+
+## 7. Commercial License
+
+Production use, commercial use, hosted use, white-label use, redistribution,
+or any use outside the limited permission above requires a separate written
+commercial license from WARO Colombia.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,19 @@
+# Notice
+
+WARO Colombia, warocol.com, and the WARO Colombia API are proprietary products
+and trade identifiers of WARO Colombia and/or its authorized owner(s).
+
+This repository is publicly visible as source-available proprietary software.
+It is not licensed as open source. No permission is granted to use this code in
+production, commercial services, hosted services, white-label offerings,
+competing products, public deployments, or third-party integrations outside the
+limited evaluation rights in `LICENSE.md` without a separate written commercial
+license from WARO Colombia.
+
+Do not publish secrets, credentials, tenant data, customer data, database dumps,
+private keys, certificates, production environment files, or infrastructure
+configuration in this repository.
+
+If you believe you need a commercial license, partnership agreement, API
+authorization, or written permission, contact WARO Colombia through the official
+channels at https://warocol.com.

--- a/README.md
+++ b/README.md
@@ -128,4 +128,15 @@ Commit the regenerated `dbdoc/` in the same PR as the migration.
 
 ## License
 
-Proprietary — [warocol.com](https://warocol.com)
+This repository is source-available proprietary software owned by WARO Colombia
+and/or its authorized owner(s). It is not open source.
+
+You may view, clone, and run the code privately for non-commercial evaluation,
+review, education, security research, interoperability, or authorized
+contribution preparation. Commercial use, production deployment, hosted use,
+redistribution, sublicensing, white-label use, competing products, public
+deployments, or third-party services require a separate written commercial
+license from WARO Colombia.
+
+See [`LICENSE.md`](LICENSE.md), [`NOTICE.md`](NOTICE.md), and
+[`CONTRIBUTING.md`](CONTRIBUTING.md).


### PR DESCRIPTION
## Summary
- Add a formal WARO Colombia source-available proprietary license
- Add CONTRIBUTING and NOTICE files clarifying contribution rights, sensitive-data restrictions, trademark restrictions, and commercial-use limits
- Add a PR template requiring contributor authorization and confirming no equity/royalty/ownership claim
- Update README license language to state this repository is not open source

## Verification
- Reviewed legal file diffs manually
- Checked for contradictory open-source language in README/legal files