### PR TITLE
Fix billing activation period timestamp cast

### DIFF
--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -497,8 +497,8 @@ async def _activate_subscription_with_period(
     updated = await conn.fetchrow("""
         UPDATE tenant_subscriptions
         SET status               = 'active',
-            current_period_start = $3,
-            current_period_end   = $3 + CASE
+            current_period_start = $3::timestamptz,
+            current_period_end   = $3::timestamptz + CASE
                 WHEN $2::text = 'monthly' THEN interval '1 month'
                 ELSE interval '1 year'
             END,

--- a/tests/test_billing_activation.py
+++ b/tests/test_billing_activation.py
@@ -26,6 +26,8 @@ def _conn_with_activation(
         if "FROM tenant_subscriptions ts" in sql:
             return sub_row
         if "UPDATE tenant_subscriptions" in sql:
+            assert "current_period_start = $3::timestamptz" in sql
+            assert "current_period_end = $3::timestamptz + CASE" in sql
             assert args[1] in ("monthly", "annual")
             if period_anchor is not None:
                 assert args[2] == period_anchor


### PR DESCRIPTION
## Summary\n- cast the payment period anchor parameter as timestamptz in subscription activation SQL\n- add a regression assertion so asyncpg does not infer the anchor as interval\n\n## Tests\n- pytest tests/test_billing_activation.py tests/test_billing_subscription_access.py tests/test_billing_payment_failure.py