### PR TITLE
Add convert-to-resale endpoint for empty menu products

### DIFF
--- a/app/models/product.py
+++ b/app/models/product.py
@@ -154,6 +154,25 @@ class ProductCreate(ProductBase):
             raise ValueError("resale_unit_weight_gr is required when auto_resale_ingredient is true")
         return self
 
+class ProductConvertToResale(BaseModel):
+    """Convert an existing menu product (no recipe) to atomic resale."""
+
+    resale_unit_weight_gr: float = Field(..., gt=0, description="Weight/volume per und for linked ingredient")
+    resale_unit_weight_unit: Literal["gr", "ml"] = Field(
+        "gr",
+        description="Unit for resale_unit_weight_gr on auto-created ingredient",
+    )
+    resale_ingredient_type: Literal["food", "supply"] = Field(
+        "food",
+        description="Ingredient type for auto-created resale ingredient",
+    )
+    resale_ingredient_category: Optional[str] = Field(
+        None,
+        max_length=255,
+        description="Ingredient category label; defaults to menu category name when omitted",
+    )
+
+
 class ProductUpdate(BaseModel):
     """Update product fields"""
     name: Optional[str] = Field(None, min_length=1, max_length=255)

--- a/app/routers/products.py
+++ b/app/routers/products.py
@@ -6,6 +6,7 @@ from app.core.exceptions import AuthenticationError
 from app.core.permissions import Module, require_module
 from app.services.products_service import (
     create_product_with_recipe,
+    convert_product_to_resale,
     get_product_by_id,
     get_products_list,
     get_product_stats,
@@ -15,6 +16,7 @@ from app.services.products_service import (
 )
 from app.models.product import (
     ProductCreate,
+    ProductConvertToResale,
     ProductUpdate,
     ProductResponse,
     ProductsListResponse,
@@ -167,6 +169,25 @@ async def get_product_endpoint(
     Requires valid session with tenant context.
     """
     return await get_product_by_id(request, product_id)
+
+
+@router.post(
+    "/{product_id}/convert-to-resale",
+    response_model=ProductResponse,
+    dependencies=[Depends(require_module(Module.MENU))],
+)
+async def convert_product_to_resale_endpoint(
+    request: Request,
+    product_id: UUID,
+    body: ProductConvertToResale = Body(...),
+):
+    """
+    Convert a menu product without recipe into atomic resale (1 sale = 1 und).
+
+    Requires: not already resale, no recipe rows, not combo/open-priced, no modifier groups.
+    Atomically creates linked tenant ingredient + product_recipes row and sets is_resale=true.
+    """
+    return await convert_product_to_resale(request, product_id, body)
 
 
 @router.put("/{product_id}", response_model=ProductResponse, dependencies=[Depends(require_module(Module.MENU))])

--- a/app/services/products_service.py
+++ b/app/services/products_service.py
@@ -6,7 +6,7 @@ from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError
 from app.models.product import (
-    Product, ProductCreate, ProductUpdate, ProductsListResponse,
+    Product, ProductCreate, ProductConvertToResale, ProductUpdate, ProductsListResponse,
     ProductResponse, ProductStats, RecipeBaseLink
 )
 from app.services import menu_history_service
@@ -937,6 +937,180 @@ async def get_product_stats(request: Request) -> ProductStats:
     except Exception as e:
         logger.error(f"Error fetching product stats: {str(e)}")
         raise APIError(f"Error fetching product stats: {str(e)}", status_code=500)
+
+
+async def convert_product_to_resale(
+    request: Request,
+    product_id: UUID,
+    data: ProductConvertToResale,
+) -> ProductResponse:
+    """
+    Convert a menu product without recipe into atomic resale in one transaction.
+    Mirrors create_product_with_recipe auto_resale_ingredient on an existing row.
+    """
+    try:
+        session_context = require_valid_session(request)
+        tenant_id = session_context.tenant_id
+
+        if not tenant_id:
+            raise AuthenticationError("Tenant ID is required")
+
+        async with get_db_connection() as conn:
+            product_row = await conn.fetchrow(
+                """
+                SELECT id, name, category_id, is_resale, open_priced, is_combo,
+                       product_base_type_id, costo_percibido
+                FROM product
+                WHERE id = $1 AND tenant_id = $2
+                """,
+                product_id,
+                tenant_id,
+            )
+
+            if not product_row:
+                raise HTTPException(status_code=404, detail="Product not found")
+
+            if product_row["is_resale"]:
+                raise HTTPException(status_code=422, detail="El producto ya es de reventa")
+
+            if product_row["open_priced"]:
+                raise HTTPException(
+                    status_code=422,
+                    detail="Los productos de venta libre no se pueden convertir a reventa",
+                )
+
+            if product_row["is_combo"]:
+                raise HTTPException(
+                    status_code=422,
+                    detail="Los combos no se pueden convertir a reventa desde aquí",
+                )
+
+            if product_row["product_base_type_id"] is not None:
+                raise HTTPException(
+                    status_code=422,
+                    detail="El producto tiene una receta base asignada; quítala antes de convertir",
+                )
+
+            if await cost_resolution_service.product_has_any_recipe(product_id, conn):
+                raise HTTPException(
+                    status_code=422,
+                    detail="El producto tiene ingredientes o recetas; quítalos antes de convertir",
+                )
+
+            modifier_count = await conn.fetchval(
+                "SELECT COUNT(*)::int FROM product_modifier_groups WHERE product_id = $1",
+                product_id,
+            )
+            if modifier_count and modifier_count > 0:
+                raise HTTPException(
+                    status_code=422,
+                    detail="Quita los modificadores asignados antes de convertir a reventa",
+                )
+
+            old_snapshot = await menu_history_service.get_product_snapshot(conn, product_id, tenant_id)
+            product_name = product_row["name"]
+            user_id = session_context.user_id if hasattr(session_context, "user_id") else None
+            auto_resale_ingredient_id: Optional[UUID] = None
+
+            async with conn.transaction():
+                ingredient_category = await _resolve_resale_ingredient_category(
+                    conn,
+                    tenant_id,
+                    product_row["category_id"],
+                    data.resale_ingredient_category,
+                )
+                costo_ingredient = None
+                if product_row["costo_percibido"] is not None:
+                    costo_ingredient = float(product_row["costo_percibido"])
+
+                ing_result = await create_tenant_ingredient(
+                    conn,
+                    tenant_id,
+                    TenantIngredientCreate(
+                        name=product_row["name"].strip(),
+                        unit="und",
+                        type=data.resale_ingredient_type,
+                        category=ingredient_category,
+                        is_resale=True,
+                        unit_weight_gr=data.resale_unit_weight_gr,
+                        unit_weight_unit=data.resale_unit_weight_unit,
+                        costo_unitario=costo_ingredient,
+                        purchase_units=[
+                            PurchaseUnitInput(purchase_unit="und", is_default=True),
+                        ],
+                    ),
+                )
+                auto_resale_ingredient_id = UUID(ing_result["id"])
+
+                await conn.execute(
+                    """
+                    UPDATE product
+                    SET is_resale = TRUE,
+                        allow_modifiers = FALSE,
+                        controla_stock = TRUE,
+                        updated_at = NOW()
+                    WHERE id = $1 AND tenant_id = $2
+                    """,
+                    product_id,
+                    tenant_id,
+                )
+
+                base_qty, base_unit = await resolve_to_base_unit(
+                    conn,
+                    auto_resale_ingredient_id,
+                    1,
+                    "und",
+                )
+                await conn.execute(
+                    """
+                    INSERT INTO product_recipes (
+                        product_id, ingredient_id, quantity, unit, tenant_id
+                    )
+                    VALUES ($1, $2, $3, $4, $5)
+                    """,
+                    product_id,
+                    auto_resale_ingredient_id,
+                    base_qty,
+                    base_unit,
+                    tenant_id,
+                )
+
+                await cost_resolution_service.persist_product_costo_calculado(
+                    product_id,
+                    tenant_id,
+                    conn,
+                    tracks_inventory=True,
+                )
+
+                if old_snapshot:
+                    new_snapshot = await menu_history_service.get_product_snapshot(
+                        conn, product_id, tenant_id
+                    )
+                    if new_snapshot:
+                        await menu_history_service.compare_and_record_product_changes(
+                            conn,
+                            tenant_id,
+                            product_id,
+                            product_name,
+                            old_snapshot,
+                            new_snapshot,
+                            user_id,
+                        )
+
+                response = await get_product_by_id(request, product_id, conn)
+                if auto_resale_ingredient_id:
+                    response.data.resale_ingredient_id = auto_resale_ingredient_id
+                return response
+
+    except HTTPException:
+        raise
+    except AuthenticationError as e:
+        raise e
+    except asyncpg.UniqueViolationError:
+        raise HTTPException(status_code=409, detail=_DUPLICATE_PRODUCT_NAME_DETAIL)
+    except Exception as e:
+        logger.error(f"Error converting product to resale: {str(e)}")
+        raise APIError(f"Error converting product to resale: {str(e)}", status_code=500)
 
 
 async def update_product_with_recipe(

--- a/tests/test_product_convert_to_resale.py
+++ b/tests/test_product_convert_to_resale.py
@@ -1,0 +1,239 @@
+"""Convert menu product without recipe to atomic resale."""
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import asyncpg
+import pytest
+from fastapi import HTTPException, Request
+from pydantic import ValidationError
+
+from app.core.middleware import SessionContext
+from app.models.product import ProductConvertToResale
+from app.services.products_service import convert_product_to_resale
+
+
+def _session():
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@warocol.com",
+        "name": "Test",
+        "expires_at": None,
+        "is_active": True,
+    })
+
+
+def _convert_body(**overrides):
+    data = {
+        "resale_unit_weight_gr": 350.0,
+        "resale_unit_weight_unit": "ml",
+    }
+    data.update(overrides)
+    return ProductConvertToResale(**data)
+
+
+def test_convert_to_resale_requires_unit_weight():
+    with pytest.raises(ValidationError):
+        ProductConvertToResale(resale_unit_weight_gr=0)
+
+
+@pytest.mark.asyncio
+async def test_convert_product_to_resale_happy_path():
+    request = MagicMock(spec=Request)
+    session = _session()
+    product_id = uuid4()
+    ingredient_id = uuid4()
+    category_id = uuid4()
+    create_ingredient_calls = []
+    persist_calls = []
+
+    async def _fetchrow(query, *args):
+        if "FROM product" in query and "WHERE id" in query:
+            return {
+                "id": product_id,
+                "name": "Gaseosa 350ml",
+                "category_id": category_id,
+                "is_resale": False,
+                "open_priced": False,
+                "is_combo": False,
+                "product_base_type_id": None,
+                "costo_percibido": None,
+            }
+        if "SELECT name FROM categories" in query:
+            return {"name": "Bebidas"}
+        return None
+
+    async def _fetchval(query, *args):
+        if "product_modifier_groups" in query:
+            return 0
+        if "EXISTS" in query:
+            return False
+        return None
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=_fetchrow)
+    conn.fetchval = AsyncMock(side_effect=_fetchval)
+    conn.execute = AsyncMock()
+
+    async def _persist(pid, tid, c, *, tracks_inventory):
+        persist_calls.append(tracks_inventory)
+
+    async def _create_ingredient(conn, tenant_id, data):
+        create_ingredient_calls.append(data)
+        return {"id": str(ingredient_id)}
+
+    @asynccontextmanager
+    async def _txn():
+        yield
+
+    conn.transaction.return_value = _txn()
+
+    @asynccontextmanager
+    async def _db_ctx():
+        yield conn
+
+    mock_response = MagicMock()
+    mock_response.data = MagicMock()
+
+    with patch("app.services.products_service.require_valid_session", return_value=session), \
+         patch("app.services.products_service.get_db_connection", side_effect=_db_ctx), \
+         patch("app.services.products_service.create_tenant_ingredient", AsyncMock(side_effect=_create_ingredient)), \
+         patch("app.services.products_service.resolve_to_base_unit", AsyncMock(return_value=(Decimal("1"), "und"))), \
+         patch("app.services.products_service.cost_resolution_service.persist_product_costo_calculado", AsyncMock(side_effect=_persist)), \
+         patch("app.services.products_service.cost_resolution_service.product_has_any_recipe", AsyncMock(return_value=False)), \
+         patch("app.services.products_service.menu_history_service.get_product_snapshot", AsyncMock(return_value=None)), \
+         patch("app.services.products_service.get_product_by_id", AsyncMock(return_value=mock_response)):
+        result = await convert_product_to_resale(request, product_id, _convert_body())
+
+    assert result is mock_response
+    assert result.data.resale_ingredient_id == ingredient_id
+    assert len(create_ingredient_calls) == 1
+    assert create_ingredient_calls[0].is_resale is True
+    assert persist_calls == [True]
+
+
+@pytest.mark.asyncio
+async def test_convert_product_to_resale_rejects_already_resale():
+    request = MagicMock(spec=Request)
+    session = _session()
+    product_id = uuid4()
+
+    async def _fetchrow(query, *args):
+        return {
+            "id": product_id,
+            "name": "Snack",
+            "category_id": uuid4(),
+            "is_resale": True,
+            "open_priced": False,
+            "is_combo": False,
+            "product_base_type_id": None,
+            "costo_percibido": None,
+        }
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=_fetchrow)
+
+    @asynccontextmanager
+    async def _db_ctx():
+        yield conn
+
+    with patch("app.services.products_service.require_valid_session", return_value=session), \
+         patch("app.services.products_service.get_db_connection", side_effect=_db_ctx):
+        with pytest.raises(HTTPException) as exc:
+            await convert_product_to_resale(request, product_id, _convert_body())
+
+    assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_convert_product_to_resale_rejects_with_recipe():
+    request = MagicMock(spec=Request)
+    session = _session()
+    product_id = uuid4()
+
+    async def _fetchrow(query, *args):
+        return {
+            "id": product_id,
+            "name": "Pizza",
+            "category_id": uuid4(),
+            "is_resale": False,
+            "open_priced": False,
+            "is_combo": False,
+            "product_base_type_id": None,
+            "costo_percibido": None,
+        }
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=_fetchrow)
+
+    @asynccontextmanager
+    async def _db_ctx():
+        yield conn
+
+    with patch("app.services.products_service.require_valid_session", return_value=session), \
+         patch("app.services.products_service.get_db_connection", side_effect=_db_ctx), \
+         patch("app.services.products_service.cost_resolution_service.product_has_any_recipe", AsyncMock(return_value=True)):
+        with pytest.raises(HTTPException) as exc:
+            await convert_product_to_resale(request, product_id, _convert_body())
+
+    assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_convert_product_to_resale_ingredient_duplicate_409():
+    request = MagicMock(spec=Request)
+    session = _session()
+    product_id = uuid4()
+
+    async def _fetchrow(query, *args):
+        if "FROM product" in query:
+            return {
+                "id": product_id,
+                "name": "Gaseosa",
+                "category_id": uuid4(),
+                "is_resale": False,
+                "open_priced": False,
+                "is_combo": False,
+                "product_base_type_id": None,
+                "costo_percibido": None,
+            }
+        if "SELECT name FROM categories" in query:
+            return {"name": "Bebidas"}
+        return None
+
+    async def _fetchval(query, *args):
+        if "product_modifier_groups" in query:
+            return 0
+        return False
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=_fetchrow)
+    conn.fetchval = AsyncMock(side_effect=_fetchval)
+    conn.execute = AsyncMock()
+    conn.transaction = MagicMock()
+
+    @asynccontextmanager
+    async def _txn():
+        yield
+
+    conn.transaction.return_value = _txn()
+
+    @asynccontextmanager
+    async def _db_ctx():
+        yield conn
+
+    with patch("app.services.products_service.require_valid_session", return_value=session), \
+         patch("app.services.products_service.get_db_connection", side_effect=_db_ctx), \
+         patch("app.services.products_service.cost_resolution_service.product_has_any_recipe", AsyncMock(return_value=False)), \
+         patch("app.services.products_service.menu_history_service.get_product_snapshot", AsyncMock(return_value=None)), \
+         patch(
+             "app.services.products_service.create_tenant_ingredient",
+             AsyncMock(side_effect=HTTPException(status_code=409, detail="ingredient exists")),
+         ):
+        with pytest.raises(HTTPException) as exc:
+            await convert_product_to_resale(request, product_id, _convert_body())
+
+    assert exc.value.status_code == 409


### PR DESCRIPTION
## Summary
- Add `POST /menu/products/{id}/convert-to-resale` to atomically convert menu products without recipe into resale items.
- Create linked warehouse ingredient (`und`, `is_resale`) and one `product_recipes` row (1 sale = 1 und).
- Guard against combos, open-priced products, existing recipes, and assigned modifier groups.

## Test plan
- [x] `pytest tests/test_product_convert_to_resale.py`
- [ ] Convert a menu product with inventory toggle OFF and no modifiers via API
- [ ] Verify linked ingredient appears in Abastecimiento and stock deducts 1 und on sale


Made with [Cursor](https://cursor.com)