### PR TITLE
Expose pending terms reminder notification

### DIFF
--- a/app/routers/notifications.py
+++ b/app/routers/notifications.py
@@ -4,12 +4,11 @@ Authenticated endpoints for restaurant operators to manage notifications.
 """
 import asyncio
 import asyncpg
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from uuid import UUID
 from app.config import settings
 from app.core.middleware import require_valid_session
-from app.core.permissions import Module, require_module
 from app.services import notifications_service
 
 router = APIRouter(prefix="/notifications", tags=["notifications"])
@@ -51,10 +50,7 @@ async def _remove_listener_if_empty(channel: str) -> None:
             _channel_locks.pop(channel, None)
 
 
-@router.get(
-    "/stream",
-    dependencies=[Depends(require_module(Module.POS))],
-)
+@router.get("/stream")
 async def notification_stream(request: Request):
     """
     SSE endpoint — keeps connection open and pushes new order notifications in real time.
@@ -100,10 +96,7 @@ async def notification_stream(request: Request):
     )
 
 
-@router.get(
-    "",
-    dependencies=[Depends(require_module(Module.POS))],
-)
+@router.get("")
 async def get_notifications(request: Request):
     """
     List last 50 unread notifications for the authenticated tenant.
@@ -113,10 +106,7 @@ async def get_notifications(request: Request):
     return await notifications_service.get_unread_notifications(request)
 
 
-@router.patch(
-    "/{notification_id}/read",
-    dependencies=[Depends(require_module(Module.POS))],
-)
+@router.patch("/{notification_id}/read")
 async def mark_read(request: Request, notification_id: UUID):
     """
     Mark a single notification as read.
@@ -128,10 +118,7 @@ async def mark_read(request: Request, notification_id: UUID):
     return await notifications_service.mark_notification_read(request, notification_id)
 
 
-@router.post(
-    "/read-all",
-    dependencies=[Depends(require_module(Module.POS))],
-)
+@router.post("/read-all")
 async def mark_all_read(request: Request):
     """
     Mark all unread notifications as read for the authenticated tenant.

--- a/app/services/notifications_service.py
+++ b/app/services/notifications_service.py
@@ -4,13 +4,18 @@ Tenant-scoped notification management for restaurant operators.
 """
 import json
 import logging
+from datetime import datetime, timezone
+from typing import Optional
 from uuid import UUID
+from uuid import NAMESPACE_URL, uuid5
 from fastapi import Request
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError, NotFoundError
+from app.services import billing_service, legal_service
 
 logger = logging.getLogger(__name__)
+TERMS_ACCEPTANCE_REQUIRED_TYPE = "terms_acceptance_required"
 
 
 async def create_order_notification(conn, tenant_id, order_id, payload: dict):
@@ -69,6 +74,7 @@ async def get_unread_notifications(request: Request) -> dict:
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection() as conn:
+            terms_notification = await _build_terms_acceptance_notification(conn, tenant_id)
             rows = await conn.fetch(
                 """SELECT id, order_id, type, payload, created_at
                    FROM notifications
@@ -79,7 +85,7 @@ async def get_unread_notifications(request: Request) -> dict:
             )
             return {
                 "success": True,
-                "data": [
+                "data": ([terms_notification] if terms_notification else []) + [
                     {
                         "id": str(r["id"]),
                         "order_id": str(r["order_id"]) if r["order_id"] else None,
@@ -147,3 +153,40 @@ async def mark_all_notifications_read(request: Request) -> dict:
     except Exception as e:
         logger.error(f"Error marking all notifications as read: {str(e)}")
         raise APIError(f"Error marking all notifications as read: {str(e)}", status_code=500)
+
+
+async def _build_terms_acceptance_notification(conn, tenant_id: UUID) -> Optional[dict]:
+    """
+    Return a virtual unread notification for paid tenants pending current TyC.
+
+    It is intentionally not persisted: the reminder is derived from legal and
+    subscription state, so it remains visible after "mark all read" until the
+    tenant accepts the current document version.
+    """
+    access = await billing_service.get_subscription_access(tenant_id, conn)
+    if access.subscription_status not in {"active", "past_due"}:
+        return None
+
+    status = await legal_service.get_terms_status(conn, tenant_id)
+    data = status.get("data") or {}
+    if not data.get("requires_acceptance"):
+        return None
+
+    current = data.get("current") or {}
+    version_id = current.get("version_id")
+    version = current.get("version")
+    notification_id = uuid5(
+        NAMESPACE_URL,
+        f"waro:terms_acceptance_required:{tenant_id}:{version_id or version or 'current'}",
+    )
+    return {
+        "id": str(notification_id),
+        "order_id": None,
+        "type": TERMS_ACCEPTANCE_REQUIRED_TYPE,
+        "payload": {
+            "document_version_id": version_id,
+            "version": version,
+            "return_to": "/gestion/billing",
+        },
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }

--- a/tests/test_notifications_terms_reminder.py
+++ b/tests/test_notifications_terms_reminder.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services import notifications_service
+
+
+@pytest.mark.asyncio
+async def test_terms_acceptance_reminder_for_active_tenant_pending_terms():
+    tenant_id = uuid4()
+    conn = MagicMock()
+
+    with patch(
+        "app.services.notifications_service.billing_service.get_subscription_access",
+        new=AsyncMock(return_value=SimpleNamespace(subscription_status="active")),
+    ), patch(
+        "app.services.notifications_service.legal_service.get_terms_status",
+        new=AsyncMock(return_value={
+            "success": True,
+            "data": {
+                "requires_acceptance": True,
+                "current": {"version_id": str(uuid4()), "version": "1.0"},
+                "acceptance": None,
+            },
+        }),
+    ):
+        notification = await notifications_service._build_terms_acceptance_notification(conn, tenant_id)
+
+    assert notification is not None
+    assert notification["type"] == "terms_acceptance_required"
+    assert notification["order_id"] is None
+    assert notification["payload"]["version"] == "1.0"
+    assert notification["payload"]["return_to"] == "/gestion/billing"
+
+
+@pytest.mark.asyncio
+async def test_terms_acceptance_reminder_skips_pending_checkout_subscription():
+    tenant_id = uuid4()
+    conn = MagicMock()
+
+    with patch(
+        "app.services.notifications_service.billing_service.get_subscription_access",
+        new=AsyncMock(return_value=SimpleNamespace(subscription_status="pending")),
+    ), patch(
+        "app.services.notifications_service.legal_service.get_terms_status",
+        new=AsyncMock(),
+    ) as status_mock:
+        notification = await notifications_service._build_terms_acceptance_notification(conn, tenant_id)
+
+    assert notification is None
+    status_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_terms_acceptance_reminder_skips_accepted_terms():
+    tenant_id = uuid4()
+    conn = MagicMock()
+
+    with patch(
+        "app.services.notifications_service.billing_service.get_subscription_access",
+        new=AsyncMock(return_value=SimpleNamespace(subscription_status="active")),
+    ), patch(
+        "app.services.notifications_service.legal_service.get_terms_status",
+        new=AsyncMock(return_value={
+            "success": True,
+            "data": {
+                "requires_acceptance": False,
+                "current": {"version_id": str(uuid4()), "version": "1.0"},
+                "acceptance": {"id": str(uuid4())},
+            },
+        }),
+    ):
+        notification = await notifications_service._build_terms_acceptance_notification(conn, tenant_id)
+
+    assert notification is None


### PR DESCRIPTION
## Summary
- synthesize a virtual unread terms-acceptance notification for active/past-due tenants who have not accepted the current TyC
- allow authenticated notification endpoints to serve legal reminders outside POS-gated access
- add focused tests for paid, pending-checkout, and accepted terms cases

## Tests
- ./venv/bin/pytest tests/test_notifications_terms_reminder.py
- ./venv/bin/python -m compileall app/routers/notifications.py app/services/notifications_service.py

Refs uno0uno/warocol.com#1330