### PR TITLE
Audit TyC acceptance evidence retention

### DIFF
--- a/app/routers/legal.py
+++ b/app/routers/legal.py
@@ -1,6 +1,8 @@
+from datetime import datetime
 from typing import Optional
+from uuid import UUID
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel
 
 from app.core.middleware import require_valid_session
@@ -16,6 +18,12 @@ class AcceptTermsBody(BaseModel):
     source: Optional[str] = "api"
 
 
+def _require_session_tenant_id(session) -> UUID:
+    if not session.tenant_id:
+        raise HTTPException(status_code=401, detail="Tenant ID is required")
+    return session.tenant_id
+
+
 @router.get("/terms/current")
 async def get_current_terms(request: Request):
     session = require_valid_session(request)
@@ -29,6 +37,39 @@ async def get_terms_status(request: Request):
     session = require_valid_session(request)
     async with get_db_connection(use_transaction=False) as conn:
         return await legal_service.get_terms_status(conn, session.tenant_id)
+
+
+@router.get("/terms/audit")
+async def list_terms_acceptance_audit(
+    request: Request,
+    document_version_id: Optional[UUID] = None,
+    actor_email: Optional[str] = None,
+    accepted_from: Optional[datetime] = None,
+    accepted_to: Optional[datetime] = None,
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+):
+    session = require_valid_session(request)
+    tenant_id = _require_session_tenant_id(session)
+    async with get_db_connection(use_transaction=False) as conn:
+        return await legal_service.list_acceptance_audit_records(
+            conn,
+            tenant_id,
+            document_version_id=document_version_id,
+            actor_email=actor_email,
+            accepted_from=accepted_from,
+            accepted_to=accepted_to,
+            limit=limit,
+            offset=offset,
+        )
+
+
+@router.get("/terms/audit/{acceptance_id}")
+async def get_terms_acceptance_audit(acceptance_id: UUID, request: Request):
+    session = require_valid_session(request)
+    tenant_id = _require_session_tenant_id(session)
+    async with get_db_connection(use_transaction=False) as conn:
+        return await legal_service.get_acceptance_audit_record(conn, tenant_id, acceptance_id)
 
 
 @router.post("/terms/accept", status_code=201)

--- a/app/services/legal_service.py
+++ b/app/services/legal_service.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from typing import Any, Dict, Optional
 from uuid import UUID
 
@@ -139,6 +140,67 @@ async def get_acceptance_for_version(conn, tenant_id: UUID, version_id: UUID) ->
         version_id,
     )
     return _serialize_acceptance(row) if row else None
+
+
+async def list_acceptance_audit_records(
+    conn,
+    tenant_id: UUID,
+    *,
+    document_version_id: Optional[UUID] = None,
+    actor_email: Optional[str] = None,
+    accepted_from: Optional[datetime] = None,
+    accepted_to: Optional[datetime] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> Dict[str, Any]:
+    rows = await conn.fetch(
+        """
+        SELECT *
+        FROM tenant_legal_acceptances
+        WHERE tenant_id = $1
+          AND ($2::uuid IS NULL OR document_version_id = $2)
+          AND (
+            $3::text IS NULL
+            OR actor_email_snapshot ILIKE '%' || $3 || '%'
+            OR email_snapshot ILIKE '%' || $3 || '%'
+          )
+          AND ($4::timestamptz IS NULL OR accepted_at >= $4)
+          AND ($5::timestamptz IS NULL OR accepted_at <= $5)
+        ORDER BY accepted_at DESC, created_at DESC
+        LIMIT $6 OFFSET $7
+        """,
+        tenant_id,
+        document_version_id,
+        actor_email,
+        accepted_from,
+        accepted_to,
+        limit,
+        offset,
+    )
+    return {
+        "success": True,
+        "data": {
+            "records": [_serialize_acceptance(row) for row in rows],
+            "limit": limit,
+            "offset": offset,
+        },
+    }
+
+
+async def get_acceptance_audit_record(conn, tenant_id: UUID, acceptance_id: UUID) -> Dict[str, Any]:
+    row = await conn.fetchrow(
+        """
+        SELECT *
+        FROM tenant_legal_acceptances
+        WHERE tenant_id = $1 AND id = $2
+        LIMIT 1
+        """,
+        tenant_id,
+        acceptance_id,
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Legal acceptance evidence not found")
+    return {"success": True, "data": _serialize_acceptance(row)}
 
 
 async def get_terms_status(conn, tenant_id: Optional[UUID]) -> Dict[str, Any]:

--- a/migrations/086_legal_acceptance_immutability.sql
+++ b/migrations/086_legal_acceptance_immutability.sql
@@ -1,0 +1,24 @@
+-- Migration 086: make legal acceptance evidence append-only
+--
+-- TyC acceptance rows are electronic evidence. They must remain available for
+-- audit/legal review for at least 10 years, so normal application changes must
+-- not update or delete the accepted snapshot after insert.
+
+CREATE OR REPLACE FUNCTION prevent_tenant_legal_acceptance_mutation()
+RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION 'tenant_legal_acceptances rows are immutable legal evidence'
+        USING ERRCODE = '45000';
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_tenant_legal_acceptances_immutable
+    ON tenant_legal_acceptances;
+
+CREATE TRIGGER trg_tenant_legal_acceptances_immutable
+BEFORE UPDATE OR DELETE ON tenant_legal_acceptances
+FOR EACH ROW
+EXECUTE FUNCTION prevent_tenant_legal_acceptance_mutation();
+
+COMMENT ON FUNCTION prevent_tenant_legal_acceptance_mutation() IS
+    'Blocks UPDATE/DELETE on tenant_legal_acceptances; retain acceptance evidence for at least 10 years.';

--- a/tests/test_legal_terms_acceptance.py
+++ b/tests/test_legal_terms_acceptance.py
@@ -1,5 +1,6 @@
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -148,6 +149,55 @@ async def test_accept_current_terms_is_idempotent_for_same_version():
 
 
 @pytest.mark.asyncio
+async def test_acceptance_audit_list_is_tenant_scoped_and_filterable():
+    tenant_id = uuid4()
+    version_id = uuid4()
+    row = _acceptance_row(tenant_id, version_id)
+    accepted_from = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    accepted_to = datetime(2026, 6, 30, tzinfo=timezone.utc)
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[row])
+
+    result = await legal_service.list_acceptance_audit_records(
+        conn,
+        tenant_id,
+        document_version_id=version_id,
+        actor_email="test@warocol.com",
+        accepted_from=accepted_from,
+        accepted_to=accepted_to,
+        limit=25,
+        offset=5,
+    )
+
+    assert result["data"]["records"][0]["tenant_id"] == str(tenant_id)
+    assert result["data"]["records"][0]["document_version_id"] == str(version_id)
+    query_args = conn.fetch.await_args.args
+    assert query_args[1] == tenant_id
+    assert query_args[2] == version_id
+    assert query_args[3] == "test@warocol.com"
+    assert query_args[4] == accepted_from
+    assert query_args[5] == accepted_to
+    assert query_args[6] == 25
+    assert query_args[7] == 5
+
+
+@pytest.mark.asyncio
+async def test_acceptance_audit_detail_requires_tenant_match():
+    tenant_id = uuid4()
+    acceptance_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await legal_service.get_acceptance_audit_record(conn, tenant_id, acceptance_id)
+
+    assert exc_info.value.status_code == 404
+    query_args = conn.fetchrow.await_args.args
+    assert query_args[1] == tenant_id
+    assert query_args[2] == acceptance_id
+
+
+@pytest.mark.asyncio
 async def test_current_version_query_filters_to_published_effective_versions():
     conn = MagicMock()
     conn.fetchrow = AsyncMock(return_value=None)
@@ -160,13 +210,25 @@ async def test_current_version_query_filters_to_published_effective_versions():
     assert "v.effective_at <= now()" in query
 
 
+def test_legal_acceptance_migrations_preserve_and_lock_evidence():
+    migrations_dir = Path(__file__).resolve().parents[1] / "migrations"
+    schema_sql = (migrations_dir / "085_legal_terms_acceptance.sql").read_text()
+    immutability_sql = (migrations_dir / "086_legal_acceptance_immutability.sql").read_text()
+
+    assert "retention_years INTEGER NOT NULL DEFAULT 10 CHECK (retention_years >= 10)" in schema_sql
+    assert "tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT" in schema_sql
+    assert "document_version_id UUID NOT NULL REFERENCES legal_document_versions(id) ON DELETE RESTRICT" in schema_sql
+    assert "BEFORE UPDATE OR DELETE ON tenant_legal_acceptances" in immutability_sql
+    assert "retain acceptance evidence for at least 10 years" in immutability_sql
+
+
 def test_accept_endpoint_uses_forwarded_ip_and_user_agent():
     app = FastAPI()
     app.include_router(router)
     session = _session()
 
     @asynccontextmanager
-    async def _db():
+    async def _db(**_kwargs):
         yield MagicMock()
 
     with patch("app.routers.legal.require_valid_session", return_value=session), \
@@ -187,3 +249,34 @@ def test_accept_endpoint_uses_forwarded_ip_and_user_agent():
     assert kwargs["client_ip"] == "198.51.100.10"
     assert kwargs["user_agent"] == "pytest-browser"
     assert kwargs["source"] == "billing_checkout"
+
+
+def test_audit_endpoint_returns_tenant_scoped_evidence():
+    app = FastAPI()
+    app.include_router(router)
+    session = _session()
+
+    @asynccontextmanager
+    async def _db(**_kwargs):
+        yield MagicMock()
+
+    audit_payload = {
+        "success": True,
+        "data": {
+            "records": [_acceptance_row(session.tenant_id, uuid4())],
+            "limit": 10,
+            "offset": 0,
+        },
+    }
+
+    with patch("app.routers.legal.require_valid_session", return_value=session), \
+         patch("app.routers.legal.get_db_connection", side_effect=_db), \
+         patch("app.routers.legal.legal_service.list_acceptance_audit_records", new=AsyncMock(return_value=audit_payload)) as audit_mock:
+        client = TestClient(app)
+        res = client.get("/legal/terms/audit?limit=10")
+
+    assert res.status_code == 200
+    assert res.json()["success"] is True
+    _, args, kwargs = audit_mock.mock_calls[0]
+    assert args[1] == session.tenant_id
+    assert kwargs["limit"] == 10


### PR DESCRIPTION
## Summary
- add tenant-scoped legal acceptance audit list/detail endpoints
- add append-only migration guard for TyC acceptance evidence
- cover audit lookup, retention, and immutability with targeted tests

## Tests
- pytest tests/test_legal_terms_acceptance.py tests/test_billing_subscribe_cycle.py tests/test_notifications_terms_reminder.py

Closes #449