### PR TITLE
Expose internal access flag in auth session

### DIFF
--- a/app/core/internal_roles.py
+++ b/app/core/internal_roles.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 
-LEGACY_INTERNAL_TEAM_ROLES = ("superuser", "admin", "employee", "member")
+LEGACY_INTERNAL_TEAM_ROLES = ("superuser", "admin", "employee", "member", "promotor")
 
 
 def is_legacy_internal_team_role(role: Optional[str]) -> bool:

--- a/app/models/auth.py
+++ b/app/models/auth.py
@@ -34,6 +34,7 @@ class SessionResponse(BaseModel):
     success: bool = True
     user: User
     session: Session
+    has_internal_access: bool = False
     current_tenant: Optional[Tenant] = Field(alias='currentTenant', default=None)
     
     class Config:

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -97,6 +97,7 @@ async def get_session_data(request: Request, response: Response) -> SessionRespo
             return SessionResponse(
                 user=user,
                 session=session,
+                has_internal_access=is_legacy_internal_team_role(user_role),
                 currentTenant=current_tenant
             )
             

--- a/tests/test_customer_internal_access.py
+++ b/tests/test_customer_internal_access.py
@@ -38,6 +38,21 @@ def _request():
     return request
 
 
+def _session_row(session_token, tenant_id, user_id, expires_at, role_email):
+    return {
+        "id": session_token,
+        "tenant_id": tenant_id,
+        "user_id": user_id,
+        "email": role_email,
+        "name": "Session User",
+        "user_created_at": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        "expires_at": expires_at,
+        "created_at": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        "ip_address": None,
+        "login_method": "magic_link",
+    }
+
+
 @pytest.mark.asyncio
 async def test_send_magic_link_denies_customer_only_membership():
     """A customer-only row is filtered out before an internal magic token is created."""
@@ -53,7 +68,7 @@ async def test_send_magic_link_denies_customer_only_membership():
 
     conn.execute.assert_not_awaited()
     assert conn.fetchrow.await_args.args[2] == tenant_id
-    assert conn.fetchrow.await_args.args[3] == ["superuser", "admin", "employee", "member"]
+    assert conn.fetchrow.await_args.args[3] == ["superuser", "admin", "employee", "member", "promotor"]
 
 
 @pytest.mark.asyncio
@@ -72,7 +87,59 @@ async def test_verify_token_denies_customer_only_membership_before_session_creat
 
     conn.execute.assert_not_awaited()
     assert conn.fetchrow.await_args.args[3] == tenant_id
-    assert conn.fetchrow.await_args.args[4] == ["superuser", "admin", "employee", "member"]
+    assert conn.fetchrow.await_args.args[4] == ["superuser", "admin", "employee", "member", "promotor"]
+
+
+@pytest.mark.asyncio
+async def test_auth_session_reports_internal_access_for_promotor():
+    """Promotor is a valid internal role and gets an explicit allow flag."""
+    from app.services.auth_service import get_session_data
+
+    session_token = str(uuid4())
+    tenant_id = uuid4()
+    user_id = uuid4()
+    expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+    db_ctx, conn = _build_db_mock(fetchrow_side_effect=[
+        _session_row(session_token, tenant_id, user_id, expires_at, "promotor@example.com"),
+        {"id": tenant_id, "name": "Tijuana Cafe Bar", "slug": "tijuana-cafe-bar"},
+        {"role": "promotor"},
+    ])
+
+    with patch("app.services.auth_service.get_db_connection", side_effect=db_ctx), \
+         patch("app.services.auth_service.get_session_token", new=AsyncMock(return_value=session_token)):
+        result = await get_session_data(_request(), MagicMock())
+
+    assert result.has_internal_access is True
+    assert result.user.role == "promotor"
+    assert result.current_tenant.slug == "tijuana-cafe-bar"
+    conn.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auth_session_denies_customer_role_before_payload():
+    """Customer-only internal sessions keep being invalidated instead of returning an allow payload."""
+    from app.services.auth_service import get_session_data
+
+    session_token = str(uuid4())
+    tenant_id = uuid4()
+    user_id = uuid4()
+    expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+    response = MagicMock()
+    db_ctx, conn = _build_db_mock(fetchrow_side_effect=[
+        _session_row(session_token, tenant_id, user_id, expires_at, "customer@example.com"),
+        {"id": tenant_id, "name": "Tijuana Cafe Bar", "slug": "tijuana-cafe-bar"},
+        {"role": "customer"},
+    ])
+
+    with patch("app.services.auth_service.get_db_connection", side_effect=db_ctx), \
+         patch("app.services.auth_service.get_session_token", new=AsyncMock(return_value=session_token)), \
+         patch("app.services.auth_service.clear_session_cookie", new=AsyncMock()) as clear_cookie:
+        with pytest.raises(AuthenticationError):
+            await get_session_data(_request(), response)
+
+    conn.execute.assert_awaited_once()
+    assert conn.execute.await_args.args[1] == session_token
+    clear_cookie.assert_awaited_once_with(response, session_token)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Adds `has_internal_access` to `/auth/session` responses.
- Derives the flag from the backend internal-role source of truth.
- Covers promotor allow and customer-role denial behavior in focused auth tests.

## Validation

- `pytest tests/test_customer_internal_access.py -q`
- `pytest tests/test_auth.py -q`

Manual/API validation for reviewers: call `GET /auth/session` with a promotor internal session and confirm `has_internal_access: true`; repeat with a customer-only/internal-denied session and confirm denial/cleared session behavior.

Closes #443
