### PR TITLE
Preserve customer status in team invitations

### DIFF
--- a/app/services/invitation_service.py
+++ b/app/services/invitation_service.py
@@ -9,6 +9,7 @@ from app.core.security import set_session_cookie, get_client_ip, get_current_use
 from app.core.middleware import require_valid_tenant, require_valid_session
 from app.core.exceptions import AuthenticationError, ValidationError, AuthorizationError
 from app.core.email_utils import normalize_email
+from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
 from app.models.invitation import (
     SendInvitationRequest,
     SendInvitationResponse,
@@ -73,6 +74,7 @@ async def send_invitation(request: Request, payload: SendInvitationRequest) -> S
             permission_query = """
                 SELECT role FROM tenant_members
                 WHERE user_id = $1 AND tenant_id = $2
+                  AND is_active = true
             """
             user_role = await conn.fetchval(permission_query, current_user_id, session_tenant_id)
 
@@ -88,8 +90,16 @@ async def send_invitation(request: Request, payload: SendInvitationRequest) -> S
             if existing_user:
                 # Check if already member of this tenant
                 existing_member = await conn.fetchval(
-                    "SELECT id FROM tenant_members WHERE user_id = $1 AND tenant_id = $2",
-                    existing_user['id'], session_tenant_id
+                    """
+                    SELECT id FROM tenant_members
+                    WHERE user_id = $1
+                      AND tenant_id = $2
+                      AND is_active = true
+                      AND role = ANY($3::text[])
+                    """,
+                    existing_user['id'],
+                    session_tenant_id,
+                    list(LEGACY_INTERNAL_TEAM_ROLES),
                 )
                 if existing_member:
                     raise ValidationError("User is already a member of this team")
@@ -259,13 +269,22 @@ async def accept_invitation(request: Request, response: Response, token: str) ->
                 invitation['id']
             )
 
-            # Add user to tenant_members
-            member_exists = await conn.fetchval(
-                "SELECT id FROM tenant_members WHERE user_id = $1 AND tenant_id = $2",
-                invitation['user_id'], invitation['tenant_id']
+            # Add or reactivate an internal team membership without touching customer state.
+            team_member = await conn.fetchrow(
+                """
+                SELECT id, is_active FROM tenant_members
+                WHERE user_id = $1
+                  AND tenant_id = $2
+                  AND role = ANY($3::text[])
+                ORDER BY is_active DESC
+                LIMIT 1
+                """,
+                invitation['user_id'],
+                invitation['tenant_id'],
+                list(LEGACY_INTERNAL_TEAM_ROLES),
             )
 
-            if not member_exists:
+            if not team_member:
                 await conn.execute(
                     """INSERT INTO tenant_members (id, user_id, tenant_id, role)
                        VALUES (gen_random_uuid(), $1, $2, $3)""",
@@ -275,14 +294,18 @@ async def accept_invitation(request: Request, response: Response, token: str) ->
                 )
                 logger.info(f"👥 User added to tenant_members with role: {invitation['role']}")
             else:
-                # Update role if already exists
                 await conn.execute(
-                    "UPDATE tenant_members SET role = $1 WHERE user_id = $2 AND tenant_id = $3",
+                    """
+                    UPDATE tenant_members
+                    SET role = $1,
+                        is_active = true,
+                        terminated_at = NULL
+                    WHERE id = $2
+                    """,
                     invitation['role'],
-                    invitation['user_id'],
-                    invitation['tenant_id']
+                    team_member['id'],
                 )
-                logger.info(f"🔄 Updated existing member role to: {invitation['role']}")
+                logger.info(f"🔄 Activated existing team member role to: {invitation['role']}")
 
             # Create session (same as magic link flow)
             session_id = secrets.token_hex(16)
@@ -364,8 +387,14 @@ async def get_pending_invitations(request: Request) -> PendingInvitationsRespons
         async with get_db_connection() as conn:
             # Check permission
             user_role = await conn.fetchval(
-                "SELECT role FROM tenant_members WHERE user_id = $1 AND tenant_id = $2",
-                current_user_id, tenant_context.tenant_id
+                """
+                SELECT role FROM tenant_members
+                WHERE user_id = $1
+                  AND tenant_id = $2
+                  AND is_active = true
+                """,
+                current_user_id,
+                tenant_context.tenant_id,
             )
 
             if user_role not in ('admin', 'superuser'):
@@ -426,8 +455,14 @@ async def cancel_invitation(request: Request, invitation_id: str) -> CancelInvit
         async with get_db_connection() as conn:
             # Check permission
             user_role = await conn.fetchval(
-                "SELECT role FROM tenant_members WHERE user_id = $1 AND tenant_id = $2",
-                current_user_id, session_tenant_id
+                """
+                SELECT role FROM tenant_members
+                WHERE user_id = $1
+                  AND tenant_id = $2
+                  AND is_active = true
+                """,
+                current_user_id,
+                session_tenant_id,
             )
 
             if user_role not in ('admin', 'superuser'):

--- a/app/services/tenants_service.py
+++ b/app/services/tenants_service.py
@@ -233,7 +233,7 @@ async def update_member_role(request: Request, member_id: str, new_role: str) ->
     Only superuser can change roles
     Cannot change your own role
     """
-    VALID_ROLES = ['superuser', 'admin', 'employee', 'member']
+    VALID_ROLES = list(LEGACY_INTERNAL_TEAM_ROLES)
 
     try:
         session_context = require_valid_session(request)
@@ -250,8 +250,16 @@ async def update_member_role(request: Request, member_id: str, new_role: str) ->
         async with get_db_connection() as conn:
             # Check current user's role - ONLY superuser can change roles
             user_role = await conn.fetchval(
-                "SELECT role FROM tenant_members WHERE user_id = $1 AND tenant_id = $2",
-                current_user_id, current_tenant_id
+                """
+                SELECT role FROM tenant_members
+                WHERE user_id = $1
+                  AND tenant_id = $2
+                  AND is_active = true
+                  AND role = ANY($3::text[])
+                """,
+                current_user_id,
+                current_tenant_id,
+                VALID_ROLES,
             )
 
             if user_role != 'superuser':
@@ -262,8 +270,13 @@ async def update_member_role(request: Request, member_id: str, new_role: str) ->
                 """SELECT tm.id, tm.user_id, tm.role, p.name, p.email
                    FROM tenant_members tm
                    JOIN profile p ON tm.user_id = p.id
-                   WHERE tm.id = $1 AND tm.tenant_id = $2""",
-                member_id, current_tenant_id
+                   WHERE tm.id = $1
+                     AND tm.tenant_id = $2
+                     AND tm.is_active = true
+                     AND tm.role = ANY($3::text[])""",
+                member_id,
+                current_tenant_id,
+                VALID_ROLES,
             )
 
             if not member_info:

--- a/tests/test_invitation_team_membership.py
+++ b/tests/test_invitation_team_membership.py
@@ -1,0 +1,205 @@
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.exceptions import ValidationError
+from app.models.invitation import InvitationRole, SendInvitationRequest
+from app.services import invitation_service, tenants_service
+
+
+def _db_context(conn):
+    @asynccontextmanager
+    async def _ctx():
+        yield conn
+
+    return _ctx
+
+
+def _session(user_id, tenant_id):
+    return SimpleNamespace(user_id=user_id, tenant_id=tenant_id)
+
+
+def _tenant_context(tenant_id):
+    return SimpleNamespace(
+        tenant_id=tenant_id,
+        tenant_email="team@example.com",
+        site="tenant.example.com",
+    )
+
+
+def _request():
+    request = MagicMock()
+    request.headers = {
+        "origin": "http://localhost:8080",
+        "user-agent": "pytest",
+    }
+    return request
+
+
+@pytest.mark.asyncio
+async def test_send_invitation_allows_existing_customer_without_team_membership():
+    tenant_id = uuid4()
+    inviter_id = uuid4()
+    customer_profile_id = uuid4()
+    invitation_id = uuid4()
+    expires_at = datetime.utcnow() + timedelta(days=7)
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {
+                "id": tenant_id,
+                "name": "Tenant",
+                "slug": "tenant",
+                "tenant_email": "tenant@example.com",
+                "brand_name": "Tenant",
+            },
+            {"id": customer_profile_id, "email": "buyer@example.com"},
+            {
+                "id": invitation_id,
+                "email": "buyer@example.com",
+                "role": "admin",
+                "status": "pending",
+                "expires_at": expires_at,
+            },
+        ]
+    )
+    conn.fetchval = AsyncMock(side_effect=["admin", None, None, "Inviter"])
+    conn.execute = AsyncMock(return_value=None)
+
+    payload = SendInvitationRequest(
+        email="buyer@example.com",
+        phone="3001234567",
+        name="Buyer",
+        role=InvitationRole.ADMIN,
+    )
+
+    with (
+        patch("app.services.invitation_service.require_valid_session", return_value=_session(inviter_id, tenant_id)),
+        patch("app.services.invitation_service.require_valid_tenant", return_value=_tenant_context(tenant_id)),
+        patch("app.services.invitation_service.get_db_connection", side_effect=_db_context(conn)),
+        patch("app.services.aws_ses_service.ses_service") as ses_service,
+    ):
+        ses_service.send_email = AsyncMock(return_value=True)
+        response = await invitation_service.send_invitation(_request(), payload)
+
+    assert response.success is True
+    existing_member_query = conn.fetchval.await_args_list[1].args[0]
+    assert "role = ANY" in existing_member_query
+    assert "is_active = true" in existing_member_query
+    assert conn.fetchval.await_args_list[1].args[1:] == (
+        customer_profile_id,
+        tenant_id,
+        ["superuser", "admin", "employee", "member"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_accept_invitation_inserts_team_membership_without_updating_legacy_customer_row():
+    tenant_id = uuid4()
+    profile_id = uuid4()
+    invitation_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {
+                "id": invitation_id,
+                "tenant_id": tenant_id,
+                "user_id": profile_id,
+                "email": "buyer@example.com",
+                "name": "Buyer",
+                "role": "admin",
+            },
+            None,
+        ]
+    )
+    conn.fetchval = AsyncMock(return_value="Tenant")
+    conn.execute = AsyncMock(return_value=None)
+
+    with (
+        patch("app.services.invitation_service.require_valid_tenant", return_value=_tenant_context(tenant_id)),
+        patch("app.services.invitation_service.get_db_connection", side_effect=_db_context(conn)),
+        patch("app.services.invitation_service.set_session_cookie", new=AsyncMock()),
+    ):
+        response = await invitation_service.accept_invitation(_request(), MagicMock(), "token")
+
+    assert response.success is True
+    team_lookup_query = conn.fetchrow.await_args_list[1].args[0]
+    assert "role = ANY" in team_lookup_query
+    assert conn.fetchrow.await_args_list[1].args[1:] == (
+        profile_id,
+        tenant_id,
+        ["superuser", "admin", "employee", "member"],
+    )
+
+    executed_sql = [call.args[0] for call in conn.execute.await_args_list]
+    tenant_member_writes = [sql for sql in executed_sql if "tenant_members" in sql]
+    assert len(tenant_member_writes) == 1
+    assert "INSERT INTO tenant_members" in tenant_member_writes[0]
+    assert "UPDATE tenant_members" not in tenant_member_writes[0]
+
+
+@pytest.mark.asyncio
+async def test_accept_invitation_reactivates_existing_team_membership_by_id():
+    tenant_id = uuid4()
+    profile_id = uuid4()
+    invitation_id = uuid4()
+    member_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {
+                "id": invitation_id,
+                "tenant_id": tenant_id,
+                "user_id": profile_id,
+                "email": "employee@example.com",
+                "name": "Employee",
+                "role": "admin",
+            },
+            {"id": member_id, "is_active": False},
+        ]
+    )
+    conn.fetchval = AsyncMock(return_value="Tenant")
+    conn.execute = AsyncMock(return_value=None)
+
+    with (
+        patch("app.services.invitation_service.require_valid_tenant", return_value=_tenant_context(tenant_id)),
+        patch("app.services.invitation_service.get_db_connection", side_effect=_db_context(conn)),
+        patch("app.services.invitation_service.set_session_cookie", new=AsyncMock()),
+    ):
+        await invitation_service.accept_invitation(_request(), MagicMock(), "token")
+
+    tenant_member_writes = [
+        call.args for call in conn.execute.await_args_list
+        if "tenant_members" in call.args[0]
+    ]
+    assert len(tenant_member_writes) == 1
+    assert "WHERE id = $2" in tenant_member_writes[0][0]
+    assert tenant_member_writes[0][1:] == ("admin", member_id)
+
+
+@pytest.mark.asyncio
+async def test_update_member_role_rejects_non_team_member_row():
+    tenant_id = uuid4()
+    superuser_id = uuid4()
+    member_id = uuid4()
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value="superuser")
+    conn.fetchrow = AsyncMock(return_value=None)
+    conn.execute = AsyncMock(return_value=None)
+
+    with (
+        patch("app.services.tenants_service.require_valid_session", return_value=_session(superuser_id, tenant_id)),
+        patch("app.services.tenants_service.get_db_connection", side_effect=_db_context(conn)),
+    ):
+        with pytest.raises(ValidationError):
+            await tenants_service.update_member_role(_request(), str(member_id), "admin")
+
+    member_lookup_query = conn.fetchrow.await_args.args[0]
+    assert "tm.role = ANY" in member_lookup_query
+    assert "tm.is_active = true" in member_lookup_query
+    conn.execute.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Limit invitation “already member” checks to active internal team roles so customer-only profiles can be invited.
- Accept invitations by inserting or reactivating an internal team membership without rewriting customer relationship state.
- Restrict Equipo role updates to active internal team rows.

## Validation

- `pytest tests/test_invitation_team_membership.py tests/test_customer_identity_model.py`
- `git diff --check`

Closes #430
