### PR TITLE
feat(accounting): composite modifier COGS on edit and online orders (#1124)

### DIFF
--- a/app/services/online_orders_service.py
+++ b/app/services/online_orders_service.py
@@ -21,7 +21,10 @@ from app.services.comandas_service import fire_comandas
 # order_item_ingredients (per-line ingredient cost). Without this the COGS
 # GL entry posted right after deduction sums an empty table and skips,
 # leaving online sales out of CMV. Same function, same idempotency guarantees.
-from app.services.pos_cart_service import _capture_order_item_ingredients
+from app.services.pos_cart_service import (
+    _capture_order_item_ingredients,
+    _deduct_modifier_inventory_for_order_item,
+)
 import logging
 
 logger = logging.getLogger(__name__)
@@ -128,6 +131,33 @@ async def _deduct_stock_for_order(conn, order_id: UUID, tenant_id, changed_by) -
             logger.info(
                 f"Stock deducted (online order): {ingredient['ingredient_name']} "
                 f"-{quantity_to_deduct}{ingredient['unit']} (Order #{order_number})"
+            )
+
+        modifier_rows = await conn.fetch(
+            """
+            SELECT modifier_id, modifier_name, quantity
+            FROM order_item_modifiers
+            WHERE order_item_id = $1
+            """,
+            item["order_item_id"],
+        )
+        for mod in modifier_rows:
+            if not mod["modifier_id"]:
+                continue
+            modifier_qty = float(mod["quantity"]) if mod["quantity"] else 1.0
+            await _deduct_modifier_inventory_for_order_item(
+                conn,
+                tenant_id=tenant_id,
+                user_id=changed_by,
+                order_id=order_id,
+                order_item_id=item["order_item_id"],
+                order_number=order_number,
+                item_quantity=float(item["quantity"]),
+                modifier={
+                    "id": str(mod["modifier_id"]),
+                    "name": mod["modifier_name"],
+                },
+                modifier_qty=modifier_qty,
             )
 
 

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -33,6 +33,19 @@ def parse_date(date_str: Optional[str]) -> Optional[date]:
 
 logger = logging.getLogger(__name__)
 
+def _pos_modifier_inventory_helpers():
+    from app.services.pos_cart_service import (
+        _deduct_modifier_inventory_for_order_item,
+        return_modifier_inventory_for_order_item,
+        return_order_item_inventory_from_snapshots,
+    )
+    return (
+        _deduct_modifier_inventory_for_order_item,
+        return_modifier_inventory_for_order_item,
+        return_order_item_inventory_from_snapshots,
+    )
+
+
 
 POS_LIKE_FILTER = (
     "(pos_cart_id IS NOT NULL OR table_session_id IS NOT NULL "
@@ -2331,75 +2344,60 @@ async def delete_order_item(
                 item_quantity = float(item_row['quantity'])
                 product_name = item_row['product_name']
 
-                # 1. Return ingredients from product recipes + base recipes
-                ingredients_query = """
-                    -- Direct product ingredients
-                    SELECT
-                        pr.ingredient_id,
-                        pr.quantity,
-                        pr.unit,
-                        i.name as ingredient_name
-                    FROM product_recipes pr
-                    JOIN ingredients i ON pr.ingredient_id = i.id
-                    WHERE pr.product_id = $1
+                _, return_modifier_inventory_for_order_item, return_order_item_inventory_from_snapshots = _pos_modifier_inventory_helpers()
+                returned_from_snapshots = await return_order_item_inventory_from_snapshots(
+                    conn,
+                    tenant_id=tenant_id,
+                    user_id=user_id,
+                    order_id=order_id,
+                    order_number=order_number,
+                    order_item_id=item_id,
+                    reason_detail=f"Devolución por eliminación de {int(item_quantity)}x {product_name}",
+                )
 
-                    UNION ALL
-
-                    -- Ingredients from recipe bases (Issue #517: multiply by pbr.quantity)
-                    SELECT
-                        brt.ingredient_id,
-                        brt.base_quantity * pbr.quantity as quantity,
-                        brt.unit,
-                        i.name as ingredient_name
-                    FROM product_base_recipes pbr
-                    JOIN base_recipe_templates brt ON pbr.product_base_type_id = brt.product_base_type_id
-                    JOIN ingredients i ON brt.ingredient_id = i.id
-                    WHERE pbr.product_id = $1
-                """
-                ingredients = await conn.fetch(ingredients_query, product_id)
-
-                for ingredient in ingredients:
-                    quantity_to_return = item_quantity * float(ingredient['quantity'])
-                    await _return_ingredient_to_stock(
-                        conn, tenant_id, user_id, order_id, order_number,
-                        ingredient['ingredient_id'],
-                        quantity_to_return,
-                        ingredient['unit'],
-                        ingredient['ingredient_name'],
-                        f"Devolución por eliminación de {int(item_quantity)}x {product_name}"
-                    )
-
-                # 2. Return ingredients from modifiers
-                modifiers_query = """
-                    SELECT
-                        oim.modifier_id,
-                        oim.modifier_name,
-                        oim.quantity as modifier_qty,
-                        m.ingredient_id,
-                        m.ingredient_quantity,
-                        m.ingredient_unit,
-                        i.name as ingredient_name
-                    FROM order_item_modifiers oim
-                    LEFT JOIN modifiers m ON oim.modifier_id = m.id
-                    LEFT JOIN ingredients i ON m.ingredient_id = i.id
-                    WHERE oim.order_item_id = $1
-                """
-                modifiers = await conn.fetch(modifiers_query, item_id)
-
-                for modifier in modifiers:
-                    if modifier['ingredient_id'] and modifier['ingredient_quantity']:
-                        modifier_qty = float(modifier['modifier_qty']) if modifier['modifier_qty'] else 1.0
-                        quantity_to_return = item_quantity * modifier_qty * float(modifier['ingredient_quantity'])
+                if not returned_from_snapshots:
+                    ingredients = await conn.fetch(_INGREDIENTS_QUERY, product_id)
+                    for ingredient in ingredients:
+                        quantity_to_return = item_quantity * float(ingredient['quantity'])
                         await _return_ingredient_to_stock(
                             conn, tenant_id, user_id, order_id, order_number,
-                            modifier['ingredient_id'],
+                            ingredient['ingredient_id'],
                             quantity_to_return,
-                            modifier['ingredient_unit'] or 'und',
-                            modifier['ingredient_name'],
-                            f"Devolución modificador {modifier['modifier_name']} de {product_name}"
+                            ingredient['unit'],
+                            ingredient['ingredient_name'],
+                            f"Devolución por eliminación de {int(item_quantity)}x {product_name}",
                         )
 
-                # 3. Delete associated modifiers (foreign key constraint)
+                    modifiers = await conn.fetch(
+                        """
+                        SELECT
+                            oim.modifier_id,
+                            oim.modifier_name,
+                            oim.quantity AS modifier_qty
+                        FROM order_item_modifiers oim
+                        WHERE oim.order_item_id = $1
+                        """,
+                        item_id,
+                    )
+                    for modifier in modifiers:
+                        if not modifier['modifier_id']:
+                            continue
+                        modifier_qty = float(modifier['modifier_qty']) if modifier['modifier_qty'] else 1.0
+                        await return_modifier_inventory_for_order_item(
+                            conn,
+                            tenant_id=tenant_id,
+                            user_id=user_id,
+                            order_id=order_id,
+                            order_number=order_number,
+                            order_item_id=item_id,
+                            item_quantity=item_quantity,
+                            modifier_id=modifier['modifier_id'],
+                            modifier_qty=modifier_qty,
+                            modifier_name=modifier['modifier_name'],
+                            product_name=product_name,
+                        )
+
+                # Delete associated modifiers (foreign key constraint)
                 await conn.execute(
                     "DELETE FROM order_item_modifiers WHERE order_item_id = $1",
                     item_id
@@ -2658,19 +2656,22 @@ async def delete_order_item_modifier(
                     raise APIError("Modifier not found", status_code=404)
 
                 modifier_name = modifier_row['modifier_name']
+                modifier_qty = float(modifier_row['modifier_qty']) if modifier_row['modifier_qty'] else 1.0
 
-                # Return ingredient to stock if modifier has linked ingredient
-                if modifier_row['ingredient_id'] and modifier_row['ingredient_quantity']:
-                    modifier_qty = float(modifier_row['modifier_qty']) if modifier_row['modifier_qty'] else 1.0
-                    quantity_to_return = item_quantity * modifier_qty * float(modifier_row['ingredient_quantity'])
-
-                    await _return_ingredient_to_stock(
-                        conn, tenant_id, user_id, order_id, order_number,
-                        modifier_row['ingredient_id'],
-                        quantity_to_return,
-                        modifier_row['ingredient_unit'] or 'und',
-                        modifier_row['ingredient_name'],
-                        f"Devolución modificador {modifier_name} de {product_name}"
+                _, return_modifier_inventory_for_order_item, _ = _pos_modifier_inventory_helpers()
+                if modifier_row['original_modifier_id']:
+                    await return_modifier_inventory_for_order_item(
+                        conn,
+                        tenant_id=tenant_id,
+                        user_id=user_id,
+                        order_id=order_id,
+                        order_number=order_number,
+                        order_item_id=item_id,
+                        item_quantity=item_quantity,
+                        modifier_id=modifier_row['original_modifier_id'],
+                        modifier_qty=modifier_qty,
+                        modifier_name=modifier_name,
+                        product_name=product_name,
                     )
 
                 # Delete the modifier
@@ -3031,6 +3032,8 @@ async def create_manual_order(
 
                 order_id = order_row["id"]
 
+                deduct_modifier_inventory, _, _ = _pos_modifier_inventory_helpers()
+
                 for item in items:
                     modifiers = item.get("modifiers", [])
                     modifiers_total = sum(float(m.get("price", 0)) for m in modifiers)
@@ -3066,62 +3069,20 @@ async def create_manual_order(
                             float(modifier.get("price", 0))
                         )
 
-                        # Deduct inventory for modifier ingredient (if linked)
-                        modifier_ingredient = await conn.fetchrow(
-                            """
-                            SELECT
-                                m.ingredient_id,
-                                m.ingredient_quantity,
-                                m.ingredient_unit,
-                                i.name AS ingredient_name
-                            FROM modifiers m
-                            LEFT JOIN ingredients i ON m.ingredient_id = i.id
-                            WHERE m.id = $1 AND m.ingredient_id IS NOT NULL
-                            """,
-                            UUID(modifier["id"])
+                        await deduct_modifier_inventory(
+                            conn,
+                            tenant_id=tenant_id,
+                            user_id=user_id,
+                            order_id=order_id,
+                            order_item_id=order_item_id,
+                            order_number=order_row["order_number"],
+                            item_quantity=float(item["quantity"]),
+                            modifier={
+                                "id": modifier["id"],
+                                "name": modifier["name"],
+                            },
+                            modifier_qty=1.0,
                         )
-
-                        if modifier_ingredient and modifier_ingredient["ingredient_id"] and modifier_ingredient["ingredient_quantity"]:
-                            total_deduction = float(item["quantity"]) * float(modifier_ingredient["ingredient_quantity"])
-                            stock_row = await conn.fetchrow(
-                                "SELECT current_stock FROM tenant_inventory WHERE ingredient_id = $1 AND tenant_id = $2",
-                                modifier_ingredient["ingredient_id"],
-                                tenant_id
-                            )
-                            previous_stock = float(stock_row["current_stock"]) if stock_row else 0.0
-                            new_stock = previous_stock - total_deduction
-
-                            if stock_row:
-                                await conn.execute(
-                                    "UPDATE tenant_inventory SET current_stock = $1, last_updated = NOW() WHERE ingredient_id = $2 AND tenant_id = $3",
-                                    new_stock, modifier_ingredient["ingredient_id"], tenant_id
-                                )
-                            else:
-                                await conn.execute(
-                                    "INSERT INTO tenant_inventory (tenant_id, ingredient_id, current_stock, minimum_stock, last_updated) VALUES ($1, $2, $3, 0, NOW())",
-                                    tenant_id, modifier_ingredient["ingredient_id"], -total_deduction
-                                )
-
-                            await conn.execute(
-                                """
-                                INSERT INTO tenant_ingredient_movements (
-                                    tenant_id, ingredient_id, movement_type,
-                                    quantity_change, unit, previous_stock, new_stock,
-                                    reference_table, reference_id, reason, created_by, created_at
-                                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW())
-                                """,
-                                tenant_id,
-                                modifier_ingredient["ingredient_id"],
-                                "consumption",
-                                -total_deduction,
-                                modifier_ingredient["ingredient_unit"] or "und",
-                                previous_stock,
-                                new_stock,
-                                "orders",
-                                order_id,
-                                f"Modificador {modifier['name']} - Orden #{order_row['order_number']}",
-                                user_id
-                            )
 
                     # Deduct inventory for product ingredients (direct + base recipes)
                     ingredients = await conn.fetch(

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -2657,6 +2657,155 @@ async def _capture_modifier_ingredient_snapshot(
     )
 
 
+async def _subtract_order_item_ingredient_snapshot(
+    conn,
+    order_item_id,
+    ingredient_id,
+    quantity: float,
+) -> None:
+    """Reduce or remove a COGS snapshot row after returning modifier stock."""
+    row = await conn.fetchrow(
+        """
+        SELECT quantity, unit_cost
+        FROM order_item_ingredients
+        WHERE order_item_id = $1 AND ingredient_id = $2
+        """,
+        order_item_id,
+        ingredient_id,
+    )
+    if not row:
+        return
+
+    new_qty = float(row["quantity"] or 0) - quantity
+    if new_qty <= 0:
+        await conn.execute(
+            """
+            DELETE FROM order_item_ingredients
+            WHERE order_item_id = $1 AND ingredient_id = $2
+            """,
+            order_item_id,
+            ingredient_id,
+        )
+        return
+
+    unit_cost = row["unit_cost"]
+    total_cost = new_qty * float(unit_cost) if unit_cost is not None else None
+    await conn.execute(
+        """
+        UPDATE order_item_ingredients
+        SET quantity = $3,
+            total_cost = $4
+        WHERE order_item_id = $1 AND ingredient_id = $2
+        """,
+        order_item_id,
+        ingredient_id,
+        new_qty,
+        total_cost,
+    )
+
+
+async def return_order_item_inventory_from_snapshots(
+    conn,
+    *,
+    tenant_id,
+    user_id,
+    order_id,
+    order_number: int,
+    order_item_id,
+    reason_detail: str,
+) -> bool:
+    """
+    Return stock from order_item_ingredients and delete snapshot rows.
+    Returns True when snapshots existed (caller may skip legacy recipe returns).
+    """
+    from app.services.orders_service import _return_ingredient_to_stock
+
+    snapshots = await conn.fetch(
+        """
+        SELECT ingredient_id, ingredient_name, quantity, unit
+        FROM order_item_ingredients
+        WHERE order_item_id = $1
+        """,
+        order_item_id,
+    )
+    if not snapshots:
+        return False
+
+    for snap in snapshots:
+        qty = float(snap["quantity"] or 0)
+        if qty <= 0:
+            continue
+        await _return_ingredient_to_stock(
+            conn,
+            tenant_id,
+            user_id,
+            order_id,
+            order_number,
+            snap["ingredient_id"],
+            qty,
+            snap["unit"] or "und",
+            snap["ingredient_name"],
+            reason_detail,
+        )
+
+    await conn.execute(
+        "DELETE FROM order_item_ingredients WHERE order_item_id = $1",
+        order_item_id,
+    )
+    return True
+
+
+async def return_modifier_inventory_for_order_item(
+    conn,
+    *,
+    tenant_id,
+    user_id,
+    order_id,
+    order_number: int,
+    order_item_id,
+    item_quantity: float,
+    modifier_id,
+    modifier_qty: float,
+    modifier_name: str,
+    product_name: str,
+) -> None:
+    """Reverse composite modifier consumption and adjust COGS snapshots."""
+    from app.services.modifier_option_service import resolve_modifier_ingredient_lines
+    from app.services.orders_service import _return_ingredient_to_stock
+
+    ingredient_lines = await resolve_modifier_ingredient_lines(
+        conn, modifier_id, tenant_id
+    )
+    if not ingredient_lines:
+        return
+
+    for line in ingredient_lines:
+        qty = float(item_quantity) * float(modifier_qty) * float(line["quantity"])
+        if qty <= 0:
+            continue
+
+        if line.get("controla_inventario") is not False:
+            await _return_ingredient_to_stock(
+                conn,
+                tenant_id,
+                user_id,
+                order_id,
+                order_number,
+                line["ingredient_id"],
+                qty,
+                line.get("unit") or "und",
+                line["ingredient_name"],
+                f"Devolución modificador {modifier_name} de {product_name}",
+            )
+
+        await _subtract_order_item_ingredient_snapshot(
+            conn,
+            order_item_id,
+            line["ingredient_id"],
+            qty,
+        )
+
+
 async def fire_pos_cart(request: Request, cart_id: UUID) -> dict:
     """
     Explicitly fire all 'new' items in a POS cart to the kitchen stations.

--- a/tests/test_order_modifier_cogs.py
+++ b/tests/test_order_modifier_cogs.py
@@ -1,0 +1,118 @@
+"""Sale edit + COGS paths for composite modifier options (#1124)."""
+from datetime import date
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services import pos_cart_service
+from app.services.cierre_service import _post_order_cogs_gl_entry
+
+ORDER_ITEM_ID = uuid4()
+MODIFIER_ID = uuid4()
+ING_A = uuid4()
+ING_B = uuid4()
+TENANT_ID = uuid4()
+ORDER_ID = uuid4()
+USER_ID = uuid4()
+
+
+@pytest.mark.asyncio
+async def test_subtract_snapshot_deletes_row_when_quantity_zero():
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(return_value={"quantity": 50.0, "unit_cost": 2.0})
+    mock_conn.execute = AsyncMock()
+
+    await pos_cart_service._subtract_order_item_ingredient_snapshot(
+        mock_conn, ORDER_ITEM_ID, ING_A, 50.0
+    )
+
+    sql = mock_conn.execute.await_args.args[0]
+    assert "DELETE FROM order_item_ingredients" in sql
+
+
+@pytest.mark.asyncio
+async def test_subtract_snapshot_reduces_quantity_and_total_cost():
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(return_value={"quantity": 100.0, "unit_cost": 3.0})
+    mock_conn.execute = AsyncMock()
+
+    await pos_cart_service._subtract_order_item_ingredient_snapshot(
+        mock_conn, ORDER_ITEM_ID, ING_A, 40.0
+    )
+
+    sql = mock_conn.execute.await_args.args[0]
+    assert "UPDATE order_item_ingredients" in sql
+    assert mock_conn.execute.await_args.args[3] == pytest.approx(60.0)
+    assert mock_conn.execute.await_args.args[4] == pytest.approx(180.0)
+
+
+@pytest.mark.asyncio
+async def test_return_modifier_inventory_reverses_composite_lines():
+    mock_conn = AsyncMock()
+    lines = [
+        {
+            "ingredient_id": ING_A,
+            "quantity": 10.0,
+            "unit": "gr",
+            "ingredient_name": "Queso",
+            "controla_inventario": True,
+        },
+        {
+            "ingredient_id": ING_B,
+            "quantity": 5.0,
+            "unit": "gr",
+            "ingredient_name": "Tocineta",
+            "controla_inventario": True,
+        },
+    ]
+
+    with patch(
+        "app.services.modifier_option_service.resolve_modifier_ingredient_lines",
+        new=AsyncMock(return_value=lines),
+    ), patch(
+        "app.services.orders_service._return_ingredient_to_stock",
+        new=AsyncMock(),
+    ) as mock_return, patch.object(
+        pos_cart_service,
+        "_subtract_order_item_ingredient_snapshot",
+        new=AsyncMock(),
+    ) as mock_subtract:
+        await pos_cart_service.return_modifier_inventory_for_order_item(
+            mock_conn,
+            tenant_id=TENANT_ID,
+            user_id=USER_ID,
+            order_id=ORDER_ID,
+            order_number=42,
+            order_item_id=ORDER_ITEM_ID,
+            item_quantity=2.0,
+            modifier_id=MODIFIER_ID,
+            modifier_qty=1.0,
+            modifier_name="Extra",
+            product_name="Hamburguesa",
+        )
+
+    assert mock_return.await_count == 2
+    assert mock_subtract.await_count == 2
+    first_return_qty = mock_return.await_args_list[0].args[6]
+    assert first_return_qty == pytest.approx(20.0)
+
+
+@pytest.mark.asyncio
+async def test_cogs_gl_query_sums_order_item_ingredients():
+    mock_conn = AsyncMock()
+    mock_conn.fetchval = AsyncMock(side_effect=[None, 2500.0])
+    mock_conn.fetchrow = AsyncMock(return_value=None)
+
+    await _post_order_cogs_gl_entry(
+        mock_conn,
+        TENANT_ID,
+        ORDER_ID,
+        date(2026, 6, 2),
+        order_number=99,
+    )
+
+    cogs_query = mock_conn.fetchval.await_args_list[1].args[0]
+    assert "order_item_ingredients" in cogs_query
+    assert "SUM(oii.total_cost)" in cogs_query
+    assert mock_conn.fetchval.await_args_list[1].args[1] == ORDER_ID


### PR DESCRIPTION
## Summary

- Add shared snapshot reversal helpers in `pos_cart_service` for sale edits
- Wire `orders_service` delete item/modifier + manual order creation to composite modifier explosion
- Wire `online_orders_service` order acceptance to deduct modifiers and write COGS snapshots
- Add unit tests for snapshot subtraction and COGS query path

Revenue PUC (4175) unchanged — modifier prices already live in `order_items.subtotal`/`net_total`. COGS (6135/1435) picks up composite modifier cost via existing `orden_cogs` sum over `order_item_ingredients`.

## Test plan

- [ ] POS sale with RECIPE modifier (2+ ingredients) → `order_item_ingredients` rows + `orden_cogs` journal
- [ ] POS sale with PRODUCT modifier → inventory movements + COGS snapshots
- [ ] Edit sale: remove modifier → stock returned, snapshots reduced/deleted
- [ ] Online order accept with modifiers → modifier snapshots before COGS GL
- [x] `pytest tests/test_order_modifier_cogs.py tests/test_order_item_ingredient_snapshots.py tests/test_modifier_option_types.py`

Refs uno0uno/warocol.com#1124

Made with [Cursor](https://cursor.com)