### PR TITLE
Tests: cover nighttime cierre open-table regression

### DIFF
--- a/tests/test_cierre_open_shift.py
+++ b/tests/test_cierre_open_shift.py
@@ -120,3 +120,69 @@ async def test_create_cierre_rejects_day_only_when_open_shift_overlaps():
     compute_preview.assert_not_awaited()
     conn.fetchrow.assert_not_awaited()
     conn.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_cierre_rejects_rebel_rebel_open_table_before_writes():
+    tenant_id = uuid4()
+    conn = AsyncMock()
+
+    @asynccontextmanager
+    async def db_ctx(**_kwargs):
+        yield conn
+
+    class FrozenDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            current = datetime(2026, 6, 6, 22, 35, tzinfo=BOG)
+            return current if tz is None else current.astimezone(tz)
+
+    preview = {
+        "totalSales": 0.0,
+        "itemsSold": 0,
+        "totalTips": 0.0,
+        "totalTipTax": 0.0,
+        "totalCharged": 0.0,
+        "cashTips": 0.0,
+        "totalCash": 0.0,
+        "totalCard": 0.0,
+        "totalDigital": 0.0,
+        "totalCredit": 0.0,
+        "gastosEfectivo": 0.0,
+        "cashExpected": 0.0,
+        "openTablesCount": 1,
+    }
+    body = CierreCreate(
+        periodStart=date(2026, 6, 6),
+        periodEnd=date(2026, 6, 6),
+        cashCounted=0,
+    )
+
+    with patch(
+        "app.services.cierre_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id),
+    ), patch(
+        "app.services.cierre_service.get_db_connection",
+        side_effect=db_ctx,
+    ), patch(
+        "app.services.cierre_service._find_overlapping_period_id",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "app.services.cierre_service._fetch_open_shift_for_window",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "app.services.cierre_service._compute_preview",
+        new=AsyncMock(return_value=preview),
+    ) as compute_preview, patch(
+        "app.services.cierre_service.datetime",
+        FrozenDateTime,
+    ):
+        with pytest.raises(APIError) as exc:
+            await create_cierre(AsyncMock(), body)
+
+    assert exc.value.status_code == 409
+    assert "Hay 1 mesa(s) con cuenta abierta" in exc.value.message
+    assert "Cierra todas las mesas antes de registrar el cierre del día" in exc.value.message
+    compute_preview.assert_awaited_once()
+    conn.fetchrow.assert_not_awaited()
+    conn.execute.assert_not_awaited()

--- a/tests/test_cierre_shift_filters.py
+++ b/tests/test_cierre_shift_filters.py
@@ -1,8 +1,11 @@
 """Unit tests for cierre shift-window filter builders (issue #685)."""
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from zoneinfo import ZoneInfo
 
+import pytest
+
 from app.services.cierre_service import (
+    _compute_preview,
     _build_expense_filter,
     _build_open_tables_filter,
     _build_order_date_filter,
@@ -59,6 +62,21 @@ def test_open_tables_filter_date_only_uses_bogota_dates():
     assert params == [date(2026, 5, 18), date(2026, 5, 18)]
 
 
+def test_open_tables_filter_covers_rebel_rebel_night_opened_at():
+    opened_bogota = datetime(2026, 6, 6, 21, 52, tzinfo=BOG)
+    opened_utc = opened_bogota.astimezone(timezone.utc)
+
+    assert opened_utc.date() == date(2026, 6, 7)
+
+    sql, params = _build_open_tables_filter(
+        date(2026, 6, 6), date(2026, 6, 6), None, None
+    )
+
+    assert "(ts.opened_at AT TIME ZONE 'America/Bogota')::date" in sql
+    assert "opened_at::date" not in sql
+    assert params == [date(2026, 6, 6), date(2026, 6, 6)]
+
+
 def test_open_tables_filter_shift_uses_opened_at_before_end():
     end = datetime(2026, 5, 18, 22, 0, tzinfo=BOG)
     sql, params = _build_open_tables_filter(
@@ -67,3 +85,52 @@ def test_open_tables_filter_shift_uses_opened_at_before_end():
     assert "ts.opened_at <=" in sql
     assert "opened_at::date" not in sql
     assert params == [end]
+
+
+class _PreviewConn:
+    def __init__(self, open_tables_count):
+        self.open_tables_count = open_tables_count
+        self.open_tables_sql = None
+        self.open_tables_args = None
+
+    async def fetchrow(self, sql, *args):
+        if "FROM table_sessions ts" in sql:
+            self.open_tables_sql = sql
+            self.open_tables_args = args
+            return {"open_tables_count": self.open_tables_count}
+        if "AS items_sold" in sql:
+            return {"total_sales": 0, "items_sold": 0}
+        if "AS total_tips" in sql:
+            return {"total_tips": 0, "total_tip_tax": 0}
+        if "AS cash_tips" in sql:
+            return {"cash_tips": 0}
+        if "AS gastos_efectivo" in sql:
+            return {"gastos_efectivo": 0}
+        raise AssertionError(f"unexpected fetchrow SQL: {sql}")
+
+    async def fetch(self, *_args):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_preview_open_tables_count_excludes_permanent_bar_sessions(monkeypatch):
+    async def no_wallet_recharges(*_args, **_kwargs):
+        return {}
+
+    monkeypatch.setattr(
+        "app.services.customer_wallet_service.fetch_wallet_recharge_totals_for_cierre",
+        no_wallet_recharges,
+    )
+    conn = _PreviewConn(open_tables_count=0)
+
+    preview = await _compute_preview(
+        conn,
+        tenant_id="tenant-id",
+        period_start=date(2026, 6, 6),
+        period_end=date(2026, 6, 6),
+    )
+
+    assert preview["openTablesCount"] == 0
+    assert "JOIN tables t ON t.id = ts.table_id" in conn.open_tables_sql
+    assert "AND t.is_bar IS FALSE" in conn.open_tables_sql
+    assert conn.open_tables_args == ("tenant-id", date(2026, 6, 6), date(2026, 6, 6))


### PR DESCRIPTION
## Summary

- Add the Rebel Rebel nighttime open-table regression for a table opened at 2026-06-06 21:52 America/Bogota, whose UTC date is 2026-06-07.
- Assert POST cierre blocks with the restaurant-facing open-table message before any accounting-period or closing-summary writes.
- Cover preview open-table aggregation keeping permanent bar sessions excluded.

## Validation

- `pytest tests/test_cierre_shift_filters.py tests/test_cierre_open_shift.py -q`

Closes #399
