### PR TITLE
Post cartera payment GL entries

### DIFF
--- a/app/services/credit_service.py
+++ b/app/services/credit_service.py
@@ -7,7 +7,7 @@ Issue: https://github.com/uno0uno/warocol.com/issues/294
 from typing import Optional
 from uuid import UUID
 from decimal import Decimal
-from datetime import date
+from datetime import date, datetime, timezone
 from fastapi import Request
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
@@ -15,6 +15,171 @@ from app.core.exceptions import AuthenticationError, APIError
 import logging
 
 logger = logging.getLogger(__name__)
+
+_PAYMENT_DEBIT_FALLBACKS = {
+    "cash": "1105",
+    "digital": "1110",
+    "card": "1110",
+    "credit": "1305",
+}
+_CARTERA_RECEIVABLE_CODE = "1305"
+
+
+async def _resolve_account_id(conn, tenant_id: UUID, code: str) -> Optional[UUID]:
+    return await conn.fetchval(
+        """
+        SELECT id
+        FROM tenant_accounts
+        WHERE tenant_id = $1 AND code = $2 AND is_active = true
+        """,
+        tenant_id,
+        code,
+    )
+
+
+async def _resolve_credit_payment_debit_code(
+    conn,
+    tenant_id: UUID,
+    payment_method: str,
+    group_id: UUID,
+    payment_method_id: Optional[UUID],
+) -> str:
+    if payment_method_id:
+        method_code = await conn.fetchval(
+            """
+            SELECT COALESCE(pm.gl_account_code, pmg.gl_account_code)
+            FROM payment_methods pm
+            JOIN payment_method_groups pmg ON pm.group_id = pmg.id
+            WHERE pm.id = $1
+              AND pm.tenant_id = $2
+              AND pm.group_id = $3
+            """,
+            payment_method_id,
+            tenant_id,
+            group_id,
+        )
+        if method_code:
+            return str(method_code)
+
+    group_code = await conn.fetchval(
+        """
+        SELECT gl_account_code
+        FROM payment_method_groups
+        WHERE id = $1
+          AND is_active = true
+          AND (tenant_id IS NULL OR tenant_id = $2)
+        """,
+        group_id,
+        tenant_id,
+    )
+    if group_code:
+        return str(group_code)
+
+    return _PAYMENT_DEBIT_FALLBACKS.get(payment_method or "", "1105")
+
+
+async def _post_credit_payment_gl(
+    conn,
+    tenant_id: UUID,
+    payment_id: UUID,
+    order_id: UUID,
+    amount: Decimal,
+    payment_method: str,
+    group_id: UUID,
+    payment_method_id: Optional[UUID],
+    payment_date_value,
+    created_by: Optional[UUID],
+) -> Optional[UUID]:
+    existing = await conn.fetchval(
+        """
+        SELECT id
+        FROM tenant_journal_entries
+        WHERE tenant_id = $1
+          AND source_module = 'cartera'
+          AND source_id = $2
+        """,
+        tenant_id,
+        payment_id,
+    )
+    if existing:
+        logger.info("[credit GL] Payment %s already posted as journal %s", payment_id, existing)
+        return existing
+
+    debit_code = await _resolve_credit_payment_debit_code(
+        conn,
+        tenant_id,
+        payment_method,
+        group_id,
+        payment_method_id,
+    )
+    credit_code = _CARTERA_RECEIVABLE_CODE
+    debit_account_id = await _resolve_account_id(conn, tenant_id, debit_code)
+    credit_account_id = await _resolve_account_id(conn, tenant_id, credit_code)
+    if not debit_account_id or not credit_account_id:
+        logger.warning(
+            "[credit GL] Missing accounts debit=%s credit=%s tenant=%s payment=%s",
+            debit_code,
+            credit_code,
+            tenant_id,
+            payment_id,
+        )
+        raise APIError(
+            "No se pudo registrar el asiento contable del abono de cartera.",
+            status_code=500,
+            details={"code": "credit_payment_gl_account_missing"},
+        )
+
+    entry_date = (
+        payment_date_value.date()
+        if isinstance(payment_date_value, datetime)
+        else payment_date_value
+    )
+    amt = float(amount)
+    description = f"Abono cartera orden {order_id}"
+    entry_row = await conn.fetchrow(
+        """
+        INSERT INTO tenant_journal_entries
+            (tenant_id, entry_date, period_year, period_month,
+             description, reference, source_module, source_id,
+             status, total_debit, total_credit, created_by, posted_at)
+        VALUES ($1, $2, $3, $4, $5, $6, 'cartera', $7,
+                'posted', $8, $8, $9, now())
+        RETURNING id
+        """,
+        tenant_id,
+        entry_date,
+        entry_date.year,
+        entry_date.month,
+        description,
+        f"credit-payment-{payment_id}",
+        payment_id,
+        amt,
+        created_by,
+    )
+    entry_id = entry_row["id"]
+    await conn.execute(
+        """
+        INSERT INTO tenant_journal_lines
+            (journal_entry_id, account_id, debit, credit, description, line_order)
+        VALUES ($1, $2, $3, 0, $4, 0)
+        """,
+        entry_id,
+        debit_account_id,
+        amt,
+        f"Dr {debit_code} - abono cartera",
+    )
+    await conn.execute(
+        """
+        INSERT INTO tenant_journal_lines
+            (journal_entry_id, account_id, debit, credit, description, line_order)
+        VALUES ($1, $2, 0, $3, $4, 1)
+        """,
+        entry_id,
+        credit_account_id,
+        amt,
+        f"Cr {credit_code} - clientes por cobrar",
+    )
+    return entry_id
 
 
 async def register_credit_payment(
@@ -124,7 +289,6 @@ async def register_credit_payment(
                         )
 
                 # 3. Insert payment record
-                from datetime import datetime, timezone
                 effective_payment_date = (
                     datetime.combine(payment_date, datetime.min.time()).replace(tzinfo=timezone.utc)
                     if payment_date
@@ -172,6 +336,19 @@ async def register_credit_payment(
                     new_paid,
                     new_status,
                     order_id,
+                )
+
+                await _post_credit_payment_gl(
+                    conn,
+                    tenant_id,
+                    payment_row["id"],
+                    order_id,
+                    amount,
+                    payment_method,
+                    group_row["id"],
+                    payment_method_id,
+                    payment_row["payment_date"],
+                    user_id,
                 )
 
                 logger.info(

--- a/sql/20260608_credit_payments_payment_method_id.sql
+++ b/sql/20260608_credit_payments_payment_method_id.sql
@@ -1,0 +1,8 @@
+-- api-warolabs#411/#410 dependency - persist selected custom payment method for credit payments.
+
+ALTER TABLE credit_payments
+    ADD COLUMN IF NOT EXISTS payment_method_id UUID REFERENCES payment_methods(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_credit_payments_payment_method_id
+    ON credit_payments (payment_method_id)
+    WHERE payment_method_id IS NOT NULL;

--- a/tests/test_credit_payment_methods.py
+++ b/tests/test_credit_payment_methods.py
@@ -41,6 +41,27 @@ def _credit_order(tenant_id, customer_id):
 
 
 @pytest.mark.asyncio
+async def test_credit_payment_debit_code_uses_group_puc_when_method_has_no_puc():
+    tenant_id = uuid4()
+    group_id = uuid4()
+    method_id = uuid4()
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(side_effect=["112010"])
+
+    code = await credit_service._resolve_credit_payment_debit_code(
+        conn,
+        tenant_id,
+        "digital",
+        group_id,
+        method_id,
+    )
+
+    assert code == "112010"
+    lookup_args = conn.fetchval.await_args.args
+    assert lookup_args[1:] == (method_id, tenant_id, group_id)
+
+
+@pytest.mark.asyncio
 async def test_register_credit_payment_base_method_persists_null_method_id():
     tenant_id = uuid4()
     user_id = uuid4()
@@ -56,7 +77,9 @@ async def test_register_credit_payment_base_method_persists_null_method_id():
         _credit_order(tenant_id, customer_id),
         {"id": group_id},
         {"id": payment_id, "payment_date": payment_date, "created_at": payment_date},
+        {"id": uuid4()},
     ])
+    conn.fetchval = AsyncMock(side_effect=[None, None, uuid4(), uuid4()])
     conn.execute = AsyncMock()
 
     with patch(
@@ -78,7 +101,7 @@ async def test_register_credit_payment_base_method_persists_null_method_id():
     insert_args = conn.fetchrow.await_args_list[2].args
     assert insert_args[5] == "cash"
     assert insert_args[6] is None
-    conn.execute.assert_awaited_once()
+    assert conn.execute.await_count == 3
 
 
 @pytest.mark.asyncio
@@ -99,7 +122,9 @@ async def test_register_credit_payment_custom_method_validates_and_persists_id()
         {"id": group_id},
         {"id": method_id},
         {"id": payment_id, "payment_date": payment_date, "created_at": payment_date},
+        {"id": uuid4()},
     ])
+    conn.fetchval = AsyncMock(side_effect=[None, "112005", uuid4(), uuid4()])
     conn.execute = AsyncMock()
 
     with patch(
@@ -123,7 +148,127 @@ async def test_register_credit_payment_custom_method_validates_and_persists_id()
     insert_args = conn.fetchrow.await_args_list[3].args
     assert insert_args[5] == "digital"
     assert insert_args[6] == method_id
-    conn.execute.assert_awaited_once()
+    assert conn.execute.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_register_credit_payment_posts_gl_with_custom_method_puc():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    order_id = uuid4()
+    customer_id = uuid4()
+    group_id = uuid4()
+    method_id = uuid4()
+    payment_id = uuid4()
+    journal_id = uuid4()
+    debit_account_id = uuid4()
+    credit_account_id = uuid4()
+    payment_date = datetime(2026, 6, 8, tzinfo=timezone.utc)
+
+    conn = MagicMock()
+    conn.transaction.return_value = _AsyncContext(None)
+    conn.fetchrow = AsyncMock(side_effect=[
+        _credit_order(tenant_id, customer_id),
+        {"id": group_id},
+        {"id": method_id},
+        {"id": payment_id, "payment_date": payment_date, "created_at": payment_date},
+        {"id": journal_id},
+    ])
+    conn.fetchval = AsyncMock(side_effect=[
+        None,
+        "112005",
+        debit_account_id,
+        credit_account_id,
+    ])
+    conn.execute = AsyncMock()
+
+    with patch(
+        "app.services.credit_service.require_valid_session",
+        return_value=_session(tenant_id, user_id),
+    ), patch(
+        "app.services.credit_service.get_db_connection",
+        return_value=_AsyncContext(conn),
+    ):
+        result = await credit_service.register_credit_payment(
+            _request(),
+            order_id,
+            Decimal("20.00"),
+            "digital",
+            method_id,
+        )
+
+    assert result["data"]["payment_id"] == str(payment_id)
+    entry_args = conn.fetchrow.await_args_list[4].args
+    assert entry_args[1:5] == (tenant_id, payment_date.date(), 2026, 6)
+    assert entry_args[7] == payment_id
+    assert entry_args[8] == 20.0
+    assert entry_args[9] == user_id
+    debit_args = conn.execute.await_args_list[1].args
+    credit_args = conn.execute.await_args_list[2].args
+    assert debit_args[1:5] == (
+        journal_id,
+        debit_account_id,
+        20.0,
+        "Dr 112005 - abono cartera",
+    )
+    assert credit_args[1:5] == (
+        journal_id,
+        credit_account_id,
+        20.0,
+        "Cr 1305 - clientes por cobrar",
+    )
+
+
+@pytest.mark.asyncio
+async def test_register_credit_payment_gl_uses_slug_fallback_without_puc():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    order_id = uuid4()
+    customer_id = uuid4()
+    group_id = uuid4()
+    payment_id = uuid4()
+    debit_account_id = uuid4()
+    credit_account_id = uuid4()
+    payment_date = datetime(2026, 6, 8, tzinfo=timezone.utc)
+
+    conn = MagicMock()
+    conn.transaction.return_value = _AsyncContext(None)
+    conn.fetchrow = AsyncMock(side_effect=[
+        _credit_order(tenant_id, customer_id),
+        {"id": group_id},
+        {"id": payment_id, "payment_date": payment_date, "created_at": payment_date},
+        {"id": uuid4()},
+    ])
+    conn.fetchval = AsyncMock(side_effect=[
+        None,
+        None,
+        debit_account_id,
+        credit_account_id,
+    ])
+    conn.execute = AsyncMock()
+
+    with patch(
+        "app.services.credit_service.require_valid_session",
+        return_value=_session(tenant_id, user_id),
+    ), patch(
+        "app.services.credit_service.get_db_connection",
+        return_value=_AsyncContext(conn),
+    ):
+        await credit_service.register_credit_payment(
+            _request(),
+            order_id,
+            Decimal("20.00"),
+            "digital",
+        )
+
+    debit_account_lookup_args = conn.fetchval.await_args_list[2].args
+    credit_account_lookup_args = conn.fetchval.await_args_list[3].args
+    assert debit_account_lookup_args[1:] == (tenant_id, "1110")
+    assert credit_account_lookup_args[1:] == (tenant_id, "1305")
+    debit_args = conn.execute.await_args_list[1].args
+    credit_args = conn.execute.await_args_list[2].args
+    assert debit_args[3] == 20.0
+    assert credit_args[3] == 20.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- post a balanced cartera journal entry for each credit payment
- resolve debit PUC from method account, group account, then existing slug fallback
- add the missing credit_payments.payment_method_id migration dependency

## Validation
- pytest tests/test_credit_payment_methods.py

Closes #411