### PR TITLE
Block customer-only internal auth

### DIFF
--- a/app/core/internal_roles.py
+++ b/app/core/internal_roles.py
@@ -1,0 +1,8 @@
+from typing import Optional
+
+
+LEGACY_INTERNAL_TEAM_ROLES = ("superuser", "admin", "employee", "member")
+
+
+def is_legacy_internal_team_role(role: Optional[str]) -> bool:
+    return role in LEGACY_INTERNAL_TEAM_ROLES

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -5,6 +5,7 @@ from urllib.parse import unquote
 from uuid import UUID
 from fastapi import Request, HTTPException, Response
 from app.config import settings
+from app.core.internal_roles import is_legacy_internal_team_role
 from typing import List, Optional
 
 logger = logging.getLogger(__name__)
@@ -376,6 +377,7 @@ async def get_session_from_request(request: Request) -> Optional[dict]:
                 LEFT JOIN tenant_members tm
                   ON tm.user_id = s.user_id
                  AND tm.tenant_id = s.tenant_id
+                 AND tm.is_active = true
                 WHERE s.id = $1
                   AND s.expires_at > NOW()
                   AND s.is_active = true
@@ -386,6 +388,22 @@ async def get_session_from_request(request: Request) -> Optional[dict]:
             if not session_result:
                 return None
 
+            resolved_role = session_result['role']
+            if resolved_role is not None and not is_legacy_internal_team_role(resolved_role):
+                await conn.execute("""
+                    UPDATE sessions
+                    SET is_active = false,
+                        ended_at = NOW(),
+                        end_reason = 'customer_role_denied'
+                    WHERE id = $1 AND is_active = true
+                """, session_token)
+                logger.warning(
+                    "Denied internal session %s for non-team role %s",
+                    session_token[:8],
+                    resolved_role,
+                )
+                return None
+
             return {
                 'user_id': session_result['user_id'],
                 'tenant_id': session_result['tenant_id'],
@@ -393,7 +411,7 @@ async def get_session_from_request(request: Request) -> Optional[dict]:
                 'name': session_result['name'],
                 'expires_at': session_result['expires_at'],
                 'is_active': session_result['is_active'],
-                'role': session_result['role'],
+                'role': resolved_role,
             }
 
     except Exception as e:

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -6,6 +6,7 @@ from fastapi import Request, Response
 from app.database import get_db_connection
 from app.core.security import get_session_token, clear_session_cookie, set_session_cookie, get_client_ip
 from app.core.exceptions import AuthenticationError
+from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES, is_legacy_internal_team_role
 from app.core.middleware import require_valid_session
 from app.models.auth import User, Session, Tenant, SessionResponse, SwitchTenantResponse, UpdateProfileResponse
 
@@ -49,16 +50,32 @@ async def get_session_data(request: Request, response: Response) -> SessionRespo
                         name=tenant_result['name'],
                         slug=tenant_result['slug']
                     )
-                # Only read role from ACTIVE memberships (#201).
-                # Terminated members keep their row with the old role value
-                # until purged; filtering ensures their stale role never
-                # reaches SessionContext. See docs/permissions-router-mapping.md §9.
+                # Only read role from ACTIVE memberships (#201). Customer rows
+                # are active memberships, but they are not internal team access.
                 role_result = await conn.fetchrow(
                     "SELECT role FROM tenant_members WHERE tenant_id = $1 AND user_id = $2 AND is_active = true LIMIT 1",
                     session_result['tenant_id'], session_result['user_id']
                 )
                 if role_result:
                     user_role = role_result['role']
+                    if not is_legacy_internal_team_role(user_role):
+                        await conn.execute(
+                            """
+                            UPDATE sessions
+                            SET is_active = false,
+                                ended_at = NOW(),
+                                end_reason = 'customer_role_denied'
+                            WHERE id = $1 AND is_active = true
+                            """,
+                            session_token,
+                        )
+                        await clear_session_cookie(response, session_token)
+                        logger.warning(
+                            "Denied /auth/session for non-team role %s on session %s",
+                            user_role,
+                            session_token[:8],
+                        )
+                        raise AuthenticationError("Access denied")
 
             # Build response models
             user = User(
@@ -98,6 +115,8 @@ async def switch_tenant(request: Request, response: Response, tenant_slug: str) 
         # Get session context from middleware
         session_context = require_valid_session(request)
         current_session_token = await get_session_token(request)
+        if not is_legacy_internal_team_role(session_context.role):
+            raise AuthenticationError("Access denied to this tenant")
         
         # Get the target site from encrypted origin header
         target_site = None
@@ -165,10 +184,18 @@ async def switch_tenant(request: Request, response: Response, tenant_slug: str) 
                 FROM tenants t
                 INNER JOIN tenant_members tm ON t.id = tm.tenant_id
                 LEFT JOIN tenant_sites ts ON t.id = ts.tenant_id AND ts.is_active = true
-                WHERE t.slug = $1 AND tm.user_id = $2 AND tm.is_active = true
+                WHERE t.slug = $1
+                  AND tm.user_id = $2
+                  AND tm.is_active = true
+                  AND tm.role = ANY($3::text[])
                 LIMIT 1
             """
-            tenant_access_result = await conn.fetchrow(tenant_access_query, tenant_slug, user_id)
+            tenant_access_result = await conn.fetchrow(
+                tenant_access_query,
+                tenant_slug,
+                user_id,
+                list(LEGACY_INTERNAL_TEAM_ROLES),
+            )
             
             if not tenant_access_result:
                 logger.warning(f"Access denied to tenant {tenant_slug} for user {user_id}")

--- a/app/services/magic_link_service.py
+++ b/app/services/magic_link_service.py
@@ -10,6 +10,7 @@ from app.core.security import set_session_cookie, get_client_ip
 from app.core.middleware import require_valid_tenant
 from app.core.exceptions import AuthenticationError, ValidationError
 from app.core.email_utils import normalize_email
+from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
 from app.models.auth import User, Tenant, MagicLinkResponse, VerifyCodeResponse, VerifyTokenResponse
 
 logger = logging.getLogger(__name__)
@@ -32,18 +33,26 @@ async def send_magic_link(request: Request, email: str, redirect: Optional[str] 
             verification_code = str(random.randint(100000, 999999))  # 6-digit code
             expires_at = datetime.utcnow() + timedelta(minutes=15)  # 15 minutes
 
-            # Check if user exists AND is member of ANY tenant
+            # Internal magic-link auth is only for active team members of this tenant.
             user_tenant_query = """
                 SELECT p.id as user_id, p.email, p.name, tm.role, tm.tenant_id
                 FROM profile p
                 INNER JOIN tenant_members tm ON p.id = tm.user_id
                 WHERE lower(trim(p.email)) = $1
+                  AND tm.tenant_id = $2
+                  AND tm.is_active = true
+                  AND tm.role = ANY($3::text[])
                 LIMIT 1
             """
-            user_result = await conn.fetchrow(user_tenant_query, email)
+            user_result = await conn.fetchrow(
+                user_tenant_query,
+                email,
+                tenant_context.tenant_id,
+                list(LEGACY_INTERNAL_TEAM_ROLES),
+            )
 
             if not user_result:
-                logger.warning(f"❌ User {email} does not exist or is not a member of any tenant")
+                logger.warning(f"❌ User {email} is not an active team member for tenant {tenant_context.tenant_id}")
                 raise AuthenticationError("User not found. Please contact an administrator.")
 
             user_id = user_result['user_id']
@@ -148,13 +157,22 @@ async def verify_code(request: Request, response: Response, email: str, code: st
                        tm.role as user_role
                 FROM magic_tokens mt
                 JOIN profile p ON mt.user_id = p.id
-                LEFT JOIN tenant_members tm ON tm.user_id = p.id AND tm.tenant_id = mt.tenant_id
+                INNER JOIN tenant_members tm ON tm.user_id = p.id AND tm.tenant_id = mt.tenant_id
                 WHERE lower(trim(p.email)) = $1 AND mt.verification_code = $2
                 AND mt.expires_at > NOW() AND mt.used = false
+                AND mt.tenant_id = $3
+                AND tm.is_active = true
+                AND tm.role = ANY($4::text[])
                 LIMIT 1
             """
 
-            token_data = await conn.fetchrow(verify_query, email, code)
+            token_data = await conn.fetchrow(
+                verify_query,
+                email,
+                code,
+                tenant_context.tenant_id,
+                list(LEGACY_INTERNAL_TEAM_ROLES),
+            )
             
             if not token_data:
                 logger.warning(f"❌ Invalid verification code for {email} on {tenant_context.site}")
@@ -282,13 +300,22 @@ async def verify_token(request: Request, response: Response, email: str, token: 
                        tm.role as user_role
                 FROM magic_tokens mt
                 JOIN profile p ON mt.user_id = p.id
-                LEFT JOIN tenant_members tm ON tm.user_id = p.id AND tm.tenant_id = mt.tenant_id
+                INNER JOIN tenant_members tm ON tm.user_id = p.id AND tm.tenant_id = mt.tenant_id
                 WHERE lower(trim(p.email)) = $1 AND mt.token = $2
                 AND mt.expires_at > NOW() AND mt.used = false
+                AND mt.tenant_id = $3
+                AND tm.is_active = true
+                AND tm.role = ANY($4::text[])
                 LIMIT 1
             """
 
-            token_data = await conn.fetchrow(verify_query, email, token)
+            token_data = await conn.fetchrow(
+                verify_query,
+                email,
+                token,
+                tenant_context.tenant_id,
+                list(LEGACY_INTERNAL_TEAM_ROLES),
+            )
             
             if not token_data:
                 logger.warning(f"❌ Invalid or expired token for {email} on {tenant_context.site}")

--- a/app/services/tenants_service.py
+++ b/app/services/tenants_service.py
@@ -5,6 +5,7 @@ from fastapi import Request
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, AuthorizationError, ValidationError
+from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
 from app.models.auth import Tenant, UserTenantsResponse
 from app.models.tenant import (
     TenantMembersResponse, TenantMemberDetail, TenantMemberProfile,
@@ -36,11 +37,13 @@ async def get_user_tenants(request: Request) -> UserTenantsResponse:
                   t.slug
                 FROM tenants t
                 INNER JOIN tenant_members tm ON t.id = tm.tenant_id
-                WHERE tm.user_id = $1 AND tm.is_active = true
+                WHERE tm.user_id = $1
+                  AND tm.is_active = true
+                  AND tm.role = ANY($2::text[])
                 ORDER BY t.name
             """
-            
-            tenant_rows = await conn.fetch(query, user_id)
+
+            tenant_rows = await conn.fetch(query, user_id, list(LEGACY_INTERNAL_TEAM_ROLES))
             
             
             # Convert to Tenant models

--- a/tests/test_customer_internal_access.py
+++ b/tests/test_customer_internal_access.py
@@ -1,0 +1,106 @@
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.exceptions import AuthenticationError
+
+
+def _build_db_mock(fetchrow_side_effect=None):
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=fetchrow_side_effect)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.execute = AsyncMock(return_value=None)
+
+    @asynccontextmanager
+    async def _ctx():
+        yield conn
+
+    return _ctx, conn
+
+
+def _tenant_context(tenant_id):
+    return MagicMock(
+        tenant_id=tenant_id,
+        tenant_name="Tijuana Cafe Bar",
+        tenant_email="admin@example.com",
+        site="warocol.com",
+        brand_name="WARO",
+    )
+
+
+def _request():
+    request = MagicMock()
+    request.headers = {"origin": "http://localhost:8080", "user-agent": "pytest"}
+    request.client = MagicMock(host="127.0.0.1")
+    return request
+
+
+@pytest.mark.asyncio
+async def test_send_magic_link_denies_customer_only_membership():
+    """A customer-only row is filtered out before an internal magic token is created."""
+    from app.services.magic_link_service import send_magic_link
+
+    tenant_id = uuid4()
+    db_ctx, conn = _build_db_mock(fetchrow_side_effect=[None])
+
+    with patch("app.services.magic_link_service.get_db_connection", side_effect=db_ctx), \
+         patch("app.services.magic_link_service.require_valid_tenant", return_value=_tenant_context(tenant_id)):
+        with pytest.raises(AuthenticationError):
+            await send_magic_link(_request(), "customer@example.com")
+
+    conn.execute.assert_not_awaited()
+    assert conn.fetchrow.await_args.args[2] == tenant_id
+    assert conn.fetchrow.await_args.args[3] == ["superuser", "admin", "employee", "member"]
+
+
+@pytest.mark.asyncio
+async def test_verify_token_denies_customer_only_membership_before_session_creation():
+    """Legacy customer tokens cannot be exchanged for internal sessions."""
+    from app.services.magic_link_service import verify_token
+
+    tenant_id = uuid4()
+    response = MagicMock()
+    db_ctx, conn = _build_db_mock(fetchrow_side_effect=[None])
+
+    with patch("app.services.magic_link_service.get_db_connection", side_effect=db_ctx), \
+         patch("app.services.magic_link_service.require_valid_tenant", return_value=_tenant_context(tenant_id)):
+        with pytest.raises(AuthenticationError):
+            await verify_token(_request(), response, "customer@example.com", "token")
+
+    conn.execute.assert_not_awaited()
+    assert conn.fetchrow.await_args.args[3] == tenant_id
+    assert conn.fetchrow.await_args.args[4] == ["superuser", "admin", "employee", "member"]
+
+
+@pytest.mark.asyncio
+async def test_session_resolver_invalidates_customer_internal_session():
+    """Middleware session resolution denies active sessions whose resolved role is customer."""
+    from app.core.security import get_session_from_request
+
+    session_token = str(uuid4())
+    tenant_id = uuid4()
+    user_id = uuid4()
+    expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+    db_ctx, conn = _build_db_mock(fetchrow_side_effect=[
+        {"id": session_token, "expires_at": expires_at, "is_active": True, "ended_at": None},
+        {
+            "user_id": user_id,
+            "tenant_id": tenant_id,
+            "expires_at": expires_at,
+            "is_active": True,
+            "email": "customer@example.com",
+            "name": "Customer User",
+            "role": "customer",
+        },
+    ])
+
+    with patch("app.database.get_db_connection", side_effect=db_ctx), \
+         patch("app.core.security.get_session_token", new=AsyncMock(return_value=session_token)):
+        result = await get_session_from_request(_request())
+
+    assert result is None
+    conn.execute.assert_awaited_once()
+    assert conn.execute.await_args.args[1] == session_token

--- a/tests/test_switch_tenant_membership.py
+++ b/tests/test_switch_tenant_membership.py
@@ -24,7 +24,7 @@ from app.core.middleware import SessionContext
 # ─── Fixtures ─────────────────────────────────────────────────────────
 
 
-def _build_session():
+def _build_session(role="admin"):
     """A valid session context for an arbitrary user/tenant pair."""
     return SessionContext({
         "user_id": uuid4(),
@@ -33,7 +33,7 @@ def _build_session():
         "name": "Test User",
         "expires_at": None,
         "is_active": True,
-        "role": "admin",
+        "role": role,
     })
 
 
@@ -189,6 +189,24 @@ async def test_non_member_cannot_switch_tenant():
     assert exc_info.value.status_code == 401
 
 
+@pytest.mark.asyncio
+async def test_customer_member_cannot_switch_tenant():
+    """Customer-only memberships are not internal team access."""
+    from app.services.auth_service import switch_tenant
+
+    session = _build_session(role="customer")
+    request = _build_request_with_session(session)
+    response = _build_response()
+
+    with patch("app.services.auth_service.get_session_token", new=AsyncMock(return_value="tok")), \
+         patch("app.services.auth_service.require_valid_session", return_value=session):
+        with pytest.raises(AuthenticationError) as exc_info:
+            await switch_tenant(request, response, "target-tenant")
+
+    assert "Access denied" in str(exc_info.value)
+    assert exc_info.value.status_code == 401
+
+
 # ─── get_session_data tests ────────────────────────────────────────────
 
 
@@ -241,6 +259,49 @@ async def test_get_session_data_role_null_when_terminated():
     assert result.user.email == "term@example.com"
 
 
+@pytest.mark.asyncio
+async def test_get_session_data_denies_customer_role_and_clears_cookie():
+    """Existing active internal sessions with role=customer are invalidated."""
+    from app.services.auth_service import get_session_data
+
+    user_id = uuid4()
+    tenant_id = uuid4()
+    session_token = "fake-token"
+    request = MagicMock()
+    request.cookies = {"session-token": session_token}
+    request.headers = {}
+    response = _build_response()
+
+    fetchrow_responses = [
+        {
+            "user_id": user_id,
+            "email": "customer@example.com",
+            "name": "Customer User",
+            "user_created_at": "2024-01-01T00:00:00Z",
+            "tenant_id": tenant_id,
+            "expires_at": "2030-01-01T00:00:00Z",
+            "created_at": "2025-01-01T00:00:00Z",
+            "ip_address": "127.0.0.1",
+            "login_method": "magic-link",
+        },
+        {"id": tenant_id, "name": "Some Tenant", "slug": "some-tenant"},
+        {"role": "customer"},
+    ]
+
+    db_ctx, conn = _build_db_mock(fetchrow_side_effect=fetchrow_responses)
+
+    with patch("app.services.auth_service.get_db_connection", side_effect=db_ctx), \
+         patch("app.services.auth_service.get_session_token", new=AsyncMock(return_value=session_token)), \
+         patch("app.services.auth_service.clear_session_cookie", new=AsyncMock(return_value=None)) as clear_cookie:
+        with pytest.raises(AuthenticationError) as exc_info:
+            await get_session_data(request, response)
+
+    assert exc_info.value.status_code == 401
+    conn.execute.assert_awaited_once()
+    assert conn.execute.await_args.args[1] == session_token
+    clear_cookie.assert_awaited_once_with(response, session_token)
+
+
 # ─── get_user_tenants tests ────────────────────────────────────────────
 
 
@@ -264,7 +325,7 @@ async def test_get_user_tenants_excludes_terminated_memberships():
         {"id": active_tenant_id, "name": "Active Tenant", "slug": "active-tenant"},
     ]
 
-    db_ctx, _ = _build_db_mock(fetch_return=fetch_return)
+    db_ctx, conn = _build_db_mock(fetch_return=fetch_return)
 
     with patch("app.services.tenants_service.get_db_connection", side_effect=db_ctx), \
          patch("app.services.tenants_service.require_valid_session", return_value=session):
@@ -273,3 +334,4 @@ async def test_get_user_tenants_excludes_terminated_memberships():
     assert len(result.data) == 1
     assert result.data[0].slug == "active-tenant"
     assert result.data[0].id == active_tenant_id
+    assert conn.fetch.await_args.args[2] == ["superuser", "admin", "employee", "member"]


### PR DESCRIPTION
## Summary

- Require active legacy team roles for internal magic-link issuance and code/token verification.
- Deny and invalidate existing internal sessions when the resolved active role is not an internal team role, including `customer`.
- Restrict tenant switching and `/tenants/user-tenants` to internal team roles only.
- Add focused regression coverage for customer-only denial and team-role paths.

## Validation

- `python3 -m py_compile app/core/internal_roles.py app/core/security.py app/services/magic_link_service.py app/services/auth_service.py app/services/tenants_service.py tests/test_switch_tenant_membership.py tests/test_customer_internal_access.py`
- `pytest tests/test_auth.py tests/test_switch_tenant_membership.py tests/test_customer_internal_access.py`

Closes #428
