### PR TITLE
Protect pending sale inventory finalization

### DIFF
--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -56,6 +56,12 @@ class TabAddRequest(BaseModel):
     items: List[TabItem] = Field(..., min_length=1)
 
 
+class TabDeferDeliveryPaymentRequest(BaseModel):
+    customer_id: UUID = Field(..., description="Identified customer that owns the delivery address")
+    delivery_address_id: UUID = Field(..., description="Delivery address owned by customer_id")
+    delivery_instructions: Optional[str] = Field(None, description="Optional delivery notes")
+
+
 class UpdateTabItemRequest(BaseModel):
     quantity: int = Field(..., ge=1)
     reason: Optional[str] = Field(
@@ -312,6 +318,25 @@ async def add_tab_items(request: Request, table_id: UUID, body: TabAddRequest):
         for item in body.items
     ]
     return await tables_service.add_tab_items(request, table_id, items)
+
+
+@router.post("/{table_id}/tab/defer-delivery-payment", dependencies=[Depends(require_module(Module.POS))])
+async def defer_tab_delivery_payment(
+    request: Request,
+    table_id: UUID,
+    body: TabDeferDeliveryPaymentRequest,
+):
+    """
+    Convert the open bar tab into a delivery order that remains pending until
+    the payment method is known.
+    """
+    return await tables_service.defer_tab_delivery_payment(
+        request,
+        table_id,
+        body.customer_id,
+        body.delivery_address_id,
+        body.delivery_instructions,
+    )
 
 
 class RemoveTabItemRequest(BaseModel):

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -1075,6 +1075,9 @@ async def update_order_status(
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
 
+        waros_award_order_id = None
+        waros_award_customer_id = None
+
         async with get_db_connection() as conn:
             row = await conn.fetchrow(
                 """SELECT id, status, order_number, table_session_id, pos_cart_id,
@@ -1212,7 +1215,14 @@ async def update_order_status(
             # Stock adjustment based on transition
             if old_status != status:
                 if old_status != 'completed' and status == 'completed':
-                    if not (row['pos_cart_id'] and old_status == 'pending'):
+                    inventory_already_consumed = await _order_inventory_already_consumed_before_completion(
+                        conn,
+                        row=row,
+                        order_id=order_id,
+                        tenant_id=tenant_id,
+                        old_status=old_status,
+                    )
+                    if not inventory_already_consumed:
                         await _deduct_stock_for_status_update(conn, order_id, tenant_id, user_id, order_number)
                     try:
                         completed_order = await conn.fetchrow(
@@ -1226,6 +1236,9 @@ async def update_order_status(
                             tenant_id,
                         )
                         if completed_order:
+                            if cid:
+                                waros_award_order_id = completed_order["id"]
+                                waros_award_customer_id = cid
                             order_date = completed_order["order_date"]
                             gl_order_date = (
                                 order_date.astimezone(_BOG).date()
@@ -1292,6 +1305,14 @@ async def update_order_status(
                 except Exception as _fe:
                     logger.error(f"Auto-fire failed for manual order {order_id} (preparing): {_fe}")
 
+        if waros_award_order_id and waros_award_customer_id:
+            try:
+                asyncio.create_task(
+                    evaluate_and_award(waros_award_order_id, waros_award_customer_id, tenant_id)
+                )
+            except Exception as _waros_err:
+                logger.warning(f"Could not schedule waros evaluation: {_waros_err}")
+
         return {"success": True, "message": f"Estado actualizado a {status}"}
 
     except (AuthenticationError, APIError) as e:
@@ -1299,6 +1320,39 @@ async def update_order_status(
     except Exception as e:
         logger.error(f"Error updating order status: {str(e)}")
         raise APIError(f"Error al actualizar estado: {str(e)}", status_code=500)
+
+
+async def _order_inventory_already_consumed_before_completion(
+    conn,
+    *,
+    row,
+    order_id: UUID,
+    tenant_id: UUID,
+    old_status: str,
+) -> bool:
+    """Return true when a pending order already consumed inventory at creation time."""
+    if old_status != "pending":
+        return False
+    if row["pos_cart_id"]:
+        return True
+    if not row["table_session_id"]:
+        return False
+
+    return bool(await conn.fetchval(
+        """
+        SELECT EXISTS (
+            SELECT 1
+            FROM tenant_ingredient_movements
+            WHERE tenant_id = $1
+              AND reference_table = 'orders'
+              AND reference_id = $2
+              AND movement_type = 'consumption'
+              AND quantity_change < 0
+        )
+        """,
+        tenant_id,
+        order_id,
+    ))
 
 
 async def get_order_items(

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -1773,6 +1773,132 @@ async def add_session_payment(
         raise APIError(f"Error adding session payment: {e}", status_code=500)
 
 
+async def defer_tab_delivery_payment(
+    request: Request,
+    table_id: UUID,
+    customer_id: UUID,
+    delivery_address_id: UUID,
+    delivery_instructions: Optional[str] = None,
+) -> dict:
+    """
+    Assign customer and delivery metadata to the open bar tab without posting
+    payment/accounting yet. The order stays pending and is finalized later from
+    /ventas when the courier knows the tender.
+    """
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    instructions = (delivery_instructions or "").strip() or None
+
+    async with get_db_connection() as conn:
+        async with conn.transaction():
+            session_row = await conn.fetchrow(
+                """
+                SELECT ts.id AS session_id, t.id AS table_id, t.is_bar, t.name AS table_name
+                  FROM table_sessions ts
+                  JOIN tables t ON t.id = ts.table_id
+                 WHERE ts.table_id = $1
+                   AND ts.tenant_id = $2
+                   AND ts.closed_at IS NULL
+                """,
+                table_id,
+                tenant_id,
+            )
+            if not session_row:
+                raise NotFoundError("No hay una cuenta abierta para esta barra")
+            if not session_row["is_bar"]:
+                raise APIError("Esta acción solo aplica para barra", status_code=400)
+
+            customer_phone = await conn.fetchval(
+                "SELECT phone_number FROM profile WHERE id = $1",
+                customer_id,
+            )
+            if customer_phone is None:
+                raise NotFoundError("Cliente no encontrado")
+            if customer_phone == "0000000000":
+                raise APIError(
+                    "El domicilio requiere un cliente identificado (no anónimo)",
+                    status_code=400,
+                )
+
+            address_ok = await conn.fetchval(
+                """
+                SELECT 1
+                  FROM addresses_profile
+                 WHERE id = $1
+                   AND user_id = $2
+                   AND deleted_at IS NULL
+                """,
+                delivery_address_id,
+                customer_id,
+            )
+            if not address_ok:
+                raise APIError(
+                    "Dirección de entrega no válida o no pertenece al cliente",
+                    status_code=400,
+                )
+
+            order_row = await conn.fetchrow(
+                """
+                UPDATE orders
+                   SET customer_id = $1,
+                       delivery_address_id = $2,
+                       delivery_instructions = $3,
+                       payment_method = NULL,
+                       payment_method_id = NULL,
+                       payment_status = NULL
+                 WHERE id = (
+                       SELECT id
+                         FROM orders
+                        WHERE table_session_id = $4
+                          AND tenant_id = $5
+                          AND status = 'pending'
+                        ORDER BY order_date ASC
+                        LIMIT 1
+                 )
+                RETURNING id, order_number, total_amount, status, payment_status
+                """,
+                customer_id,
+                delivery_address_id,
+                instructions,
+                session_row["session_id"],
+                tenant_id,
+            )
+            if not order_row:
+                raise APIError("No hay productos pendientes en esta cuenta", status_code=400)
+
+            await conn.execute(
+                "UPDATE table_sessions SET closed_at = now() WHERE id = $1",
+                session_row["session_id"],
+            )
+            new_session_row = await conn.fetchrow(
+                """
+                INSERT INTO table_sessions (table_id, tenant_id, opened_by_user_id)
+                VALUES ($1, $2, NULL)
+                RETURNING id
+                """,
+                table_id,
+                tenant_id,
+            )
+
+    return {
+        "success": True,
+        "message": "Venta guardada como pendiente",
+        "data": {
+            "order_id": str(order_row["id"]),
+            "order_number": order_row["order_number"],
+            "total_amount": float(order_row["total_amount"]),
+            "status": order_row["status"],
+            "payment_status": order_row["payment_status"],
+            "payment_method": None,
+            "delivery_address_id": str(delivery_address_id),
+            "next_table_session_id": str(new_session_row["id"]),
+        },
+    }
+
+
 async def get_current_session(request: Request, table_id: UUID) -> dict:
     """
     Get the open session for a table with all linked orders and running total.

--- a/tests/test_manual_order_gl_cogs.py
+++ b/tests/test_manual_order_gl_cogs.py
@@ -108,7 +108,13 @@ async def test_update_order_status_finalizes_pending_pos_with_gl_cogs_without_do
     ), patch(
         "app.services.orders_service._post_order_cogs_gl_entry",
         new=post_cogs,
-    ):
+    ), patch(
+        "app.services.orders_service.evaluate_and_award",
+        new=MagicMock(return_value=object()),
+    ) as award_waros, patch(
+        "app.services.orders_service.asyncio.create_task",
+        new=MagicMock(),
+    ) as create_task:
         result = await orders_service.update_order_status(
             Request({"type": "http"}),
             order_id,
@@ -134,6 +140,187 @@ async def test_update_order_status_finalizes_pending_pos_with_gl_cogs_without_do
         order_date=date(2026, 6, 16),
         order_number=8521,
     )
+    award_waros.assert_called_once_with(order_id, customer_id, tenant_id)
+    create_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_update_order_status_finalizes_pending_table_with_gl_cogs_without_double_stock():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    order_id = uuid4()
+    table_session_id = uuid4()
+    customer_id = uuid4()
+    payment_method_id = uuid4()
+    group_id = uuid4()
+    order_date = datetime(2026, 6, 16, 14, 30)
+
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {
+                "id": order_id,
+                "status": "pending",
+                "order_number": 8522,
+                "table_session_id": table_session_id,
+                "pos_cart_id": None,
+                "payment_status": None,
+                "order_date": order_date,
+                "total_amount": 52000,
+                "customer_id": customer_id,
+            },
+            {"id": group_id},
+            {"id": payment_method_id},
+            {
+                "id": order_id,
+                "order_number": 8522,
+                "total_amount": 52000,
+                "payment_method": "card",
+                "payment_method_id": payment_method_id,
+                "order_date": order_date,
+                "tip_amount": 0,
+                "tip_tax_amount": 0,
+            },
+        ]
+    )
+    conn.fetchval = AsyncMock(return_value=True)
+    conn.execute = AsyncMock()
+
+    deduct_stock = AsyncMock()
+    post_gl = AsyncMock()
+    post_cogs = AsyncMock()
+
+    with patch(
+        "app.services.orders_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id, user_id=user_id),
+    ), patch(
+        "app.services.orders_service.get_db_connection",
+        return_value=_AsyncContext(conn),
+    ), patch(
+        "app.services.orders_service.assert_order_not_in_closed_monthly_period",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.orders_service._deduct_stock_for_status_update",
+        new=deduct_stock,
+    ), patch(
+        "app.services.orders_service._get_tenant_tax_config",
+        new=AsyncMock(return_value={"inc_enabled": True}),
+    ), patch(
+        "app.services.orders_service._post_order_gl_entry",
+        new=post_gl,
+    ), patch(
+        "app.services.orders_service._post_order_cogs_gl_entry",
+        new=post_cogs,
+    ), patch(
+        "app.services.orders_service.evaluate_and_award",
+        new=MagicMock(return_value=object()),
+    ) as award_waros, patch(
+        "app.services.orders_service.asyncio.create_task",
+        new=MagicMock(),
+    ) as create_task:
+        result = await orders_service.update_order_status(
+            Request({"type": "http"}),
+            order_id,
+            "completed",
+            "card",
+            str(payment_method_id),
+        )
+
+    assert result["success"] is True
+    conn.fetchval.assert_awaited_once()
+    deduct_stock.assert_not_awaited()
+    post_gl.assert_awaited_once()
+    post_cogs.assert_awaited_once_with(
+        conn=conn,
+        tenant_id=tenant_id,
+        order_id=order_id,
+        order_date=date(2026, 6, 16),
+        order_number=8522,
+    )
+    award_waros.assert_called_once_with(order_id, customer_id, tenant_id)
+    create_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_update_order_status_deducts_stock_for_pending_table_without_consumption_movements():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    order_id = uuid4()
+    table_session_id = uuid4()
+    customer_id = uuid4()
+    group_id = uuid4()
+    order_date = datetime(2026, 6, 16, 14, 30)
+
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {
+                "id": order_id,
+                "status": "pending",
+                "order_number": 8523,
+                "table_session_id": table_session_id,
+                "pos_cart_id": None,
+                "payment_status": None,
+                "order_date": order_date,
+                "total_amount": 62000,
+                "customer_id": customer_id,
+            },
+            {"id": group_id},
+            {
+                "id": order_id,
+                "order_number": 8523,
+                "total_amount": 62000,
+                "payment_method": "cash",
+                "payment_method_id": None,
+                "order_date": order_date,
+                "tip_amount": 0,
+                "tip_tax_amount": 0,
+            },
+        ]
+    )
+    conn.fetchval = AsyncMock(return_value=False)
+    conn.execute = AsyncMock()
+
+    deduct_stock = AsyncMock()
+
+    with patch(
+        "app.services.orders_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id, user_id=user_id),
+    ), patch(
+        "app.services.orders_service.get_db_connection",
+        return_value=_AsyncContext(conn),
+    ), patch(
+        "app.services.orders_service.assert_order_not_in_closed_monthly_period",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.orders_service._deduct_stock_for_status_update",
+        new=deduct_stock,
+    ), patch(
+        "app.services.orders_service._get_tenant_tax_config",
+        new=AsyncMock(return_value={"inc_enabled": True}),
+    ), patch(
+        "app.services.orders_service._post_order_gl_entry",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.orders_service._post_order_cogs_gl_entry",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.orders_service.evaluate_and_award",
+        new=MagicMock(return_value=object()),
+    ), patch(
+        "app.services.orders_service.asyncio.create_task",
+        new=MagicMock(),
+    ):
+        result = await orders_service.update_order_status(
+            Request({"type": "http"}),
+            order_id,
+            "completed",
+            "cash",
+        )
+
+    assert result["success"] is True
+    conn.fetchval.assert_awaited_once()
+    deduct_stock.assert_awaited_once_with(conn, order_id, tenant_id, user_id, 8523)
 
 
 def _pending_status_conn(order_id, order_date, customer_id=None, *, group_row=None, method_row=None):


### PR DESCRIPTION
## Summary
- skip duplicate inventory deduction when table/bar pending orders already have consumption movements
- keep pending completion GL/COGS posting and schedule WaRos awards after successful completion
- add focused regression coverage for POS pending, table pending, and fallback stock deduction

## Tests
- pytest tests/test_manual_order_gl_cogs.py
- pytest tests/test_tables_tab_promo_persist.py tests/test_waro_wallet_checkout.py

Closes uno0uno/warocol.com#1359