### PR TITLE
Assign electronic invoice entitlement

### DIFF
--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 ELECTRONIC_INVOICE_PLAN_SLUG = "facturacion-electronica"
 ELECTRONIC_INVOICE_PERIOD_LIMIT = 200
+ELECTRONIC_INVOICE_LIMIT_FEATURE = "electronic_invoice_limit"
 
 
 async def check_scan_quota(tenant_id: UUID, conn) -> None:
@@ -296,6 +297,35 @@ def _serialize_plan(row) -> Dict[str, Any]:
         "created_at": row["created_at"].isoformat(),
         "updated_at": row["updated_at"].isoformat(),
     }
+
+
+def _jsonb_to_dict(value: Any) -> Dict[str, Any]:
+    if not value:
+        return {}
+    if isinstance(value, str):
+        return json.loads(value)
+    return dict(value)
+
+
+def _electronic_invoice_limit_for_plan(plan_slug: str, features: Any) -> int:
+    if plan_slug != ELECTRONIC_INVOICE_PLAN_SLUG:
+        return 0
+
+    plan_features = _jsonb_to_dict(features)
+    configured_limit = plan_features.get(ELECTRONIC_INVOICE_LIMIT_FEATURE)
+    if configured_limit is None:
+        return ELECTRONIC_INVOICE_PERIOD_LIMIT
+
+    try:
+        return max(int(configured_limit), 0)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid %s feature for plan=%s: %r",
+            ELECTRONIC_INVOICE_LIMIT_FEATURE,
+            plan_slug,
+            configured_limit,
+        )
+        return 0
 
 
 # ── Tenant subscription flows — issue #60 ────────────────────────────────────
@@ -621,6 +651,7 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
             ts.current_period_start,
             ts.current_period_end,
             sp.slug AS plan_slug,
+            sp.features AS plan_features,
             sp.scan_limit AS plan_scan_limit,
             COALESCE(su.scans_used, 0) AS scans_used,
             COALESCE(su.scans_limit, sp.scan_limit) AS scans_limit
@@ -643,10 +674,9 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
     scans_used = int(row["scans_used"] or 0)
     scans_limit = int(row["scans_limit"] or row["plan_scan_limit"] or 0)
 
-    invoice_limit = (
-        ELECTRONIC_INVOICE_PERIOD_LIMIT
-        if row["plan_slug"] == ELECTRONIC_INVOICE_PLAN_SLUG
-        else 0
+    invoice_limit = _electronic_invoice_limit_for_plan(
+        row["plan_slug"],
+        row["plan_features"],
     )
     invoice_used = 0
     if invoice_limit > 0:
@@ -1026,4 +1056,3 @@ async def mark_subscription_past_due(
         "tenant_name": tenant["name"] if tenant else "",
         "tenant_email": tenant["email"] if tenant else None,
     }
-

--- a/migrations/087_add_premium_subscription_plan.sql
+++ b/migrations/087_add_premium_subscription_plan.sql
@@ -23,6 +23,7 @@ VALUES (
     500,
     true,
     jsonb_build_object(
+        'electronic_invoice_limit', 200,
         'electronic_invoices', '200 facturas electrónicas incluidas',
         'digital_signature', 'Firma digital incluida vía Matías API',
         'cost_control', 'Control de costos en tiempo real',

--- a/migrations/088_add_electronic_invoice_limit_feature.sql
+++ b/migrations/088_add_electronic_invoice_limit_feature.sql
@@ -1,0 +1,15 @@
+-- Migration 088: store electronic invoice entitlement as structured metadata
+--
+-- 087 added the plan, but existing environments may already have run it before
+-- the numeric entitlement key existed. Keep this idempotent.
+
+UPDATE subscription_plans
+SET
+    features = jsonb_set(
+        COALESCE(features, '{}'::jsonb),
+        '{electronic_invoice_limit}',
+        '200'::jsonb,
+        true
+    ),
+    updated_at = now()
+WHERE slug = 'facturacion-electronica';

--- a/tests/test_billing_remaining_usage.py
+++ b/tests/test_billing_remaining_usage.py
@@ -11,6 +11,7 @@ from app.services import billing_service
 def _subscription_row(
     *,
     plan_slug: str,
+    plan_features=None,
     scans_used: int = 0,
     scans_limit: int = 500,
 ):
@@ -18,6 +19,7 @@ def _subscription_row(
         "current_period_start": datetime(2026, 6, 1, tzinfo=timezone.utc),
         "current_period_end": datetime(2026, 7, 1, tzinfo=timezone.utc),
         "plan_slug": plan_slug,
+        "plan_features": plan_features or {},
         "plan_scan_limit": scans_limit,
         "scans_used": scans_used,
         "scans_limit": scans_limit,
@@ -52,6 +54,27 @@ async def test_remaining_usage_non_fe_plan_reports_zero_invoice_quota():
     subscription_query = conn.fetchrow.await_args.args[0]
     assert "su.period_start <= now()" in subscription_query
     assert "su.period_end > now()" in subscription_query
+    assert "sp.features AS plan_features" in subscription_query
+    conn.fetchval.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_remaining_usage_non_fe_plan_ignores_invoice_feature_metadata():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value=_subscription_row(
+            plan_slug="pro",
+            plan_features={"electronic_invoice_limit": 200},
+        )
+    )
+    conn.fetchval = AsyncMock()
+
+    result = await billing_service.get_remaining_billing_usage(conn, tenant_id)
+
+    assert result["electronic_invoice_usage"]["used"] == 0
+    assert result["electronic_invoice_usage"]["limit"] == 0
+    assert result["electronic_invoice_usage"]["remaining"] == 0
     conn.fetchval.assert_not_awaited()
 
 
@@ -62,6 +85,7 @@ async def test_remaining_usage_fe_plan_counts_accepted_invoices_in_period():
     conn.fetchrow = AsyncMock(
         return_value=_subscription_row(
             plan_slug="facturacion-electronica",
+            plan_features={"electronic_invoice_limit": 200},
             scans_used=20,
             scans_limit=500,
         )
@@ -90,12 +114,32 @@ async def test_remaining_usage_fe_plan_counts_accepted_invoices_in_period():
 
 
 @pytest.mark.asyncio
+async def test_remaining_usage_fe_plan_reads_numeric_invoice_limit_from_features():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value=_subscription_row(
+            plan_slug="facturacion-electronica",
+            plan_features={"electronic_invoice_limit": "150"},
+        )
+    )
+    conn.fetchval = AsyncMock(return_value=12)
+
+    result = await billing_service.get_remaining_billing_usage(conn, tenant_id)
+
+    assert result["electronic_invoice_usage"]["used"] == 12
+    assert result["electronic_invoice_usage"]["limit"] == 150
+    assert result["electronic_invoice_usage"]["remaining"] == 138
+
+
+@pytest.mark.asyncio
 async def test_remaining_usage_caps_remaining_at_zero():
     tenant_id = uuid4()
     conn = MagicMock()
     conn.fetchrow = AsyncMock(
         return_value=_subscription_row(
             plan_slug="facturacion-electronica",
+            plan_features={"electronic_invoice_limit": 200},
             scans_used=550,
             scans_limit=500,
         )


### PR DESCRIPTION
## Summary
- Read electronic invoice quota from structured plan features for the FE plan
- Seed electronic_invoice_limit=200 for fresh and already-migrated environments
- Keep non-FE plans reporting invoice usage as 0/0/0

## Tests
- pytest tests/test_billing_remaining_usage.py tests/test_billing_activation.py

Refs uno0uno/warocol.com#1344

Stacked on #456.