### PR TITLE
Add inventory movement direction filter

### DIFF
--- a/app/routers/inventory.py
+++ b/app/routers/inventory.py
@@ -3,7 +3,7 @@ Inventory Router
 Endpoints for inventory management and stock tracking
 """
 from fastapi import APIRouter, Depends, Request, Response, Query
-from typing import Optional
+from typing import Literal, Optional
 from uuid import UUID
 from app.core.permissions import Module, require_module
 from app.services import inventory_service
@@ -55,6 +55,7 @@ async def get_inventory_movements(
     offset: int = Query(0, ge=0, description="Number of items to skip"),
     ingredient_id: Optional[UUID] = Query(None, description="Filter by ingredient ID"),
     movement_type: Optional[str] = Query(None, description="Filter by movement type: purchase, consumption, adjustment, loss, transfer, return"),
+    quantity_direction: Optional[Literal["positive", "negative"]] = Query(None, description="Filter by quantity direction: positive, negative"),
     start_date: Optional[str] = Query(None, description="Filter by start date (ISO format)"),
     end_date: Optional[str] = Query(None, description="Filter by end date (ISO format)")
 ):
@@ -74,6 +75,7 @@ async def get_inventory_movements(
         offset=offset,
         ingredient_id=ingredient_id,
         movement_type=movement_type,
+        quantity_direction=quantity_direction,
         start_date=start_date,
         end_date=end_date
     )

--- a/app/services/inventory_service.py
+++ b/app/services/inventory_service.py
@@ -255,6 +255,7 @@ async def get_inventory_movements(
     offset: int = 0,
     ingredient_id: Optional[UUID] = None,
     movement_type: Optional[str] = None,  # 'purchase', 'consumption', 'adjustment', etc.
+    quantity_direction: Optional[str] = None,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None
 ) -> Dict[str, Any]:
@@ -268,6 +269,7 @@ async def get_inventory_movements(
         offset: Number of records to skip
         ingredient_id: Filter by specific ingredient
         movement_type: Filter by movement type
+        quantity_direction: Filter by quantity sign ('positive' or 'negative')
         start_date: Filter by start date
         end_date: Filter by end date
 
@@ -336,6 +338,13 @@ async def get_inventory_movements(
                 count_query += f" AND tim.movement_type = ${param_count}"
                 params.append(movement_type)
                 param_count += 1
+
+            if quantity_direction == "positive":
+                base_query += " AND tim.quantity_change >= 0"
+                count_query += " AND tim.quantity_change >= 0"
+            elif quantity_direction == "negative":
+                base_query += " AND tim.quantity_change < 0"
+                count_query += " AND tim.quantity_change < 0"
 
             if start_date:
                 base_query += f" AND tim.created_at >= ${param_count}::timestamp"

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -124,6 +124,22 @@ class TestInventoryMovementsEndpoint:
         assert response.status_code in [200, 401, 403, 500]
 
     @pytest.mark.asyncio
+    async def test_get_inventory_movements_filter_by_positive_direction(self, client: AsyncClient):
+        """Test inventory movements filtered by positive quantity direction"""
+        response = await client.get(
+            "/inventory/movements?movement_type=adjustment&quantity_direction=positive"
+        )
+        assert response.status_code in [200, 401, 403, 500]
+
+    @pytest.mark.asyncio
+    async def test_get_inventory_movements_filter_by_negative_direction(self, client: AsyncClient):
+        """Test inventory movements filtered by negative quantity direction"""
+        response = await client.get(
+            "/inventory/movements?movement_type=adjustment&quantity_direction=negative"
+        )
+        assert response.status_code in [200, 401, 403, 500]
+
+    @pytest.mark.asyncio
     async def test_get_inventory_movements_filter_by_date(self, client: AsyncClient):
         """Test inventory movements filtered by date range"""
         response = await client.get(


### PR DESCRIPTION
## Summary
- Add `quantity_direction=positive|negative` to `/inventory/movements`
- Apply direction filtering to both movement data and count queries
- Add targeted inventory endpoint coverage for positive and negative adjustment direction

## Validation
- `.venv-ship/bin/pytest tests/test_inventory.py -q` passed, 24 tests

Refs uno0uno/warocol.com#1237