### PR TITLE
API: aceptar métodos personalizados en abonos de cartera

### DIFF
--- a/app/routers/credit.py
+++ b/app/routers/credit.py
@@ -18,7 +18,11 @@ router = APIRouter(prefix="/credit", tags=["credit"])
 
 class RegisterCreditPaymentRequest(BaseModel):
     amount: Decimal = Field(..., gt=0, description="Payment amount (must be > 0)")
-    payment_method: str = Field(..., description="cash | card | digital")
+    payment_method: str = Field(..., description="Payment method group slug")
+    payment_method_id: Optional[UUID] = Field(
+        None,
+        description="UUID of the selected payment_methods row",
+    )
     notes: Optional[str] = Field(None, description="Optional notes for this payment")
     payment_date: Optional[date] = Field(None, description="Payment date (defaults to now)")
 
@@ -43,6 +47,7 @@ async def register_payment(
         order_id,
         body.amount,
         body.payment_method,
+        body.payment_method_id,
         body.notes,
         body.payment_date,
     )

--- a/app/services/cartera_service.py
+++ b/app/services/cartera_service.py
@@ -275,6 +275,7 @@ async def get_customer_cartera(
                     cp.id,
                     cp.amount,
                     cp.payment_method,
+                    cp.payment_method_id,
                     cp.payment_date,
                     cp.notes,
                     cp.created_at
@@ -297,6 +298,11 @@ async def get_customer_cartera(
                         "id": str(p["id"]),
                         "amount": float(p["amount"]),
                         "payment_method": p["payment_method"],
+                        "payment_method_id": (
+                            str(p["payment_method_id"])
+                            if p["payment_method_id"]
+                            else None
+                        ),
                         "payment_date": p["payment_date"].isoformat(),
                         "notes": p["notes"],
                         "created_at": p["created_at"].isoformat(),

--- a/app/services/credit_service.py
+++ b/app/services/credit_service.py
@@ -22,6 +22,7 @@ async def register_credit_payment(
     order_id: UUID,
     amount: Decimal,
     payment_method: str,
+    payment_method_id: Optional[UUID] = None,
     notes: Optional[str] = None,
     payment_date: Optional[date] = None,
 ) -> dict:
@@ -83,6 +84,45 @@ async def register_credit_payment(
                         status_code=400,
                     )
 
+                group_row = await conn.fetchrow(
+                    """
+                    SELECT id
+                    FROM payment_method_groups
+                    WHERE slug = $1
+                      AND is_active = true
+                      AND (tenant_id IS NULL OR tenant_id = $2)
+                    """,
+                    payment_method,
+                    tenant_id,
+                )
+                if not group_row:
+                    raise APIError(
+                        f"Método de pago '{payment_method}' no es válido para este restaurante.",
+                        status_code=400,
+                        details={"code": "payment_method_invalid"},
+                    )
+
+                if payment_method_id:
+                    method_row = await conn.fetchrow(
+                        """
+                        SELECT id
+                        FROM payment_methods
+                        WHERE id = $1
+                          AND tenant_id = $2
+                          AND group_id = $3
+                          AND is_active = true
+                        """,
+                        payment_method_id,
+                        tenant_id,
+                        group_row["id"],
+                    )
+                    if not method_row:
+                        raise APIError(
+                            "El método seleccionado no pertenece al grupo elegido.",
+                            status_code=400,
+                            details={"code": "payment_method_id_invalid"},
+                        )
+
                 # 3. Insert payment record
                 from datetime import datetime, timezone
                 effective_payment_date = (
@@ -95,11 +135,11 @@ async def register_credit_payment(
                     """
                     INSERT INTO credit_payments (
                         order_id, customer_id, tenant_id,
-                        amount, payment_method, notes,
+                        amount, payment_method, payment_method_id, notes,
                         created_by_user_id,
                         payment_date
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, COALESCE($8, now()))
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, COALESCE($9, now()))
                     RETURNING id, payment_date, created_at
                     """,
                     order_id,
@@ -107,6 +147,7 @@ async def register_credit_payment(
                     tenant_id,
                     amount,
                     payment_method,
+                    payment_method_id,
                     notes,
                     user_id,
                     effective_payment_date,
@@ -147,6 +188,7 @@ async def register_credit_payment(
                         "order_id": str(order_id),
                         "amount": float(amount),
                         "payment_method": payment_method,
+                        "payment_method_id": str(payment_method_id) if payment_method_id else None,
                         "payment_date": payment_row["payment_date"].isoformat(),
                         "new_payment_status": new_status,
                         "credit_paid_amount": float(new_paid),
@@ -189,6 +231,7 @@ async def get_credit_payments(request: Request, order_id: UUID) -> dict:
                     cp.id,
                     cp.amount,
                     cp.payment_method,
+                    cp.payment_method_id,
                     cp.payment_date,
                     cp.notes,
                     cp.created_at,
@@ -217,6 +260,11 @@ async def get_credit_payments(request: Request, order_id: UUID) -> dict:
                         "id": str(row["id"]),
                         "amount": float(row["amount"]),
                         "payment_method": row["payment_method"],
+                        "payment_method_id": (
+                            str(row["payment_method_id"])
+                            if row["payment_method_id"]
+                            else None
+                        ),
                         "payment_date": row["payment_date"].isoformat(),
                         "notes": row["notes"],
                         "created_at": row["created_at"].isoformat(),

--- a/migrations/084_add_payment_method_id_to_credit_payments.sql
+++ b/migrations/084_add_payment_method_id_to_credit_payments.sql
@@ -1,0 +1,10 @@
+-- Migration 084: add payment_method_id to credit_payments (api-warolabs#410)
+-- Stores the selected tenant payment sub-method while keeping payment_method
+-- as the parent group slug for backward compatibility.
+
+ALTER TABLE credit_payments
+  ADD COLUMN IF NOT EXISTS payment_method_id uuid REFERENCES payment_methods(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_credit_payments_payment_method_id
+  ON credit_payments(payment_method_id)
+  WHERE payment_method_id IS NOT NULL;

--- a/tests/test_credit_payment_methods.py
+++ b/tests/test_credit_payment_methods.py
@@ -1,0 +1,242 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.exceptions import APIError
+from app.services import credit_service
+
+
+class _AsyncContext:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _request():
+    return MagicMock()
+
+
+def _session(tenant_id, user_id):
+    return SimpleNamespace(tenant_id=tenant_id, user_id=user_id)
+
+
+def _credit_order(tenant_id, customer_id):
+    return {
+        "id": uuid4(),
+        "tenant_id": tenant_id,
+        "customer_id": customer_id,
+        "total_amount": Decimal("100.00"),
+        "payment_status": "credit",
+        "credit_paid_amount": Decimal("25.00"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_register_credit_payment_base_method_persists_null_method_id():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    order_id = uuid4()
+    customer_id = uuid4()
+    payment_id = uuid4()
+    group_id = uuid4()
+    payment_date = datetime(2026, 6, 8, tzinfo=timezone.utc)
+
+    conn = MagicMock()
+    conn.transaction.return_value = _AsyncContext(None)
+    conn.fetchrow = AsyncMock(side_effect=[
+        _credit_order(tenant_id, customer_id),
+        {"id": group_id},
+        {"id": payment_id, "payment_date": payment_date, "created_at": payment_date},
+    ])
+    conn.execute = AsyncMock()
+
+    with patch(
+        "app.services.credit_service.require_valid_session",
+        return_value=_session(tenant_id, user_id),
+    ), patch(
+        "app.services.credit_service.get_db_connection",
+        return_value=_AsyncContext(conn),
+    ):
+        result = await credit_service.register_credit_payment(
+            _request(),
+            order_id,
+            Decimal("20.00"),
+            "cash",
+        )
+
+    assert result["data"]["payment_method"] == "cash"
+    assert result["data"]["payment_method_id"] is None
+    insert_args = conn.fetchrow.await_args_list[2].args
+    assert insert_args[5] == "cash"
+    assert insert_args[6] is None
+    conn.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_register_credit_payment_custom_method_validates_and_persists_id():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    order_id = uuid4()
+    customer_id = uuid4()
+    group_id = uuid4()
+    method_id = uuid4()
+    payment_id = uuid4()
+    payment_date = datetime(2026, 6, 8, tzinfo=timezone.utc)
+
+    conn = MagicMock()
+    conn.transaction.return_value = _AsyncContext(None)
+    conn.fetchrow = AsyncMock(side_effect=[
+        _credit_order(tenant_id, customer_id),
+        {"id": group_id},
+        {"id": method_id},
+        {"id": payment_id, "payment_date": payment_date, "created_at": payment_date},
+    ])
+    conn.execute = AsyncMock()
+
+    with patch(
+        "app.services.credit_service.require_valid_session",
+        return_value=_session(tenant_id, user_id),
+    ), patch(
+        "app.services.credit_service.get_db_connection",
+        return_value=_AsyncContext(conn),
+    ):
+        result = await credit_service.register_credit_payment(
+            _request(),
+            order_id,
+            Decimal("20.00"),
+            "digital",
+            method_id,
+        )
+
+    assert result["data"]["payment_method_id"] == str(method_id)
+    method_lookup_args = conn.fetchrow.await_args_list[2].args
+    assert method_lookup_args[1:] == (method_id, tenant_id, group_id)
+    insert_args = conn.fetchrow.await_args_list[3].args
+    assert insert_args[5] == "digital"
+    assert insert_args[6] == method_id
+    conn.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_register_credit_payment_rejects_invalid_method_id_before_insert():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    order_id = uuid4()
+    customer_id = uuid4()
+    group_id = uuid4()
+    method_id = uuid4()
+
+    conn = MagicMock()
+    conn.transaction.return_value = _AsyncContext(None)
+    conn.fetchrow = AsyncMock(side_effect=[
+        _credit_order(tenant_id, customer_id),
+        {"id": group_id},
+        None,
+    ])
+    conn.execute = AsyncMock()
+
+    with patch(
+        "app.services.credit_service.require_valid_session",
+        return_value=_session(tenant_id, user_id),
+    ), patch(
+        "app.services.credit_service.get_db_connection",
+        return_value=_AsyncContext(conn),
+    ):
+        with pytest.raises(APIError) as exc:
+            await credit_service.register_credit_payment(
+                _request(),
+                order_id,
+                Decimal("20.00"),
+                "digital",
+                method_id,
+            )
+
+    assert exc.value.status_code == 400
+    assert exc.value.details["code"] == "payment_method_id_invalid"
+    assert conn.fetchrow.await_count == 3
+    conn.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_register_credit_payment_rejects_invalid_group_before_insert():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    order_id = uuid4()
+    customer_id = uuid4()
+
+    conn = MagicMock()
+    conn.transaction.return_value = _AsyncContext(None)
+    conn.fetchrow = AsyncMock(side_effect=[
+        _credit_order(tenant_id, customer_id),
+        None,
+    ])
+    conn.execute = AsyncMock()
+
+    with patch(
+        "app.services.credit_service.require_valid_session",
+        return_value=_session(tenant_id, user_id),
+    ), patch(
+        "app.services.credit_service.get_db_connection",
+        return_value=_AsyncContext(conn),
+    ):
+        with pytest.raises(APIError) as exc:
+            await credit_service.register_credit_payment(
+                _request(),
+                order_id,
+                Decimal("20.00"),
+                "not-a-method",
+            )
+
+    assert exc.value.status_code == 400
+    assert exc.value.details["code"] == "payment_method_invalid"
+    assert conn.fetchrow.await_count == 2
+    conn.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_credit_payments_returns_payment_method_id():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    order_id = uuid4()
+    method_id = uuid4()
+    payment_id = uuid4()
+    payment_date = datetime(2026, 6, 8, tzinfo=timezone.utc)
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "id": order_id,
+        "total_amount": Decimal("100.00"),
+        "payment_status": "partial",
+        "credit_paid_amount": Decimal("40.00"),
+    })
+    conn.fetch = AsyncMock(return_value=[{
+        "id": payment_id,
+        "amount": Decimal("40.00"),
+        "payment_method": "digital",
+        "payment_method_id": method_id,
+        "payment_date": payment_date,
+        "notes": "Nequi",
+        "created_at": payment_date,
+        "created_by_user_id": user_id,
+    }])
+
+    with patch(
+        "app.services.credit_service.require_valid_session",
+        return_value=_session(tenant_id, user_id),
+    ), patch(
+        "app.services.credit_service.get_db_connection",
+        return_value=_AsyncContext(conn),
+    ):
+        result = await credit_service.get_credit_payments(_request(), order_id)
+
+    assert result["data"]["payments"][0]["payment_method"] == "digital"
+    assert result["data"]["payments"][0]["payment_method_id"] == str(method_id)


### PR DESCRIPTION
## Summary

- Add optional `payment_method_id` to credit payment registration.
- Validate payment group slug plus tenant-owned active sub-method before inserting an abono.
- Persist and return `payment_method_id` in credit payment and cartera histories.
- Add a safe migration for `credit_payments.payment_method_id`.

## Validation

- `pytest -q tests/test_credit_payment_methods.py`
- `python3 -m py_compile app/routers/credit.py app/services/credit_service.py app/services/cartera_service.py tests/test_credit_payment_methods.py`
- `git diff --check`

## Out of scope

- GL/PUC journal posting remains for #411.
- Frontend cartera selector remains for #412.

Closes #410