### PR TITLE
Lock POS cart promotion eligibility

### DIFF
--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -109,8 +109,94 @@ def _cart_items_to_promo_lines(items: List[dict]) -> List[dict]:
             line["promo_eligible_subtotal"] = (
                 float(raw_unit_price) + eligible_modifier_total
             ) * quantity
+        for key in (
+            "locked_promotion_id",
+            "locked_promotion_name",
+            "locked_promo_type",
+            "locked_promo_savings",
+        ):
+            if item.get(key) is not None:
+                line[key] = item[key]
         lines.append(line)
     return lines
+
+
+async def _refresh_cart_item_promotion_lock(
+    conn,
+    tenant_id: UUID,
+    cart_id: UUID,
+    item_id: UUID,
+) -> None:
+    reset_ids = {str(item_id)}
+    await conn.execute(
+        """
+        UPDATE pos_cart_items
+        SET locked_promotion_id = NULL,
+            promotion_locked_at = NULL,
+            locked_promo_eligible_subtotal = NULL,
+            locked_promo_eligible_unit_price = NULL,
+            locked_promotion_name = NULL,
+            locked_promo_type = NULL,
+            locked_promo_savings = NULL
+        WHERE id = $1
+        """,
+        item_id,
+    )
+    items = await get_cart_items(conn, cart_id)
+    if not items:
+        return
+
+    from app.services.promotions_service import evaluate_checkout_promotions
+
+    locked_at = datetime.now(_BOG)
+    promo_lines = _cart_items_to_promo_lines(items)
+    checkout_eval = await evaluate_checkout_promotions(
+        conn,
+        UUID(str(tenant_id)),
+        promo_lines,
+        at=locked_at,
+    )
+    items_by_id = {item["id"]: item for item in items}
+    promo_lines_by_id = {line["id"]: line for line in promo_lines}
+    for eval_line in checkout_eval.get("lines") or []:
+        line_id = eval_line["id"]
+        item = items_by_id.get(line_id)
+        if not item or item.get("promo_opt_out"):
+            continue
+        if line_id not in reset_ids and item.get("locked_promotion_id"):
+            continue
+        promo_id = eval_line.get("promotion_id")
+        promo_savings = round(float(eval_line.get("promo_savings") or 0))
+        if not promo_id or promo_savings <= 0:
+            continue
+
+        promo_line = promo_lines_by_id[line_id]
+        eligible_subtotal = float(
+            promo_line.get("promo_eligible_subtotal") or promo_line.get("subtotal") or 0
+        )
+        quantity = int(promo_line.get("quantity") or 1)
+        eligible_unit_price = eligible_subtotal / quantity if quantity > 0 else 0
+        await conn.execute(
+            """
+            UPDATE pos_cart_items
+            SET locked_promotion_id = $1,
+                promotion_locked_at = $2,
+                locked_promo_eligible_subtotal = $3,
+                locked_promo_eligible_unit_price = $4,
+                locked_promotion_name = $5,
+                locked_promo_type = $6,
+                locked_promo_savings = $7
+            WHERE id = $8
+            """,
+            UUID(str(promo_id)),
+            locked_at,
+            eligible_subtotal,
+            eligible_unit_price,
+            eval_line.get("promotion_name"),
+            eval_line.get("promo_type"),
+            promo_savings,
+            UUID(str(line_id)),
+        )
 
 
 def _manual_discount_amount(
@@ -337,6 +423,8 @@ async def create_cart_with_batch_items(
                                 mod['price']
                             )
 
+                    await _refresh_cart_item_promotion_lock(conn, tenant_id, cart_id, item_id)
+
                 # Update cart total
                 await update_cart_total(conn, cart_id)
 
@@ -382,6 +470,13 @@ async def get_cart_items(conn, cart_id: UUID) -> List[dict]:
             ci.subtotal,
             ci.notes,
             ci.promo_opt_out,
+            ci.locked_promotion_id,
+            ci.promotion_locked_at,
+            ci.locked_promo_eligible_subtotal,
+            ci.locked_promo_eligible_unit_price,
+            ci.locked_promotion_name,
+            ci.locked_promo_type,
+            ci.locked_promo_savings,
             p.name as product_name,
             p.category_id as category_id,
             COALESCE(p.tax_category, 'standard') AS tax_category,
@@ -405,7 +500,10 @@ async def get_cart_items(conn, cart_id: UUID) -> List[dict]:
         LEFT JOIN modifier_groups mg ON mg.id = mod.modifier_group_id
         WHERE ci.cart_id = $1
         GROUP BY ci.id, ci.product_id, ci.quantity, ci.unit_price, ci.subtotal,
-                 ci.notes, ci.promo_opt_out, ci.created_at, p.name, p.category_id, p.tax_category, p.is_resale
+                 ci.notes, ci.promo_opt_out, ci.locked_promotion_id, ci.promotion_locked_at,
+                 ci.locked_promo_eligible_subtotal, ci.locked_promo_eligible_unit_price,
+                 ci.locked_promotion_name, ci.locked_promo_type, ci.locked_promo_savings,
+                 ci.created_at, p.name, p.category_id, p.tax_category, p.is_resale
         ORDER BY ci.created_at
     """
     items_rows = await conn.fetch(items_query, cart_id)
@@ -443,6 +541,25 @@ async def get_cart_items(conn, cart_id: UUID) -> List[dict]:
             "notes": item_row['notes'],
             "subtotal": float(item_row['subtotal']),
             "promo_opt_out": bool(item_row.get("promo_opt_out")),
+            "locked_promotion_id": (
+                str(item_row["locked_promotion_id"])
+                if item_row["locked_promotion_id"] else None
+            ),
+            "promotion_locked_at": item_row["promotion_locked_at"],
+            "locked_promo_eligible_subtotal": (
+                float(item_row["locked_promo_eligible_subtotal"])
+                if item_row["locked_promo_eligible_subtotal"] is not None else None
+            ),
+            "locked_promo_eligible_unit_price": (
+                float(item_row["locked_promo_eligible_unit_price"])
+                if item_row["locked_promo_eligible_unit_price"] is not None else None
+            ),
+            "locked_promotion_name": item_row["locked_promotion_name"],
+            "locked_promo_type": item_row["locked_promo_type"],
+            "locked_promo_savings": (
+                float(item_row["locked_promo_savings"])
+                if item_row["locked_promo_savings"] is not None else None
+            ),
         })
 
     return items
@@ -505,6 +622,7 @@ async def update_cart_item_promo_opt_out(
                     promo_opt_out,
                     item_id,
                 )
+                await _refresh_cart_item_promotion_lock(conn, tenant_id, cart_id, item_id)
 
         return {
             "success": True,
@@ -584,6 +702,8 @@ async def add_item_to_cart(
                             mod['name'],
                             mod['price']
                         )
+
+                await _refresh_cart_item_promotion_lock(conn, tenant_id, cart_id, item_id)
 
                 # Update cart total
                 await update_cart_total(conn, cart_id)
@@ -704,6 +824,8 @@ async def update_cart_item(
                             mod['name'],
                             mod['price']
                         )
+
+                await _refresh_cart_item_promotion_lock(conn, tenant_id, cart_id, item_id)
 
                 # Update cart total
                 await update_cart_total(conn, cart_id)

--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -1257,6 +1257,19 @@ def _compute_line_promo_savings(line: Dict[str, Any], promo: Dict[str, Any]) -> 
     return 0
 
 
+def _locked_promo_from_line(line: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    promo_id = line.get("locked_promotion_id")
+    savings = round(float(line.get("locked_promo_savings") or 0))
+    if not promo_id or savings <= 0:
+        return None
+    return {
+        "id": promo_id,
+        "name": line.get("locked_promotion_name") or "Promocion",
+        "promo_type": line.get("locked_promo_type") or "locked",
+        "locked_savings": savings,
+    }
+
+
 def _line_promo_eligible_unit_price(line: Dict[str, Any]) -> float:
     quantity = int(line.get("quantity") or 1)
     if quantity <= 0:
@@ -1339,8 +1352,12 @@ def evaluate_cart_promotions(
         subtotal = float(line["subtotal"])
         original_subtotal += subtotal
 
+        locked_promo = None if line.get("promo_opt_out") else _locked_promo_from_line(line)
+
         if line.get("promo_opt_out"):
             promo = None
+        elif locked_promo is not None:
+            promo = locked_promo
         else:
             promo = _pick_best_promotion_for_line(
                 promotions,
@@ -1386,6 +1403,12 @@ def evaluate_cart_promotions(
         promo = state["promo"]
         if promo is None:
             savings_by_line_id.setdefault(line_id, 0)
+            continue
+        if promo.get("locked_savings") is not None:
+            savings_by_line_id[line_id] = min(
+                int(promo["locked_savings"]),
+                round(float(state["line"].get("subtotal") or 0)),
+            )
             continue
         if promo["promo_type"] == "bogo":
             savings_by_line_id.setdefault(line_id, 0)

--- a/sql/20260609_pos_cart_promotion_locks.sql
+++ b/sql/20260609_pos_cart_promotion_locks.sql
@@ -1,0 +1,38 @@
+ALTER TABLE pos_cart_items
+    ADD COLUMN IF NOT EXISTS locked_promotion_id uuid,
+    ADD COLUMN IF NOT EXISTS promotion_locked_at timestamptz,
+    ADD COLUMN IF NOT EXISTS locked_promo_eligible_subtotal numeric(10,2),
+    ADD COLUMN IF NOT EXISTS locked_promo_eligible_unit_price numeric(10,2),
+    ADD COLUMN IF NOT EXISTS locked_promotion_name text,
+    ADD COLUMN IF NOT EXISTS locked_promo_type text,
+    ADD COLUMN IF NOT EXISTS locked_promo_savings numeric(10,2);
+
+COMMENT ON COLUMN pos_cart_items.locked_promotion_id IS
+    'Promotion captured when the POS cart line was last created or materially edited while eligible.';
+COMMENT ON COLUMN pos_cart_items.promotion_locked_at IS
+    'Timestamp used to evaluate and lock the line promotion.';
+COMMENT ON COLUMN pos_cart_items.locked_promo_eligible_subtotal IS
+    'Line subtotal basis eligible for the locked promotion.';
+COMMENT ON COLUMN pos_cart_items.locked_promo_eligible_unit_price IS
+    'Per-unit basis eligible for the locked promotion, including required/default modifiers.';
+COMMENT ON COLUMN pos_cart_items.locked_promo_savings IS
+    'Authoritative promotion savings captured for the locked POS cart line.';
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'pos_cart_items_locked_promotion_id_fkey'
+    ) THEN
+        ALTER TABLE pos_cart_items
+            ADD CONSTRAINT pos_cart_items_locked_promotion_id_fkey
+            FOREIGN KEY (locked_promotion_id)
+            REFERENCES tenant_promotions(id)
+            ON DELETE SET NULL;
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_pos_cart_items_locked_promotion_id
+    ON pos_cart_items (locked_promotion_id)
+    WHERE locked_promotion_id IS NOT NULL;

--- a/tests/test_promo_cart_evaluation.py
+++ b/tests/test_promo_cart_evaluation.py
@@ -93,6 +93,40 @@ def test_ineligible_lines_unchanged():
     assert result["subtotal_after_promos"] == 8000
 
 
+def test_locked_line_keeps_promo_when_current_promos_empty():
+    promo_id = uuid4()
+    lines = [
+        {
+            **_line(subtotal=10000),
+            "locked_promotion_id": str(promo_id),
+            "locked_promotion_name": "Happy hour",
+            "locked_promo_type": "percent_off",
+            "locked_promo_savings": 1000,
+        },
+        _line(subtotal=5000),
+    ]
+    result = evaluate_cart_promotions(lines, [])
+    assert result["promo_savings"] == 1000
+    assert result["subtotal_after_promos"] == 14000
+    assert result["lines"][0]["promotion_id"] == str(promo_id)
+    assert result["lines"][0]["promotion_name"] == "Happy hour"
+    assert result["lines"][1]["promo_savings"] == 0
+
+
+def test_locked_line_opt_out_ignores_snapshot():
+    lines = [{
+        **_line(subtotal=10000),
+        "promo_opt_out": True,
+        "locked_promotion_id": str(uuid4()),
+        "locked_promotion_name": "Happy hour",
+        "locked_promo_type": "percent_off",
+        "locked_promo_savings": 1000,
+    }]
+    result = evaluate_cart_promotions(lines, [])
+    assert result["promo_savings"] == 0
+    assert result["lines"][0].get("promotion_id") is None
+
+
 def test_percent_off_category_scoped():
     """Happy hour % off all items in a category (warocol.com#983)."""
     category_id = uuid4()


### PR DESCRIPTION
## Summary
- add nullable POS cart-line promotion lock columns
- capture/re-capture promotion locks when cart lines are created, edited, or promo opt-out changes
- honor locked line promo savings during preview/checkout without globally applying expired promotions

## Validation
- `pytest tests/test_promo_cart_evaluation.py tests/test_order_promo_persist.py`
- `python3 -m py_compile app/services/promotions_service.py app/services/pos_cart_service.py`

Closes #424