### PR TITLE
Preserve Table QR modifier quantities

### DIFF
--- a/app/routers/public_table_qr.py
+++ b/app/routers/public_table_qr.py
@@ -15,6 +15,7 @@ router = APIRouter()
 
 class TableQrRequestModifier(BaseModel):
     id: UUID
+    quantity: int = Field(1, ge=1)
 
 
 class TableQrRequestItem(BaseModel):
@@ -72,7 +73,10 @@ async def submit_table_qr_request(
         {
             "product_id": str(item.product_id),
             "quantity": item.quantity,
-            "modifiers": [{"id": str(m.id)} for m in item.modifiers] if item.modifiers else [],
+            "modifiers": [
+                {"id": str(m.id), "quantity": m.quantity}
+                for m in item.modifiers
+            ] if item.modifiers else [],
             "notes": item.notes,
         }
         for item in body.items

--- a/app/services/public_table_qr_service.py
+++ b/app/services/public_table_qr_service.py
@@ -398,6 +398,12 @@ async def _build_item_snapshots(
             mod_map = {row["id"]: row for row in mod_rows}
             for mod in modifiers_in:
                 mod_id = UUID(str(mod["id"]))
+                mod_quantity = int(mod.get("quantity", 1))
+                if mod_quantity < 1:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="La cantidad del modificador debe ser al menos 1.",
+                    )
                 db_mod = mod_map.get(mod_id)
                 if not db_mod:
                     raise HTTPException(
@@ -405,11 +411,12 @@ async def _build_item_snapshots(
                         detail=f"Modifier '{mod_id}' does not exist or is not available",
                     )
                 price = Decimal(str(db_mod["price"]))
-                modifier_total += price
+                modifier_total += price * mod_quantity
                 resolved_modifiers.append({
                     "id": str(mod_id),
                     "name": db_mod["name"],
                     "price": float(price),
+                    "quantity": mod_quantity,
                 })
 
         line_total = (unit_price + modifier_total) * quantity

--- a/tests/test_table_qr_public.py
+++ b/tests/test_table_qr_public.py
@@ -120,6 +120,7 @@ def test_submit_endpoint_delegates_to_service():
     app = FastAPI()
     app.include_router(public_table_qr_router.router, prefix="/public/table-qr")
 
+    modifier_id = uuid4()
     submit_result = {
         "request_id": str(uuid4()),
         "status": "pending",
@@ -138,9 +139,140 @@ def test_submit_endpoint_delegates_to_service():
         res = client.post(
             f"/public/table-qr/tok-abc/requests",
             json={
-                "items": [{"product_id": product_id, "quantity": 1}],
+                "items": [{
+                    "product_id": product_id,
+                    "quantity": 1,
+                    "modifiers": [{"id": str(modifier_id), "quantity": 2}],
+                }],
                 "payment_method": "cash",
             },
         )
         assert res.status_code == 200
         assert res.json()["data"]["status"] == "pending"
+
+        forwarded_items = (
+            public_table_qr_service.submit_table_qr_request.await_args.kwargs["items"]
+        )
+        assert forwarded_items[0]["modifiers"] == [{
+            "id": str(modifier_id),
+            "quantity": 2,
+        }]
+
+
+def test_submit_endpoint_defaults_modifier_quantity_to_one():
+    app = FastAPI()
+    app.include_router(public_table_qr_router.router, prefix="/public/table-qr")
+
+    with patch(
+        "app.routers.public_table_qr.public_table_qr_service.submit_table_qr_request",
+        new_callable=AsyncMock,
+        return_value={"status": "pending"},
+    ):
+        client = TestClient(app)
+        product_id = str(uuid4())
+        modifier_id = uuid4()
+        res = client.post(
+            "/public/table-qr/tok-abc/requests",
+            json={
+                "items": [{
+                    "product_id": product_id,
+                    "quantity": 1,
+                    "modifiers": [{"id": str(modifier_id)}],
+                }],
+            },
+        )
+
+        assert res.status_code == 200
+        forwarded_items = (
+            public_table_qr_service.submit_table_qr_request.await_args.kwargs["items"]
+        )
+        assert forwarded_items[0]["modifiers"][0]["quantity"] == 1
+
+
+def test_submit_endpoint_rejects_invalid_modifier_quantity():
+    app = FastAPI()
+    app.include_router(public_table_qr_router.router, prefix="/public/table-qr")
+
+    client = TestClient(app)
+    res = client.post(
+        "/public/table-qr/tok-abc/requests",
+        json={
+            "items": [{
+                "product_id": str(uuid4()),
+                "quantity": 1,
+                "modifiers": [{"id": str(uuid4()), "quantity": 0}],
+            }],
+        },
+    )
+
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_build_item_snapshots_multiplies_and_persists_modifier_quantity():
+    tenant_id = uuid4()
+    product_id = uuid4()
+    modifier_id = uuid4()
+    conn = MagicMock()
+    conn.fetch = AsyncMock(side_effect=[
+        [{"id": product_id, "name": "Hamburguesa", "price": 10000}],
+        [{"id": modifier_id, "name": "Tocineta", "price": 2500}],
+    ])
+
+    with patch(
+        "app.services.public_table_qr_service.validate_products_belong_to_tenant",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.public_table_qr_service.validate_modifiers_for_item",
+        new=AsyncMock(),
+    ):
+        snapshots, total = await public_table_qr_service._build_item_snapshots(
+            conn,
+            tenant_id,
+            [{
+                "product_id": str(product_id),
+                "quantity": 2,
+                "modifiers": [{"id": str(modifier_id), "quantity": 3}],
+            }],
+        )
+
+    assert total == 35000
+    assert snapshots[0]["line_total"] == 35000.0
+    assert snapshots[0]["modifiers"] == [{
+        "id": str(modifier_id),
+        "name": "Tocineta",
+        "price": 2500.0,
+        "quantity": 3,
+    }]
+
+
+@pytest.mark.asyncio
+async def test_build_item_snapshots_rejects_invalid_modifier_quantity():
+    tenant_id = uuid4()
+    product_id = uuid4()
+    modifier_id = uuid4()
+    conn = MagicMock()
+    conn.fetch = AsyncMock(side_effect=[
+        [{"id": product_id, "name": "Hamburguesa", "price": 10000}],
+        [{"id": modifier_id, "name": "Tocineta", "price": 2500}],
+    ])
+
+    with patch(
+        "app.services.public_table_qr_service.validate_products_belong_to_tenant",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.public_table_qr_service.validate_modifiers_for_item",
+        new=AsyncMock(),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await public_table_qr_service._build_item_snapshots(
+                conn,
+                tenant_id,
+                [{
+                    "product_id": str(product_id),
+                    "quantity": 1,
+                    "modifiers": [{"id": str(modifier_id), "quantity": 0}],
+                }],
+            )
+
+    assert exc.value.status_code == 400

--- a/tests/test_table_qr_requests.py
+++ b/tests/test_table_qr_requests.py
@@ -162,6 +162,81 @@ async def test_accept_conflicting_payment_methods_409():
         assert exc.value.status_code == 409
 
 
+@pytest.mark.asyncio
+async def test_accept_requests_passes_persisted_modifier_quantity_to_tab_core():
+    session = _session()
+    request_id = uuid4()
+    table_id = uuid4()
+    request_items = [{
+        "product_id": str(uuid4()),
+        "quantity": 1,
+        "unit_price": 10.0,
+        "modifiers": [{
+            "id": str(uuid4()),
+            "name": "Tocineta",
+            "price": 2.5,
+            "quantity": 3,
+        }],
+        "line_total": 17.5,
+    }]
+
+    conn = MagicMock()
+    tx = MagicMock()
+    tx.__aenter__ = AsyncMock(return_value=None)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction.return_value = tx
+    conn.fetch = AsyncMock(side_effect=[
+        [{
+            "id": request_id,
+            "table_id": table_id,
+            "status": "pending",
+            "items": json.dumps(request_items),
+            "payment_method": None,
+            "payment_method_id": None,
+            "customer_notes": None,
+            "created_at": MagicMock(),
+        }],
+        [{"id": request_id}],
+    ])
+    conn.execute = AsyncMock()
+
+    with patch(
+        "app.services.table_qr_requests_service.require_valid_session",
+        return_value=session,
+    ), patch(
+        "app.services.table_qr_requests_service.get_db_connection",
+    ) as mock_conn, patch(
+        "app.services.table_qr_requests_service._resolve_tenant_member_id",
+        new=AsyncMock(return_value=uuid4()),
+    ), patch(
+        "app.services.table_qr_requests_service._ensure_open_session_in_tx",
+        new=AsyncMock(return_value=uuid4()),
+    ), patch(
+        "app.services.table_qr_requests_service._add_tab_items_core",
+        new=AsyncMock(return_value={
+            "session_id": uuid4(),
+            "order_id": uuid4(),
+            "order_number": 12,
+            "items_count": 1,
+            "total_amount": 17.5,
+        }),
+    ) as add_tab_mock, patch(
+        "app.services.table_qr_requests_service.fire_table_items",
+        new=AsyncMock(),
+    ):
+        mock_conn.return_value.__aenter__ = AsyncMock(return_value=conn)
+        mock_conn.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await table_qr_requests_service.accept_requests(
+            MagicMock(),
+            [request_id],
+        )
+
+    assert result["success"] is True
+    forwarded_items = add_tab_mock.await_args.args[4]
+    assert forwarded_items[0]["modifiers"][0]["quantity"] == 3
+
+
 def test_list_endpoint_delegates():
     app = FastAPI()
     app.include_router(table_qr_requests_router.router, prefix="/table-qr-requests")

--- a/tests/test_tables_tab_modifier_inventory.py
+++ b/tests/test_tables_tab_modifier_inventory.py
@@ -31,6 +31,7 @@ async def test_add_tab_items_core_deducts_modifier_inventory():
         None,
         {"id": order_id, "order_number": 42, "total_amount": 43.0},
         {"id": order_item_id},
+        {"total_amount": 43.0},
     ])
     mock_conn.fetch = AsyncMock(return_value=[])
     mock_conn.execute = AsyncMock()
@@ -99,6 +100,7 @@ async def test_add_tab_items_core_persists_modifier_quantity():
         None,
         {"id": order_id, "order_number": 42, "total_amount": 61.0},
         {"id": order_item_id},
+        {"total_amount": 52.0},
     ])
     mock_conn.fetch = AsyncMock(return_value=[])
     mock_conn.execute = AsyncMock()
@@ -219,6 +221,7 @@ async def test_deduct_modifier_inventory_for_order_item_writes_movement():
     mock_conn = AsyncMock()
     mock_conn.fetchrow = AsyncMock(side_effect=[
         {
+            "option_type": "INGREDIENT",
             "ingredient_id": ingredient_id,
             "ingredient_quantity": 1,
             "ingredient_unit": "und",
@@ -230,10 +233,10 @@ async def test_deduct_modifier_inventory_for_order_item_writes_movement():
     mock_conn.execute = AsyncMock()
 
     with patch(
-        "app.services.pos_cart_service.resolve_recipe_quantity_to_base_unit",
+        "app.services.modifier_option_service.resolve_recipe_quantity_to_base_unit",
         new=AsyncMock(return_value=1.0),
     ), patch(
-        "app.services.pos_cart_service._capture_modifier_ingredient_snapshot",
+        "app.services.pos_cart_service._capture_modifier_ingredient_line_snapshot",
         new=AsyncMock(),
     ) as snapshot_mock:
         await pos_cart_service._deduct_modifier_inventory_for_order_item(


### PR DESCRIPTION
## Summary
- accept and forward `modifier.quantity` from public Table QR request payloads
- multiply modifier unit prices by modifier quantity in pending request snapshots
- preserve persisted modifier quantity through accept-to-mesa handoff coverage
- refresh stale modifier inventory test fixtures for current resolver behavior

## Validation
- `pytest tests/test_table_qr_public.py tests/test_table_qr_requests.py tests/test_tables_tab_modifier_inventory.py`

Closes #419