### PR TITLE
Preserve online cart modifier quantities

### DIFF
--- a/.wr/408.yaml
+++ b/.wr/408.yaml
@@ -1,0 +1,42 @@
+issue: 408
+title: "Preserve online cart modifier quantities for COGS and accounting"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-408-online-cart-modifier-quantity
+
+paths:
+  - app/models/online_cart.py
+  - app/services/online_cart_service.py
+  - sql/20260608_online_cart_modifier_quantity.sql
+  - tests/test_online_cart_batch.py
+
+ac:
+  - OnlineCartItemCreate.modifiers accepts optional quantity default 1
+  - Online cart subtotal multiplies modifier unit price by modifier quantity
+  - online_cart_item_modifiers persists and returns quantity
+  - checkout_cart copies stored modifier quantity into order_item_modifiers
+  - Focused backend coverage for modifier quantity greater than 1
+
+out_of_scope:
+  - Frontend UI changes
+  - Broad accounting or PUC redesign
+  - POS/table/manual order flows
+
+hints:
+  entry: "app.services.online_cart_service.create_cart_with_batch_items / checkout_cart"
+  pattern: "app.services.pos_cart_service uses modifier.get('quantity', 1) and persists order_item_modifiers.quantity"
+  tests: "pytest tests/test_online_cart_batch.py"
+
+risk:
+  sensitive: false
+  areas: ["online checkout totals", "COGS/inventory quantity handoff"]
+
+skip:
+  audits:
+    - repo-wide audit
+    - frontend validation
+
+next:
+  after_pr: "none"

--- a/app/models/online_cart.py
+++ b/app/models/online_cart.py
@@ -10,9 +10,10 @@ from decimal import Decimal
 
 
 class ModifierInput(BaseModel):
-    """Modifier input for cart items — only the ID is required.
+    """Modifier input for cart items.
     Price and name are always looked up from the DB."""
     id: UUID
+    quantity: int = Field(default=1, ge=1)
 
 
 class OnlineCartItemCreate(BaseModel):
@@ -29,6 +30,7 @@ class OnlineCartItemModifier(BaseModel):
     modifier_id: UUID
     modifier_name: str
     price: Decimal
+    quantity: Decimal
 
 
 class OnlineCartItem(BaseModel):

--- a/app/services/online_cart_service.py
+++ b/app/services/online_cart_service.py
@@ -37,7 +37,7 @@ async def get_cart_items(conn, cart_id: UUID) -> List[dict]:
     for item_row in item_rows:
         # Get modifiers for this item
         modifiers_query = """
-            SELECT id, modifier_id, modifier_name, price
+            SELECT id, modifier_id, modifier_name, price, quantity
             FROM online_cart_item_modifiers
             WHERE cart_item_id = $1
         """
@@ -56,7 +56,8 @@ async def get_cart_items(conn, cart_id: UUID) -> List[dict]:
                     "id": str(mod['id']),
                     "modifier_id": str(mod['modifier_id']),
                     "modifier_name": mod['modifier_name'],
-                    "price": float(mod['price'])
+                    "price": float(mod['price']),
+                    "quantity": float(mod['quantity'] or 1)
                 }
                 for mod in modifier_rows
             ]
@@ -67,7 +68,10 @@ async def get_cart_items(conn, cart_id: UUID) -> List[dict]:
 
 def calculate_item_subtotal(unit_price: float, modifiers: List[dict], quantity: int) -> float:
     """Calculate item subtotal including modifiers"""
-    modifier_total = sum(mod.get('price', 0) for mod in modifiers)
+    modifier_total = sum(
+        float(mod.get('price', 0)) * float(mod.get('quantity') or 1)
+        for mod in modifiers
+    )
     return (unit_price + modifier_total) * quantity
 
 
@@ -241,11 +245,12 @@ async def create_cart_with_batch_items(
                                 resolved_modifiers.append({
                                     'id': mod['id'],
                                     'name': db_mod['name'],
-                                    'price': Decimal(str(db_mod['price']))
+                                    'price': Decimal(str(db_mod['price'])),
+                                    'quantity': Decimal(str(mod.get('quantity') or 1)),
                                 })
 
                     # Calculate subtotal from DB prices
-                    modifier_total = sum(m['price'] for m in resolved_modifiers)
+                    modifier_total = sum(m['price'] * m['quantity'] for m in resolved_modifiers)
                     subtotal = (unit_price + modifier_total) * quantity
 
                     # Insert cart item
@@ -271,16 +276,17 @@ async def create_cart_with_batch_items(
                     for mod in resolved_modifiers:
                         mod_insert_query = """
                             INSERT INTO online_cart_item_modifiers (
-                                cart_item_id, modifier_id, modifier_name, price
+                                cart_item_id, modifier_id, modifier_name, price, quantity
                             )
-                            VALUES ($1, $2, $3, $4)
+                            VALUES ($1, $2, $3, $4, $5)
                         """
                         await conn.execute(
                             mod_insert_query,
                             item_id,
                             mod['id'],
                             mod['name'],
-                            mod['price']
+                            mod['price'],
+                            mod['quantity'],
                         )
 
                     cart_total += subtotal
@@ -834,7 +840,7 @@ async def checkout_cart(
                             mod['modifier_id'],
                             mod['modifier_name'],
                             Decimal(str(mod['price'])),
-                            1
+                            Decimal(str(mod.get('quantity') or 1))
                         )
 
                 # 9. Fetch delivery address for the confirmation email (inside transaction,

--- a/sql/20260608_online_cart_modifier_quantity.sql
+++ b/sql/20260608_online_cart_modifier_quantity.sql
@@ -1,0 +1,9 @@
+ALTER TABLE online_cart_item_modifiers
+ADD COLUMN IF NOT EXISTS quantity numeric(10,4) NOT NULL DEFAULT 1;
+
+ALTER TABLE online_cart_item_modifiers
+DROP CONSTRAINT IF EXISTS online_cart_item_modifiers_quantity_positive;
+
+ALTER TABLE online_cart_item_modifiers
+ADD CONSTRAINT online_cart_item_modifiers_quantity_positive
+CHECK (quantity > 0);

--- a/tests/test_online_cart_batch.py
+++ b/tests/test_online_cart_batch.py
@@ -112,6 +112,29 @@ class TestOnlineCartBatchModifierValidation:
         assert data["data"]["items"][0]["subtotal"] == 56000.0
 
     @pytest.mark.asyncio
+    async def test_modifier_quantity_multiplies_subtotal_and_response(self, client: AsyncClient):
+        """Modifier quantity is preserved and priced with DB-sourced unit price."""
+        payload = _batch_payload([{
+            "product_id": PRODUCT_ID,
+            "quantity": 2,
+            "unit_price": 25000.0,
+            "modifiers": [
+                {"id": MODIFIER_ACHIOTE, "name": "Ignored", "price": 0.0, "quantity": 2},
+            ],
+        }])
+        response = await client.post("/online/cart/batch", json=payload)
+        assert response.status_code == 200
+        data = response.json()["data"]
+        item = data["items"][0]
+        modifier = item["modifiers"][0]
+
+        # subtotal = (25000 + (3000 * 2)) * 2 = 62000
+        assert item["subtotal"] == 62000.0
+        assert data["total_amount"] == 62000.0
+        assert modifier["price"] == 3000.0
+        assert modifier["quantity"] == 2.0
+
+    @pytest.mark.asyncio
     async def test_no_modifiers_returns_200(self, client: AsyncClient):
         """Empty modifiers array skips validation entirely and creates cart."""
         payload = _batch_payload([{


### PR DESCRIPTION
## Summary
- Accept and persist online cart modifier quantities with a default of 1
- Multiply online cart modifier totals by modifier quantity and return stored quantity in responses
- Copy stored modifier quantity into order item modifiers during checkout
- Add an idempotent SQL migration for online_cart_item_modifiers.quantity

## Validation
- psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f sql/20260608_online_cart_modifier_quantity.sql
- psql "$DATABASE_URL" -c "\\d+ online_cart_item_modifiers"
- pytest tests/test_online_cart_batch.py

Closes #408