### PR TITLE
Add modifier required-state filtering

### DIFF
--- a/app/routers/modifiers.py
+++ b/app/routers/modifiers.py
@@ -38,11 +38,12 @@ async def get_modifier_groups(
     page: int = Query(1, ge=1),
     limit: int = Query(50, ge=1, le=250),
     search: Optional[str] = Query(None),
-    product_id: Optional[UUID] = Query(None)
+    product_id: Optional[UUID] = Query(None),
+    is_required: Optional[bool] = Query(None)
 ):
     """Get list of modifier groups with pagination and filters"""
     return await modifiers_service.get_modifier_groups_list(
-        request, response, page, limit, search, product_id
+        request, response, page, limit, search, product_id, is_required
     )
 
 

--- a/app/services/modifiers_service.py
+++ b/app/services/modifiers_service.py
@@ -376,7 +376,8 @@ async def get_modifier_groups_list(
     page: int = 1,
     limit: int = 50,
     search: Optional[str] = None,
-    product_id: Optional[UUID] = None
+    product_id: Optional[UUID] = None,
+    is_required: Optional[bool] = None
 ) -> ModifierGroupsListResponse:
     """Get list of modifier groups with filters. Now supports multiple products per group."""
     try:
@@ -427,6 +428,12 @@ async def get_modifier_groups_list(
                 base_query += f" AND pmg.product_id = ${param_count}"
                 count_query += f" AND pmg.product_id = ${param_count}"
                 params.append(product_id)
+                param_count += 1
+
+            if is_required is not None:
+                base_query += f" AND mg.is_required = ${param_count}"
+                count_query += f" AND mg.is_required = ${param_count}"
+                params.append(is_required)
                 param_count += 1
 
             # Add pagination

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -55,6 +55,18 @@ class TestModifierGroupsListEndpoint:
         assert response.status_code in [200, 401, 403, 500]
 
     @pytest.mark.asyncio
+    async def test_get_modifier_groups_filter_required(self, client: AsyncClient):
+        """Test modifier groups filtered by required state"""
+        response = await client.get("/menu/modifier-groups?is_required=true")
+        assert response.status_code in [200, 401, 403, 500]
+
+    @pytest.mark.asyncio
+    async def test_get_modifier_groups_filter_optional(self, client: AsyncClient):
+        """Test modifier groups filtered by optional state"""
+        response = await client.get("/menu/modifier-groups?is_required=false")
+        assert response.status_code in [200, 401, 403, 500]
+
+    @pytest.mark.asyncio
     async def test_get_modifier_groups_invalid_page(self, client: AsyncClient):
         """Test modifier groups with invalid page"""
         response = await client.get("/menu/modifier-groups?page=0")


### PR DESCRIPTION
## Summary
- Adds `is_required` as an optional query param for modifier group listing.
- Applies required-state filtering to both data and count SQL so pagination totals stay truthful.
- Adds focused endpoint coverage for `is_required=true` and `is_required=false`.

## Validation
- `pytest tests/test_modifiers.py tests/test_recipe_bases.py`

## Related
- Companion frontend issue: uno0uno/warocol.com#1235