### PR TITLE
Support stock category and unit filters

### DIFF
--- a/app/routers/inventory.py
+++ b/app/routers/inventory.py
@@ -19,6 +19,8 @@ async def get_inventory_stock(
     offset: int = Query(0, ge=0, description="Number of items to skip"),
     search: Optional[str] = Query(None, description="Search by ingredient name"),
     status_filter: Optional[str] = Query('all', description="Filter by status: low, critical, ok, all"),
+    category: Optional[str] = Query(None, description="Filter by ingredient category"),
+    unit: Optional[str] = Query(None, description="Filter by ingredient unit"),
     sort_field: str = Query("current_stock", description="Field to sort by"),
     sort_direction: str = Query("desc", description="Sort direction: asc, desc")
 ):
@@ -38,6 +40,8 @@ async def get_inventory_stock(
         offset=offset,
         search=search,
         status_filter=status_filter,
+        category=category,
+        unit=unit,
         sort_field=sort_field,
         sort_direction=sort_direction
     )

--- a/app/services/inventory_service.py
+++ b/app/services/inventory_service.py
@@ -20,6 +20,8 @@ async def get_inventory_stock(
     offset: int = 0,
     search: Optional[str] = None,
     status_filter: Optional[str] = None,  # 'low', 'critical', 'ok', 'all'
+    category: Optional[str] = None,
+    unit: Optional[str] = None,
     sort_field: str = "current_stock",
     sort_direction: str = "desc"
 ) -> Dict[str, Any]:
@@ -33,6 +35,8 @@ async def get_inventory_stock(
         offset: Number of records to skip
         search: Search term for ingredient name
         status_filter: Filter by stock status (low, critical, ok, all)
+        category: Filter by ingredient category
+        unit: Filter by ingredient unit
         sort_field: Field to sort by
         sort_direction: Sort direction (asc, desc)
 
@@ -122,6 +126,18 @@ async def get_inventory_stock(
                     base_query += " AND ti.current_stock > ti.minimum_stock"
                     count_query += " AND ti.current_stock > ti.minimum_stock"
 
+            if category:
+                base_query += f" AND i.category = ${param_count}"
+                count_query += f" AND i.category = ${param_count}"
+                params.append(category)
+                param_count += 1
+
+            if unit:
+                base_query += f" AND i.unit = ${param_count}"
+                count_query += f" AND i.unit = ${param_count}"
+                params.append(unit)
+                param_count += 1
+
             # Add sorting
             valid_sort_fields = {
                 'ingredient_name': 'i.name',
@@ -157,6 +173,33 @@ async def get_inventory_stock(
             """
             stats = await conn.fetchrow(stats_query, tenant_id)
 
+            filter_options_query = """
+                SELECT
+                    COALESCE((
+                        SELECT ARRAY_AGG(category ORDER BY category)
+                        FROM (
+                            SELECT DISTINCT i.category
+                            FROM tenant_inventory ti
+                            JOIN ingredients i ON ti.ingredient_id = i.id
+                            WHERE ti.tenant_id = $1
+                              AND ti.current_stock != 0
+                              AND i.category IS NOT NULL
+                        ) categories
+                    ), ARRAY[]::text[]) AS categories,
+                    COALESCE((
+                        SELECT ARRAY_AGG(unit ORDER BY unit)
+                        FROM (
+                            SELECT DISTINCT i.unit
+                            FROM tenant_inventory ti
+                            JOIN ingredients i ON ti.ingredient_id = i.id
+                            WHERE ti.tenant_id = $1
+                              AND ti.current_stock != 0
+                              AND i.unit IS NOT NULL
+                        ) units
+                    ), ARRAY[]::text[]) AS units
+            """
+            filter_options = await conn.fetchrow(filter_options_query, tenant_id)
+
             # Format inventory data
             inventory_list = []
             for row in inventory_data:
@@ -191,6 +234,10 @@ async def get_inventory_stock(
                     "low_stock_count": stats['low_stock_count'],
                     "ok_count": stats['ok_count'],
                     "total_inventory_value": float(stats['total_inventory_value']) if stats['total_inventory_value'] else 0
+                },
+                "filter_options": {
+                    "categories": list(filter_options['categories'] or []),
+                    "units": list(filter_options['units'] or [])
                 }
             }
 

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -44,6 +44,24 @@ class TestInventoryStockEndpoint:
         assert response.status_code in [200, 401, 403, 500]
 
     @pytest.mark.asyncio
+    async def test_get_inventory_stock_filter_category(self, client: AsyncClient):
+        """Test inventory stock filtered by category"""
+        response = await client.get("/inventory/stock?category=Verduras")
+        assert response.status_code in [200, 401, 403, 500]
+
+    @pytest.mark.asyncio
+    async def test_get_inventory_stock_filter_unit(self, client: AsyncClient):
+        """Test inventory stock filtered by unit"""
+        response = await client.get("/inventory/stock?unit=gr")
+        assert response.status_code in [200, 401, 403, 500]
+
+    @pytest.mark.asyncio
+    async def test_get_inventory_stock_filter_category_unit_and_status(self, client: AsyncClient):
+        """Test inventory stock combining backend filters"""
+        response = await client.get("/inventory/stock?category=Verduras&unit=gr&status_filter=low")
+        assert response.status_code in [200, 401, 403, 500]
+
+    @pytest.mark.asyncio
     async def test_get_inventory_stock_filter_low(self, client: AsyncClient):
         """Test inventory stock filtered by status=low"""
         response = await client.get("/inventory/stock?status_filter=low")


### PR DESCRIPTION
## Summary

- Adds `category` and `unit` query params to `GET /inventory/stock`.
- Applies category/unit filters to both stock row and count queries so pagination totals stay aligned.
- Returns pagination-safe `filter_options.categories` and `filter_options.units` metadata from unpaginated tenant stock rows.
- Adds targeted inventory endpoint coverage for category, unit, and composed filters.

## Validation

- `pytest tests/test_inventory.py` — 22 passed
- `python3 -m py_compile app/routers/inventory.py app/services/inventory_service.py tests/test_inventory.py`

## Manual validation route

- `/abastecimiento/stock`

Supports uno0uno/warocol.com#1236.
