### PR TITLE
Migrate customer filters to tenant relationships

### DIFF
--- a/app/routers/customers.py
+++ b/app/routers/customers.py
@@ -200,7 +200,7 @@ async def get_customer_by_id_endpoint(
 ):
     """
     Get a single customer by id, including fiscal fields.
-    Customer must belong to the current tenant (tenant_members).
+    Customer must belong to the current tenant.
     """
     return await get_customer_by_id(request, customer_id)
 

--- a/app/services/customer_wallet_service.py
+++ b/app/services/customer_wallet_service.py
@@ -17,6 +17,7 @@ from app.core.exceptions import APIError, AuthenticationError
 from app.core.middleware import require_valid_session
 from app.database import get_db_connection
 from app.services.cierre_service import _SLUG_DEBIT_CODE
+from app.services.customer_relationship_service import is_tenant_customer
 
 logger = logging.getLogger(__name__)
 
@@ -87,15 +88,7 @@ async def assert_wallet_customer_identified(conn, profile_id: UUID) -> None:
 
 
 async def _assert_tenant_customer(conn, profile_id: UUID, tenant_id: UUID) -> None:
-    ok = await conn.fetchval(
-        """
-        SELECT 1 FROM tenant_members
-        WHERE user_id = $1 AND tenant_id = $2 AND role = 'customer'
-        """,
-        profile_id,
-        tenant_id,
-    )
-    if not ok:
+    if not await is_tenant_customer(conn, profile_id, tenant_id):
         raise APIError("Cliente no pertenece a este negocio", status_code=404)
 
 

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -1331,7 +1331,7 @@ async def get_customers_list(
             if search:
                 param_count += 1
                 outer_conditions.append(
-                    f"(tc.name ILIKE ${param_count} OR tc.phone ILIKE ${param_count})"
+                    f"(tcp.name ILIKE ${param_count} OR tcp.phone ILIKE ${param_count})"
                 )
                 params.append(f"%{search}%")
 
@@ -1348,17 +1348,15 @@ async def get_customers_list(
             offset_param = param_count
 
             query = f"""
-                WITH tenant_customers AS (
+                WITH tenant_customer_profiles AS (
                     SELECT
                         p.id AS customer_id,
                         COALESCE(p.name, 'Sin identificar') AS name,
                         p.phone_number AS phone
                     FROM profile p
-                    INNER JOIN tenant_members tm ON tm.user_id = p.id
-                    WHERE tm.tenant_id = $1
-                      AND tm.role = 'customer'
-                      AND tm.is_active = true
-                      AND tm.terminated_at IS NULL
+                    INNER JOIN tenant_customers tc ON tc.profile_id = p.id
+                    WHERE tc.tenant_id = $1
+                      AND tc.is_active = true
                 ),
                 order_agg AS (
                     SELECT
@@ -1372,19 +1370,19 @@ async def get_customers_list(
                     GROUP BY o.customer_id
                 )
                 SELECT
-                    tc.customer_id,
-                    tc.name,
-                    tc.phone,
+                    tcp.customer_id,
+                    tcp.name,
+                    tcp.phone,
                     COALESCE(oa.total_spent, 0)   AS total_spent,
                     COALESCE(oa.order_count, 0)   AS order_count,
                     COALESCE(oa.avg_ticket, 0)    AS avg_ticket,
                     oa.last_order_date,
                     COUNT(*) OVER() AS total_count,
                     SUM(COALESCE(oa.total_spent, 0)) OVER() AS total_revenue
-                FROM tenant_customers tc
-                {join_type} JOIN order_agg oa ON oa.customer_id = tc.customer_id
+                FROM tenant_customer_profiles tcp
+                {join_type} JOIN order_agg oa ON oa.customer_id = tcp.customer_id
                 {outer_where}
-                ORDER BY COALESCE(oa.total_spent, 0) DESC, tc.name ASC
+                ORDER BY COALESCE(oa.total_spent, 0) DESC, tcp.name ASC
                 LIMIT ${limit_param} OFFSET ${offset_param}
             """
 
@@ -1479,10 +1477,10 @@ async def get_customer_detail(
                         p.phone_number                       AS phone,
                         p.email                              AS email
                     FROM profile p
-                    JOIN tenant_members tm ON tm.user_id = p.id
+                    JOIN tenant_customers tc ON tc.profile_id = p.id
                     WHERE p.id = $1
-                      AND tm.tenant_id = $2
-                      AND tm.role = 'customer'
+                      AND tc.tenant_id = $2
+                      AND tc.is_active = true
                     LIMIT 1
                     """,
                     customer_id,

--- a/tests/test_customer_detail.py
+++ b/tests/test_customer_detail.py
@@ -14,6 +14,8 @@ _CUSTOMER_ID = uuid4()
 
 
 class _SeqConnCtx:
+    latest_conn = None
+
     def __init__(self, fetchrow_responses, fetch_responses=None):
         self._frows = iter(fetchrow_responses)
         self._fetch = iter(fetch_responses or [])
@@ -22,6 +24,7 @@ class _SeqConnCtx:
         conn = MagicMock()
         conn.fetchrow = AsyncMock(side_effect=lambda *a, **k: next(self._frows))
         conn.fetch = AsyncMock(side_effect=lambda *a, **k: next(self._fetch))
+        _SeqConnCtx.latest_conn = conn
         return conn
 
     async def __aexit__(self, *_):
@@ -68,6 +71,12 @@ async def test_get_customer_detail_profile_without_orders_returns_zeroed_stats()
     assert result['customer']['last_purchase'] is None
     assert result['orders']['items'] == []
     assert result['orders']['total'] == 0
+    fallback_query = _SeqConnCtx.latest_conn.fetchrow.await_args_list[1].args[0]
+    assert "tenant_customers tc" in fallback_query
+    assert "tc.profile_id" in fallback_query
+    assert "tc.is_active = true" in fallback_query
+    assert "tenant_members" not in fallback_query
+    assert "role = 'customer'" not in fallback_query
 
 
 @pytest.mark.asyncio

--- a/tests/test_customer_wallet.py
+++ b/tests/test_customer_wallet.py
@@ -38,15 +38,18 @@ class TestAnonymousGuard:
 
 class TestTenantCustomerGuard:
     @pytest.mark.asyncio
-    async def test_uses_user_id_column(self):
+    async def test_uses_tenant_customer_relationship(self):
         conn = AsyncMock()
         conn.fetchval = AsyncMock(return_value=1)
         profile_id = uuid4()
         tenant_id = uuid4()
         await _assert_tenant_customer(conn, profile_id, tenant_id)
         query = conn.fetchval.await_args.args[0]
-        assert "user_id" in query
-        assert "profile_id" not in query
+        assert "tenant_customers" in query
+        assert "profile_id" in query
+        assert "is_active = true" in query
+        assert "tenant_members" not in query
+        assert "role = 'customer'" not in query
 
     @pytest.mark.asyncio
     async def test_missing_association_raises_404(self):

--- a/tests/test_customers_list.py
+++ b/tests/test_customers_list.py
@@ -13,12 +13,15 @@ _CUSTOMER_NO_ORDERS = uuid4()
 
 
 class _ConnCtx:
+    latest_conn = None
+
     def __init__(self, rows):
         self._rows = rows
 
     async def __aenter__(self):
         conn = MagicMock()
         conn.fetch = AsyncMock(return_value=self._rows)
+        _ConnCtx.latest_conn = conn
         return conn
 
     async def __aexit__(self, *_):
@@ -78,3 +81,9 @@ async def test_customers_list_includes_zero_order_customer():
   assert zero_row['order_count'] == 0
   assert zero_row['total_spent'] == 0.0
   assert zero_row['last_order_date'] is None
+  query = _ConnCtx.latest_conn.fetch.await_args.args[0]
+  assert "tenant_customers tc" in query
+  assert "tc.profile_id" in query
+  assert "tc.is_active = true" in query
+  assert "tenant_members" not in query
+  assert "role = 'customer'" not in query


### PR DESCRIPTION
## Summary

- migrate wallet customer eligibility to the explicit `tenant_customers` relationship
- update order customer list/detail reporting to use `tenant_customers` instead of exclusive `tenant_members.role = 'customer'`
- add regression assertions for wallet, customer list, and zero-order customer detail query sources

## Validation

- `pytest tests/test_customer_wallet.py tests/test_customers_list.py tests/test_customer_detail.py tests/test_customer_identity_model.py`

Closes #431
