### PR TITLE
Preserve mesa promo snapshots after promo window

### DIFF
--- a/.wr/1167.yaml
+++ b/.wr/1167.yaml
@@ -1,0 +1,44 @@
+issue: 1167
+title: "Fix promo preservation when closing mesa after promo window"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-1167-preserve-mesa-promos
+
+paths:
+  - app/services/promotions_service.py
+  - app/services/tables_service.py
+  - tests/test_tables_tab_promo_persist.py
+
+ac:
+  - Promo persisted on mesa/tab line inside schedule remains applied when mesa closes after schedule expires.
+  - Lines added outside the promo window do not receive an expired promo retroactively.
+  - promo_opt_out still prevents/purges promo application for that line.
+  - Existing active promo, BOGO, cart/tab, comanda, receipt/breakdown behavior is not degraded.
+  - Validate DB shape with API .env psql tunnel variables without destructive production writes.
+
+out_of_scope:
+  - Redesigning promo conflict/priority rules.
+  - Recalculating historical orders.
+  - Destructive data migrations or production data changes.
+
+hints:
+  entry: "app/services/tables_service.py close_session and current mesa session promo summary"
+  pattern: "app/services/promotions_service.py persist_session_tab_promos already persists applied_promotion_id/promo_savings_allocated"
+  tests: "pytest tests/test_tables_tab_promo_persist.py"
+
+risk:
+  sensitive: false
+  areas:
+    - "POS mesa close totals"
+    - "order_items promo persistence"
+    - "promotion schedule evaluation"
+
+skip:
+  audits:
+    - "No broad frontend audit; symptom maps to API persistence/re-evaluation."
+    - "No schema migration unless DB validation proves columns are missing."
+
+next:
+  after_pr: "none"

--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -1289,9 +1289,11 @@ def _allocate_bogo_savings_cheapest_first(
 
 def evaluate_cart_promotions(
     lines: Sequence[Dict[str, Any]],
-    promotions: Sequence[Dict[str, Any]],
+    promotions: Optional[Sequence[Dict[str, Any]]] = None,
     *,
     promo_type_block_map: Optional[Dict[str, Any]] = None,
+    preserve_persisted_promos: bool = False,
+    promos: Optional[Sequence[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """
     Evaluate active promotions against checkout lines.
@@ -1299,6 +1301,9 @@ def evaluate_cart_promotions(
     Each input line needs: id, product_id, category_id (optional), quantity, subtotal.
     Returns authoritative promo savings and per-line breakdown (batch #982).
     """
+    if promotions is None:
+        promotions = promos or []
+
     evaluated_lines: List[Dict[str, Any]] = []
     breakdown_by_id: Dict[str, Dict[str, Any]] = {}
     total_promo_savings = 0
@@ -1317,8 +1322,20 @@ def evaluate_cart_promotions(
         subtotal = float(line["subtotal"])
         original_subtotal += subtotal
 
+        persisted_promo_id = line.get("applied_promotion_id")
+        persisted_savings = round(float(line.get("promo_savings_allocated") or 0))
+        persisted_promo: Optional[Dict[str, Any]] = None
+        if preserve_persisted_promos and persisted_promo_id and persisted_savings > 0:
+            persisted_promo = {
+                "id": persisted_promo_id,
+                "name": line.get("promotion_name") or "Promoción",
+                "promo_type": line.get("promo_type") or line.get("promotion_type") or "",
+            }
+
         if line.get("promo_opt_out"):
             promo = None
+        elif persisted_promo is not None:
+            promo = persisted_promo
         else:
             promo = _pick_best_promotion_for_line(
                 promotions,
@@ -1335,9 +1352,18 @@ def evaluate_cart_promotions(
             "category_id": category_id,
             "subtotal": subtotal,
             "promo": promo,
+            "persisted_promo_savings": (
+                persisted_savings
+                if persisted_promo is not None and promo is persisted_promo
+                else None
+            ),
         })
 
-        if promo is not None and promo["promo_type"] == "bogo":
+        if (
+            promo is not None
+            and promo["promo_type"] == "bogo"
+            and persisted_promo is None
+        ):
             group_key = (str(product_id), str(promo["id"]))
             bogo_group_indices.setdefault(group_key, []).append(idx)
 
@@ -1361,6 +1387,13 @@ def evaluate_cart_promotions(
     for state in pending:
         line_id = state["line_id"]
         promo = state["promo"]
+        persisted_promo_savings = state.get("persisted_promo_savings")
+        if persisted_promo_savings is not None:
+            savings_by_line_id[line_id] = min(
+                round(float(persisted_promo_savings)),
+                round(float(state["subtotal"])),
+            )
+            continue
         if promo is None:
             savings_by_line_id.setdefault(line_id, 0)
             continue
@@ -1562,6 +1595,7 @@ async def evaluate_checkout_promotions(
     manual_discount_amount: float = 0,
     discount_type: Optional[str] = None,
     discount_value: Optional[float] = None,
+    preserve_persisted_promos: bool = False,
 ) -> Dict[str, Any]:
     """DB-backed promo evaluation + optional manual discount stacking."""
     evaluation_at = at or default_at_bogota()
@@ -1581,6 +1615,7 @@ async def evaluate_checkout_promotions(
         lines,
         promotions,
         promo_type_block_map=type_block_map,
+        preserve_persisted_promos=preserve_persisted_promos,
     )
     manual_discount = float(manual_discount_amount or 0)
     if discount_type and discount_value is not None and discount_value > 0:
@@ -1609,11 +1644,14 @@ def promo_persist_fields_from_eval_line(
 
 _SESSION_PENDING_PROMO_ITEMS_SQL = """
     SELECT oi.id, oi.subtotal, oi.quantity, oi.product_id, oi.promo_opt_out,
+           oi.applied_promotion_id, oi.promo_savings_allocated,
+           tp.name AS promotion_name, tp.promo_type,
            p.category_id,
            COALESCE(p.tax_category, 'standard') AS tax_category
     FROM order_items oi
     JOIN orders o ON o.id = oi.order_id
     JOIN product p ON p.id = oi.product_id
+    LEFT JOIN tenant_promotions tp ON tp.id = oi.applied_promotion_id
     WHERE o.table_session_id = $1 AND o.status = 'pending'
 """
 
@@ -1629,6 +1667,16 @@ def item_rows_to_promo_lines(item_rows: Sequence[Any]) -> List[Dict[str, Any]]:
             "subtotal": float(row["subtotal"]),
             "tax_category": row["tax_category"] or "standard",
             "promo_opt_out": bool(row.get("promo_opt_out")),
+            "applied_promotion_id": (
+                str(row["applied_promotion_id"])
+                if row.get("applied_promotion_id") else None
+            ),
+            "promo_savings_allocated": (
+                float(row["promo_savings_allocated"] or 0)
+                if row.get("promo_savings_allocated") is not None else 0
+            ),
+            "promotion_name": row.get("promotion_name"),
+            "promo_type": row.get("promo_type"),
         }
         for row in item_rows
     ]

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -932,11 +932,14 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                     item_rows = await conn.fetch(
                         """
                         SELECT oi.id, oi.subtotal, oi.quantity, oi.product_id, oi.promo_opt_out,
+                               oi.applied_promotion_id, oi.promo_savings_allocated,
+                               tp.name AS promotion_name, tp.promo_type,
                                p.category_id,
                                COALESCE(p.tax_category, 'standard') AS tax_category
                         FROM order_items oi
                         JOIN orders o ON o.id = oi.order_id
                         JOIN product p ON p.id = oi.product_id
+                        LEFT JOIN tenant_promotions tp ON tp.id = oi.applied_promotion_id
                         WHERE o.table_session_id = $1 AND o.status = 'pending'
                         """,
                         session_row["id"],
@@ -950,6 +953,10 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                             "subtotal": float(row["subtotal"]),
                             "tax_category": row["tax_category"] or "standard",
                             "promo_opt_out": bool(row.get("promo_opt_out")),
+                            "applied_promotion_id": str(row["applied_promotion_id"]) if row.get("applied_promotion_id") else None,
+                            "promo_savings_allocated": float(row["promo_savings_allocated"] or 0) if row.get("promo_savings_allocated") is not None else 0,
+                            "promotion_name": row.get("promotion_name"),
+                            "promo_type": row.get("promo_type"),
                         }
                         for row in item_rows
                     ]
@@ -959,6 +966,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                         promo_lines,
                         discount_type=discount_type,
                         discount_value=discount_value,
+                        preserve_persisted_promos=True,
                     )
                     from app.services.waros_service import (
                         apply_checkout_waro_redemption,
@@ -1872,11 +1880,16 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                             oi.subtotal,
                             oi.product_id,
                             oi.promo_opt_out,
+                            oi.applied_promotion_id,
+                            oi.promo_savings_allocated,
+                            tp.name AS promotion_name,
+                            tp.promo_type,
                             p.category_id,
                             COALESCE(p.tax_category, 'standard') AS tax_category
                         FROM order_items oi
                         JOIN orders o ON o.id = oi.order_id
                         JOIN product p ON p.id = oi.product_id
+                        LEFT JOIN tenant_promotions tp ON tp.id = oi.applied_promotion_id
                         WHERE o.id = ANY($1::uuid[])
                         """,
                         order_ids,
@@ -1890,6 +1903,10 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                             "subtotal": float(row["subtotal"]),
                             "tax_category": row["tax_category"] or "standard",
                             "promo_opt_out": bool(row.get("promo_opt_out")),
+                            "applied_promotion_id": str(row["applied_promotion_id"]) if row.get("applied_promotion_id") else None,
+                            "promo_savings_allocated": float(row["promo_savings_allocated"] or 0) if row.get("promo_savings_allocated") is not None else 0,
+                            "promotion_name": row.get("promotion_name"),
+                            "promo_type": row.get("promo_type"),
                         }
                         for row in eval_rows
                     ]
@@ -1897,6 +1914,7 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                         conn,
                         UUID(str(tenant_id)),
                         promo_lines,
+                        preserve_persisted_promos=True,
                     )
                     _promo_savings = float(checkout_eval.get("promo_savings") or 0)
                     _subtotal_after_promos = float(checkout_eval.get("subtotal_after_promos") or 0)

--- a/tests/test_tables_tab_promo_persist.py
+++ b/tests/test_tables_tab_promo_persist.py
@@ -101,6 +101,82 @@ def test_bogo_wins_over_percent_on_tab_line():
     assert result["promo_savings"] == 10000
 
 
+def test_preserve_persisted_promo_when_no_active_promos():
+    promo_id = uuid4()
+    product_id = uuid4()
+    lines = [{
+        "id": str(uuid4()),
+        "product_id": str(product_id),
+        "category_id": None,
+        "quantity": 2,
+        "subtotal": 20000,
+        "applied_promotion_id": str(promo_id),
+        "promo_savings_allocated": 10000,
+        "promotion_name": "Rebel and Rebel 2x1",
+        "promo_type": "bogo",
+    }]
+
+    result = evaluate_cart_promotions(
+        lines,
+        [],
+        preserve_persisted_promos=True,
+    )
+
+    assert result["promo_savings"] == 10000
+    assert result["subtotal_after_promos"] == 10000
+    assert result["lines"][0]["promotion_id"] == str(promo_id)
+    assert result["lines"][0]["promotion_name"] == "Rebel and Rebel 2x1"
+    assert result["promo_breakdown"][0]["promotion_name"] == "Rebel and Rebel 2x1"
+
+
+def test_line_without_persisted_promo_does_not_get_expired_promo():
+    product_id = uuid4()
+    lines = [{
+        "id": str(uuid4()),
+        "product_id": str(product_id),
+        "category_id": None,
+        "quantity": 2,
+        "subtotal": 20000,
+    }]
+
+    result = evaluate_cart_promotions(
+        lines,
+        [],
+        preserve_persisted_promos=True,
+    )
+
+    assert result["promo_savings"] == 0
+    assert result["subtotal_after_promos"] == 20000
+    assert "promotion_id" not in result["lines"][0]
+
+
+def test_promo_opt_out_ignores_persisted_promo_snapshot():
+    promo_id = uuid4()
+    product_id = uuid4()
+    lines = [{
+        "id": str(uuid4()),
+        "product_id": str(product_id),
+        "category_id": None,
+        "quantity": 2,
+        "subtotal": 20000,
+        "promo_opt_out": True,
+        "applied_promotion_id": str(promo_id),
+        "promo_savings_allocated": 10000,
+        "promotion_name": "Rebel and Rebel 2x1",
+        "promo_type": "bogo",
+    }]
+
+    result = evaluate_cart_promotions(
+        lines,
+        [],
+        preserve_persisted_promos=True,
+    )
+
+    assert result["promo_savings"] == 0
+    assert result["subtotal_after_promos"] == 20000
+    assert "promotion_id" not in result["lines"][0]
+
+
 @pytest.mark.asyncio
 async def test_apply_promo_eval_to_order_items_updates_rows():
     item_id = uuid4()


### PR DESCRIPTION
## Summary

- Preserve already-persisted mesa/tab promotion snapshots when previewing or closing a mesa after the promo schedule window expires.
- Keep normal active-promo evaluation unchanged by default, so new lines outside the promo window do not receive expired promos.
- Carry persisted promo metadata from `order_items` through mesa preview/close evaluation and keep `promo_opt_out` authoritative.
- Add focused tests for preserved BOGO snapshots, expired/no-snapshot lines, opt-out, cart promo evaluation, and existing tab promo persistence.

## Validation

- `pytest tests/test_tables_tab_promo_persist.py`
- `pytest tests/test_promo_cart_evaluation.py tests/test_promo_line_opt_out.py tests/test_tables_tab_promo_persist.py`
- `python3 -m py_compile app/services/promotions_service.py app/services/tables_service.py tests/test_tables_tab_promo_persist.py`
- DB read-only validation via API `.env` `DATABASE_URL` on local tunnel (`localhost:5432`): confirmed `order_items` has `applied_promotion_id`, `promo_savings_allocated`, `discount_allocated`, `net_total`, and `promo_opt_out`.

Observed existing warning: Pydantic `model_settings` protected namespace warning during pytest.

Closes uno0uno/warocol.com#1167
