### PR TITLE
Accept zero-delta inventory adjustments

### DIFF
--- a/app/services/inventory_service.py
+++ b/app/services/inventory_service.py
@@ -532,8 +532,8 @@ async def create_adjustment(
         purchase_unit = body.get('unit')  # Optional: unit selected by user
         cost_per_unit = body.get('cost_per_unit')  # Optional: cost per unit (only for positive adjustments)
 
-        if not ingredient_id or quantity_change == 0:
-            raise HTTPException(status_code=400, detail="ingredient_id and quantity_change are required")
+        if not ingredient_id:
+            raise HTTPException(status_code=400, detail="ingredient_id is required")
 
         async with get_db_connection() as conn:
             # Start transaction
@@ -593,6 +593,21 @@ async def create_adjustment(
                     previous_stock = 0
                 else:
                     previous_stock = float(stock_row['current_stock']) if stock_row['current_stock'] else 0
+
+                # Idempotent: "set to current stock" (e.g. confirm 0 when already 0).
+                if quantity_change == 0:
+                    return {
+                        "success": True,
+                        "message": "El stock ya coincide con el valor indicado",
+                        "data": {
+                            "ingredient_id": str(ingredient_id),
+                            "quantity_change": 0,
+                            "previous_stock": previous_stock,
+                            "new_stock": previous_stock,
+                            "reason": reason,
+                            "created_at": None,
+                        },
+                    }
 
                 # Calculate new stock (using converted quantity)
                 new_stock = max(0, previous_stock + quantity_in_base_unit)


### PR DESCRIPTION
## Summary
- Stop rejecting manual adjustments when `quantity_change` is `0`
- Return idempotent success when stock already matches the requested target (e.g. confirm zero stock)
- Avoid creating phantom inventory movements for no-op adjustments

## Test plan
- [ ] POST adjustment with negative delta that sets stock to `0` from a positive value
- [ ] POST adjustment with `quantity_change: 0` when stock is already `0` and confirm 200 without movement row
- [ ] Confirm increment/decrement flows are unchanged


Made with [Cursor](https://cursor.com)