### PR TITLE
Harden customer/team data migration

### DIFF
--- a/docs/customer-team-migration-runbook.md
+++ b/docs/customer-team-migration-runbook.md
@@ -1,0 +1,124 @@
+# Customer/team migration runbook
+
+Issue: api-warolabs#433
+
+This rollout separates customer relationship state from internal team role state.
+Customers live in `tenant_customers`; internal platform access remains in
+`tenant_members` with one of `superuser`, `admin`, `employee`, or `member`.
+
+## Preflight
+
+Estimate rows created from legacy customer memberships:
+
+```sql
+SELECT tenant_id, count(*) AS legacy_customer_members
+FROM tenant_members
+WHERE role = 'customer'
+  AND COALESCE(is_active, true) = true
+  AND terminated_at IS NULL
+GROUP BY tenant_id
+ORDER BY legacy_customer_members DESC;
+```
+
+Estimate customer relationships recoverable from customer-linked activity:
+
+```sql
+WITH customer_activity AS (
+    SELECT tenant_id, customer_id AS profile_id
+    FROM orders
+    WHERE customer_id IS NOT NULL
+    UNION
+    SELECT tenant_id, profile_id FROM customer_wallet_balances
+    UNION
+    SELECT tenant_id, profile_id FROM customer_wallet_movements
+    UNION
+    SELECT tenant_id, profile_id FROM waros_wallets
+    UNION
+    SELECT tenant_id, profile_id FROM waros_transactions
+    UNION
+    SELECT tenant_id, customer_id AS profile_id
+    FROM online_carts
+    WHERE customer_id IS NOT NULL
+)
+SELECT tenant_id, count(*) AS customer_activity_profiles
+FROM customer_activity
+GROUP BY tenant_id
+ORDER BY customer_activity_profiles DESC;
+```
+
+Identify active internal sessions that currently resolve to customer-only role:
+
+```sql
+SELECT s.tenant_id, count(*) AS active_customer_role_sessions
+FROM sessions s
+JOIN tenant_members tm
+  ON tm.tenant_id = s.tenant_id
+ AND tm.user_id = s.user_id
+ AND tm.is_active = true
+WHERE s.is_active = true
+  AND s.expires_at > now()
+  AND tm.role = 'customer'
+GROUP BY s.tenant_id
+ORDER BY active_customer_role_sessions DESC;
+```
+
+## Rollout
+
+Apply `sql/20260613_tenant_customers.sql`. It:
+
+- creates `tenant_customers`
+- backfills from legacy `tenant_members.role = 'customer'`
+- backfills from customer-linked activity tables
+- invalidates active customer-role internal sessions with
+  `end_reason = 'customer_role_denied'`
+
+## Manual remediation
+
+If a known production customer was already converted from `customer` to an
+internal team role before this migration and has no customer-linked activity in
+the backfill sources, insert the relationship explicitly:
+
+```sql
+INSERT INTO tenant_customers (tenant_id, profile_id, is_active)
+VALUES ('<tenant_id>', '<profile_id>', true)
+ON CONFLICT (tenant_id, profile_id) DO UPDATE
+SET is_active = true,
+    updated_at = now();
+```
+
+Use this for Karen/Tijuana-style cases only after confirming the `profile.id`
+and `tenant.id`.
+
+## Verification
+
+Confirm there are no remaining active customer-role internal sessions:
+
+```sql
+SELECT s.id, s.tenant_id, s.user_id, tm.role
+FROM sessions s
+JOIN tenant_members tm
+  ON tm.tenant_id = s.tenant_id
+ AND tm.user_id = s.user_id
+ AND tm.is_active = true
+WHERE s.is_active = true
+  AND s.expires_at > now()
+  AND tm.role = 'customer';
+```
+
+Confirm customer+team coexistence is represented by both tables:
+
+```sql
+SELECT tc.tenant_id, tc.profile_id, tm.role
+FROM tenant_customers tc
+JOIN tenant_members tm
+  ON tm.tenant_id = tc.tenant_id
+ AND tm.user_id = tc.profile_id
+ AND tm.is_active = true
+WHERE tc.is_active = true
+  AND tm.role = ANY(ARRAY['superuser', 'admin', 'employee', 'member'])
+ORDER BY tc.tenant_id, tc.profile_id;
+```
+
+Spot-check a known customer+team profile in customer search/detail, Equipo, and
+wallet/order metrics. The same `profile.id` should remain visible as a customer
+and as an internal team member.

--- a/sql/20260613_tenant_customers.sql
+++ b/sql/20260613_tenant_customers.sql
@@ -22,11 +22,58 @@ COMMENT ON COLUMN tenant_customers.profile_id IS
     'Customer profile identity; orders, wallet, and addresses stay linked to profile.id.';
 
 INSERT INTO tenant_customers (tenant_id, profile_id, is_active)
-SELECT tm.tenant_id, tm.user_id, COALESCE(tm.is_active, true)
-FROM tenant_members tm
-WHERE tm.role = 'customer'
-  AND COALESCE(tm.is_active, true) = true
-  AND tm.terminated_at IS NULL
+SELECT source.tenant_id, source.profile_id, true
+FROM (
+    SELECT tm.tenant_id, tm.user_id AS profile_id
+    FROM tenant_members tm
+    WHERE tm.role = 'customer'
+      AND COALESCE(tm.is_active, true) = true
+      AND tm.terminated_at IS NULL
+
+    UNION
+
+    SELECT o.tenant_id, o.customer_id AS profile_id
+    FROM orders o
+    WHERE o.customer_id IS NOT NULL
+
+    UNION
+
+    SELECT cwb.tenant_id, cwb.profile_id
+    FROM customer_wallet_balances cwb
+
+    UNION
+
+    SELECT cwm.tenant_id, cwm.profile_id
+    FROM customer_wallet_movements cwm
+
+    UNION
+
+    SELECT ww.tenant_id, ww.profile_id
+    FROM waros_wallets ww
+
+    UNION
+
+    SELECT wt.tenant_id, wt.profile_id
+    FROM waros_transactions wt
+
+    UNION
+
+    SELECT oc.tenant_id, oc.customer_id AS profile_id
+    FROM online_carts oc
+    WHERE oc.customer_id IS NOT NULL
+) AS source
 ON CONFLICT (tenant_id, profile_id) DO UPDATE
 SET is_active = true,
     updated_at = now();
+
+UPDATE sessions s
+SET is_active = false,
+    ended_at = now(),
+    end_reason = 'customer_role_denied'
+FROM tenant_members tm
+WHERE tm.tenant_id = s.tenant_id
+  AND tm.user_id = s.user_id
+  AND tm.is_active = true
+  AND tm.role = 'customer'
+  AND s.is_active = true
+  AND s.expires_at > now();

--- a/tests/test_customer_team_migration_regression.py
+++ b/tests/test_customer_team_migration_regression.py
@@ -1,0 +1,164 @@
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services import customers_service, tenants_service
+
+
+MIGRATION_SQL = Path(__file__).resolve().parents[1] / "sql" / "20260613_tenant_customers.sql"
+
+
+def _session(tenant_id, user_id=None):
+    session = MagicMock()
+    session.tenant_id = tenant_id
+    session.user_id = user_id or uuid4()
+    return session
+
+
+def _request():
+    request = MagicMock()
+    request.headers = {"user-agent": "pytest"}
+    request.client = MagicMock(host="127.0.0.1")
+    return request
+
+
+def _profile_row(profile_id, name="Karen Tijuana", email="karen@example.com"):
+    return {
+        "id": profile_id,
+        "phone_number": "3001234567",
+        "name": name,
+        "email": email,
+        "fiscal_id_type": None,
+        "fiscal_id": None,
+        "fiscal_business_name": None,
+        "fiscal_email": None,
+        "created_at": datetime(2026, 6, 13, tzinfo=timezone.utc),
+        "updated_at": datetime(2026, 6, 13, tzinfo=timezone.utc),
+    }
+
+
+def _db_context(conn):
+    @asynccontextmanager
+    async def _ctx():
+        yield conn
+
+    return _ctx
+
+
+def test_migration_backfills_activity_and_invalidates_customer_role_sessions():
+    sql = MIGRATION_SQL.read_text()
+
+    assert "CREATE TABLE IF NOT EXISTS tenant_customers" in sql
+    assert "FROM tenant_members tm" in sql
+    assert "tm.role = 'customer'" in sql
+    assert "FROM orders o" in sql
+    assert "FROM customer_wallet_balances cwb" in sql
+    assert "FROM customer_wallet_movements cwm" in sql
+    assert "FROM waros_wallets ww" in sql
+    assert "FROM waros_transactions wt" in sql
+    assert "FROM online_carts oc" in sql
+    assert "UPDATE sessions s" in sql
+    assert "end_reason = 'customer_role_denied'" in sql
+
+
+@pytest.mark.asyncio
+async def test_karen_tijuana_customer_admin_coexistence_stays_visible_in_customer_and_team_flows():
+    tenant_id = uuid4()
+    profile_id = uuid4()
+    team_member_id = uuid4()
+
+    customer_conn = MagicMock()
+    customer_conn.fetchrow = AsyncMock(return_value=_profile_row(profile_id))
+
+    with patch(
+        "app.services.customers_service.require_valid_session",
+        return_value=_session(tenant_id),
+    ), patch(
+        "app.services.customers_service.get_db_connection",
+        side_effect=_db_context(customer_conn),
+    ):
+        customer = await customers_service.get_customer_by_id(_request(), profile_id)
+
+    assert customer.data.id == profile_id
+    customer_query = customer_conn.fetchrow.await_args.args[0]
+    assert "tenant_customers tc" in customer_query
+    assert "tenant_members" not in customer_query
+    assert "role = 'customer'" not in customer_query
+
+    team_conn = MagicMock()
+    team_conn.fetch = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "id": team_member_id,
+                    "tenant_id": tenant_id,
+                    "user_id": profile_id,
+                    "role": "admin",
+                    "profile_id": profile_id,
+                    "name": "Karen Tijuana",
+                    "user_name": None,
+                    "email": "karen@example.com",
+                    "logo_avatar": None,
+                }
+            ],
+            [],
+        ]
+    )
+
+    with patch(
+        "app.services.tenants_service.require_valid_session",
+        return_value=_session(tenant_id),
+    ), patch(
+        "app.services.tenants_service.get_db_connection",
+        side_effect=_db_context(team_conn),
+    ):
+        members = await tenants_service.get_tenant_members(_request())
+
+    assert members.data[0].user_id == profile_id
+    assert members.data[0].role == "admin"
+    team_query = team_conn.fetch.await_args_list[0].args[0]
+    assert "tm.role IN ('superuser', 'admin', 'employee', 'member')" in team_query
+    assert "tm.role = 'customer'" not in team_query
+
+
+@pytest.mark.asyncio
+async def test_karen_tijuana_legacy_customer_role_session_is_denied_after_migration():
+    from app.core.security import get_session_from_request
+
+    session_token = str(uuid4())
+    tenant_id = uuid4()
+    profile_id = uuid4()
+    expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {"id": session_token, "expires_at": expires_at, "is_active": True, "ended_at": None},
+            {
+                "user_id": profile_id,
+                "tenant_id": tenant_id,
+                "expires_at": expires_at,
+                "is_active": True,
+                "email": "karen@example.com",
+                "name": "Karen Tijuana",
+                "role": "customer",
+            },
+        ]
+    )
+    conn.fetch = AsyncMock(return_value=[])
+    conn.execute = AsyncMock(return_value=None)
+
+    with patch("app.database.get_db_connection", side_effect=_db_context(conn)), patch(
+        "app.core.security.get_session_token",
+        new=AsyncMock(return_value=session_token),
+    ):
+        result = await get_session_from_request(_request())
+
+    assert result is None
+    conn.execute.assert_awaited_once()
+    assert "end_reason = 'customer_role_denied'" in conn.execute.await_args.args[0]
+    assert conn.execute.await_args.args[1] == session_token


### PR DESCRIPTION
## Summary

- backfill `tenant_customers` from legacy customer memberships plus customer-linked activity tables
- invalidate active internal sessions that still resolve to `tenant_members.role = 'customer'`
- add a production rollout runbook with preflight, manual remediation, cleanup, and verification SQL
- add Karen/Tijuana-style regression coverage for customer+admin coexistence and legacy customer-role session denial

## Validation

```bash
pytest tests/test_customer_internal_access.py tests/test_switch_tenant_membership.py tests/test_customer_identity_model.py tests/test_customer_wallet.py tests/test_customer_team_migration_regression.py
```

Result: 24 passed.

Closes #433
