### PR TITLE
Fix Bogota date filter for open tables

### DIFF
--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -941,7 +941,7 @@ def _build_open_tables_filter(
     """
     Open tables (closed_at IS NULL applied by caller).
 
-    Date-only: opened on a calendar day in [period_start, period_end].
+    Date-only: opened on a Bogota calendar day in [period_start, period_end].
     Shift window: session started on or before shift end (still-open tables
     that began before the shift still block the close).
     """
@@ -951,8 +951,8 @@ def _build_open_tables_filter(
     p2 = f"${param_offset}"
     p3 = f"${param_offset + 1}"
     sql = (
-        f"AND ts.opened_at::date >= {p2} "
-        f"AND ts.opened_at::date <= {p3}"
+        f"AND (ts.opened_at AT TIME ZONE 'America/Bogota')::date >= {p2} "
+        f"AND (ts.opened_at AT TIME ZONE 'America/Bogota')::date <= {p3}"
     )
     return sql, [period_start, period_end]
 

--- a/tests/test_cierre_shift_filters.py
+++ b/tests/test_cierre_shift_filters.py
@@ -50,11 +50,12 @@ def test_expense_filter_shift_uses_created_at():
     assert params == [start, end]
 
 
-def test_open_tables_filter_date_only_uses_opened_at_date():
+def test_open_tables_filter_date_only_uses_bogota_dates():
     sql, params = _build_open_tables_filter(
         date(2026, 5, 18), date(2026, 5, 18), None, None
     )
-    assert "opened_at::date" in sql
+    assert "AT TIME ZONE 'America/Bogota'" in sql
+    assert "opened_at::date" not in sql
     assert params == [date(2026, 5, 18), date(2026, 5, 18)]
 
 


### PR DESCRIPTION
## Summary
- Update date-only open-table cierre filtering to use the America/Bogota calendar date instead of the DB/server date.
- Keep shift-window behavior and bar-table exclusion unchanged.
- Update the focused cierre filter test to lock the Bogota timezone behavior.

## Validation
- `pytest tests/test_cierre_shift_filters.py`

Closes #397
