### PR TITLE
feat(pos): tab line edit gate with bitácora audit

### DIFF
--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -64,6 +64,18 @@ class UpdateTabItemRequest(BaseModel):
     )
 
 
+class TabItemContentModifier(BaseModel):
+    id: Optional[str] = None
+    name: str
+    price: float = Field(..., ge=0)
+    quantity: int = Field(1, ge=1)
+
+
+class UpdateTabItemContentRequest(BaseModel):
+    modifiers: List[TabItemContentModifier] = Field(default_factory=list)
+    notes: Optional[str] = None
+
+
 class TableQrToggleRequest(BaseModel):
     enabled: bool
 
@@ -327,6 +339,42 @@ async def update_tab_item_quantity(request: Request, table_id: UUID, order_item_
     """Update the quantity of an order item in the running tab."""
     return await tables_service.update_tab_item_quantity(
         request, table_id, order_item_id, body.quantity, body.reason,
+    )
+
+
+@router.get(
+    "/{table_id}/tab/items/{order_item_id}/edit-eligibility",
+    dependencies=[Depends(require_module(Module.POS))],
+)
+async def tab_item_edit_eligibility(
+    request: Request,
+    table_id: UUID,
+    order_item_id: UUID,
+    record_attempt: bool = Query(False, description="Record bitácora when edit is blocked"),
+):
+    """Whether tab line modifiers/notes can be edited (kitchen-acceptance gate, #1151)."""
+    return await tables_service.get_tab_item_edit_eligibility(
+        request, table_id, order_item_id, record_attempt=record_attempt,
+    )
+
+
+@router.patch(
+    "/{table_id}/tab/items/{order_item_id}/content",
+    dependencies=[Depends(require_module(Module.POS))],
+)
+async def update_tab_item_content(
+    request: Request,
+    table_id: UUID,
+    order_item_id: UUID,
+    body: UpdateTabItemContentRequest,
+):
+    """Replace modifiers and notes on a tab line (#1151)."""
+    modifiers = [
+        {"id": m.id, "name": m.name, "price": m.price, "quantity": m.quantity}
+        for m in body.modifiers
+    ]
+    return await tables_service.update_tab_item_content(
+        request, table_id, order_item_id, modifiers, body.notes,
     )
 
 

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -2228,6 +2228,301 @@ def _tab_item_requires_remove_reason(
     return comanda_item_row is not None
 
 
+_TAB_ITEM_EDIT_BLOCKED_FULFILLMENT = frozenset({"preparing", "ready", "cancelled"})
+_TAB_ITEM_EDIT_BLOCKED_COMANDA = frozenset({"preparing", "ready", "delivered", "cancelled"})
+
+_FULFILLMENT_LABELS = {
+    "new": "Sin enviar",
+    "sent": "En cocina",
+    "preparing": "Preparando",
+    "ready": "Listo",
+    "cancelled": "Cancelado",
+}
+
+
+def _tab_item_edit_block_reason(
+    fulfillment_status: Optional[str],
+    comanda_status: Optional[str] = None,
+) -> Optional[str]:
+    """Return human-readable block reason, or None if tab line content edit is allowed (#1151)."""
+    status = fulfillment_status or "new"
+    if status in _TAB_ITEM_EDIT_BLOCKED_FULFILLMENT:
+        label = _FULFILLMENT_LABELS.get(status, status)
+        return (
+            f"La cocina ya aceptó este ítem (estado: {label}). "
+            "No se pueden cambiar modificadores ni notas."
+        )
+    if comanda_status and comanda_status in _TAB_ITEM_EDIT_BLOCKED_COMANDA:
+        return (
+            "La cocina ya aceptó este ítem en comanda. "
+            "No se pueden cambiar modificadores ni notas."
+        )
+    return None
+
+
+async def _fetch_tab_item_comanda_context(conn, order_item_id: UUID) -> Optional[Any]:
+    return await conn.fetchrow(
+        """
+        SELECT ci.id AS comanda_item_id, ci.status AS comanda_item_status,
+               c.id AS comanda_id, c.status AS comanda_status
+        FROM comanda_items ci
+        JOIN comandas c ON c.id = ci.comanda_id
+        WHERE ci.order_item_id = $1
+          AND ci.status <> 'cancelled'
+        ORDER BY c.created_at DESC
+        LIMIT 1
+        """,
+        order_item_id,
+    )
+
+
+async def _fetch_open_tab_item_row(
+    conn, order_item_id: UUID, table_id: UUID, tenant_id: UUID,
+) -> Optional[Any]:
+    return await conn.fetchrow(
+        """
+        SELECT
+            oi.id, oi.product_id, oi.quantity, oi.price_at_purchase,
+            oi.subtotal, oi.notes, oi.fulfillment_status,
+            o.id AS order_id, o.total_amount, o.order_number,
+            p.name AS product_name,
+            t.name AS table_name,
+            t.is_bar,
+            ts.id AS table_session_id,
+            COALESCE(ts.attended_by_member_id, t.assigned_member_id)
+                AS effective_waiter_member_id
+        FROM order_items oi
+        JOIN orders o ON o.id = oi.order_id
+        JOIN table_sessions ts ON ts.id = o.table_session_id
+        JOIN tables t ON t.id = ts.table_id
+        JOIN product p ON p.id = oi.product_id
+        WHERE oi.id = $1
+          AND ts.table_id = $2
+          AND ts.tenant_id = $3
+          AND ts.closed_at IS NULL
+        """,
+        order_item_id, table_id, tenant_id,
+    )
+
+
+async def get_tab_item_edit_eligibility(
+    request: Request,
+    table_id: UUID,
+    order_item_id: UUID,
+    *,
+    record_attempt: bool = False,
+) -> dict:
+    """Check whether tab line content edit is allowed; optionally audit blocked attempts."""
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+    user_id = session_context.user_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    async with get_db_connection(use_transaction=True) as conn:
+        row = await _fetch_open_tab_item_row(conn, order_item_id, table_id, tenant_id)
+        if not row:
+            raise NotFoundError("Order item not found or session already closed")
+
+        comanda_ctx = await _fetch_tab_item_comanda_context(conn, order_item_id)
+        comanda_status = comanda_ctx["comanda_status"] if comanda_ctx else None
+        block_reason = _tab_item_edit_block_reason(row["fulfillment_status"], comanda_status)
+        fulfillment_status = row["fulfillment_status"] or "new"
+
+        if block_reason and record_attempt:
+            tab_ctx = {
+                "channel": "barra" if row["is_bar"] else "mesa",
+                "table_name": row["table_name"],
+                "table_session_id": row["table_session_id"],
+                "effective_waiter_member_id": row["effective_waiter_member_id"],
+            }
+            await _record_tab_operation_event(
+                conn,
+                tenant_id,
+                user_id=user_id,
+                table_id=table_id,
+                tab_ctx=tab_ctx,
+                action="tab_item_edit_blocked",
+                order_id=row["order_id"],
+                order_item_id=order_item_id,
+                comanda_item_id=comanda_ctx["comanda_item_id"] if comanda_ctx else None,
+                payload={
+                    "product_name": row["product_name"],
+                    "fulfillment_status": fulfillment_status,
+                    "comanda_status": comanda_status,
+                },
+            )
+
+        if block_reason:
+            raise APIError(
+                block_reason,
+                status_code=409,
+                details={
+                    "code": "TAB_ITEM_EDIT_KITCHEN_ACCEPTED",
+                    "fulfillment_status": fulfillment_status,
+                    "comanda_status": comanda_status,
+                },
+            )
+
+        return {
+            "success": True,
+            "data": {
+                "allowed": True,
+                "fulfillment_status": fulfillment_status,
+                "comanda_status": comanda_status,
+            },
+        }
+
+
+async def update_tab_item_content(
+    request: Request,
+    table_id: UUID,
+    order_item_id: UUID,
+    modifiers: List[dict],
+    notes: Optional[str],
+) -> dict:
+    """Replace modifiers and notes on a tab line when kitchen has not accepted yet (#1151)."""
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+    user_id = session_context.user_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    async with get_db_connection(use_transaction=True) as conn:
+        row = await _fetch_open_tab_item_row(conn, order_item_id, table_id, tenant_id)
+        if not row:
+            raise NotFoundError("Order item not found or session already closed")
+
+        comanda_ctx = await _fetch_tab_item_comanda_context(conn, order_item_id)
+        comanda_status = comanda_ctx["comanda_status"] if comanda_ctx else None
+        block_reason = _tab_item_edit_block_reason(row["fulfillment_status"], comanda_status)
+        if block_reason:
+            raise APIError(
+                block_reason,
+                status_code=409,
+                details={
+                    "code": "TAB_ITEM_EDIT_KITCHEN_ACCEPTED",
+                    "fulfillment_status": row["fulfillment_status"] or "new",
+                    "comanda_status": comanda_status,
+                },
+            )
+
+        old_modifiers = await _fetch_order_item_modifiers(conn, order_item_id)
+        old_notes = row["notes"]
+        quantity = float(row["quantity"])
+
+        await conn.execute(
+            "DELETE FROM order_item_modifiers WHERE order_item_id = $1",
+            order_item_id,
+        )
+        modifier_sum = 0.0
+        for mod in modifiers or []:
+            mod_qty = float(mod.get("quantity") or 1)
+            mod_price = float(mod.get("price") or 0)
+            modifier_sum += mod_price * mod_qty
+            mod_id = mod.get("id")
+            await conn.execute(
+                """
+                INSERT INTO order_item_modifiers (
+                    order_item_id, modifier_id, modifier_name, price_at_purchase, quantity
+                )
+                VALUES ($1, $2, $3, $4, $5)
+                """,
+                order_item_id,
+                mod_id,
+                mod.get("name"),
+                mod_price,
+                mod_qty,
+            )
+
+        normalized_notes = (notes or "").strip() or None
+        effective_unit_price = float(row["price_at_purchase"]) + modifier_sum
+        new_subtotal = effective_unit_price * quantity
+        old_subtotal = float(row["subtotal"])
+
+        await conn.execute(
+            """
+            UPDATE order_items
+            SET notes = $1, subtotal = $2
+            WHERE id = $3
+            """,
+            normalized_notes,
+            new_subtotal,
+            order_item_id,
+        )
+        new_total = max(0.0, float(row["total_amount"]) - old_subtotal + new_subtotal)
+        await conn.execute(
+            "UPDATE orders SET total_amount = $1 WHERE id = $2",
+            new_total,
+            row["order_id"],
+        )
+
+        if comanda_ctx and comanda_status == "pending":
+            snapshot = [
+                {
+                    "name": m.get("name"),
+                    "price": float(m.get("price") or 0),
+                    "quantity": int(m.get("quantity") or 1),
+                }
+                for m in (modifiers or [])
+            ]
+            await conn.execute(
+                """
+                UPDATE comanda_items
+                SET modifiers_snapshot = $1::jsonb, notes = $2
+                WHERE id = $3
+                """,
+                json.dumps(snapshot) if snapshot else None,
+                normalized_notes,
+                comanda_ctx["comanda_item_id"],
+            )
+
+        new_modifiers = await _fetch_order_item_modifiers(conn, order_item_id)
+        tab_ctx = {
+            "channel": "barra" if row["is_bar"] else "mesa",
+            "table_name": row["table_name"],
+            "table_session_id": row["table_session_id"],
+            "effective_waiter_member_id": row["effective_waiter_member_id"],
+        }
+        payload = _build_tab_item_payload(
+            product_id=row["product_id"],
+            product_name=row["product_name"],
+            quantity=quantity,
+            unit_price=row["price_at_purchase"],
+            subtotal=new_subtotal,
+            modifiers=new_modifiers,
+            notes=normalized_notes,
+            table_id=table_id,
+            table_name=row["table_name"],
+            order_number=row["order_number"],
+        )
+        payload["previous_modifiers"] = old_modifiers
+        payload["previous_notes"] = old_notes
+
+        await _record_tab_operation_event(
+            conn,
+            tenant_id,
+            user_id=user_id,
+            table_id=table_id,
+            tab_ctx=tab_ctx,
+            action="tab_item_edited",
+            order_id=row["order_id"],
+            order_item_id=order_item_id,
+            comanda_item_id=comanda_ctx["comanda_item_id"] if comanda_ctx else None,
+            payload=payload,
+        )
+
+        return {
+            "success": True,
+            "data": {
+                "order_item_id": str(order_item_id),
+                "subtotal": new_subtotal,
+                "notes": normalized_notes,
+                "modifiers": new_modifiers,
+            },
+        }
+
+
 def _normalize_audit_reason(reason: Optional[str]) -> Optional[str]:
     normalized = (reason or "").strip()
     return normalized or None

--- a/tests/test_tables_tab_item_edit.py
+++ b/tests/test_tables_tab_item_edit.py
@@ -1,0 +1,85 @@
+"""Tab line content edit gate (#1151)."""
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.exceptions import APIError
+from app.services import tables_service
+
+
+def test_tab_item_edit_block_reason_preparing():
+    reason = tables_service._tab_item_edit_block_reason("preparing", None)
+    assert reason is not None
+    assert "Preparando" in reason
+
+
+def test_tab_item_edit_block_reason_sent_pending_comanda():
+    assert tables_service._tab_item_edit_block_reason("sent", "pending") is None
+
+
+def test_tab_item_edit_block_reason_new():
+    assert tables_service._tab_item_edit_block_reason("new", None) is None
+
+
+@pytest.mark.asyncio
+async def test_get_tab_item_edit_eligibility_blocked_records_attempt():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    order_item_id = uuid4()
+    order_id = uuid4()
+
+    row = {
+        "id": order_item_id,
+        "product_id": uuid4(),
+        "quantity": 1,
+        "price_at_purchase": 10.0,
+        "subtotal": 10.0,
+        "notes": None,
+        "fulfillment_status": "preparing",
+        "order_id": order_id,
+        "total_amount": 10.0,
+        "order_number": 1,
+        "product_name": "Tomate",
+        "table_name": "Mesa 1",
+        "is_bar": False,
+        "table_session_id": uuid4(),
+        "effective_waiter_member_id": None,
+    }
+    comanda_ctx = {
+        "comanda_item_id": uuid4(),
+        "comanda_item_status": "pending",
+        "comanda_id": uuid4(),
+        "comanda_status": "preparing",
+    }
+
+    mock_conn = AsyncMock()
+    record_mock = AsyncMock()
+
+    request = AsyncMock()
+
+    with patch(
+        "app.services.tables_service.require_valid_session",
+        return_value=AsyncMock(tenant_id=tenant_id, user_id=user_id),
+    ), patch(
+        "app.services.tables_service.get_db_connection",
+    ) as conn_ctx, patch(
+        "app.services.tables_service._fetch_open_tab_item_row",
+        new=AsyncMock(return_value=row),
+    ), patch(
+        "app.services.tables_service._fetch_tab_item_comanda_context",
+        new=AsyncMock(return_value=comanda_ctx),
+    ), patch(
+        "app.services.tables_service._record_tab_operation_event",
+        record_mock,
+    ):
+        conn_ctx.return_value.__aenter__.return_value = mock_conn
+        with pytest.raises(APIError) as exc:
+            await tables_service.get_tab_item_edit_eligibility(
+                request, table_id, order_item_id, record_attempt=True,
+            )
+        assert exc.value.status_code == 409
+        assert exc.value.details.get("code") == "TAB_ITEM_EDIT_KITCHEN_ACCEPTED"
+        record_mock.assert_awaited_once()
+        assert record_mock.call_args.kwargs["action"] == "tab_item_edit_blocked"


### PR DESCRIPTION
## Summary
- Add `GET .../edit-eligibility` with optional `record_attempt` for blocked-edit bitácora
- Add `PATCH .../content` to update tab line modifiers/notes with kitchen-acceptance gate
- Emit `tab_item_edited` / `tab_item_edit_blocked` audit events

Closes uno0uno/warocol.com#1151

## Test plan
- [x] `venv/bin/pytest tests/test_tables_tab_item_edit.py -q`
- [ ] Edit tab line before kitchen accepts → PATCH succeeds + bitácora
- [ ] Edit after `preparing` → 409 `TAB_ITEM_EDIT_KITCHEN_ACCEPTED`

## wr-context
See `.wr/1151.yaml` on branch (local gitignore).

Made with [Cursor](https://cursor.com)