### PR TITLE
Publish legal terms v1.1 from R2

### DIFF
--- a/app/services/aws_s3_service.py
+++ b/app/services/aws_s3_service.py
@@ -11,6 +11,7 @@ from app.config import settings
 import uuid
 import mimetypes
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -274,6 +275,64 @@ class AWSS3Service:
             return None
         except Exception as e:
             logger.error(f"Unexpected error uploading public image for tenant {tenant_id}: {str(e)}")
+            logger.exception(e)
+            return None
+
+    async def upload_public_asset(
+        self,
+        file_bytes: bytes,
+        s3_key: str,
+        content_type: str,
+        metadata: Optional[dict] = None,
+    ) -> Optional[str]:
+        """
+        Upload a stable public asset to the public R2 bucket and return its URL.
+
+        Intended for versioned public documents such as legal PDFs where the
+        object key is part of the published contract metadata.
+        """
+        if not settings.r2_public_url:
+            logger.error("r2_public_url not configured — cannot generate permanent asset URL")
+            return None
+
+        normalized_key = s3_key.strip().lstrip("/")
+        if not normalized_key or ".." in normalized_key or not re.fullmatch(r"[A-Za-z0-9._/-]+", normalized_key):
+            logger.error("Invalid public asset key: %s", s3_key)
+            return None
+
+        try:
+            access_key = settings.r2_access_key_id or settings.aws_access_key_id
+            secret_key = settings.r2_secret_access_key or settings.aws_secret_access_key
+
+            public_client = boto3.client(
+                's3',
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+                endpoint_url=settings.r2_endpoint,
+                region_name='auto',
+            )
+
+            extra_args = {'ContentType': content_type}
+            if metadata:
+                extra_args['Metadata'] = {str(k): str(v) for k, v in metadata.items()}
+
+            public_client.upload_fileobj(
+                BytesIO(file_bytes),
+                settings.r2_public_bucket,
+                normalized_key,
+                ExtraArgs=extra_args,
+            )
+
+            public_url = f"{settings.r2_public_url.rstrip('/')}/{normalized_key}"
+            logger.info("Uploaded public asset: %s", public_url)
+            return public_url
+
+        except ClientError as e:
+            logger.error(f"ClientError uploading public asset {normalized_key}: {str(e)}")
+            logger.exception(e)
+            return None
+        except Exception as e:
+            logger.error(f"Unexpected error uploading public asset {normalized_key}: {str(e)}")
             logger.exception(e)
             return None
 

--- a/app/services/legal_service.py
+++ b/app/services/legal_service.py
@@ -128,6 +128,118 @@ async def get_current_terms(conn, tenant_id: Optional[UUID] = None) -> Optional[
     return _serialize_version(row, [_serialize_annex(a) for a in annex_rows])
 
 
+async def publish_terms_version(
+    conn,
+    *,
+    version: str,
+    effective_at: datetime,
+    content_url: str,
+    content_sha256: str,
+    metadata: Dict[str, Any],
+    status: str = "published",
+) -> Dict[str, Any]:
+    """
+    Create or update a legal terms version without touching acceptance evidence.
+
+    If a version already has tenant acceptances, its source document hash cannot
+    change. This keeps the accepted contract snapshot stable for audit purposes.
+    """
+    if status not in {"draft", "published", "archived"}:
+        raise ValueError("Invalid legal document version status")
+
+    document_id = await conn.fetchval(
+        """
+        INSERT INTO legal_documents (code, title, retention_years)
+        VALUES ($1, 'Terminos y Condiciones WARO', 10)
+        ON CONFLICT (code) DO UPDATE SET title = EXCLUDED.title
+        RETURNING id
+        """,
+        TERMS_DOCUMENT_CODE,
+    )
+
+    existing = await conn.fetchrow(
+        """
+        SELECT
+            v.id,
+            v.content_sha256,
+            COUNT(a.id)::int AS acceptance_count
+        FROM legal_document_versions v
+        LEFT JOIN tenant_legal_acceptances a ON a.document_version_id = v.id
+        WHERE v.document_id = $1 AND v.version = $2
+        GROUP BY v.id, v.content_sha256
+        """,
+        document_id,
+        version,
+    )
+
+    if (
+        existing
+        and existing["acceptance_count"] > 0
+        and existing["content_sha256"] != content_sha256
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail="Cannot change source content for a legal version that already has acceptances",
+        )
+
+    row = await conn.fetchrow(
+        """
+        INSERT INTO legal_document_versions (
+            document_id,
+            version,
+            status,
+            effective_at,
+            published_at,
+            content_url,
+            content_sha256,
+            metadata
+        )
+        VALUES ($1, $2, $3, $4, now(), $5, $6, $7::jsonb)
+        ON CONFLICT (document_id, version) DO UPDATE
+        SET status = EXCLUDED.status,
+            effective_at = EXCLUDED.effective_at,
+            published_at = CASE
+                WHEN EXCLUDED.status = 'published' THEN COALESCE(legal_document_versions.published_at, now())
+                ELSE legal_document_versions.published_at
+            END,
+            content_url = EXCLUDED.content_url,
+            content_sha256 = EXCLUDED.content_sha256,
+            metadata = EXCLUDED.metadata
+        RETURNING id
+        """,
+        document_id,
+        version,
+        status,
+        effective_at,
+        content_url,
+        content_sha256,
+        json.dumps(metadata),
+    )
+
+    # RETURNING cannot reference legal_documents columns directly in the upsert.
+    version_row = await conn.fetchrow(
+        """
+        SELECT
+            d.id AS document_id,
+            d.code AS document_code,
+            d.title AS document_title,
+            d.retention_years,
+            v.id AS version_id,
+            v.version,
+            v.effective_at,
+            v.published_at,
+            v.content_url,
+            v.content_sha256,
+            v.metadata
+        FROM legal_documents d
+        JOIN legal_document_versions v ON v.document_id = d.id
+        WHERE v.id = $1
+        """,
+        row["id"],
+    )
+    return _serialize_version(version_row, [])
+
+
 async def get_acceptance_for_version(conn, tenant_id: UUID, version_id: UUID) -> Optional[Dict[str, Any]]:
     row = await conn.fetchrow(
         """

--- a/scripts/publish_legal_terms_v11.py
+++ b/scripts/publish_legal_terms_v11.py
@@ -1,0 +1,206 @@
+"""
+Publish WARO legal Terms and Conditions v1.1.
+
+Default production usage expects the SSH tunnel and .env variables:
+    ssh -L 5432:localhost:5432 warolabs -N
+    python scripts/publish_legal_terms_v11.py
+
+Dry run:
+    python scripts/publish_legal_terms_v11.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import html
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import asyncpg
+from dotenv import load_dotenv
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+load_dotenv(ROOT / ".env")
+
+from app.services.aws_s3_service import AWSS3Service  # noqa: E402
+from app.services.legal_service import publish_terms_version  # noqa: E402
+
+
+DEFAULT_PDF = Path("/Users/saifer/Documents/TyC_WARO_v1.1.pdf")
+DEFAULT_VERSION = "1.1"
+DEFAULT_R2_KEY = "legal/terms/TyC_WARO_v1.1.pdf"
+DEFAULT_EFFECTIVE_AT = "2026-06-15T00:00:00-05:00"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Publish TyC WARO v1.1 to R2 and legal_document_versions")
+    parser.add_argument("--pdf", type=Path, default=DEFAULT_PDF)
+    parser.add_argument("--version", default=DEFAULT_VERSION)
+    parser.add_argument("--r2-key", default=DEFAULT_R2_KEY)
+    parser.add_argument("--effective-at", default=DEFAULT_EFFECTIVE_AT)
+    parser.add_argument("--database-url", default=None)
+    parser.add_argument("--content-url", default=None, help="Use an already-uploaded public PDF URL and skip R2 upload")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _extract_pdf_text(pdf_path: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["pdftotext", "-layout", "-enc", "UTF-8", str(pdf_path), "-"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("pdftotext is required to extract legal PDF content") from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"pdftotext failed: {exc.stderr.strip()}") from exc
+    return result.stdout
+
+
+def _is_heading(text: str) -> bool:
+    compact = text.strip()
+    if not compact or len(compact) > 140:
+        return False
+    letters = [ch for ch in compact if ch.isalpha()]
+    if len(letters) < 4:
+        return False
+    uppercase_ratio = sum(1 for ch in letters if ch.isupper()) / len(letters)
+    return uppercase_ratio > 0.75 and not compact.endswith(".")
+
+
+def build_body_html_from_text(text: str) -> str:
+    """
+    Convert pdftotext output to safe, readable HTML for the current frontend.
+
+    This intentionally escapes all text and preserves paragraphs/headings instead
+    of trusting arbitrary HTML.
+    """
+    blocks: list[str] = []
+    paragraph: list[str] = []
+    first_heading = True
+
+    def flush_paragraph() -> None:
+        if not paragraph:
+            return
+        value = " ".join(part.strip() for part in paragraph if part.strip())
+        paragraph.clear()
+        if value:
+            blocks.append(f"<p>{html.escape(value)}</p>")
+
+    for raw_line in text.replace("\f", "\n\n").splitlines():
+        line = raw_line.strip()
+        if not line:
+            flush_paragraph()
+            continue
+        if line.startswith("Página ") and line[7:].isdigit():
+            flush_paragraph()
+            continue
+
+        if _is_heading(line):
+            flush_paragraph()
+            tag = "h1" if first_heading else "h2"
+            first_heading = False
+            blocks.append(f"<{tag}>{html.escape(line)}</{tag}>")
+            continue
+
+        paragraph.append(line)
+
+    flush_paragraph()
+    return "\n".join(blocks)
+
+
+def _connect_kwargs() -> dict:
+    return {
+        "host": os.getenv("DB_HOST_OVERRIDE", "localhost"),
+        "port": int(os.getenv("NUXT_PRIVATE_DB_PORT", "5432")),
+        "user": os.getenv("NUXT_PRIVATE_DB_USER"),
+        "password": os.getenv("NUXT_PRIVATE_DB_PASSWORD"),
+        "database": os.getenv("NUXT_PRIVATE_DB_NAME"),
+    }
+
+
+async def _publish(args: argparse.Namespace) -> None:
+    pdf_path = args.pdf.expanduser().resolve()
+    if not pdf_path.exists():
+        raise FileNotFoundError(f"PDF not found: {pdf_path}")
+
+    pdf_bytes = pdf_path.read_bytes()
+    pdf_sha256 = _sha256(pdf_bytes)
+    body_html = build_body_html_from_text(_extract_pdf_text(pdf_path))
+    effective_at = datetime.fromisoformat(args.effective_at)
+
+    print(f"PDF: {pdf_path}")
+    print(f"Version: {args.version}")
+    print(f"SHA256: {pdf_sha256}")
+    print(f"R2 key: {args.r2_key}")
+    print(f"HTML chars: {len(body_html)}")
+
+    if args.dry_run:
+        print("Dry run complete; no R2 upload or DB write performed.")
+        return
+
+    content_url = args.content_url
+    if not content_url:
+        content_url = await AWSS3Service().upload_public_asset(
+            pdf_bytes,
+            args.r2_key,
+            "application/pdf",
+            metadata={
+                "source": pdf_path.name,
+                "version": args.version,
+                "sha256": pdf_sha256,
+            },
+        )
+        if not content_url:
+            raise RuntimeError("Failed to upload legal PDF to public R2")
+
+    metadata = {
+        "source": pdf_path.name,
+        "body_html": body_html,
+        "status": "published",
+        "privacy_policy_url": "#politica-datos-personales",
+    }
+
+    if args.database_url:
+        conn = await asyncpg.connect(args.database_url)
+    else:
+        conn = await asyncpg.connect(**_connect_kwargs())
+
+    try:
+        async with conn.transaction():
+            current = await publish_terms_version(
+                conn,
+                version=args.version,
+                effective_at=effective_at,
+                content_url=content_url,
+                content_sha256=pdf_sha256,
+                metadata=metadata,
+            )
+    finally:
+        await conn.close()
+
+    print("Published legal terms:")
+    print(f"  version: {current['version']}")
+    print(f"  content_url: {current['content_url']}")
+    print(f"  content_sha256: {current['content_sha256']}")
+
+
+def main() -> None:
+    asyncio.run(_publish(_parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/publish_legal_terms_v11.py
+++ b/scripts/publish_legal_terms_v11.py
@@ -14,9 +14,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import hashlib
-import html
 import os
-import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -55,73 +53,6 @@ def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def _extract_pdf_text(pdf_path: Path) -> str:
-    try:
-        result = subprocess.run(
-            ["pdftotext", "-layout", "-enc", "UTF-8", str(pdf_path), "-"],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except FileNotFoundError as exc:
-        raise RuntimeError("pdftotext is required to extract legal PDF content") from exc
-    except subprocess.CalledProcessError as exc:
-        raise RuntimeError(f"pdftotext failed: {exc.stderr.strip()}") from exc
-    return result.stdout
-
-
-def _is_heading(text: str) -> bool:
-    compact = text.strip()
-    if not compact or len(compact) > 140:
-        return False
-    letters = [ch for ch in compact if ch.isalpha()]
-    if len(letters) < 4:
-        return False
-    uppercase_ratio = sum(1 for ch in letters if ch.isupper()) / len(letters)
-    return uppercase_ratio > 0.75 and not compact.endswith(".")
-
-
-def build_body_html_from_text(text: str) -> str:
-    """
-    Convert pdftotext output to safe, readable HTML for the current frontend.
-
-    This intentionally escapes all text and preserves paragraphs/headings instead
-    of trusting arbitrary HTML.
-    """
-    blocks: list[str] = []
-    paragraph: list[str] = []
-    first_heading = True
-
-    def flush_paragraph() -> None:
-        if not paragraph:
-            return
-        value = " ".join(part.strip() for part in paragraph if part.strip())
-        paragraph.clear()
-        if value:
-            blocks.append(f"<p>{html.escape(value)}</p>")
-
-    for raw_line in text.replace("\f", "\n\n").splitlines():
-        line = raw_line.strip()
-        if not line:
-            flush_paragraph()
-            continue
-        if line.startswith("Página ") and line[7:].isdigit():
-            flush_paragraph()
-            continue
-
-        if _is_heading(line):
-            flush_paragraph()
-            tag = "h1" if first_heading else "h2"
-            first_heading = False
-            blocks.append(f"<{tag}>{html.escape(line)}</{tag}>")
-            continue
-
-        paragraph.append(line)
-
-    flush_paragraph()
-    return "\n".join(blocks)
-
-
 def _connect_kwargs() -> dict:
     return {
         "host": os.getenv("DB_HOST_OVERRIDE", "localhost"),
@@ -139,14 +70,12 @@ async def _publish(args: argparse.Namespace) -> None:
 
     pdf_bytes = pdf_path.read_bytes()
     pdf_sha256 = _sha256(pdf_bytes)
-    body_html = build_body_html_from_text(_extract_pdf_text(pdf_path))
     effective_at = datetime.fromisoformat(args.effective_at)
 
     print(f"PDF: {pdf_path}")
     print(f"Version: {args.version}")
     print(f"SHA256: {pdf_sha256}")
     print(f"R2 key: {args.r2_key}")
-    print(f"HTML chars: {len(body_html)}")
 
     if args.dry_run:
         print("Dry run complete; no R2 upload or DB write performed.")
@@ -169,9 +98,8 @@ async def _publish(args: argparse.Namespace) -> None:
 
     metadata = {
         "source": pdf_path.name,
-        "body_html": body_html,
         "status": "published",
-        "privacy_policy_url": "#politica-datos-personales",
+        "display_mode": "pdf",
     }
 
     if args.database_url:

--- a/tests/test_legal_terms_acceptance.py
+++ b/tests/test_legal_terms_acceptance.py
@@ -11,6 +11,9 @@ from fastapi.testclient import TestClient
 from app.core.middleware import SessionContext
 from app.routers.legal import router
 from app.services import legal_service
+from app.services import aws_s3_service
+from app.services.aws_s3_service import AWSS3Service
+from scripts.publish_legal_terms_v11 import build_body_html_from_text
 
 
 def _version_row(version="1.0"):
@@ -66,6 +69,56 @@ def _session(tenant_id=None):
         "is_active": True,
         "role": "owner",
     })
+
+
+def test_publish_script_builds_safe_body_html():
+    html = build_body_html_from_text(
+        "TÉRMINOS Y CONDICIONES\n\n"
+        "AVISO IMPORTANTE\n"
+        "Lea <todo> antes de aceptar.\n\n"
+        "Página 1\n"
+        "CONDICIONES FINALES\n"
+        "Texto final."
+    )
+
+    assert "<h1>TÉRMINOS Y CONDICIONES</h1>" in html
+    assert "<h2>AVISO IMPORTANTE</h2>" in html
+    assert "Lea &lt;todo&gt; antes de aceptar." in html
+    assert "Página 1" not in html
+
+
+@pytest.mark.asyncio
+async def test_public_asset_upload_uses_public_r2_bucket(monkeypatch):
+    calls = {}
+
+    class FakeClient:
+        def upload_fileobj(self, fileobj, bucket, key, ExtraArgs=None):
+            calls["bucket"] = bucket
+            calls["key"] = key
+            calls["extra_args"] = ExtraArgs
+            calls["bytes"] = fileobj.read()
+
+    monkeypatch.setattr(aws_s3_service.settings, "r2_public_url", "https://pub.example")
+    monkeypatch.setattr(aws_s3_service.settings, "r2_public_bucket", "warocol-public-assets")
+    monkeypatch.setattr(aws_s3_service.settings, "r2_access_key_id", "key")
+    monkeypatch.setattr(aws_s3_service.settings, "r2_secret_access_key", "secret")
+    monkeypatch.setattr(aws_s3_service.settings, "r2_endpoint", "https://r2.example")
+    monkeypatch.setattr(aws_s3_service.boto3, "client", lambda *args, **kwargs: FakeClient())
+
+    service = object.__new__(AWSS3Service)
+    url = await service.upload_public_asset(
+        b"pdf",
+        "legal/terms/TyC_WARO_v1.1.pdf",
+        "application/pdf",
+        metadata={"version": "1.1"},
+    )
+
+    assert url == "https://pub.example/legal/terms/TyC_WARO_v1.1.pdf"
+    assert calls["bucket"] == "warocol-public-assets"
+    assert calls["key"] == "legal/terms/TyC_WARO_v1.1.pdf"
+    assert calls["extra_args"]["ContentType"] == "application/pdf"
+    assert calls["extra_args"]["Metadata"]["version"] == "1.1"
+    assert calls["bytes"] == b"pdf"
 
 
 @pytest.mark.asyncio
@@ -208,6 +261,72 @@ async def test_current_version_query_filters_to_published_effective_versions():
     query = conn.fetchrow.await_args.args[0]
     assert "v.status = 'published'" in query
     assert "v.effective_at <= now()" in query
+
+
+@pytest.mark.asyncio
+async def test_publish_terms_version_upserts_without_touching_acceptances():
+    version_id = uuid4()
+    document_id = uuid4()
+    now = datetime(2026, 6, 15, 5, 0, tzinfo=timezone.utc)
+    final_row = {
+        "document_id": document_id,
+        "document_code": "terms_conditions",
+        "document_title": "Terminos y Condiciones WARO",
+        "retention_years": 10,
+        "version_id": version_id,
+        "version": "1.1",
+        "effective_at": now,
+        "published_at": now,
+        "content_url": "https://pub.example/legal/terms/TyC_WARO_v1.1.pdf",
+        "content_sha256": "abc123",
+        "metadata": {"body_html": "<p>Completo</p>"},
+    }
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=document_id)
+    conn.fetchrow = AsyncMock(side_effect=[
+        None,
+        {"id": version_id},
+        final_row,
+    ])
+
+    result = await legal_service.publish_terms_version(
+        conn,
+        version="1.1",
+        effective_at=now,
+        content_url=final_row["content_url"],
+        content_sha256="abc123",
+        metadata={"body_html": "<p>Completo</p>"},
+    )
+
+    assert result["version"] == "1.1"
+    assert result["content_url"] == final_row["content_url"]
+    assert result["metadata"]["body_html"] == "<p>Completo</p>"
+
+
+@pytest.mark.asyncio
+async def test_publish_terms_version_rejects_hash_change_after_acceptance():
+    version_id = uuid4()
+    document_id = uuid4()
+    now = datetime(2026, 6, 15, 5, 0, tzinfo=timezone.utc)
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=document_id)
+    conn.fetchrow = AsyncMock(return_value={
+        "id": version_id,
+        "content_sha256": "old-hash",
+        "acceptance_count": 1,
+    })
+
+    with pytest.raises(HTTPException) as exc_info:
+        await legal_service.publish_terms_version(
+            conn,
+            version="1.1",
+            effective_at=now,
+            content_url="https://pub.example/legal/terms/TyC_WARO_v1.1.pdf",
+            content_sha256="new-hash",
+            metadata={"body_html": "<p>Completo</p>"},
+        )
+
+    assert exc_info.value.status_code == 409
 
 
 def test_legal_acceptance_migrations_preserve_and_lock_evidence():

--- a/tests/test_legal_terms_acceptance.py
+++ b/tests/test_legal_terms_acceptance.py
@@ -13,7 +13,6 @@ from app.routers.legal import router
 from app.services import legal_service
 from app.services import aws_s3_service
 from app.services.aws_s3_service import AWSS3Service
-from scripts.publish_legal_terms_v11 import build_body_html_from_text
 
 
 def _version_row(version="1.0"):
@@ -69,22 +68,6 @@ def _session(tenant_id=None):
         "is_active": True,
         "role": "owner",
     })
-
-
-def test_publish_script_builds_safe_body_html():
-    html = build_body_html_from_text(
-        "TÉRMINOS Y CONDICIONES\n\n"
-        "AVISO IMPORTANTE\n"
-        "Lea <todo> antes de aceptar.\n\n"
-        "Página 1\n"
-        "CONDICIONES FINALES\n"
-        "Texto final."
-    )
-
-    assert "<h1>TÉRMINOS Y CONDICIONES</h1>" in html
-    assert "<h2>AVISO IMPORTANTE</h2>" in html
-    assert "Lea &lt;todo&gt; antes de aceptar." in html
-    assert "Página 1" not in html
 
 
 @pytest.mark.asyncio
@@ -279,7 +262,7 @@ async def test_publish_terms_version_upserts_without_touching_acceptances():
         "published_at": now,
         "content_url": "https://pub.example/legal/terms/TyC_WARO_v1.1.pdf",
         "content_sha256": "abc123",
-        "metadata": {"body_html": "<p>Completo</p>"},
+        "metadata": {"display_mode": "pdf"},
     }
     conn = MagicMock()
     conn.fetchval = AsyncMock(return_value=document_id)
@@ -295,12 +278,12 @@ async def test_publish_terms_version_upserts_without_touching_acceptances():
         effective_at=now,
         content_url=final_row["content_url"],
         content_sha256="abc123",
-        metadata={"body_html": "<p>Completo</p>"},
+        metadata={"display_mode": "pdf"},
     )
 
     assert result["version"] == "1.1"
     assert result["content_url"] == final_row["content_url"]
-    assert result["metadata"]["body_html"] == "<p>Completo</p>"
+    assert result["metadata"]["display_mode"] == "pdf"
 
 
 @pytest.mark.asyncio
@@ -323,7 +306,7 @@ async def test_publish_terms_version_rejects_hash_change_after_acceptance():
             effective_at=now,
             content_url="https://pub.example/legal/terms/TyC_WARO_v1.1.pdf",
             content_sha256="new-hash",
-            metadata={"body_html": "<p>Completo</p>"},
+            metadata={"display_mode": "pdf"},
         )
 
     assert exc_info.value.status_code == 409


### PR DESCRIPTION
## Summary

- Add a generic public R2 asset uploader for stable legal PDF URLs.
- Add an idempotent legal terms publisher that records v1.1 `content_url`, `content_sha256`, and full `metadata.body_html` while protecting accepted versions from hash changes.
- Add `scripts/publish_legal_terms_v11.py` to extract the local PDF, upload it to R2, and publish version 1.1.

## Tests

- `python3 -m py_compile app/services/aws_s3_service.py app/services/legal_service.py scripts/publish_legal_terms_v11.py`
- `/tmp/waro-api-test-venv/bin/python scripts/publish_legal_terms_v11.py --dry-run`
- `/tmp/waro-api-test-venv/bin/pytest tests/test_legal_terms_acceptance.py tests/test_notifications_terms_reminder.py`
- `git diff --check`

Closes #453
