### PR TITLE
Post GL and COGS for manual orders

### DIFF
--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -3,15 +3,22 @@ Orders Service
 Handles listing and filtering of POS orders
 """
 import asyncio
+from decimal import Decimal
 from typing import Any, Dict, Optional, List
 from uuid import UUID
+from zoneinfo import ZoneInfo
 from fastapi import Request
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError
 from app.services.aws_ses_service import ses_service
 from app.services.waros_service import evaluate_and_award
-from app.services.cierre_service import assert_order_not_in_closed_monthly_period, _get_tenant_tax_config
+from app.services.cierre_service import (
+    assert_order_not_in_closed_monthly_period,
+    _get_tenant_tax_config,
+    _post_order_cogs_gl_entry,
+    _post_order_gl_entry,
+)
 from app.services.email_helpers import send_pos_receipt_email
 from fastapi import HTTPException
 from datetime import datetime, date
@@ -32,6 +39,7 @@ def parse_date(date_str: Optional[str]) -> Optional[date]:
         return None
 
 logger = logging.getLogger(__name__)
+_BOG = ZoneInfo("America/Bogota")
 
 def _pos_modifier_inventory_helpers():
     from app.services.pos_cart_service import (
@@ -44,6 +52,12 @@ def _pos_modifier_inventory_helpers():
         return_modifier_inventory_for_order_item,
         return_order_item_inventory_from_snapshots,
     )
+
+
+def _pos_order_item_ingredient_snapshot_helper():
+    from app.services.pos_cart_service import _capture_order_item_ingredients
+
+    return _capture_order_item_ingredients
 
 
 
@@ -3105,11 +3119,13 @@ async def create_manual_order(
                 order_id = order_row["id"]
 
                 deduct_modifier_inventory, _, _ = _pos_modifier_inventory_helpers()
+                capture_order_item_ingredients = _pos_order_item_ingredient_snapshot_helper()
 
                 for item in items:
                     modifiers = item.get("modifiers", [])
                     modifiers_total = sum(float(m.get("price", 0)) for m in modifiers)
                     subtotal = float(item["quantity"]) * float(item["unit_price"]) + modifiers_total
+                    product_id = UUID(item["product_id"])
                     order_item_row = await conn.fetchrow(
                         """
                         INSERT INTO order_items (
@@ -3119,7 +3135,7 @@ async def create_manual_order(
                         RETURNING id
                         """,
                         order_id,
-                        UUID(item["product_id"]),
+                        product_id,
                         float(item["quantity"]),
                         float(item["unit_price"]),
                         subtotal
@@ -3173,7 +3189,7 @@ async def create_manual_order(
                         JOIN ingredients i ON brt.ingredient_id = i.id
                         WHERE pbr.product_id = $1
                         """,
-                        UUID(item["product_id"])
+                        product_id
                     )
 
                     for ingredient in ingredients:
@@ -3217,6 +3233,48 @@ async def create_manual_order(
                             f"Venta de {item['quantity']}x {item.get('product_name', '')} - Orden #{order_row['order_number']}",
                             user_id
                         )
+
+                    await capture_order_item_ingredients(
+                        conn,
+                        order_item_id,
+                        product_id,
+                        float(item["quantity"]),
+                        str(tenant_id),
+                    )
+
+                gl_order_date = (
+                    order_datetime.astimezone(_BOG).date()
+                    if order_datetime.tzinfo
+                    else order_datetime.date()
+                )
+                gl_payment_method_id = UUID(payment_method_id) if payment_method_id else None
+
+                try:
+                    tax_config = await _get_tenant_tax_config(conn, tenant_id)
+                    await _post_order_gl_entry(
+                        conn=conn,
+                        tenant_id=tenant_id,
+                        order_id=order_id,
+                        order_date=gl_order_date,
+                        total_amount=Decimal(str(total_amount)),
+                        payment_method=payment_method,
+                        payment_method_id=gl_payment_method_id,
+                        tax_config=tax_config,
+                        order_number=int(order_row["order_number"]),
+                    )
+                except Exception as e:
+                    logger.error(f"GL entry failed for manual order {order_id}: {e}")
+
+                try:
+                    await _post_order_cogs_gl_entry(
+                        conn=conn,
+                        tenant_id=tenant_id,
+                        order_id=order_id,
+                        order_date=gl_order_date,
+                        order_number=int(order_row["order_number"]),
+                    )
+                except Exception as e:
+                    logger.error(f"COGS GL entry failed for manual order {order_id}: {e}")
 
         # Award waros for completed manual order (fire-and-forget — never blocks)
         if customer_id:

--- a/tests/test_manual_order_gl_cogs.py
+++ b/tests/test_manual_order_gl_cogs.py
@@ -1,0 +1,174 @@
+from datetime import date, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import Request
+
+from app.services import orders_service
+
+
+class _AsyncContext:
+    def __init__(self, value=None):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _manual_order_conn(order_id, order_item_id, order_date):
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {
+                "id": order_id,
+                "order_number": 14798,
+                "order_date": order_date,
+                "created_at": order_date,
+            },
+            {"id": order_item_id},
+        ]
+    )
+    conn.fetch = AsyncMock(return_value=[])
+    conn.execute = AsyncMock()
+    conn.transaction = MagicMock(return_value=_AsyncContext())
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_create_manual_order_captures_snapshots_and_posts_gl_cogs():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    order_id = uuid4()
+    order_item_id = uuid4()
+    product_id = uuid4()
+    payment_method_id = uuid4()
+    order_date = datetime(2026, 6, 7, 10, 30)
+    conn = _manual_order_conn(order_id, order_item_id, order_date)
+
+    capture_snapshot = AsyncMock()
+    deduct_modifier_inventory = AsyncMock()
+    post_gl = AsyncMock()
+    post_cogs = AsyncMock()
+
+    with patch(
+        "app.services.orders_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id, user_id=user_id),
+    ), patch(
+        "app.services.orders_service.get_db_connection",
+        return_value=_AsyncContext(conn),
+    ), patch(
+        "app.services.orders_service.assert_order_not_in_closed_monthly_period",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.orders_service._pos_modifier_inventory_helpers",
+        return_value=(deduct_modifier_inventory, None, None),
+    ), patch(
+        "app.services.orders_service._pos_order_item_ingredient_snapshot_helper",
+        return_value=capture_snapshot,
+    ), patch(
+        "app.services.orders_service._get_tenant_tax_config",
+        new=AsyncMock(return_value={"inc_enabled": True}),
+    ), patch(
+        "app.services.orders_service._post_order_gl_entry",
+        new=post_gl,
+    ), patch(
+        "app.services.orders_service._post_order_cogs_gl_entry",
+        new=post_cogs,
+    ):
+        result = await orders_service.create_manual_order(
+            Request({"type": "http"}),
+            order_date="2026-06-07T10:30:00",
+            payment_method="digital",
+            payment_method_id=str(payment_method_id),
+            items=[
+                {
+                    "product_id": str(product_id),
+                    "quantity": 2,
+                    "unit_price": 15000,
+                    "modifiers": [],
+                }
+            ],
+        )
+
+    assert result["success"] is True
+    capture_snapshot.assert_awaited_once_with(
+        conn,
+        order_item_id,
+        product_id,
+        2.0,
+        str(tenant_id),
+    )
+    post_gl.assert_awaited_once()
+    assert post_gl.await_args.kwargs["order_id"] == order_id
+    assert post_gl.await_args.kwargs["order_date"] == date(2026, 6, 7)
+    assert post_gl.await_args.kwargs["payment_method_id"] == payment_method_id
+    assert post_gl.await_args.kwargs["payment_method"] == "digital"
+    post_cogs.assert_awaited_once_with(
+        conn=conn,
+        tenant_id=tenant_id,
+        order_id=order_id,
+        order_date=date(2026, 6, 7),
+        order_number=14798,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_manual_order_accounting_failures_do_not_block_sale():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    order_id = uuid4()
+    order_item_id = uuid4()
+    product_id = uuid4()
+    payment_method_id = uuid4()
+    order_date = datetime(2026, 6, 7, 10, 30)
+    conn = _manual_order_conn(order_id, order_item_id, order_date)
+
+    with patch(
+        "app.services.orders_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id, user_id=user_id),
+    ), patch(
+        "app.services.orders_service.get_db_connection",
+        return_value=_AsyncContext(conn),
+    ), patch(
+        "app.services.orders_service.assert_order_not_in_closed_monthly_period",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.orders_service._pos_modifier_inventory_helpers",
+        return_value=(AsyncMock(), None, None),
+    ), patch(
+        "app.services.orders_service._pos_order_item_ingredient_snapshot_helper",
+        return_value=AsyncMock(),
+    ), patch(
+        "app.services.orders_service._get_tenant_tax_config",
+        new=AsyncMock(return_value={"inc_enabled": True}),
+    ), patch(
+        "app.services.orders_service._post_order_gl_entry",
+        new=AsyncMock(side_effect=RuntimeError("gl failed")),
+    ) as post_gl, patch(
+        "app.services.orders_service._post_order_cogs_gl_entry",
+        new=AsyncMock(side_effect=RuntimeError("cogs failed")),
+    ) as post_cogs:
+        result = await orders_service.create_manual_order(
+            Request({"type": "http"}),
+            order_date="2026-06-07T10:30:00",
+            payment_method="digital",
+            payment_method_id=str(payment_method_id),
+            items=[
+                {
+                    "product_id": str(product_id),
+                    "quantity": 1,
+                    "unit_price": 12000,
+                    "modifiers": [],
+                }
+            ],
+        )
+
+    assert result["success"] is True
+    assert result["data"]["id"] == str(order_id)
+    post_gl.assert_awaited_once()
+    post_cogs.assert_awaited_once()


### PR DESCRIPTION
## Summary

- capture `order_item_ingredients` snapshots for manual order product/base recipe lines
- post manual order `orden` GL entries using the selected `payment_method_id`
- post manual order `orden_cogs` entries when captured ingredient costs are available
- keep GL/COGS failures non-blocking for manual sale creation

## Validation

```bash
.venv-ship/bin/python -m pytest tests/test_manual_order_gl_cogs.py tests/test_order_item_ingredient_snapshots.py tests/test_order_modifier_cogs.py
```

Manual validation route:
- `/ventas/crear` with a custom payment method configured with a method-specific PUC and a product with ingredient purchase costs.
- DB check should show one `tenant_journal_entries.source_module = 'orden'`, one `orden_cogs` when snapshot cost is positive, and the debit line using the selected method PUC.

Refs uno0uno/warocol.com#1261
