### PR TITLE
Align POS receipt liquor tax rate

### DIFF
--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -2211,7 +2211,8 @@ async def complete_pos_order(
                         _standard_tax_label = f"IVA {pct}%"
 
                     if tax_config.get('liquor_tax_applicable') and liq_subtotal > 0:
-                        _liquor_tax = round(liq_subtotal * 0.05)
+                        liq_rate = float(tax_config.get('liquor_tax_rate') or 0.05)
+                        _liquor_tax = round(liq_subtotal * liq_rate)
                 except Exception as e:
                     logger.warning(f"Tax breakdown computation failed for order {order_id}: {e}")
 


### PR DESCRIPTION
## Summary
- Use tenant configured liquor tax rate when returning POS receipt tax breakdown
- Keep the existing 5% fallback when the rate is unset

## Validation
- python3 -m py_compile app/services/pos_cart_service.py
- rg targeted tax breakdown checks

Refs uno0uno/warocol.com#397