### PR TITLE
Support finalizing pending delivery sales

### DIFF
--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -338,7 +338,9 @@ async def get_order(
 
 class UpdateOrderStatusRequest(BaseModel):
     status: str = Field(..., description="completed | cancelled | pending")
-    payment_method: Optional[str] = Field(None, description="cash | card | digital")
+    payment_method: Optional[str] = Field(None, description="Payment method group slug")
+    payment_method_id: Optional[str] = Field(None, description="UUID of the selected payment_methods row")
+    customer_id: Optional[str] = Field(None, description="UUID of customer to associate when required by payment method")
 
 
 class BulkUpdateStatusRequest(BaseModel):
@@ -374,7 +376,14 @@ async def update_order_status(
     """
     Update the status of a mesa order. Also accepts payment_method when completing.
     """
-    return await orders_service.update_order_status(request, order_id, body.status, body.payment_method)
+    return await orders_service.update_order_status(
+        request,
+        order_id,
+        body.status,
+        body.payment_method,
+        body.payment_method_id,
+        body.customer_id,
+    )
 
 
 @router.get("/{order_id}/items", dependencies=[Depends(require_module(Module.VENTAS))])

--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -202,7 +202,7 @@ async def clear_cart(
 
 
 class CompleteOrderRequest(BaseModel):
-    payment_method: str = Field(..., description="Payment method: cash, card, digital, credit")
+    payment_method: Optional[str] = Field(None, description="Payment method: cash, card, digital, credit. May be omitted only for delivery orders that remain pending until payment is known.")
     customer_id: UUID = Field(..., description="Customer ID to associate with the order")
     credit_due_date: Optional[date] = Field(None, description="Optional due date for credit orders (only used when payment_method='credit')")
     payment_method_id: Optional[UUID] = Field(None, description="UUID of the selected payment_methods row (nullable if group-level only)")
@@ -235,6 +235,7 @@ async def complete_order(
     Complete POS order:
     - Associates customer with cart (if not already)
     - Creates order record
+    - Delivery orders may be left pending when payment_method is omitted
     - Copies cart items to order_items
     - Updates inventory
     - Marks cart as completed

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -975,7 +975,8 @@ async def bulk_update_order_status(
 
                 # Stock
                 if old_status != 'completed' and status == 'completed':
-                    await _deduct_stock_for_status_update(conn, order_id_row, tenant_id, user_id, order_number)
+                    if not (row['pos_cart_id'] and old_status == 'pending'):
+                        await _deduct_stock_for_status_update(conn, order_id_row, tenant_id, user_id, order_number)
                     newly_completed_order_ids.append(order_id_row)
                 elif old_status == 'completed' and status in ('cancelled', 'pending'):
                     await _return_stock_for_order_cancellation(conn, order_id_row, tenant_id, user_id, order_number)
@@ -1059,6 +1060,8 @@ async def update_order_status(
     order_id: UUID,
     status: str,
     payment_method: Optional[str] = None,
+    payment_method_id: Optional[str] = None,
+    customer_id: Optional[str] = None,
 ) -> dict:
     """Update the status of an order (mesa orders only)."""
     allowed = {"completed", "cancelled", "pending", "preparing"}
@@ -1074,7 +1077,8 @@ async def update_order_status(
 
         async with get_db_connection() as conn:
             row = await conn.fetchrow(
-                """SELECT id, status, order_number, table_session_id, pos_cart_id, payment_status, order_date
+                """SELECT id, status, order_number, table_session_id, pos_cart_id,
+                          payment_status, order_date, total_amount, customer_id
                    FROM orders WHERE id = $1 AND tenant_id = $2""",
                 order_id, tenant_id
             )
@@ -1094,13 +1098,85 @@ async def update_order_status(
                     status_code=400
                 )
 
+            pmid = UUID(payment_method_id) if payment_method_id else None
+            cid = UUID(customer_id) if customer_id else row["customer_id"]
+
+            if payment_method_id and not payment_method:
+                raise APIError("payment_method es requerido cuando se envía payment_method_id", status_code=400)
+
+            if status == "completed" and not payment_method:
+                raise APIError("Selecciona un método de pago para completar la orden", status_code=400)
+
+            if payment_method:
+                group_row = await conn.fetchrow(
+                    """
+                    SELECT id
+                    FROM payment_method_groups
+                    WHERE tenant_id = $1
+                      AND slug = $2
+                    """,
+                    tenant_id,
+                    payment_method,
+                )
+                if payment_method_id:
+                    if not group_row:
+                        raise APIError(
+                            f"Método de pago '{payment_method}' no es válido para este restaurante.",
+                            status_code=400,
+                        )
+                    method_row = await conn.fetchrow(
+                        """
+                        SELECT id
+                        FROM payment_methods
+                        WHERE id = $1
+                          AND tenant_id = $2
+                          AND group_id = $3
+                          AND is_active = true
+                        """,
+                        pmid,
+                        tenant_id,
+                        group_row["id"],
+                    )
+                    if not method_row:
+                        raise APIError("El método seleccionado no pertenece al grupo elegido.", status_code=400)
+
+                if payment_method == "customer_wallet" and not cid:
+                    raise APIError("La billetera requiere un cliente identificado", status_code=400)
+
+                if payment_method == "customer_wallet" and cid:
+                    from app.services.customer_wallet_service import assert_wallet_customer_identified
+
+                    await assert_wallet_customer_identified(conn, cid)
+
+            payment_status_update = None
+            if status == "completed" and payment_method:
+                payment_status_update = "credit" if payment_method == "credit" else "paid"
+
             await conn.execute(
                 """UPDATE orders
                    SET status = $1,
-                       payment_method = COALESCE($2, payment_method)
+                       payment_method = COALESCE($2, payment_method),
+                       payment_method_id = CASE WHEN $2::text IS NULL THEN payment_method_id ELSE $4::uuid END,
+                       customer_id = COALESCE($5, customer_id),
+                       payment_status = COALESCE($6, payment_status)
                    WHERE id = $3""",
-                status, payment_method, order_id
+                status, payment_method, order_id, pmid, cid, payment_status_update
             )
+
+            if status == "completed" and payment_method == "customer_wallet" and cid:
+                from app.services.customer_wallet_service import apply_wallet_for_order
+
+                if old_status != "completed":
+                    amount_cop = Decimal(str(row["total_amount"]))
+                    if amount_cop > 0:
+                        await apply_wallet_for_order(
+                            conn,
+                            cid,
+                            tenant_id,
+                            amount_cop,
+                            order_id,
+                            user_id,
+                        )
 
             # If cancelling a credit order, clear payment_status so it leaves cartera
             if status == 'cancelled' and row['payment_status'] in ('credit', 'partial'):
@@ -1112,7 +1188,49 @@ async def update_order_status(
             # Stock adjustment based on transition
             if old_status != status:
                 if old_status != 'completed' and status == 'completed':
-                    await _deduct_stock_for_status_update(conn, order_id, tenant_id, user_id, order_number)
+                    if not (row['pos_cart_id'] and old_status == 'pending'):
+                        await _deduct_stock_for_status_update(conn, order_id, tenant_id, user_id, order_number)
+                    try:
+                        completed_order = await conn.fetchrow(
+                            """
+                            SELECT id, order_number, total_amount, payment_method,
+                                   payment_method_id, order_date, tip_amount, tip_tax_amount
+                            FROM orders
+                            WHERE id = $1 AND tenant_id = $2 AND status = 'completed'
+                            """,
+                            order_id,
+                            tenant_id,
+                        )
+                        if completed_order:
+                            order_date = completed_order["order_date"]
+                            gl_order_date = (
+                                order_date.astimezone(_BOG).date()
+                                if order_date.tzinfo
+                                else order_date.date()
+                            )
+                            tax_config = await _get_tenant_tax_config(conn, tenant_id)
+                            await _post_order_gl_entry(
+                                conn=conn,
+                                tenant_id=tenant_id,
+                                order_id=completed_order["id"],
+                                order_date=gl_order_date,
+                                total_amount=Decimal(str(completed_order["total_amount"])),
+                                payment_method=completed_order["payment_method"] or payment_method,
+                                payment_method_id=completed_order["payment_method_id"],
+                                tax_config=tax_config,
+                                order_number=int(completed_order["order_number"]),
+                                tip_amount=Decimal(str(completed_order["tip_amount"] or 0)),
+                                tip_tax_amount=Decimal(str(completed_order["tip_tax_amount"] or 0)),
+                            )
+                            await _post_order_cogs_gl_entry(
+                                conn=conn,
+                                tenant_id=tenant_id,
+                                order_id=completed_order["id"],
+                                order_date=gl_order_date,
+                                order_number=int(completed_order["order_number"]),
+                            )
+                    except Exception as gl_exc:
+                        logger.error(f"GL entries failed for order status update: {gl_exc}")
                 elif old_status == 'completed' and status in ('cancelled', 'pending'):
                     await _return_stock_for_order_cancellation(conn, order_id, tenant_id, user_id, order_number)
 

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -1655,7 +1655,7 @@ async def void_order_payment(
 async def complete_pos_order(
     request: Request,
     cart_id: UUID,
-    payment_method: str,
+    payment_method: Optional[str],
     customer_id: UUID,
     credit_due_date: Optional[date] = None,
     payment_method_id: Optional[UUID] = None,
@@ -1740,6 +1740,19 @@ async def complete_pos_order(
 
         async with get_db_connection() as conn:
             async with conn.transaction():
+                pending_without_payment = payment_method is None
+                if pending_without_payment:
+                    if delivery_address_id is None:
+                        raise APIError("payment_method es requerido para ventas que no son domicilio", status_code=400)
+                    if split_mode:
+                        raise APIError("El cobro dividido requiere método de pago", status_code=400)
+                    if payment_method_id is not None:
+                        raise APIError("payment_method_id no aplica cuando la venta queda pendiente", status_code=400)
+                    if credit_due_date is not None:
+                        raise APIError("credit_due_date requiere método de pago a crédito", status_code=400)
+                    if cash_received is not None or split_first_cash_received is not None:
+                        raise APIError("El efectivo recibido requiere método de pago en efectivo", status_code=400)
+
                 # 0. Backend guard: credit / wallet require an identified (non-anonymous) customer
                 if payment_method in ('credit', WALLET_PAYMENT_SLUG):
                     customer_check = await conn.fetchrow(
@@ -1808,8 +1821,13 @@ async def complete_pos_order(
                 )
 
                 # 3. Create order record (use customer_id from parameter)
-                # Compute payment_status
-                if split_mode:
+                # Compute order/payment status. Delivery orders can be dispatched
+                # before payment is known; accounting is posted only when later
+                # finalized from /ventas/:id.
+                order_status = 'pending' if pending_without_payment else 'completed'
+                if pending_without_payment:
+                    payment_status = None
+                elif split_mode:
                     payment_status = 'partial'
                 elif payment_method == 'credit':
                     payment_status = 'credit'
@@ -1892,7 +1910,7 @@ async def complete_pos_order(
                         tip_amount, tip_source,
                         tip_taxable, tip_tax_amount
                     )
-                    VALUES ($1, $2, $3, $4, $5, NOW(), $6, 'completed', $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
+                    VALUES ($1, $2, $3, $4, $5, NOW(), $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)
                     RETURNING id, order_number, created_at
                 """
                 order_row = await conn.fetchrow(
@@ -1903,6 +1921,7 @@ async def complete_pos_order(
                     payment_method,
                     cart_id,
                     _discounted_total,
+                    order_status,
                     payment_status,
                     credit_due_date,
                     payment_method_id,
@@ -2272,7 +2291,7 @@ async def complete_pos_order(
                         )
                     # Mostrador/delivery: auto-deliver after checkout. Barra: kitchen
                     # closes comandas manually (warocol.com#799).
-                    if not _is_bar_sale:
+                    if order_status == 'completed' and not _is_bar_sale:
                         try:
                             await finalize_open_comandas(conn, order_id, tenant_id)
                         except Exception as _ce:
@@ -2283,41 +2302,42 @@ async def complete_pos_order(
                 # Tax config — fetched once, used for GL entry and receipt breakdown
                 tax_config = await _get_tenant_tax_config(conn, tenant_id)
 
-                # GL journal entry — failure never blocks order completion
-                try:
-                    _gl_tip = Decimal("0")
-                    _gl_tip_tax = Decimal("0")
-                    if not split_mode or _split_is_complete:
-                        _gl_tip = Decimal(str(tip_amount))
-                        _gl_tip_tax = Decimal(str(_tip_tax_amount))
-                    await _post_order_gl_entry(
-                        conn=conn,
-                        tenant_id=tenant_id,
-                        order_id=order_id,
-                        order_date=order_row['created_at'].astimezone(_BOG).date(),
-                        total_amount=Decimal(str(_discounted_total)),
-                        payment_method=payment_method,
-                        payment_method_id=payment_method_id,
-                        tax_config=tax_config,
-                        order_number=int(order_number),
-                        tip_amount=_gl_tip,
-                        tip_tax_amount=_gl_tip_tax,
-                    )
-                except Exception as e:
-                    logger.error(f"GL entry failed for POS order {order_id}: {e}")
-                    # Do NOT re-raise — order completes regardless
+                if order_status == 'completed':
+                    # GL journal entry — failure never blocks order completion
+                    try:
+                        _gl_tip = Decimal("0")
+                        _gl_tip_tax = Decimal("0")
+                        if not split_mode or _split_is_complete:
+                            _gl_tip = Decimal(str(tip_amount))
+                            _gl_tip_tax = Decimal(str(_tip_tax_amount))
+                        await _post_order_gl_entry(
+                            conn=conn,
+                            tenant_id=tenant_id,
+                            order_id=order_id,
+                            order_date=order_row['created_at'].astimezone(_BOG).date(),
+                            total_amount=Decimal(str(_discounted_total)),
+                            payment_method=payment_method,
+                            payment_method_id=payment_method_id,
+                            tax_config=tax_config,
+                            order_number=int(order_number),
+                            tip_amount=_gl_tip,
+                            tip_tax_amount=_gl_tip_tax,
+                        )
+                    except Exception as e:
+                        logger.error(f"GL entry failed for POS order {order_id}: {e}")
+                        # Do NOT re-raise — order completes regardless
 
-                # COGS GL entry — DR 6135 Costo de ventas / CR 1435 Inventarios
-                try:
-                    await _post_order_cogs_gl_entry(
-                        conn=conn,
-                        tenant_id=tenant_id,
-                        order_id=order_id,
-                        order_date=order_row['created_at'].astimezone(_BOG).date(),
-                        order_number=int(order_number),
-                    )
-                except Exception as e:
-                    logger.error(f"COGS GL entry failed for POS order {order_id}: {e}")
+                    # COGS GL entry — DR 6135 Costo de ventas / CR 1435 Inventarios
+                    try:
+                        await _post_order_cogs_gl_entry(
+                            conn=conn,
+                            tenant_id=tenant_id,
+                            order_id=order_id,
+                            order_date=order_row['created_at'].astimezone(_BOG).date(),
+                            order_number=int(order_number),
+                        )
+                    except Exception as e:
+                        logger.error(f"COGS GL entry failed for POS order {order_id}: {e}")
 
                 # Compute tax breakdown for receipt display
                 _standard_tax = 0.0
@@ -2368,9 +2388,10 @@ async def complete_pos_order(
                 _order_date = order_row['created_at']
                 _order_number = int(order_number)
                 _total_amount = float(_discounted_total)
+                _order_status = order_status
                 _result = {
                     "success": True,
-                    "message": "Order completed successfully",
+                    "message": "Order saved as pending" if order_status == 'pending' else "Order completed successfully",
                     "data": {
                         "order_id": str(order_id),
                         "order_number": int(order_number),
@@ -2384,6 +2405,7 @@ async def complete_pos_order(
                         ),
                         "payment_method": payment_method,
                         "payment_status": payment_status,
+                        "status": order_status,
                         "credit_due_date": str(credit_due_date) if credit_due_date is not None else None,
                         "items_count": len(items),
                         "created_at": order_row['created_at'].isoformat(),
@@ -2403,7 +2425,7 @@ async def complete_pos_order(
 
         # Award waros AFTER the transaction commits — avoids race condition where
         # create_task runs at an await point inside the transaction before commit.
-        if _customer_id:
+        if _order_status == 'completed' and _customer_id:
             try:
                 asyncio.create_task(
                     evaluate_and_award(_order_id, _customer_id, _tenant_id)
@@ -2412,7 +2434,7 @@ async def complete_pos_order(
                 logger.warning(f"Could not schedule waros evaluation: {_waros_err}")
 
         # Send receipt email if requested — fire-and-forget, never blocks or fails the order
-        if receipt_email:
+        if _order_status == 'completed' and receipt_email:
             try:
                 # Look up tenant public profile for business branding in the receipt
                 _business_name = None

--- a/tests/test_manual_order_gl_cogs.py
+++ b/tests/test_manual_order_gl_cogs.py
@@ -40,6 +40,96 @@ def _manual_order_conn(order_id, order_item_id, order_date):
     return conn
 
 
+@pytest.mark.asyncio
+async def test_update_order_status_finalizes_pending_pos_with_gl_cogs_without_double_stock():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    order_id = uuid4()
+    pos_cart_id = uuid4()
+    customer_id = uuid4()
+    payment_method_id = uuid4()
+    group_id = uuid4()
+    order_date = datetime(2026, 6, 16, 14, 30)
+
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {
+                "id": order_id,
+                "status": "pending",
+                "order_number": 8521,
+                "table_session_id": None,
+                "pos_cart_id": pos_cart_id,
+                "payment_status": None,
+                "order_date": order_date,
+                "total_amount": 42000,
+                "customer_id": customer_id,
+            },
+            {"id": group_id},
+            {"id": payment_method_id},
+            {
+                "id": order_id,
+                "order_number": 8521,
+                "total_amount": 42000,
+                "payment_method": "card",
+                "payment_method_id": payment_method_id,
+                "order_date": order_date,
+                "tip_amount": 0,
+                "tip_tax_amount": 0,
+            },
+        ]
+    )
+    conn.execute = AsyncMock()
+
+    deduct_stock = AsyncMock()
+    post_gl = AsyncMock()
+    post_cogs = AsyncMock()
+
+    with patch(
+        "app.services.orders_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id, user_id=user_id),
+    ), patch(
+        "app.services.orders_service.get_db_connection",
+        return_value=_AsyncContext(conn),
+    ), patch(
+        "app.services.orders_service.assert_order_not_in_closed_monthly_period",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.orders_service._deduct_stock_for_status_update",
+        new=deduct_stock,
+    ), patch(
+        "app.services.orders_service._get_tenant_tax_config",
+        new=AsyncMock(return_value={"inc_enabled": True}),
+    ), patch(
+        "app.services.orders_service._post_order_gl_entry",
+        new=post_gl,
+    ), patch(
+        "app.services.orders_service._post_order_cogs_gl_entry",
+        new=post_cogs,
+    ):
+        result = await orders_service.update_order_status(
+            Request({"type": "http"}),
+            order_id,
+            "completed",
+            "card",
+            str(payment_method_id),
+        )
+
+    assert result["success"] is True
+    deduct_stock.assert_not_awaited()
+    post_gl.assert_awaited_once()
+    assert post_gl.await_args.kwargs["order_id"] == order_id
+    assert post_gl.await_args.kwargs["payment_method"] == "card"
+    assert post_gl.await_args.kwargs["payment_method_id"] == payment_method_id
+    post_cogs.assert_awaited_once_with(
+        conn=conn,
+        tenant_id=tenant_id,
+        order_id=order_id,
+        order_date=date(2026, 6, 16),
+        order_number=8521,
+    )
+
+
 def test_manual_order_modifier_quantity_defaults_to_one():
     modifier = ManualOrderModifier(id=str(uuid4()), name="Extra queso", price=2500)
 


### PR DESCRIPTION
## Summary\n- allow POS delivery orders to be saved pending when payment method is unknown\n- finalize pending orders with payment method/submethod capture\n- post the same order GL and COGS entries when pending sales become completed\n\n## Tests\n- python3 -m py_compile app/routers/pos_cart.py app/services/pos_cart_service.py app/routers/orders.py app/services/orders_service.py\n- pytest tests/test_manual_order_gl_cogs.py tests/test_online_order_payment_capture.py -q\n\nRefs uno0uno/warocol.com#1353\n\nCompanion front PR: uno0uno/warocol.com#1354