### PR TITLE
Add billing remaining usage endpoint

### DIFF
--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -132,6 +132,17 @@ async def get_my_subscription(request: Request):
 
 
 @tenant_router.get(
+    "/remaining-usage",
+    dependencies=[Depends(require_module(Module.MI_PLAN))],
+)
+async def get_my_remaining_usage(request: Request):
+    """Current-period remaining usage for the authenticated tenant."""
+    session = require_valid_session(request)
+    async with get_db_connection(use_transaction=False) as conn:
+        return await billing_service.get_remaining_billing_usage(conn, session.tenant_id)
+
+
+@tenant_router.get(
     "/verify-payment",
     dependencies=[Depends(require_module(Module.MI_PLAN))],
 )

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 ELECTRONIC_INVOICE_PLAN_SLUG = "facturacion-electronica"
 ELECTRONIC_INVOICE_PERIOD_LIMIT = 200
+ELECTRONIC_INVOICE_LIMIT_FEATURE = "electronic_invoice_limit"
 
 
 async def check_scan_quota(tenant_id: UUID, conn) -> None:
@@ -296,6 +297,35 @@ def _serialize_plan(row) -> Dict[str, Any]:
         "created_at": row["created_at"].isoformat(),
         "updated_at": row["updated_at"].isoformat(),
     }
+
+
+def _jsonb_to_dict(value: Any) -> Dict[str, Any]:
+    if not value:
+        return {}
+    if isinstance(value, str):
+        return json.loads(value)
+    return dict(value)
+
+
+def _electronic_invoice_limit_for_plan(plan_slug: str, features: Any) -> int:
+    if plan_slug != ELECTRONIC_INVOICE_PLAN_SLUG:
+        return 0
+
+    plan_features = _jsonb_to_dict(features)
+    configured_limit = plan_features.get(ELECTRONIC_INVOICE_LIMIT_FEATURE)
+    if configured_limit is None:
+        return ELECTRONIC_INVOICE_PERIOD_LIMIT
+
+    try:
+        return max(int(configured_limit), 0)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid %s feature for plan=%s: %r",
+            ELECTRONIC_INVOICE_LIMIT_FEATURE,
+            plan_slug,
+            configured_limit,
+        )
+        return 0
 
 
 # ── Tenant subscription flows — issue #60 ────────────────────────────────────
@@ -621,6 +651,7 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
             ts.current_period_start,
             ts.current_period_end,
             sp.slug AS plan_slug,
+            sp.features AS plan_features,
             sp.scan_limit AS plan_scan_limit,
             COALESCE(su.scans_used, 0) AS scans_used,
             COALESCE(su.scans_limit, sp.scan_limit) AS scans_limit
@@ -643,10 +674,9 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
     scans_used = int(row["scans_used"] or 0)
     scans_limit = int(row["scans_limit"] or row["plan_scan_limit"] or 0)
 
-    invoice_limit = (
-        ELECTRONIC_INVOICE_PERIOD_LIMIT
-        if row["plan_slug"] == ELECTRONIC_INVOICE_PLAN_SLUG
-        else 0
+    invoice_limit = _electronic_invoice_limit_for_plan(
+        row["plan_slug"],
+        row["plan_features"],
     )
     invoice_used = 0
     if invoice_limit > 0:
@@ -1026,4 +1056,3 @@ async def mark_subscription_past_due(
         "tenant_name": tenant["name"] if tenant else "",
         "tenant_email": tenant["email"] if tenant else None,
     }
-

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -20,6 +20,9 @@ from app.config import settings
 
 logger = logging.getLogger(__name__)
 
+ELECTRONIC_INVOICE_PLAN_SLUG = "facturacion-electronica"
+ELECTRONIC_INVOICE_PERIOD_LIMIT = 200
+
 
 async def check_scan_quota(tenant_id: UUID, conn) -> None:
     """
@@ -605,6 +608,75 @@ async def get_tenant_subscription(conn, tenant_id: UUID) -> Dict[str, Any]:
     return data
 
 
+async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
+    """
+    Return current-period remaining usage for scans and electronic invoices.
+
+    The measurement window is the tenant subscription period. Electronic invoice
+    quota is only exposed for the paid FE plan; other plans intentionally report
+    0/0/0 to avoid implying an included entitlement.
+    """
+    row = await conn.fetchrow("""
+        SELECT
+            ts.current_period_start,
+            ts.current_period_end,
+            sp.slug AS plan_slug,
+            sp.scan_limit AS plan_scan_limit,
+            COALESCE(su.scans_used, 0) AS scans_used,
+            COALESCE(su.scans_limit, sp.scan_limit) AS scans_limit
+        FROM tenant_subscriptions ts
+        JOIN subscription_plans sp ON sp.id = ts.plan_id
+        LEFT JOIN scan_usage su
+            ON su.tenant_id = ts.tenant_id
+           AND su.period_start <= now()
+           AND su.period_end > now()
+        WHERE ts.tenant_id = $1
+    """, tenant_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Subscription not found")
+
+    period_start = row["current_period_start"]
+    period_end = row["current_period_end"]
+    period_start_iso = period_start.isoformat()
+    period_end_iso = period_end.isoformat()
+
+    scans_used = int(row["scans_used"] or 0)
+    scans_limit = int(row["scans_limit"] or row["plan_scan_limit"] or 0)
+
+    invoice_limit = (
+        ELECTRONIC_INVOICE_PERIOD_LIMIT
+        if row["plan_slug"] == ELECTRONIC_INVOICE_PLAN_SLUG
+        else 0
+    )
+    invoice_used = 0
+    if invoice_limit > 0:
+        invoice_used = int(await conn.fetchval("""
+            SELECT COUNT(*)
+            FROM electronic_invoices
+            WHERE tenant_id = $1
+              AND status = 'accepted'
+              AND document_type = 'invoice'
+              AND COALESCE(emitted_at, created_at) >= $2
+              AND COALESCE(emitted_at, created_at) < $3
+        """, tenant_id, period_start, period_end) or 0)
+
+    def metric(used: int, limit: int) -> Dict[str, Any]:
+        return {
+            "used": used,
+            "limit": limit,
+            "remaining": max(limit - used, 0),
+            "period_start": period_start_iso,
+            "period_end": period_end_iso,
+        }
+
+    return {
+        "period_start": period_start_iso,
+        "period_end": period_end_iso,
+        "scan_usage": metric(scans_used, scans_limit),
+        "electronic_invoice_usage": metric(invoice_used, invoice_limit),
+    }
+
+
 async def cancel_tenant_subscription(conn, tenant_id: UUID) -> str:
     """
     Set subscription status='cancelled' in DB and return the gateway_reference
@@ -954,6 +1026,4 @@ async def mark_subscription_past_due(
         "tenant_name": tenant["name"] if tenant else "",
         "tenant_email": tenant["email"] if tenant else None,
     }
-
-
 

--- a/migrations/087_add_premium_subscription_plan.sql
+++ b/migrations/087_add_premium_subscription_plan.sql
@@ -23,6 +23,7 @@ VALUES (
     500,
     true,
     jsonb_build_object(
+        'electronic_invoice_limit', 200,
         'electronic_invoices', '200 facturas electrónicas incluidas',
         'digital_signature', 'Firma digital incluida vía Matías API',
         'cost_control', 'Control de costos en tiempo real',

--- a/migrations/088_add_electronic_invoice_limit_feature.sql
+++ b/migrations/088_add_electronic_invoice_limit_feature.sql
@@ -1,0 +1,15 @@
+-- Migration 088: store electronic invoice entitlement as structured metadata
+--
+-- 087 added the plan, but existing environments may already have run it before
+-- the numeric entitlement key existed. Keep this idempotent.
+
+UPDATE subscription_plans
+SET
+    features = jsonb_set(
+        COALESCE(features, '{}'::jsonb),
+        '{electronic_invoice_limit}',
+        '200'::jsonb,
+        true
+    ),
+    updated_at = now()
+WHERE slug = 'facturacion-electronica';

--- a/tests/test_billing_permissions.py
+++ b/tests/test_billing_permissions.py
@@ -118,6 +118,57 @@ def test_owner_role_passes_billing_under_enforce():
     assert response.json()["level"] == "full"
 
 
+def test_owner_role_passes_remaining_usage_under_enforce():
+    """Owner reaches the remaining-usage handler under enforce mode."""
+    app, session = _build_app(role="owner")
+    fake_usage = {
+        "period_start": "2026-06-01T00:00:00+00:00",
+        "period_end": "2026-07-01T00:00:00+00:00",
+        "scan_usage": {
+            "used": 1,
+            "limit": 500,
+            "remaining": 499,
+            "period_start": "2026-06-01T00:00:00+00:00",
+            "period_end": "2026-07-01T00:00:00+00:00",
+        },
+        "electronic_invoice_usage": {
+            "used": 0,
+            "limit": 0,
+            "remaining": 0,
+            "period_start": "2026-06-01T00:00:00+00:00",
+            "period_end": "2026-07-01T00:00:00+00:00",
+        },
+    }
+
+    @asynccontextmanager
+    async def _enforce_db():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetchrow = AsyncMock(return_value=None)
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.routers.billing.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db), \
+         patch(
+             "app.routers.billing.billing_service.get_remaining_billing_usage",
+             new=AsyncMock(return_value=fake_usage),
+         ) as usage_mock, \
+         patch(
+             "app.routers.billing.get_db_connection",
+             side_effect=lambda use_transaction=True: _fake_db_ctx_returning("enforce"),
+         ):
+        client = TestClient(app)
+        response = client.get("/billing/remaining-usage")
+
+    assert response.status_code == 200
+    assert response.json()["scan_usage"]["remaining"] == 499
+    usage_mock.assert_awaited_once()
+    assert usage_mock.await_args.args[1] == session.tenant_id
+
+
 def test_cashier_role_denied_billing_under_enforce():
     """Cashier hits 403 before the handler runs — dependency rejects."""
     app, session = _build_app(role="cashier")

--- a/tests/test_billing_remaining_usage.py
+++ b/tests/test_billing_remaining_usage.py
@@ -11,6 +11,7 @@ from app.services import billing_service
 def _subscription_row(
     *,
     plan_slug: str,
+    plan_features=None,
     scans_used: int = 0,
     scans_limit: int = 500,
 ):
@@ -18,6 +19,7 @@ def _subscription_row(
         "current_period_start": datetime(2026, 6, 1, tzinfo=timezone.utc),
         "current_period_end": datetime(2026, 7, 1, tzinfo=timezone.utc),
         "plan_slug": plan_slug,
+        "plan_features": plan_features or {},
         "plan_scan_limit": scans_limit,
         "scans_used": scans_used,
         "scans_limit": scans_limit,
@@ -52,6 +54,27 @@ async def test_remaining_usage_non_fe_plan_reports_zero_invoice_quota():
     subscription_query = conn.fetchrow.await_args.args[0]
     assert "su.period_start <= now()" in subscription_query
     assert "su.period_end > now()" in subscription_query
+    assert "sp.features AS plan_features" in subscription_query
+    conn.fetchval.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_remaining_usage_non_fe_plan_ignores_invoice_feature_metadata():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value=_subscription_row(
+            plan_slug="pro",
+            plan_features={"electronic_invoice_limit": 200},
+        )
+    )
+    conn.fetchval = AsyncMock()
+
+    result = await billing_service.get_remaining_billing_usage(conn, tenant_id)
+
+    assert result["electronic_invoice_usage"]["used"] == 0
+    assert result["electronic_invoice_usage"]["limit"] == 0
+    assert result["electronic_invoice_usage"]["remaining"] == 0
     conn.fetchval.assert_not_awaited()
 
 
@@ -62,6 +85,7 @@ async def test_remaining_usage_fe_plan_counts_accepted_invoices_in_period():
     conn.fetchrow = AsyncMock(
         return_value=_subscription_row(
             plan_slug="facturacion-electronica",
+            plan_features={"electronic_invoice_limit": 200},
             scans_used=20,
             scans_limit=500,
         )
@@ -90,12 +114,32 @@ async def test_remaining_usage_fe_plan_counts_accepted_invoices_in_period():
 
 
 @pytest.mark.asyncio
+async def test_remaining_usage_fe_plan_reads_numeric_invoice_limit_from_features():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value=_subscription_row(
+            plan_slug="facturacion-electronica",
+            plan_features={"electronic_invoice_limit": "150"},
+        )
+    )
+    conn.fetchval = AsyncMock(return_value=12)
+
+    result = await billing_service.get_remaining_billing_usage(conn, tenant_id)
+
+    assert result["electronic_invoice_usage"]["used"] == 12
+    assert result["electronic_invoice_usage"]["limit"] == 150
+    assert result["electronic_invoice_usage"]["remaining"] == 138
+
+
+@pytest.mark.asyncio
 async def test_remaining_usage_caps_remaining_at_zero():
     tenant_id = uuid4()
     conn = MagicMock()
     conn.fetchrow = AsyncMock(
         return_value=_subscription_row(
             plan_slug="facturacion-electronica",
+            plan_features={"electronic_invoice_limit": 200},
             scans_used=550,
             scans_limit=500,
         )

--- a/tests/test_billing_remaining_usage.py
+++ b/tests/test_billing_remaining_usage.py
@@ -1,0 +1,120 @@
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.services import billing_service
+
+
+def _subscription_row(
+    *,
+    plan_slug: str,
+    scans_used: int = 0,
+    scans_limit: int = 500,
+):
+    return {
+        "current_period_start": datetime(2026, 6, 1, tzinfo=timezone.utc),
+        "current_period_end": datetime(2026, 7, 1, tzinfo=timezone.utc),
+        "plan_slug": plan_slug,
+        "plan_scan_limit": scans_limit,
+        "scans_used": scans_used,
+        "scans_limit": scans_limit,
+    }
+
+
+@pytest.mark.asyncio
+async def test_remaining_usage_non_fe_plan_reports_zero_invoice_quota():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value=_subscription_row(plan_slug="pro", scans_used=12, scans_limit=500)
+    )
+    conn.fetchval = AsyncMock()
+
+    result = await billing_service.get_remaining_billing_usage(conn, tenant_id)
+
+    assert result["scan_usage"] == {
+        "used": 12,
+        "limit": 500,
+        "remaining": 488,
+        "period_start": "2026-06-01T00:00:00+00:00",
+        "period_end": "2026-07-01T00:00:00+00:00",
+    }
+    assert result["electronic_invoice_usage"] == {
+        "used": 0,
+        "limit": 0,
+        "remaining": 0,
+        "period_start": "2026-06-01T00:00:00+00:00",
+        "period_end": "2026-07-01T00:00:00+00:00",
+    }
+    subscription_query = conn.fetchrow.await_args.args[0]
+    assert "su.period_start <= now()" in subscription_query
+    assert "su.period_end > now()" in subscription_query
+    conn.fetchval.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_remaining_usage_fe_plan_counts_accepted_invoices_in_period():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value=_subscription_row(
+            plan_slug="facturacion-electronica",
+            scans_used=20,
+            scans_limit=500,
+        )
+    )
+    conn.fetchval = AsyncMock(return_value=37)
+
+    result = await billing_service.get_remaining_billing_usage(conn, tenant_id)
+
+    assert result["electronic_invoice_usage"] == {
+        "used": 37,
+        "limit": 200,
+        "remaining": 163,
+        "period_start": "2026-06-01T00:00:00+00:00",
+        "period_end": "2026-07-01T00:00:00+00:00",
+    }
+
+    invoice_query, query_tenant_id, period_start, period_end = conn.fetchval.await_args.args
+    assert query_tenant_id == tenant_id
+    assert period_start == datetime(2026, 6, 1, tzinfo=timezone.utc)
+    assert period_end == datetime(2026, 7, 1, tzinfo=timezone.utc)
+    assert "tenant_id = $1" in invoice_query
+    assert "status = 'accepted'" in invoice_query
+    assert "document_type = 'invoice'" in invoice_query
+    assert "COALESCE(emitted_at, created_at) >= $2" in invoice_query
+    assert "COALESCE(emitted_at, created_at) < $3" in invoice_query
+
+
+@pytest.mark.asyncio
+async def test_remaining_usage_caps_remaining_at_zero():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value=_subscription_row(
+            plan_slug="facturacion-electronica",
+            scans_used=550,
+            scans_limit=500,
+        )
+    )
+    conn.fetchval = AsyncMock(return_value=220)
+
+    result = await billing_service.get_remaining_billing_usage(conn, tenant_id)
+
+    assert result["scan_usage"]["remaining"] == 0
+    assert result["electronic_invoice_usage"]["remaining"] == 0
+
+
+@pytest.mark.asyncio
+async def test_remaining_usage_missing_subscription_mirrors_subscription_endpoint():
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc:
+        await billing_service.get_remaining_billing_usage(conn, uuid4())
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Subscription not found"


### PR DESCRIPTION
## Summary
- add GET /billing/remaining-usage for current-period billing usage
- return scan and electronic invoice usage with used/limit/remaining/period fields
- count accepted invoice documents only for facturacion-electronica tenants

## Tests
- pytest tests/test_billing_remaining_usage.py tests/test_billing_permissions.py

Refs uno0uno/warocol.com#1343