### PR TITLE
Bloquear acceso para checkout pendiente de billing

### DIFF
--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -276,10 +276,10 @@ async def get_access_status(request: Request):
 
     Levels:
       free             — no subscription; limited free plan
-      full             — active or pending subscription
+      full             — active subscription
       full_with_warning — past_due, ≤ 3 days overdue
       read_only        — past_due, 3-7 days overdue
-      blocked          — past_due > 7 days, or cancelled/expired
+      blocked          — pending checkout, past_due > 7 days, or cancelled/expired
     """
     session = require_valid_session(request)
     async with get_db_connection(use_transaction=False) as conn:

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -825,10 +825,10 @@ class SubscriptionAccess:
 
     Levels:
       free             — no subscription row; default 1000 scans/month
-      full             — active or pending subscription
+      full             — active subscription
       full_with_warning — past_due, < 3 days overdue — access OK but banner shown
       read_only        — past_due, 3-7 days overdue — IA scanner blocked
-      blocked          — past_due > 7 days OR cancelled/expired
+      blocked          — pending checkout, past_due > 7 days, or cancelled/expired
     """
     level: str
     grace_days_remaining: int
@@ -862,13 +862,22 @@ async def get_subscription_access(tenant_id: UUID, conn) -> SubscriptionAccess:
     status = sub["status"]
     period_end = sub["current_period_end"]
 
-    if status in ("active", "pending"):
+    if status == "active":
         return SubscriptionAccess(
             level="full",
             grace_days_remaining=0,
             subscription_status=status,
             next_payment_date=period_end.date().isoformat() if period_end else None,
             message="Acceso completo.",
+        )
+
+    if status == "pending":
+        return SubscriptionAccess(
+            level="blocked",
+            grace_days_remaining=0,
+            subscription_status=status,
+            next_payment_date=None,
+            message="Completa el pago pendiente para activar tu suscripción.",
         )
 
     if status == "past_due":

--- a/tests/test_billing_subscription_access.py
+++ b/tests/test_billing_subscription_access.py
@@ -70,6 +70,45 @@ async def test_active_subscription_returns_full():
 
 
 @pytest.mark.asyncio
+async def test_pending_checkout_returns_blocked():
+    tenant_id = uuid4()
+    period_end = datetime.now(timezone.utc) + timedelta(days=20)
+    conn = _conn_with_subscription("pending", period_end)
+
+    access = await billing_service.get_subscription_access(tenant_id, conn)
+
+    assert access.level == "blocked"
+    assert access.subscription_status == "pending"
+    assert access.grace_days_remaining == 0
+    assert access.next_payment_date is None
+    assert "Completa el pago pendiente" in access.message
+
+
+@pytest.mark.asyncio
+async def test_cancelled_subscription_returns_blocked():
+    tenant_id = uuid4()
+    period_end = datetime.now(timezone.utc) + timedelta(days=20)
+    conn = _conn_with_subscription("cancelled", period_end)
+
+    access = await billing_service.get_subscription_access(tenant_id, conn)
+
+    assert access.level == "blocked"
+    assert access.subscription_status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_expired_subscription_returns_blocked():
+    tenant_id = uuid4()
+    period_end = datetime.now(timezone.utc) - timedelta(days=1)
+    conn = _conn_with_subscription("expired", period_end)
+
+    access = await billing_service.get_subscription_access(tenant_id, conn)
+
+    assert access.level == "blocked"
+    assert access.subscription_status == "expired"
+
+
+@pytest.mark.asyncio
 async def test_no_subscription_returns_free():
     tenant_id = uuid4()
     conn = MagicMock()


### PR DESCRIPTION
## Summary
- Treat pending billing checkouts as blocked access instead of full access.
- Keep active and past_due grace behavior unchanged.
- Add access tests for pending, cancelled, and expired subscriptions.

## Tests
- pytest tests/test_billing_subscription_access.py tests/test_billing_permissions.py tests/test_notifications_terms_reminder.py

Closes #458