### PR TITLE
Reject ambiguous cierre shift closes

### DIFF
--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -996,6 +996,25 @@ def _requires_open_shift(
     return False
 
 
+def _is_day_only_cierre_request(
+    shift_template_id: Optional[UUID],
+    period_start_time: Optional[datetime],
+    period_end_time: Optional[datetime],
+) -> bool:
+    return not shift_template_id and not period_start_time and not period_end_time
+
+
+def _open_shift_has_explicit_window(open_shift) -> bool:
+    return bool(
+        open_shift
+        and (
+            open_shift["shift_template_id"]
+            or open_shift["period_start_time"]
+            or open_shift["period_end_time"]
+        )
+    )
+
+
 _PERIOD_WINDOW_OVERLAP_SQL = """
     AND NOT (
         COALESCE(
@@ -1955,6 +1974,14 @@ async def create_cierre(request: Request, body: CierreCreate) -> dict:
             open_shift = await _fetch_open_shift_for_window(
                 conn, tenant_id, eff_start, eff_end,
             )
+            if _open_shift_has_explicit_window(open_shift) and _is_day_only_cierre_request(
+                shift_template_id, period_start_time, period_end_time,
+            ):
+                raise APIError(
+                    "Hay un turno de caja abierto para esta fecha. "
+                    "Cierra usando el turno seleccionado o envía la ventana exacta del turno.",
+                    status_code=422,
+                )
             if _requires_open_shift(shift_template_id, period_start_time, period_end_time):
                 if not open_shift:
                     raise APIError(

--- a/tests/test_cierre_open_shift.py
+++ b/tests/test_cierre_open_shift.py
@@ -1,11 +1,21 @@
 """Unit tests for shift opening cash float helpers (warocol.com#920)."""
+from contextlib import asynccontextmanager
 from datetime import date, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 from zoneinfo import ZoneInfo
 
+import pytest
+
+from app.core.exceptions import APIError
+from app.models.cierre import CierreCreate
 from app.services.cierre_service import (
     _effective_period_bounds,
+    _is_day_only_cierre_request,
+    _open_shift_has_explicit_window,
     _requires_open_shift,
+    create_cierre,
 )
 
 BOG = ZoneInfo("America/Bogota")
@@ -39,5 +49,74 @@ def test_requires_open_shift_custom_times():
     assert _requires_open_shift(None, start, end) is True
 
 
-def test_requires_open_shift_day_complete_required():
-    assert _requires_open_shift(None, None, None) is True
+def test_day_only_cierre_request_detected():
+    assert _is_day_only_cierre_request(None, None, None) is True
+
+
+def test_open_shift_has_explicit_window_for_template_or_times():
+    assert _open_shift_has_explicit_window({
+        "shift_template_id": uuid4(),
+        "period_start_time": None,
+        "period_end_time": None,
+    }) is True
+    assert _open_shift_has_explicit_window({
+        "shift_template_id": None,
+        "period_start_time": datetime(2026, 6, 6, 0, 0, tzinfo=BOG),
+        "period_end_time": datetime(2026, 6, 6, 4, 1, tzinfo=BOG),
+    }) is True
+    assert _open_shift_has_explicit_window({
+        "shift_template_id": None,
+        "period_start_time": None,
+        "period_end_time": None,
+    }) is False
+
+
+@pytest.mark.asyncio
+async def test_create_cierre_rejects_day_only_when_open_shift_overlaps():
+    tenant_id = uuid4()
+    shift_id = uuid4()
+    conn = AsyncMock()
+
+    @asynccontextmanager
+    async def db_ctx(**_kwargs):
+        yield conn
+
+    open_shift = {
+        "id": uuid4(),
+        "opening_cash": 100_000,
+        "shift_template_id": shift_id,
+        "period_start": date(2026, 6, 6),
+        "period_end": date(2026, 6, 6),
+        "period_start_time": datetime(2026, 6, 6, 0, 0, tzinfo=BOG),
+        "period_end_time": datetime(2026, 6, 6, 4, 1, tzinfo=BOG),
+    }
+    body = CierreCreate(
+        periodStart=date(2026, 6, 6),
+        periodEnd=date(2026, 6, 6),
+        cashCounted=100_000,
+    )
+
+    with patch(
+        "app.services.cierre_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id),
+    ), patch(
+        "app.services.cierre_service.get_db_connection",
+        side_effect=db_ctx,
+    ), patch(
+        "app.services.cierre_service._find_overlapping_period_id",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "app.services.cierre_service._fetch_open_shift_for_window",
+        new=AsyncMock(return_value=open_shift),
+    ), patch(
+        "app.services.cierre_service._compute_preview",
+        new=AsyncMock(),
+    ) as compute_preview:
+        with pytest.raises(APIError) as exc:
+            await create_cierre(AsyncMock(), body)
+
+    assert exc.value.status_code == 422
+    assert "turno de caja abierto" in exc.value.message
+    compute_preview.assert_not_awaited()
+    conn.fetchrow.assert_not_awaited()
+    conn.execute.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Reject day-only cierre creation when it overlaps an open cash shift with a template or explicit window.
- Keep legacy day-only closes without explicit open-shift windows untouched.
- Add focused regression coverage to ensure the guard fires before preview, accounting_period insert, or cash_shift_openings update.

## Validation
- `pytest tests/test_cierre_open_shift.py tests/test_cierre_shift_template_create.py -q` → 12 passed

## Manual validation
1. Open a cash shift with an exact window such as 00:00-04:01.
2. POST `/api/cierre` with only `periodStart`/`periodEnd`.
3. Expect `422`, with no `accounting_period_id` written to the shift.
4. Retry with `shiftTemplateId` or exact `periodStartTime`/`periodEndTime` and confirm `accounting_period` preserves the shift fields.

Closes #398
