### PR TITLE
Fix promo basis for optional modifiers

### DIFF
--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -85,18 +85,32 @@ def _distribute_discount(items: List[dict], discount_amount: float) -> List[dict
 
 
 def _cart_items_to_promo_lines(items: List[dict]) -> List[dict]:
-    return [
-        {
+    lines = []
+    for item in items:
+        quantity = item.get("quantity") or 1
+        raw_unit_price = item.get("unit_price")
+        if raw_unit_price is None:
+            raw_unit_price = item.get("product", {}).get("price")
+        eligible_modifier_total = sum(
+            float(mod.get("price") or 0)
+            for mod in item.get("modifiers", [])
+            if mod.get("group_is_required") or mod.get("is_default")
+        )
+        line = {
             "id": item["id"],
             "product_id": item.get("product_id") or item["product"]["id"],
             "category_id": item.get("category_id"),
-            "quantity": item.get("quantity") or 1,
+            "quantity": quantity,
             "subtotal": float(item["subtotal"]),
             "tax_category": item.get("tax_category") or "standard",
             "promo_opt_out": bool(item.get("promo_opt_out")),
         }
-        for item in items
-    ]
+        if raw_unit_price is not None:
+            line["promo_eligible_subtotal"] = (
+                float(raw_unit_price) + eligible_modifier_total
+            ) * quantity
+        lines.append(line)
+    return lines
 
 
 def _manual_discount_amount(
@@ -377,7 +391,9 @@ async def get_cart_items(conn, cart_id: UUID) -> List[dict]:
                     json_build_object(
                         'id', m.modifier_id::text,
                         'name', m.modifier_name,
-                        'price', m.price
+                        'price', m.price,
+                        'is_default', COALESCE(mod.is_default, false),
+                        'group_is_required', COALESCE(mg.is_required, false)
                     ) ORDER BY m.created_at
                 ) FILTER (WHERE m.cart_item_id IS NOT NULL),
                 '[]'::json
@@ -385,6 +401,8 @@ async def get_cart_items(conn, cart_id: UUID) -> List[dict]:
         FROM pos_cart_items ci
         JOIN product p ON ci.product_id = p.id
         LEFT JOIN pos_cart_item_modifiers m ON m.cart_item_id = ci.id
+        LEFT JOIN modifiers mod ON mod.id = m.modifier_id
+        LEFT JOIN modifier_groups mg ON mg.id = mod.modifier_group_id
         WHERE ci.cart_id = $1
         GROUP BY ci.id, ci.product_id, ci.quantity, ci.unit_price, ci.subtotal,
                  ci.notes, ci.promo_opt_out, ci.created_at, p.name, p.category_id, p.tax_category, p.is_resale
@@ -416,7 +434,9 @@ async def get_cart_items(conn, cart_id: UUID) -> List[dict]:
                 {
                     "id": mod['id'],
                     "name": mod['name'],
-                    "price": float(mod['price'])
+                    "price": float(mod['price']),
+                    "is_default": bool(mod.get("is_default")),
+                    "group_is_required": bool(mod.get("group_is_required")),
                 }
                 for mod in raw_modifiers
             ],

--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -1200,11 +1200,30 @@ def _pick_best_promotion_for_line(
     return max(eligible, key=_promo_rank_key)
 
 
-def _compute_line_promo_savings(line: Dict[str, Any], promo: Dict[str, Any]) -> int:
-    """Return COP savings for one cart/order line (Toast-style BOGO uses full unit price)."""
+def _promo_eligible_subtotal(line: Dict[str, Any]) -> float:
     subtotal = float(line["subtotal"])
+    raw = line.get("promo_eligible_subtotal")
+    if raw is None:
+        return subtotal
+    return min(subtotal, max(0.0, float(raw)))
+
+
+def _promo_eligible_unit_price(line: Dict[str, Any]) -> float:
     quantity = int(line.get("quantity") or 1)
-    if subtotal <= 0 or quantity <= 0:
+    if quantity <= 0:
+        return 0.0
+    raw = line.get("promo_eligible_unit_price")
+    if raw is not None:
+        return min(max(0.0, float(raw)), _promo_eligible_subtotal(line) / quantity)
+    return _promo_eligible_subtotal(line) / quantity
+
+
+def _compute_line_promo_savings(line: Dict[str, Any], promo: Dict[str, Any]) -> int:
+    """Return COP savings for one cart/order line using its promo-eligible basis."""
+    subtotal = float(line["subtotal"])
+    eligible_subtotal = _promo_eligible_subtotal(line)
+    quantity = int(line.get("quantity") or 1)
+    if subtotal <= 0 or eligible_subtotal <= 0 or quantity <= 0:
         return 0
 
     promo_type = promo["promo_type"]
@@ -1214,13 +1233,13 @@ def _compute_line_promo_savings(line: Dict[str, Any], promo: Dict[str, Any]) -> 
         pct = float(value_json.get("percent") or 0)
         if pct <= 0:
             return 0
-        return min(round(subtotal * pct / 100), round(subtotal))
+        return min(round(eligible_subtotal * pct / 100), round(eligible_subtotal))
 
     if promo_type == "fixed_off":
         amount = float(value_json.get("amount_cop") or 0)
         if amount <= 0:
             return 0
-        return min(round(amount), round(subtotal))
+        return min(round(amount), round(eligible_subtotal))
 
     if promo_type == "bogo":
         buy_qty = int(value_json.get("buy_qty") or 0)
@@ -1231,19 +1250,18 @@ def _compute_line_promo_savings(line: Dict[str, Any], promo: Dict[str, Any]) -> 
         sets = quantity // bundle
         if sets <= 0:
             return 0
-        unit_price = subtotal / quantity
+        unit_price = _promo_eligible_unit_price(line)
         free_units = sets * get_qty
-        return min(round(free_units * unit_price), round(subtotal))
+        return min(round(free_units * unit_price), round(eligible_subtotal))
 
     return 0
 
 
-def _line_unit_price(line: Dict[str, Any]) -> float:
+def _line_promo_eligible_unit_price(line: Dict[str, Any]) -> float:
     quantity = int(line.get("quantity") or 1)
-    subtotal = float(line["subtotal"])
-    if quantity <= 0 or subtotal <= 0:
+    if quantity <= 0:
         return 0.0
-    return subtotal / quantity
+    return _promo_eligible_subtotal(line) / quantity
 
 
 def _allocate_bogo_savings_cheapest_first(
@@ -1262,27 +1280,31 @@ def _allocate_bogo_savings_cheapest_first(
 
     bundle = buy_qty + get_qty
     units: List[tuple[str, float]] = []
-    subtotal_by_line: Dict[str, float] = {}
+    cap_by_line: Dict[str, float] = {}
     for entry in entries:
         line_id = str(entry["line_id"])
         qty = max(0, int(entry.get("quantity") or 1))
         unit_price = float(entry["unit_price"])
-        subtotal_by_line[line_id] = float(entry.get("subtotal") or (unit_price * qty))
+        cap_by_line[line_id] = float(
+            entry.get("promo_eligible_subtotal")
+            if entry.get("promo_eligible_subtotal") is not None
+            else entry.get("subtotal") or (unit_price * qty)
+        )
         for _ in range(qty):
             units.append((line_id, unit_price))
 
     sets = len(units) // bundle
     free_count = sets * get_qty
-    savings_by_line: Dict[str, float] = {lid: 0.0 for lid in subtotal_by_line}
+    savings_by_line: Dict[str, float] = {lid: 0.0 for lid in cap_by_line}
     if free_count <= 0:
-        return {lid: 0 for lid in subtotal_by_line}
+        return {lid: 0 for lid in cap_by_line}
 
     units.sort(key=lambda item: item[1])
     for line_id, unit_price in units[:free_count]:
         savings_by_line[line_id] += unit_price
 
     return {
-        line_id: min(round(savings), round(subtotal_by_line[line_id]))
+        line_id: min(round(savings), round(cap_by_line[line_id]))
         for line_id, savings in savings_by_line.items()
     }
 
@@ -1350,8 +1372,9 @@ def evaluate_cart_promotions(
             {
                 "line_id": state["line_id"],
                 "quantity": int(state["line"].get("quantity") or 1),
-                "unit_price": _line_unit_price(state["line"]),
+                "unit_price": _line_promo_eligible_unit_price(state["line"]),
                 "subtotal": state["subtotal"],
+                "promo_eligible_subtotal": _promo_eligible_subtotal(state["line"]),
             }
             for state in group_states
         ]
@@ -1608,7 +1631,8 @@ def promo_persist_fields_from_eval_line(
 
 
 _SESSION_PENDING_PROMO_ITEMS_SQL = """
-    SELECT oi.id, oi.subtotal, oi.quantity, oi.product_id, oi.promo_opt_out,
+    SELECT oi.id, oi.subtotal, oi.quantity, oi.price_at_purchase,
+           oi.product_id, oi.promo_opt_out,
            p.category_id,
            COALESCE(p.tax_category, 'standard') AS tax_category
     FROM order_items oi
@@ -1618,20 +1642,84 @@ _SESSION_PENDING_PROMO_ITEMS_SQL = """
 """
 
 
+def _row_value(row: Any, key: str, default: Any = None) -> Any:
+    try:
+        return row[key]
+    except (KeyError, IndexError, TypeError):
+        if hasattr(row, "get"):
+            return row.get(key, default)
+        return default
+
+
+def _row_to_dict(row: Any) -> Dict[str, Any]:
+    if isinstance(row, dict):
+        return dict(row)
+    return {key: row[key] for key in row.keys()}
+
+
 def item_rows_to_promo_lines(item_rows: Sequence[Any]) -> List[Dict[str, Any]]:
     """Map pending order_item rows → evaluate_checkout_promotions input."""
-    return [
-        {
+    lines: List[Dict[str, Any]] = []
+    for row in item_rows:
+        quantity = int(row["quantity"])
+        line = {
             "id": str(row["id"]),
             "product_id": str(row["product_id"]),
             "category_id": str(row["category_id"]) if row["category_id"] else None,
-            "quantity": int(row["quantity"]),
+            "quantity": quantity,
             "subtotal": float(row["subtotal"]),
             "tax_category": row["tax_category"] or "standard",
-            "promo_opt_out": bool(row.get("promo_opt_out")),
+            "promo_opt_out": bool(_row_value(row, "promo_opt_out")),
         }
-        for row in item_rows
-    ]
+        explicit_eligible = _row_value(row, "promo_eligible_subtotal")
+        base_price = _row_value(row, "price_at_purchase")
+        eligible_modifier_total = _row_value(row, "promo_eligible_modifier_unit_total", 0)
+        if explicit_eligible is not None:
+            line["promo_eligible_subtotal"] = float(explicit_eligible)
+        elif base_price is not None:
+            line["promo_eligible_subtotal"] = (
+                float(base_price) + float(eligible_modifier_total or 0)
+            ) * quantity
+        lines.append(line)
+    return lines
+
+
+async def enrich_order_item_rows_with_promo_basis(
+    conn: asyncpg.Connection,
+    item_rows: Sequence[Any],
+) -> List[Dict[str, Any]]:
+    """Attach required/default modifier totals used as the promo-eligible basis."""
+    rows = [_row_to_dict(row) for row in item_rows]
+    order_item_ids = [row["id"] for row in rows]
+    if not order_item_ids:
+        return rows
+
+    basis_rows = await conn.fetch(
+        """
+        SELECT
+            oim.order_item_id,
+            SUM(
+                CASE
+                    WHEN COALESCE(mg.is_required, false) OR COALESCE(m.is_default, false)
+                    THEN oim.price_at_purchase * COALESCE(oim.quantity, 1)
+                    ELSE 0
+                END
+            ) AS eligible_modifier_unit_total
+        FROM order_item_modifiers oim
+        JOIN modifiers m ON m.id = oim.modifier_id
+        JOIN modifier_groups mg ON mg.id = m.modifier_group_id
+        WHERE oim.order_item_id = ANY($1::uuid[])
+        GROUP BY oim.order_item_id
+        """,
+        order_item_ids,
+    )
+    basis_by_id = {
+        row["order_item_id"]: float(row["eligible_modifier_unit_total"] or 0)
+        for row in basis_rows
+    }
+    for row in rows:
+        row["promo_eligible_modifier_unit_total"] = basis_by_id.get(row["id"], 0.0)
+    return rows
 
 
 async def apply_promo_eval_to_order_items(
@@ -1701,10 +1789,11 @@ async def persist_session_tab_promos(
             "promo_breakdown": [],
         }
 
+    enriched_rows = await enrich_order_item_rows_with_promo_basis(conn, item_rows)
     checkout_eval = await evaluate_checkout_promotions(
         conn,
         tenant_id,
-        item_rows_to_promo_lines(item_rows),
+        item_rows_to_promo_lines(enriched_rows),
     )
     await apply_promo_eval_to_order_items(conn, item_rows, checkout_eval)
     await recalc_pending_session_order_totals(conn, session_id)

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -925,13 +925,18 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
 
                     payment_status = 'credit' if payment_method == 'credit' else ('partial' if split_mode else 'paid')
 
-                    from app.services.promotions_service import evaluate_checkout_promotions
+                    from app.services.promotions_service import (
+                        enrich_order_item_rows_with_promo_basis,
+                        evaluate_checkout_promotions,
+                        item_rows_to_promo_lines,
+                    )
 
                     _discount_amount = None
                     _promo_breakdown = []
                     item_rows = await conn.fetch(
                         """
-                        SELECT oi.id, oi.subtotal, oi.quantity, oi.product_id, oi.promo_opt_out,
+                        SELECT oi.id, oi.subtotal, oi.quantity, oi.price_at_purchase,
+                               oi.product_id, oi.promo_opt_out,
                                p.category_id,
                                COALESCE(p.tax_category, 'standard') AS tax_category
                         FROM order_items oi
@@ -941,18 +946,8 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                         """,
                         session_row["id"],
                     )
-                    promo_lines = [
-                        {
-                            "id": str(row["id"]),
-                            "product_id": str(row["product_id"]),
-                            "category_id": str(row["category_id"]) if row["category_id"] else None,
-                            "quantity": int(row["quantity"]),
-                            "subtotal": float(row["subtotal"]),
-                            "tax_category": row["tax_category"] or "standard",
-                            "promo_opt_out": bool(row.get("promo_opt_out")),
-                        }
-                        for row in item_rows
-                    ]
+                    item_rows = await enrich_order_item_rows_with_promo_basis(conn, item_rows)
+                    promo_lines = item_rows_to_promo_lines(item_rows)
                     checkout_eval = await evaluate_checkout_promotions(
                         conn,
                         UUID(str(tenant_id)),
@@ -1859,7 +1854,11 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
             _promo_lines_by_id: Dict[str, dict] = {}
             try:
                 from app.services.orders_service import _compute_tax_breakdown
-                from app.services.promotions_service import evaluate_checkout_promotions
+                from app.services.promotions_service import (
+                    enrich_order_item_rows_with_promo_basis,
+                    evaluate_checkout_promotions,
+                    item_rows_to_promo_lines,
+                )
 
                 tax_config = await _get_tenant_tax_config(conn, tenant_id)
                 order_ids = [o["id"] for o in orders]
@@ -1870,6 +1869,7 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                             oi.id,
                             oi.quantity,
                             oi.subtotal,
+                            oi.price_at_purchase,
                             oi.product_id,
                             oi.promo_opt_out,
                             p.category_id,
@@ -1881,18 +1881,8 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                         """,
                         order_ids,
                     )
-                    promo_lines = [
-                        {
-                            "id": str(row["id"]),
-                            "product_id": str(row["product_id"]),
-                            "category_id": str(row["category_id"]) if row["category_id"] else None,
-                            "quantity": int(row["quantity"]),
-                            "subtotal": float(row["subtotal"]),
-                            "tax_category": row["tax_category"] or "standard",
-                            "promo_opt_out": bool(row.get("promo_opt_out")),
-                        }
-                        for row in eval_rows
-                    ]
+                    eval_rows = await enrich_order_item_rows_with_promo_basis(conn, eval_rows)
+                    promo_lines = item_rows_to_promo_lines(eval_rows)
                     checkout_eval = await evaluate_checkout_promotions(
                         conn,
                         UUID(str(tenant_id)),

--- a/tests/test_promo_cart_evaluation.py
+++ b/tests/test_promo_cart_evaluation.py
@@ -7,14 +7,24 @@ from app.services.promotions_service import (
 )
 
 
-def _line(*, subtotal: float, quantity: int = 1, product_id=None, category_id=None):
-    return {
+def _line(
+    *,
+    subtotal: float,
+    quantity: int = 1,
+    product_id=None,
+    category_id=None,
+    promo_eligible_subtotal=None,
+):
+    line = {
         "id": str(uuid4()),
         "product_id": str(product_id or uuid4()),
         "category_id": str(category_id) if category_id else None,
         "quantity": quantity,
         "subtotal": subtotal,
     }
+    if promo_eligible_subtotal is not None:
+        line["promo_eligible_subtotal"] = promo_eligible_subtotal
+    return line
 
 
 def _promo(
@@ -272,3 +282,62 @@ def test_bogo_cross_line_cheapest_first():
     assert by_subtotal[10000] == 10000
     assert by_subtotal[12000] == 0
     assert by_subtotal[15000] == 0
+
+
+def test_percent_off_uses_promo_eligible_subtotal():
+    """Optional modifier extras stay charged outside percent promos (api-warolabs#422)."""
+    lines = [_line(subtotal=12000, promo_eligible_subtotal=10000)]
+    promo = _promo(promo_type="percent_off", value_json={"percent": 10})
+
+    result = evaluate_cart_promotions(lines, [promo])
+
+    assert result["promo_savings"] == 1000
+    assert result["subtotal_after_promos"] == 11000
+    assert result["lines"][0]["subtotal_after_promo"] == 11000
+
+
+def test_fixed_off_caps_at_promo_eligible_subtotal():
+    """Fixed promos cannot consume optional modifier extras (api-warolabs#422)."""
+    lines = [_line(subtotal=14000, promo_eligible_subtotal=9000)]
+    promo = _promo(promo_type="fixed_off", value_json={"amount_cop": 12000})
+
+    result = evaluate_cart_promotions(lines, [promo])
+
+    assert result["promo_savings"] == 9000
+    assert result["subtotal_after_promos"] == 5000
+
+
+def test_same_line_bogo_uses_eligible_unit_price():
+    """BOGO free units use eligible unit price, not gross unit with optional extras."""
+    product_id = uuid4()
+    lines = [_line(
+        subtotal=24000,
+        quantity=2,
+        product_id=product_id,
+        promo_eligible_subtotal=20000,
+    )]
+    promo = _promo(promo_type="bogo", value_json={"buy_qty": 1, "get_qty": 1})
+
+    result = evaluate_cart_promotions(lines, [promo])
+
+    assert result["promo_savings"] == 10000
+    assert result["subtotal_after_promos"] == 14000
+
+
+def test_cross_line_bogo_uses_eligible_unit_price_and_cap():
+    """Cross-line BOGO allocation ignores optional extras when choosing free units."""
+    product_id = uuid4()
+    promo = _promo(promo_type="bogo", value_json={"buy_qty": 2, "get_qty": 1}, name="3x1")
+    lines = [
+        _line(subtotal=20000, quantity=1, product_id=product_id, promo_eligible_subtotal=10000),
+        _line(subtotal=12000, quantity=1, product_id=product_id, promo_eligible_subtotal=12000),
+        _line(subtotal=11000, quantity=1, product_id=product_id, promo_eligible_subtotal=11000),
+    ]
+
+    result = evaluate_cart_promotions(lines, [promo])
+
+    assert result["promo_savings"] == 10000
+    by_subtotal = {line["subtotal"]: line["promo_savings"] for line in result["lines"]}
+    assert by_subtotal[20000] == 10000
+    assert by_subtotal[12000] == 0
+    assert by_subtotal[11000] == 0

--- a/tests/test_promo_line_opt_out.py
+++ b/tests/test_promo_line_opt_out.py
@@ -37,6 +37,31 @@ def test_cart_items_to_promo_lines_carries_opt_out_flag():
     assert promo_lines[0]["promo_opt_out"] is True
 
 
+def test_cart_items_to_promo_lines_excludes_optional_modifier_basis():
+    product_id = str(uuid4())
+    item_id = str(uuid4())
+    items = [{
+        "id": item_id,
+        "product_id": product_id,
+        "category_id": None,
+        "quantity": 2,
+        "subtotal": 31000.0,
+        "tax_category": "standard",
+        "promo_opt_out": False,
+        "product": {"id": product_id, "price": 10000.0},
+        "modifiers": [
+            {"id": str(uuid4()), "price": 2000.0, "group_is_required": True},
+            {"id": str(uuid4()), "price": 500.0, "is_default": True},
+            {"id": str(uuid4()), "price": 3000.0},
+        ],
+    }]
+
+    promo_lines = _cart_items_to_promo_lines(items)
+
+    assert promo_lines[0]["subtotal"] == 31000.0
+    assert promo_lines[0]["promo_eligible_subtotal"] == 25000.0
+
+
 def test_evaluate_from_cart_items_respects_opt_out():
     product_id = uuid4()
     line_id = str(uuid4())
@@ -53,7 +78,7 @@ def test_evaluate_from_cart_items_respects_opt_out():
         }
     ]
     promo_lines = _cart_items_to_promo_lines(items)
-    result = evaluate_cart_promotions(promo_lines, promos=[_promo(product_id=product_id)])
+    result = evaluate_cart_promotions(promo_lines, [_promo(product_id=product_id)])
     assert result["lines"][0]["id"] == line_id
     assert result["lines"][0]["promo_savings"] == 0
     assert result["promo_savings"] == 0

--- a/tests/test_tables_tab_promo_persist.py
+++ b/tests/test_tables_tab_promo_persist.py
@@ -7,6 +7,7 @@ import pytest
 from app.services import tables_service
 from app.services.promotions_service import (
     apply_promo_eval_to_order_items,
+    enrich_order_item_rows_with_promo_basis,
     evaluate_cart_promotions,
     item_rows_to_promo_lines,
     persist_session_tab_promos,
@@ -36,6 +37,8 @@ def test_item_rows_to_promo_lines_maps_pending_rows():
         "product_id": product_id,
         "category_id": None,
         "quantity": 3,
+        "price_at_purchase": 8000.0,
+        "promo_eligible_modifier_unit_total": 2000.0,
         "subtotal": 30000.0,
         "tax_category": "standard",
         "promo_opt_out": False,
@@ -44,6 +47,33 @@ def test_item_rows_to_promo_lines_maps_pending_rows():
     assert lines[0]["id"] == str(item_id)
     assert lines[0]["quantity"] == 3
     assert lines[0]["subtotal"] == 30000.0
+    assert lines[0]["promo_eligible_subtotal"] == 30000.0
+
+
+@pytest.mark.asyncio
+async def test_enrich_order_item_rows_with_required_default_modifier_basis():
+    item_id = uuid4()
+    rows = [{
+        "id": item_id,
+        "product_id": uuid4(),
+        "category_id": None,
+        "quantity": 2,
+        "price_at_purchase": 10000.0,
+        "subtotal": 26000.0,
+        "tax_category": "standard",
+        "promo_opt_out": False,
+    }]
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(return_value=[{
+        "order_item_id": item_id,
+        "eligible_modifier_unit_total": 2000.0,
+    }])
+
+    enriched = await enrich_order_item_rows_with_promo_basis(mock_conn, rows)
+    lines = item_rows_to_promo_lines(enriched)
+
+    assert enriched[0]["promo_eligible_modifier_unit_total"] == 2000.0
+    assert lines[0]["promo_eligible_subtotal"] == 24000.0
 
 
 def test_bogo_3x1_on_tab_line_quantity():
@@ -152,7 +182,7 @@ async def test_persist_session_tab_promos_evaluates_and_recalcs():
         "promo_breakdown": [],
     }
     mock_conn = AsyncMock()
-    mock_conn.fetch = AsyncMock(return_value=item_rows)
+    mock_conn.fetch = AsyncMock(side_effect=[item_rows, []])
 
     with patch(
         "app.services.promotions_service.evaluate_checkout_promotions",


### PR DESCRIPTION
## Summary

- Adds promo-eligible subtotal/unit-price support to automatic percent, fixed, and BOGO evaluation while keeping gross line subtotals unchanged.
- Enriches POS cart and mesa/tab promo line builders from server-side modifier metadata so required/default modifiers remain eligible and optional extras stay charged.
- Covers percent, fixed, same-line BOGO, cross-line BOGO, POS mapper basis, mesa row enrichment, and promo opt-out behavior.

## Validation

```bash
pytest tests/test_promo_cart_evaluation.py tests/test_tables_tab_promo_persist.py tests/test_promo_line_opt_out.py
```

Closes #422
