### PR TITLE
Support manual modifier quantities

### DIFF
--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -216,6 +216,7 @@ class ManualOrderModifier(BaseModel):
     id: str
     name: str
     price: float = 0.0
+    quantity: float = Field(default=1, gt=0)
 
 
 class ManualOrderItem(BaseModel):

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -3147,10 +3147,18 @@ async def create_manual_order(
 
                     await assert_wallet_customer_identified(conn, customer_uuid)
 
+                def modifier_quantity(modifier: dict) -> float:
+                    return float(modifier.get("quantity") or 1)
+
+                def modifier_unit_total(modifier: dict) -> float:
+                    return float(modifier.get("price", 0)) * modifier_quantity(modifier)
+
                 # Compute total server-side — never trust client total
                 total_amount = sum(
-                    float(item["quantity"]) * float(item["unit_price"])
-                    + sum(float(m.get("price", 0)) for m in item.get("modifiers", []))
+                    float(item["quantity"]) * (
+                        float(item["unit_price"])
+                        + sum(modifier_unit_total(m) for m in item.get("modifiers", []))
+                    )
                     for item in items
                 )
 
@@ -3179,8 +3187,10 @@ async def create_manual_order(
 
                 for item in items:
                     modifiers = item.get("modifiers", [])
-                    modifiers_total = sum(float(m.get("price", 0)) for m in modifiers)
-                    subtotal = float(item["quantity"]) * float(item["unit_price"]) + modifiers_total
+                    modifiers_total = sum(modifier_unit_total(m) for m in modifiers)
+                    subtotal = float(item["quantity"]) * (
+                        float(item["unit_price"]) + modifiers_total
+                    )
                     product_id = UUID(item["product_id"])
                     order_item_row = await conn.fetchrow(
                         """
@@ -3199,18 +3209,20 @@ async def create_manual_order(
                     order_item_id = order_item_row["id"]
 
                     for modifier in modifiers:
+                        modifier_qty = modifier_quantity(modifier)
                         await conn.execute(
                             """
                             INSERT INTO order_item_modifiers (
                                 order_item_id, modifier_id, modifier_name,
                                 price_at_purchase, quantity
                             )
-                            VALUES ($1, $2, $3, $4, 1)
+                            VALUES ($1, $2, $3, $4, $5)
                             """,
                             order_item_id,
                             UUID(modifier["id"]),
                             modifier["name"],
-                            float(modifier.get("price", 0))
+                            float(modifier.get("price", 0)),
+                            modifier_qty
                         )
 
                         await deduct_modifier_inventory(
@@ -3221,11 +3233,8 @@ async def create_manual_order(
                             order_item_id=order_item_id,
                             order_number=order_row["order_number"],
                             item_quantity=float(item["quantity"]),
-                            modifier={
-                                "id": modifier["id"],
-                                "name": modifier["name"],
-                            },
-                            modifier_qty=1.0,
+                            modifier=modifier,
+                            modifier_qty=modifier_qty,
                         )
 
                     # Deduct inventory for product ingredients (direct + base recipes)

--- a/tests/test_manual_order_gl_cogs.py
+++ b/tests/test_manual_order_gl_cogs.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import pytest
 from fastapi import Request
 
+from app.routers.orders import ManualOrderModifier
 from app.services import orders_service
 
 
@@ -37,6 +38,12 @@ def _manual_order_conn(order_id, order_item_id, order_date):
     conn.execute = AsyncMock()
     conn.transaction = MagicMock(return_value=_AsyncContext())
     return conn
+
+
+def test_manual_order_modifier_quantity_defaults_to_one():
+    modifier = ManualOrderModifier(id=str(uuid4()), name="Extra queso", price=2500)
+
+    assert modifier.quantity == 1
 
 
 @pytest.mark.asyncio
@@ -172,3 +179,149 @@ async def test_create_manual_order_accounting_failures_do_not_block_sale():
     assert result["data"]["id"] == str(order_id)
     post_gl.assert_awaited_once()
     post_cogs.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_manual_order_uses_modifier_quantity_for_totals_persistence_and_inventory():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    order_id = uuid4()
+    order_item_id = uuid4()
+    product_id = uuid4()
+    modifier_id = uuid4()
+    payment_method_id = uuid4()
+    order_date = datetime(2026, 6, 7, 10, 30)
+    conn = _manual_order_conn(order_id, order_item_id, order_date)
+
+    capture_snapshot = AsyncMock()
+    deduct_modifier_inventory = AsyncMock()
+
+    with patch(
+        "app.services.orders_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id, user_id=user_id),
+    ), patch(
+        "app.services.orders_service.get_db_connection",
+        return_value=_AsyncContext(conn),
+    ), patch(
+        "app.services.orders_service.assert_order_not_in_closed_monthly_period",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.orders_service._pos_modifier_inventory_helpers",
+        return_value=(deduct_modifier_inventory, None, None),
+    ), patch(
+        "app.services.orders_service._pos_order_item_ingredient_snapshot_helper",
+        return_value=capture_snapshot,
+    ), patch(
+        "app.services.orders_service._get_tenant_tax_config",
+        new=AsyncMock(return_value={"inc_enabled": True}),
+    ), patch(
+        "app.services.orders_service._post_order_gl_entry",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.orders_service._post_order_cogs_gl_entry",
+        new=AsyncMock(),
+    ):
+        result = await orders_service.create_manual_order(
+            Request({"type": "http"}),
+            order_date="2026-06-07T10:30:00",
+            payment_method="digital",
+            payment_method_id=str(payment_method_id),
+            items=[
+                {
+                    "product_id": str(product_id),
+                    "quantity": 2,
+                    "unit_price": 15000,
+                    "modifiers": [
+                        {
+                            "id": str(modifier_id),
+                            "name": "Extra queso",
+                            "price": 2500,
+                            "quantity": 2,
+                        }
+                    ],
+                }
+            ],
+        )
+
+    assert result["success"] is True
+    order_insert_args = conn.fetchrow.await_args_list[0].args
+    item_insert_args = conn.fetchrow.await_args_list[1].args
+    modifier_insert_args = conn.execute.await_args_list[0].args
+
+    assert order_insert_args[6] == 40000
+    assert item_insert_args[5] == 40000
+    assert modifier_insert_args[5] == 2.0
+    deduct_modifier_inventory.assert_awaited_once()
+    assert deduct_modifier_inventory.await_args.kwargs["modifier_qty"] == 2.0
+    assert deduct_modifier_inventory.await_args.kwargs["modifier"]["quantity"] == 2
+
+
+@pytest.mark.asyncio
+async def test_create_manual_order_legacy_modifier_payload_defaults_quantity_to_one():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    order_id = uuid4()
+    order_item_id = uuid4()
+    product_id = uuid4()
+    modifier_id = uuid4()
+    payment_method_id = uuid4()
+    order_date = datetime(2026, 6, 7, 10, 30)
+    conn = _manual_order_conn(order_id, order_item_id, order_date)
+
+    deduct_modifier_inventory = AsyncMock()
+
+    with patch(
+        "app.services.orders_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id, user_id=user_id),
+    ), patch(
+        "app.services.orders_service.get_db_connection",
+        return_value=_AsyncContext(conn),
+    ), patch(
+        "app.services.orders_service.assert_order_not_in_closed_monthly_period",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.orders_service._pos_modifier_inventory_helpers",
+        return_value=(deduct_modifier_inventory, None, None),
+    ), patch(
+        "app.services.orders_service._pos_order_item_ingredient_snapshot_helper",
+        return_value=AsyncMock(),
+    ), patch(
+        "app.services.orders_service._get_tenant_tax_config",
+        new=AsyncMock(return_value={"inc_enabled": True}),
+    ), patch(
+        "app.services.orders_service._post_order_gl_entry",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.orders_service._post_order_cogs_gl_entry",
+        new=AsyncMock(),
+    ):
+        result = await orders_service.create_manual_order(
+            Request({"type": "http"}),
+            order_date="2026-06-07T10:30:00",
+            payment_method="digital",
+            payment_method_id=str(payment_method_id),
+            items=[
+                {
+                    "product_id": str(product_id),
+                    "quantity": 2,
+                    "unit_price": 15000,
+                    "modifiers": [
+                        {
+                            "id": str(modifier_id),
+                            "name": "Extra queso",
+                            "price": 2500,
+                        }
+                    ],
+                }
+            ],
+        )
+
+    assert result["success"] is True
+    order_insert_args = conn.fetchrow.await_args_list[0].args
+    item_insert_args = conn.fetchrow.await_args_list[1].args
+    modifier_insert_args = conn.execute.await_args_list[0].args
+
+    assert order_insert_args[6] == 35000
+    assert item_insert_args[5] == 35000
+    assert modifier_insert_args[5] == 1.0
+    assert deduct_modifier_inventory.await_args.kwargs["modifier_qty"] == 1.0


### PR DESCRIPTION
## Summary

- Accept `quantity` on manual order modifiers with a default of 1 for legacy payloads.
- Calculate manual order totals and item subtotals using modifier quantity per product unit.
- Persist real modifier quantities and pass them through to modifier inventory deduction.

## Validation

```bash
pytest tests/test_manual_order_gl_cogs.py tests/test_order_item_ingredient_snapshots.py
```

Result: 9 passed.

Closes uno0uno/warocol.com#1274
