### PR TITLE
Allow tenant customers and team members to coexist

### DIFF
--- a/app/services/customer_relationship_service.py
+++ b/app/services/customer_relationship_service.py
@@ -1,0 +1,30 @@
+from uuid import UUID
+
+
+async def upsert_tenant_customer(conn, profile_id: UUID, tenant_id: UUID) -> None:
+    await conn.execute(
+        """
+        INSERT INTO tenant_customers (tenant_id, profile_id, is_active)
+        VALUES ($1, $2, true)
+        ON CONFLICT (tenant_id, profile_id) DO UPDATE
+        SET is_active = true,
+            updated_at = NOW()
+        """,
+        tenant_id,
+        profile_id,
+    )
+
+
+async def is_tenant_customer(conn, profile_id: UUID, tenant_id: UUID) -> bool:
+    row = await conn.fetchval(
+        """
+        SELECT 1
+        FROM tenant_customers
+        WHERE profile_id = $1
+          AND tenant_id = $2
+          AND is_active = true
+        """,
+        profile_id,
+        tenant_id,
+    )
+    return bool(row)

--- a/app/services/customers_service.py
+++ b/app/services/customers_service.py
@@ -6,6 +6,7 @@ from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import APIError
 from app.core.email_utils import normalize_email
+from app.services.customer_relationship_service import upsert_tenant_customer
 from app.models.customer import (
     Customer,
     CustomerSearchOrCreate,
@@ -31,7 +32,7 @@ async def get_customer_by_id(
     customer_id: UUID,
 ) -> CustomerUpdateResponse:
     """
-    Fetch a customer profile by id, scoped to the current tenant (tenant_members).
+    Fetch a customer profile by id, scoped to the current tenant customer relationship.
     Includes fiscal fields so the POS can reuse invoice data.
     """
     try:
@@ -56,10 +57,10 @@ async def get_customer_by_id(
                     p.created_at,
                     p.updated_at
                 FROM profile p
-                JOIN tenant_members tm ON tm.user_id = p.id
+                JOIN tenant_customers tc ON tc.profile_id = p.id
                 WHERE p.id = $1
-                  AND tm.tenant_id = $2
-                  AND tm.role = 'customer'
+                  AND tc.tenant_id = $2
+                  AND tc.is_active = true
                 LIMIT 1
                 """,
                 customer_id,
@@ -149,30 +150,8 @@ async def search_or_create_customer(
                 # Customer found
                 logger.info(f"✅ Customer found: {existing_customer['phone_number']}")
 
-                # Check if customer is already associated with tenant
-                tenant_association_query = """
-                    SELECT tenant_id
-                    FROM tenant_members
-                    WHERE user_id = $1 AND tenant_id = $2
-                """
-
-                association = await conn.fetchrow(
-                    tenant_association_query,
-                    existing_customer['id'],
-                    tenant_id
-                )
-
-                # If not associated, create association
-                if not association:
-                    await conn.execute(
-                        """
-                        INSERT INTO tenant_members (id, user_id, tenant_id, role)
-                        VALUES (gen_random_uuid(), $1, $2, 'customer')
-                        """,
-                        existing_customer['id'],
-                        tenant_id
-                    )
-                    logger.info(f"✅ Associated customer {existing_customer['id']} with tenant {tenant_id}")
+                await upsert_tenant_customer(conn, existing_customer['id'], tenant_id)
+                logger.info(f"✅ Associated customer {existing_customer['id']} with tenant {tenant_id}")
 
                 # Backfill fiscal fields if the request brings them and they
                 # are not yet set on the profile (or differ from what we have).
@@ -268,15 +247,7 @@ async def search_or_create_customer(
                     customer_data.fiscal_email,
                 )
 
-                # Associate customer with tenant
-                await conn.execute(
-                    """
-                    INSERT INTO tenant_members (id, user_id, tenant_id, role)
-                    VALUES (gen_random_uuid(), $1, $2, 'customer')
-                    """,
-                    new_customer['id'],
-                    tenant_id
-                )
+                await upsert_tenant_customer(conn, new_customer['id'], tenant_id)
 
                 logger.info(f"✅ Customer created and associated with tenant: {new_customer['id']}")
 
@@ -387,7 +358,7 @@ async def search_customers_by_query(
 ) -> CustomerQuerySearchResponse:
     """
     Search customers by partial name or phone number (ILIKE OR).
-    Results are scoped to the current tenant via tenant_members.
+    Results are scoped to the current tenant via tenant_customers.
 
     Args:
         request: FastAPI request object
@@ -418,9 +389,9 @@ async def search_customers_by_query(
                     p.fiscal_id,
                     p.fiscal_id_type
                 FROM profile p
-                JOIN tenant_members tm ON tm.user_id = p.id
-                WHERE tm.tenant_id = $1
-                  AND tm.role = 'customer'
+                JOIN tenant_customers tc ON tc.profile_id = p.id
+                WHERE tc.tenant_id = $1
+                  AND tc.is_active = true
                   AND (
                       p.name ILIKE $2
                       OR p.phone_number ILIKE $2
@@ -569,7 +540,7 @@ async def update_customer(
     """
     Update name, email, and/or phone_number of a customer profile.
     Only fields explicitly provided (non-None) are updated.
-    Scoped to the current tenant — only updates customers who are members.
+    Scoped to the current tenant — only updates profiles with a customer relationship.
     """
     try:
         session_context = require_valid_session(request)
@@ -583,8 +554,10 @@ async def update_customer(
             member_check = await conn.fetchrow(
                 """
                 SELECT p.id FROM profile p
-                JOIN tenant_members tm ON tm.user_id = p.id
-                WHERE p.id = $1 AND tm.tenant_id = $2 AND tm.role = 'customer'
+                JOIN tenant_customers tc ON tc.profile_id = p.id
+                WHERE p.id = $1
+                  AND tc.tenant_id = $2
+                  AND tc.is_active = true
                 """,
                 customer_id, tenant_id
             )

--- a/sql/20260613_tenant_customers.sql
+++ b/sql/20260613_tenant_customers.sql
@@ -1,0 +1,32 @@
+-- Issue api-warolabs#429
+-- Separate tenant customer relationship from internal team membership.
+
+CREATE TABLE IF NOT EXISTS tenant_customers (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id   UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    profile_id  UUID NOT NULL REFERENCES profile(id) ON DELETE CASCADE,
+    is_active   BOOLEAN NOT NULL DEFAULT true,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT tenant_customers_tenant_profile_unique UNIQUE (tenant_id, profile_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_customers_profile_active
+    ON tenant_customers (profile_id, tenant_id)
+    WHERE is_active = true;
+
+COMMENT ON TABLE tenant_customers IS
+    'Explicit customer relationship per tenant/profile. Internal team roles remain in tenant_members.';
+
+COMMENT ON COLUMN tenant_customers.profile_id IS
+    'Customer profile identity; orders, wallet, and addresses stay linked to profile.id.';
+
+INSERT INTO tenant_customers (tenant_id, profile_id, is_active)
+SELECT tm.tenant_id, tm.user_id, COALESCE(tm.is_active, true)
+FROM tenant_members tm
+WHERE tm.role = 'customer'
+  AND COALESCE(tm.is_active, true) = true
+  AND tm.terminated_at IS NULL
+ON CONFLICT (tenant_id, profile_id) DO UPDATE
+SET is_active = true,
+    updated_at = now();

--- a/tests/test_customer_identity_model.py
+++ b/tests/test_customer_identity_model.py
@@ -1,0 +1,162 @@
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.models.customer import CustomerSearchOrCreate, CustomerUpdate
+from app.services import customers_service
+
+
+def _request():
+    return MagicMock()
+
+
+def _session(tenant_id):
+    session = MagicMock()
+    session.tenant_id = tenant_id
+    return session
+
+
+def _profile_row(profile_id=None, phone_number="3001234567", email="buyer@example.com"):
+    return {
+        "id": profile_id or uuid4(),
+        "phone_number": phone_number,
+        "name": "Buyer",
+        "email": email,
+        "fiscal_id_type": None,
+        "fiscal_id": None,
+        "fiscal_business_name": None,
+        "fiscal_email": None,
+        "created_at": "2026-06-13T00:00:00Z",
+        "updated_at": "2026-06-13T00:00:00Z",
+    }
+
+
+def _db_context(conn):
+    @asynccontextmanager
+    async def _ctx():
+        yield conn
+
+    return _ctx
+
+
+def _patch_customer_service_db(conn, tenant_id):
+    return (
+        patch("app.services.customers_service.require_valid_session", return_value=_session(tenant_id)),
+        patch("app.services.customers_service.get_db_connection", side_effect=_db_context(conn)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_or_create_customer_upserts_customer_relationship_without_touching_team_role():
+    tenant_id = uuid4()
+    profile_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_profile_row(profile_id=profile_id))
+    conn.execute = AsyncMock(return_value=None)
+
+    session_patch, db_patch = _patch_customer_service_db(conn, tenant_id)
+    with session_patch, db_patch:
+        result = await customers_service.search_or_create_customer(
+            _request(),
+            CustomerSearchOrCreate(phone_number="3001234567", name="Buyer"),
+        )
+
+    assert result.is_new is False
+    assert result.data.id == profile_id
+    executed_sql = conn.execute.await_args.args[0]
+    assert "INSERT INTO tenant_customers" in executed_sql
+    assert "tenant_members" not in executed_sql
+    assert conn.execute.await_args.args[1:] == (tenant_id, profile_id)
+
+
+@pytest.mark.asyncio
+async def test_search_or_create_customer_creates_customer_relationship_for_new_profile():
+    tenant_id = uuid4()
+    profile_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[None, _profile_row(profile_id=profile_id)])
+    conn.execute = AsyncMock(return_value=None)
+
+    session_patch, db_patch = _patch_customer_service_db(conn, tenant_id)
+    with session_patch, db_patch:
+        result = await customers_service.search_or_create_customer(
+            _request(),
+            CustomerSearchOrCreate(phone_number="3007654321", name="New Buyer"),
+        )
+
+    assert result.is_new is True
+    customer_upsert_sql = conn.execute.await_args.args[0]
+    assert "INSERT INTO tenant_customers" in customer_upsert_sql
+    assert "tenant_members" not in customer_upsert_sql
+    assert conn.execute.await_args.args[1:] == (tenant_id, profile_id)
+
+
+@pytest.mark.asyncio
+async def test_get_customer_by_id_uses_tenant_customers_as_source_of_truth():
+    tenant_id = uuid4()
+    profile_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_profile_row(profile_id=profile_id))
+
+    session_patch, db_patch = _patch_customer_service_db(conn, tenant_id)
+    with session_patch, db_patch:
+        result = await customers_service.get_customer_by_id(_request(), profile_id)
+
+    assert result.data.id == profile_id
+    query = conn.fetchrow.await_args.args[0]
+    assert "tenant_customers tc" in query
+    assert "tenant_members" not in query
+    assert "tc.is_active = true" in query
+
+
+@pytest.mark.asyncio
+async def test_search_customers_by_query_uses_tenant_customers():
+    tenant_id = uuid4()
+    profile_id = uuid4()
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[
+        {
+            "id": profile_id,
+            "name": "Buyer",
+            "phone_number": "3001234567",
+            "email": "buyer@example.com",
+            "fiscal_id": None,
+            "fiscal_id_type": None,
+        }
+    ])
+
+    session_patch, db_patch = _patch_customer_service_db(conn, tenant_id)
+    with session_patch, db_patch:
+        result = await customers_service.search_customers_by_query(_request(), "Buyer")
+
+    assert result.data[0].id == profile_id
+    query = conn.fetch.await_args.args[0]
+    assert "tenant_customers tc" in query
+    assert "tenant_members" not in query
+    assert "tc.is_active = true" in query
+
+
+@pytest.mark.asyncio
+async def test_update_customer_requires_customer_relationship_not_team_role():
+    tenant_id = uuid4()
+    profile_id = uuid4()
+    updated_row = _profile_row(profile_id=profile_id, phone_number="3009999999")
+    updated_row["name"] = "Updated Buyer"
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[{"id": profile_id}, updated_row])
+
+    session_patch, db_patch = _patch_customer_service_db(conn, tenant_id)
+    with session_patch, db_patch:
+        result = await customers_service.update_customer(
+            _request(),
+            profile_id,
+            CustomerUpdate(name="Updated Buyer"),
+        )
+
+    assert result.data.name == "Updated Buyer"
+    membership_query = conn.fetchrow.await_args_list[0].args[0]
+    assert "tenant_customers tc" in membership_query
+    assert "tenant_members" not in membership_query
+    assert "tc.is_active = true" in membership_query


### PR DESCRIPTION
## Summary
- add tenant_customers as the explicit tenant/profile customer relationship table and backfill active legacy customer rows
- add a customer relationship helper for upserting/checking customer status
- move narrow customer create/search/update eligibility paths off tenant_members.role = 'customer'

## Validation
- pytest tests/test_customer_identity_model.py tests/test_customers.py tests/test_customer_detail.py -q

Closes #429