### PR TITLE
Add legal terms acceptance registry

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, customer_portal, leads, waros, billing, payments_webhook, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
+from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, customer_portal, leads, waros, billing, legal, payments_webhook, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
 from app.config import settings
 from app.core.logging import setup_logging
 from app.core.exceptions import api_exception_handler, general_exception_handler, APIError
@@ -184,6 +184,7 @@ app.include_router(inventory.router)
 app.include_router(analytics.router)
 app.include_router(waros.router)
 app.include_router(billing.tenant_router)
+app.include_router(legal.router)
 app.include_router(payments_webhook.router)
 app.include_router(articles.router, prefix="/blog", tags=["blog"])
 app.include_router(invitations.router, prefix="/invitations", tags=["invitations"])

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -28,6 +28,7 @@ from app.services import (
     billing_service,
     billing_email_service,
     billing_webhook_service,
+    legal_service,
     wompi_service,
     wompi_colombia_webhook_service,
 )
@@ -90,6 +91,7 @@ async def subscribe(body: SubscribeBody, request: Request):
 
     async with get_db_connection() as conn:
         plan = await billing_service.get_plan_for_subscribe(conn, body.plan_id)
+        await legal_service.ensure_current_terms_accepted(conn, tenant_id)
 
         amount = plan["price_annual"]
 

--- a/app/routers/legal.py
+++ b/app/routers/legal.py
@@ -1,0 +1,44 @@
+from typing import Optional
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from app.core.middleware import require_valid_session
+from app.core.security import get_client_ip
+from app.database import get_db_connection
+from app.services import legal_service
+
+
+router = APIRouter(prefix="/legal", tags=["legal"])
+
+
+class AcceptTermsBody(BaseModel):
+    source: Optional[str] = "api"
+
+
+@router.get("/terms/current")
+async def get_current_terms(request: Request):
+    session = require_valid_session(request)
+    async with get_db_connection(use_transaction=False) as conn:
+        current = await legal_service.get_current_terms(conn, session.tenant_id)
+        return {"success": True, "data": current}
+
+
+@router.get("/terms/status")
+async def get_terms_status(request: Request):
+    session = require_valid_session(request)
+    async with get_db_connection(use_transaction=False) as conn:
+        return await legal_service.get_terms_status(conn, session.tenant_id)
+
+
+@router.post("/terms/accept", status_code=201)
+async def accept_terms(body: AcceptTermsBody, request: Request):
+    session = require_valid_session(request)
+    async with get_db_connection() as conn:
+        return await legal_service.accept_current_terms(
+            conn,
+            session,
+            client_ip=get_client_ip(request),
+            user_agent=request.headers.get("user-agent"),
+            source=body.source or "api",
+        )

--- a/app/services/legal_service.py
+++ b/app/services/legal_service.py
@@ -1,0 +1,303 @@
+import json
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from fastapi import HTTPException
+
+
+TERMS_DOCUMENT_CODE = "terms_conditions"
+
+
+def _json_value(value: Any, fallback: Any) -> Any:
+    if value is None:
+        return fallback
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
+
+
+def _iso(value: Any) -> Optional[str]:
+    return value.isoformat() if value else None
+
+
+def _serialize_annex(row: Any) -> Dict[str, Any]:
+    return {
+        "id": str(row["id"]),
+        "code": row["code"],
+        "title": row["title"],
+        "version": row["version"],
+        "scope_type": row["scope_type"],
+        "tenant_id": str(row["tenant_id"]) if row["tenant_id"] else None,
+        "country": row["country"],
+        "region": row["region"],
+        "content_url": row["content_url"],
+        "metadata": _json_value(row["metadata"], {}),
+    }
+
+
+def _serialize_version(row: Any, annexes: list) -> Dict[str, Any]:
+    return {
+        "document_id": str(row["document_id"]),
+        "document_code": row["document_code"],
+        "document_title": row["document_title"],
+        "retention_years": row["retention_years"],
+        "version_id": str(row["version_id"]),
+        "version": row["version"],
+        "effective_at": _iso(row["effective_at"]),
+        "published_at": _iso(row["published_at"]),
+        "content_url": row["content_url"],
+        "content_sha256": row["content_sha256"],
+        "metadata": _json_value(row["metadata"], {}),
+        "annexes": annexes,
+    }
+
+
+def _serialize_acceptance(row: Any) -> Dict[str, Any]:
+    return {
+        "id": str(row["id"]),
+        "tenant_id": str(row["tenant_id"]),
+        "document_version_id": str(row["document_version_id"]),
+        "user_id": str(row["user_id"]) if row["user_id"] else None,
+        "source": row["source"],
+        "accepted_at": _iso(row["accepted_at"]),
+        "client_ip": row["client_ip"],
+        "user_agent": row["user_agent"],
+        "tenant_name": row["tenant_name_snapshot"],
+        "legal_name": row["legal_name_snapshot"],
+        "document_type": row["document_type_snapshot"],
+        "document_number": row["document_number_snapshot"],
+        "email": row["email_snapshot"],
+        "actor_name": row["actor_name_snapshot"],
+        "actor_email": row["actor_email_snapshot"],
+        "document_code": row["document_code_snapshot"],
+        "document_title": row["document_title_snapshot"],
+        "version": row["version_snapshot"],
+        "annexes": _json_value(row["annexes_snapshot"], []),
+        "evidence": _json_value(row["evidence"], {}),
+    }
+
+
+def _require_tenant_id(tenant_id: Optional[UUID]) -> UUID:
+    if not tenant_id:
+        raise HTTPException(status_code=401, detail="Tenant ID is required")
+    return tenant_id
+
+
+async def get_current_terms(conn, tenant_id: Optional[UUID] = None) -> Optional[Dict[str, Any]]:
+    row = await conn.fetchrow(
+        """
+        SELECT
+            d.id AS document_id,
+            d.code AS document_code,
+            d.title AS document_title,
+            d.retention_years,
+            v.id AS version_id,
+            v.version,
+            v.effective_at,
+            v.published_at,
+            v.content_url,
+            v.content_sha256,
+            v.metadata
+        FROM legal_documents d
+        JOIN legal_document_versions v ON v.document_id = d.id
+        WHERE d.code = $1
+          AND v.status = 'published'
+          AND v.effective_at <= now()
+        ORDER BY v.effective_at DESC, v.created_at DESC
+        LIMIT 1
+        """,
+        TERMS_DOCUMENT_CODE,
+    )
+    if not row:
+        return None
+
+    annex_rows = await conn.fetch(
+        """
+        SELECT id, code, title, version, scope_type, tenant_id, country, region,
+               content_url, metadata
+        FROM legal_document_annexes
+        WHERE document_version_id = $1
+          AND is_active = true
+          AND (tenant_id IS NULL OR tenant_id = $2)
+        ORDER BY sort_order ASC, code ASC
+        """,
+        row["version_id"],
+        tenant_id,
+    )
+    return _serialize_version(row, [_serialize_annex(a) for a in annex_rows])
+
+
+async def get_acceptance_for_version(conn, tenant_id: UUID, version_id: UUID) -> Optional[Dict[str, Any]]:
+    row = await conn.fetchrow(
+        """
+        SELECT *
+        FROM tenant_legal_acceptances
+        WHERE tenant_id = $1 AND document_version_id = $2
+        LIMIT 1
+        """,
+        tenant_id,
+        version_id,
+    )
+    return _serialize_acceptance(row) if row else None
+
+
+async def get_terms_status(conn, tenant_id: Optional[UUID]) -> Dict[str, Any]:
+    tenant_id = _require_tenant_id(tenant_id)
+    current = await get_current_terms(conn, tenant_id)
+    if not current:
+        return {
+            "success": True,
+            "data": {
+                "requires_acceptance": False,
+                "current": None,
+                "acceptance": None,
+            },
+        }
+
+    acceptance = await get_acceptance_for_version(conn, tenant_id, UUID(current["version_id"]))
+    return {
+        "success": True,
+        "data": {
+            "requires_acceptance": acceptance is None,
+            "current": current,
+            "acceptance": acceptance,
+        },
+    }
+
+
+async def has_current_terms_acceptance(conn, tenant_id: Optional[UUID]) -> bool:
+    tenant_id = _require_tenant_id(tenant_id)
+    current = await get_current_terms(conn, tenant_id)
+    if not current:
+        return True
+    acceptance = await get_acceptance_for_version(conn, tenant_id, UUID(current["version_id"]))
+    return acceptance is not None
+
+
+async def ensure_current_terms_accepted(conn, tenant_id: Optional[UUID]) -> None:
+    if await has_current_terms_acceptance(conn, tenant_id):
+        return
+    current = await get_current_terms(conn, tenant_id)
+    raise HTTPException(
+        status_code=409,
+        detail={
+            "code": "terms_acceptance_required",
+            "message": "Debes aceptar los Terminos y Condiciones vigentes antes de continuar.",
+            "document_version_id": current["version_id"] if current else None,
+            "version": current["version"] if current else None,
+        },
+    )
+
+
+async def _snapshot_tenant(conn, tenant_id: UUID, fallback_email: Optional[str]) -> Dict[str, Any]:
+    row = await conn.fetchrow(
+        """
+        SELECT
+            t.name AS tenant_name,
+            t.email AS tenant_email,
+            COALESCE(tfd.business_name, li.legal_name, t.name) AS legal_name,
+            COALESCE(tfd.nit, li.nit) AS document_number,
+            COALESCE(tfd.email, li.email, t.email, $2) AS email
+        FROM tenants t
+        LEFT JOIN tenant_fiscal_data tfd ON tfd.tenant_id = t.id
+        LEFT JOIN legal_info li ON li.tenant_id = t.id
+        WHERE t.id = $1
+        LIMIT 1
+        """,
+        tenant_id,
+        fallback_email,
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+    return dict(row)
+
+
+async def accept_current_terms(
+    conn,
+    session,
+    *,
+    client_ip: Optional[str],
+    user_agent: Optional[str],
+    source: str = "api",
+) -> Dict[str, Any]:
+    tenant_id = _require_tenant_id(session.tenant_id)
+    current = await get_current_terms(conn, tenant_id)
+    if not current:
+        raise HTTPException(status_code=404, detail="No published terms document found")
+
+    existing = await get_acceptance_for_version(conn, tenant_id, UUID(current["version_id"]))
+    if existing:
+        return {
+            "success": True,
+            "data": {
+                "already_accepted": True,
+                "current": current,
+                "acceptance": existing,
+            },
+        }
+
+    snapshot = await _snapshot_tenant(conn, tenant_id, session.email)
+    annexes = current["annexes"]
+    row = await conn.fetchrow(
+        """
+        INSERT INTO tenant_legal_acceptances (
+            tenant_id,
+            document_version_id,
+            user_id,
+            source,
+            client_ip,
+            user_agent,
+            tenant_name_snapshot,
+            legal_name_snapshot,
+            document_type_snapshot,
+            document_number_snapshot,
+            email_snapshot,
+            actor_name_snapshot,
+            actor_email_snapshot,
+            document_code_snapshot,
+            document_title_snapshot,
+            version_snapshot,
+            annexes_snapshot,
+            evidence
+        )
+        VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, 'NIT', $9, $10, $11, $12, $13, $14, $15,
+            $16::jsonb,
+            jsonb_build_object('retention_years', $17::int, 'server_time_source', 'database_now')
+        )
+        ON CONFLICT (tenant_id, document_version_id) DO NOTHING
+        RETURNING *
+        """,
+        tenant_id,
+        UUID(current["version_id"]),
+        session.user_id,
+        source,
+        client_ip,
+        user_agent,
+        snapshot["tenant_name"],
+        snapshot["legal_name"],
+        snapshot["document_number"],
+        snapshot["email"],
+        session.name,
+        session.email,
+        current["document_code"],
+        current["document_title"],
+        current["version"],
+        json.dumps(annexes),
+        current["retention_years"],
+    )
+    if not row:
+        acceptance = await get_acceptance_for_version(conn, tenant_id, UUID(current["version_id"]))
+        already_accepted = True
+    else:
+        acceptance = _serialize_acceptance(row)
+        already_accepted = False
+
+    return {
+        "success": True,
+        "data": {
+            "already_accepted": already_accepted,
+            "current": current,
+            "acceptance": acceptance,
+        },
+    }

--- a/migrations/085_legal_terms_acceptance.sql
+++ b/migrations/085_legal_terms_acceptance.sql
@@ -1,0 +1,115 @@
+-- Migration 085: legal document versions and tenant acceptance evidence
+--
+-- Legal acceptances are electronic evidence and must be retained for at least
+-- 10 years. For that reason, acceptance rows keep immutable snapshots and use
+-- restrictive foreign keys instead of tenant/document cascades.
+
+CREATE TABLE IF NOT EXISTS legal_documents (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    code TEXT NOT NULL UNIQUE,
+    title TEXT NOT NULL,
+    retention_years INTEGER NOT NULL DEFAULT 10 CHECK (retention_years >= 10),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS legal_document_versions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    document_id UUID NOT NULL REFERENCES legal_documents(id) ON DELETE RESTRICT,
+    version TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'published', 'archived')),
+    effective_at TIMESTAMPTZ NOT NULL,
+    published_at TIMESTAMPTZ,
+    content_url TEXT,
+    content_sha256 TEXT,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (document_id, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_legal_document_versions_current
+    ON legal_document_versions (document_id, effective_at DESC, created_at DESC)
+    WHERE status = 'published';
+
+CREATE TABLE IF NOT EXISTS legal_document_annexes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    document_version_id UUID NOT NULL REFERENCES legal_document_versions(id) ON DELETE RESTRICT,
+    code TEXT NOT NULL,
+    title TEXT NOT NULL,
+    version TEXT NOT NULL,
+    scope_type TEXT NOT NULL DEFAULT 'global' CHECK (scope_type IN ('global', 'tenant', 'country', 'region')),
+    tenant_id UUID REFERENCES tenants(id) ON DELETE RESTRICT,
+    country TEXT,
+    region TEXT,
+    content_url TEXT,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_legal_document_annexes_version
+    ON legal_document_annexes (document_version_id, sort_order, code)
+    WHERE is_active = true;
+
+CREATE INDEX IF NOT EXISTS idx_legal_document_annexes_tenant
+    ON legal_document_annexes (tenant_id)
+    WHERE tenant_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS tenant_legal_acceptances (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+    document_version_id UUID NOT NULL REFERENCES legal_document_versions(id) ON DELETE RESTRICT,
+    user_id UUID REFERENCES profile(id) ON DELETE SET NULL,
+    source TEXT NOT NULL DEFAULT 'api',
+    accepted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    client_ip TEXT,
+    user_agent TEXT,
+    tenant_name_snapshot TEXT,
+    legal_name_snapshot TEXT,
+    document_type_snapshot TEXT,
+    document_number_snapshot TEXT,
+    email_snapshot TEXT,
+    actor_name_snapshot TEXT,
+    actor_email_snapshot TEXT,
+    document_code_snapshot TEXT NOT NULL,
+    document_title_snapshot TEXT NOT NULL,
+    version_snapshot TEXT NOT NULL,
+    annexes_snapshot JSONB NOT NULL DEFAULT '[]'::jsonb,
+    evidence JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (tenant_id, document_version_id)
+);
+
+COMMENT ON TABLE tenant_legal_acceptances IS
+    'Immutable electronic acceptance evidence for legal document versions. Retain for at least 10 years.';
+
+CREATE INDEX IF NOT EXISTS idx_tenant_legal_acceptances_tenant
+    ON tenant_legal_acceptances (tenant_id, accepted_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_legal_acceptances_version
+    ON tenant_legal_acceptances (document_version_id);
+
+INSERT INTO legal_documents (code, title, retention_years)
+VALUES ('terms_conditions', 'Terminos y Condiciones WARO', 10)
+ON CONFLICT (code) DO NOTHING;
+
+INSERT INTO legal_document_versions (
+    document_id,
+    version,
+    status,
+    effective_at,
+    published_at,
+    content_url,
+    metadata
+)
+SELECT
+    d.id,
+    '1.0',
+    'published',
+    TIMESTAMPTZ '2026-06-15 00:00:00-05',
+    now(),
+    '/terminos-y-condiciones',
+    jsonb_build_object('source', 'TyC_WARO_v1.0_BORRADOR.pdf')
+FROM legal_documents d
+WHERE d.code = 'terms_conditions'
+ON CONFLICT (document_id, version) DO NOTHING;

--- a/tests/test_billing_subscribe_cycle.py
+++ b/tests/test_billing_subscribe_cycle.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from app.core import permissions
@@ -62,3 +62,51 @@ def test_subscribe_rejects_monthly_billing_cycle():
 
     assert res.status_code == 422
     assert "anual" in res.json()["detail"].lower()
+
+
+def test_subscribe_requires_current_terms_before_wompi_link():
+    app, session = _build_app()
+    plan_id = uuid4()
+
+    @asynccontextmanager
+    async def _enforce_db():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="disabled")
+        conn.fetchrow = AsyncMock(return_value=None)
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+
+    @asynccontextmanager
+    async def _billing_db():
+        yield MagicMock()
+
+    terms_error = HTTPException(
+        status_code=409,
+        detail={
+            "code": "terms_acceptance_required",
+            "document_version_id": str(uuid4()),
+            "version": "1.0",
+        },
+    )
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.routers.billing.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db), \
+         patch("app.routers.billing.get_db_connection", side_effect=_billing_db), \
+         patch("app.routers.billing.billing_service.get_plan_for_subscribe", new=AsyncMock(return_value={
+             "id": str(plan_id),
+             "name": "Plan Pro",
+             "price_annual": 1200000.0,
+         })), \
+         patch("app.routers.billing.legal_service.ensure_current_terms_accepted", new=AsyncMock(side_effect=terms_error)), \
+         patch("app.routers.billing.wompi_service.create_payment_link", new=AsyncMock()) as wompi_mock:
+        client = TestClient(app)
+        res = client.post(
+            "/billing/subscribe",
+            json={"plan_id": str(plan_id), "billing_cycle": "annual"},
+        )
+
+    assert res.status_code == 409
+    assert res.json()["detail"]["code"] == "terms_acceptance_required"
+    wompi_mock.assert_not_awaited()

--- a/tests/test_legal_terms_acceptance.py
+++ b/tests/test_legal_terms_acceptance.py
@@ -1,0 +1,189 @@
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from app.core.middleware import SessionContext
+from app.routers.legal import router
+from app.services import legal_service
+
+
+def _version_row(version="1.0"):
+    now = datetime(2026, 6, 15, 12, 0, tzinfo=timezone.utc)
+    return {
+        "document_id": uuid4(),
+        "document_code": "terms_conditions",
+        "document_title": "Terminos y Condiciones WARO",
+        "retention_years": 10,
+        "version_id": uuid4(),
+        "version": version,
+        "effective_at": now,
+        "published_at": now,
+        "content_url": "/terminos-y-condiciones",
+        "content_sha256": None,
+        "metadata": {},
+    }
+
+
+def _acceptance_row(tenant_id, version_id):
+    now = datetime(2026, 6, 15, 12, 5, tzinfo=timezone.utc)
+    return {
+        "id": uuid4(),
+        "tenant_id": tenant_id,
+        "document_version_id": version_id,
+        "user_id": uuid4(),
+        "source": "billing_checkout",
+        "accepted_at": now,
+        "client_ip": "203.0.113.10",
+        "user_agent": "pytest-agent",
+        "tenant_name_snapshot": "Waro Colombia",
+        "legal_name_snapshot": "Waro Colombia SAS",
+        "document_type_snapshot": "NIT",
+        "document_number_snapshot": "900123456",
+        "email_snapshot": "legal@warocol.com",
+        "actor_name_snapshot": "Test User",
+        "actor_email_snapshot": "test@warocol.com",
+        "document_code_snapshot": "terms_conditions",
+        "document_title_snapshot": "Terminos y Condiciones WARO",
+        "version_snapshot": "1.0",
+        "annexes_snapshot": [],
+        "evidence": {"retention_years": 10},
+    }
+
+
+def _session(tenant_id=None):
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": tenant_id or uuid4(),
+        "email": "test@warocol.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": "owner",
+    })
+
+
+@pytest.mark.asyncio
+async def test_status_detects_missing_acceptance_for_current_version():
+    tenant_id = uuid4()
+    version = _version_row()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[version, None])
+    conn.fetch = AsyncMock(return_value=[])
+
+    result = await legal_service.get_terms_status(conn, tenant_id)
+
+    assert result["data"]["requires_acceptance"] is True
+    assert result["data"]["current"]["version"] == "1.0"
+    assert result["data"]["acceptance"] is None
+
+
+@pytest.mark.asyncio
+async def test_status_requires_tenant():
+    conn = MagicMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await legal_service.get_terms_status(conn, None)
+
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_accept_current_terms_captures_evidence_snapshot():
+    session = _session()
+    version = _version_row()
+    acceptance = _acceptance_row(session.tenant_id, version["version_id"])
+    snapshot = {
+        "tenant_name": "Waro Colombia",
+        "tenant_email": "tenant@warocol.com",
+        "legal_name": "Waro Colombia SAS",
+        "document_number": "900123456",
+        "email": "legal@warocol.com",
+    }
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[version, None, snapshot, acceptance])
+    conn.fetch = AsyncMock(return_value=[])
+
+    result = await legal_service.accept_current_terms(
+        conn,
+        session,
+        client_ip="203.0.113.10",
+        user_agent="pytest-agent",
+        source="billing_checkout",
+    )
+
+    assert result["data"]["already_accepted"] is False
+    assert result["data"]["acceptance"]["client_ip"] == "203.0.113.10"
+    assert result["data"]["acceptance"]["document_number"] == "900123456"
+    insert_args = conn.fetchrow.await_args_list[-1].args
+    assert insert_args[4] == "billing_checkout"
+    assert insert_args[5] == "203.0.113.10"
+    assert insert_args[6] == "pytest-agent"
+    assert insert_args[9] == "900123456"
+
+
+@pytest.mark.asyncio
+async def test_accept_current_terms_is_idempotent_for_same_version():
+    session = _session()
+    version = _version_row()
+    existing = _acceptance_row(session.tenant_id, version["version_id"])
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[version, existing])
+    conn.fetch = AsyncMock(return_value=[])
+
+    result = await legal_service.accept_current_terms(
+        conn,
+        session,
+        client_ip="203.0.113.10",
+        user_agent="pytest-agent",
+    )
+
+    assert result["data"]["already_accepted"] is True
+    assert result["data"]["acceptance"]["id"] == str(existing["id"])
+    assert conn.fetchrow.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_current_version_query_filters_to_published_effective_versions():
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+
+    result = await legal_service.get_current_terms(conn, uuid4())
+
+    assert result is None
+    query = conn.fetchrow.await_args.args[0]
+    assert "v.status = 'published'" in query
+    assert "v.effective_at <= now()" in query
+
+
+def test_accept_endpoint_uses_forwarded_ip_and_user_agent():
+    app = FastAPI()
+    app.include_router(router)
+    session = _session()
+
+    @asynccontextmanager
+    async def _db():
+        yield MagicMock()
+
+    with patch("app.routers.legal.require_valid_session", return_value=session), \
+         patch("app.routers.legal.get_db_connection", side_effect=_db), \
+         patch("app.routers.legal.legal_service.accept_current_terms", new=AsyncMock(return_value={"success": True, "data": {}})) as accept_mock:
+        client = TestClient(app)
+        res = client.post(
+            "/legal/terms/accept",
+            json={"source": "billing_checkout"},
+            headers={
+                "x-forwarded-for": "198.51.100.10, 10.0.0.1",
+                "user-agent": "pytest-browser",
+            },
+        )
+
+    assert res.status_code == 201
+    _, _, kwargs = accept_mock.mock_calls[0]
+    assert kwargs["client_ip"] == "198.51.100.10"
+    assert kwargs["user_agent"] == "pytest-browser"
+    assert kwargs["source"] == "billing_checkout"


### PR DESCRIPTION
## Summary
- add versioned legal document, annex, and immutable tenant acceptance tables
- expose /legal/terms current/status/accept endpoints with IP and user-agent evidence
- block billing checkout before Wompi link creation when current TyC acceptance is missing

## Tests
- pytest tests/test_legal_terms_acceptance.py tests/test_billing_subscribe_cycle.py

Closes #448