### PR TITLE
Unify tenant email senders for OTP

### DIFF
--- a/app/routers/leads.py
+++ b/app/routers/leads.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Request
 from pydantic import BaseModel, EmailStr, field_validator
 from app.database import get_db_connection
 from app.services import leads_service
+from app.core.middleware import get_tenant_context
 from app.core.email_utils import normalize_email
 
 logger = logging.getLogger(__name__)
@@ -72,6 +73,7 @@ async def capture_lead(body: LeadCaptureRequest, request: Request):
     user_agent = request.headers.get("user-agent")
 
     logger.info(f"📥 [leads/capture] email={body.email} source={body.button_source} ip={ip_address}")
+    tenant_context = get_tenant_context(request)
 
     async with get_db_connection() as conn:
         result = await leads_service.capture_lead(
@@ -81,6 +83,7 @@ async def capture_lead(body: LeadCaptureRequest, request: Request):
             ip_address=ip_address,
             user_agent=user_agent,
             button_source=body.button_source,
+            sender_email=tenant_context.tenant_email,
         )
 
     return {
@@ -105,6 +108,7 @@ async def capture_access_request(body: AccessRequestBody, request: Request):
     user_agent = request.headers.get("user-agent")
 
     logger.info(f"📥 [leads/access-request] email={body.email} source={body.button_source} ip={ip_address}")
+    tenant_context = get_tenant_context(request)
 
     async with get_db_connection() as conn:
         await leads_service.capture_access_request(
@@ -114,6 +118,7 @@ async def capture_access_request(body: AccessRequestBody, request: Request):
             ip_address=ip_address,
             user_agent=user_agent,
             button_source=body.button_source,
+            sender_email=tenant_context.tenant_email,
         )
 
     return {"success": True, "message": "¡Solicitud enviada! Nos pondremos en contacto contigo pronto."}

--- a/app/routers/online_verification.py
+++ b/app/routers/online_verification.py
@@ -2,11 +2,12 @@
 Online Verification Router
 PUBLIC endpoints for OTP verification and customer validation (NO authentication required)
 """
-from fastapi import APIRouter, Response
+from fastapi import APIRouter, Request, Response
 from typing import Optional
 from uuid import UUID
 from pydantic import BaseModel, EmailStr
 from app.services import otp_service
+from app.core.middleware import get_tenant_context
 from app.core.security import create_customer_jwt, set_customer_cookie
 
 router = APIRouter(prefix="/online/otp", tags=["Online Verification (Public)"])
@@ -39,7 +40,7 @@ class ValidateCustomerRequest(BaseModel):
 
 
 @router.post("/send")
-async def send_otp(request: SendOTPRequest):
+async def send_otp(payload: SendOTPRequest, request: Request):
     """
     Send OTP code via email (PUBLIC - no auth).
 
@@ -50,14 +51,16 @@ async def send_otp(request: SendOTPRequest):
 
     **Public endpoint - no authentication required**
     """
+    tenant_context = get_tenant_context(request)
     return await otp_service.send_otp_email(
-        email=request.email,
-        cart_id=request.cart_id
+        email=payload.email,
+        cart_id=payload.cart_id,
+        sender_email=tenant_context.tenant_email,
     )
 
 
 @router.post("/verify")
-async def verify_otp(request: VerifyOTPRequest, response: Response):
+async def verify_otp(payload: VerifyOTPRequest, response: Response):
     """
     Verify OTP code (PUBLIC - no auth).
 
@@ -74,22 +77,22 @@ async def verify_otp(request: VerifyOTPRequest, response: Response):
     **Public endpoint - no authentication required**
     """
     result = await otp_service.verify_otp_code(
-        email=request.email,
-        cart_id=request.cart_id,
-        otp_code=request.otp_code
+        email=payload.email,
+        cart_id=payload.cart_id,
+        otp_code=payload.otp_code
     )
     # Set long-lived customer session cookie for /mis-pedidos
     if result.get("success") and result.get("customer_id"):
         jwt_token = create_customer_jwt(
             customer_id=result["customer_id"],
-            email=request.email,
+            email=payload.email,
         )
         set_customer_cookie(response, jwt_token)
     return result
 
 
 @router.post("/resend")
-async def resend_otp(request: ResendOTPRequest):
+async def resend_otp(payload: ResendOTPRequest, request: Request):
     """
     Resend OTP code (PUBLIC - no auth).
 
@@ -100,10 +103,12 @@ async def resend_otp(request: ResendOTPRequest):
 
     **Public endpoint - no authentication required**
     """
+    tenant_context = get_tenant_context(request)
     # Uses the same send_otp_email function which handles cooldown
     return await otp_service.send_otp_email(
-        email=request.email,
-        cart_id=request.cart_id
+        email=payload.email,
+        cart_id=payload.cart_id,
+        sender_email=tenant_context.tenant_email,
     )
 
 

--- a/app/services/billing_email_service.py
+++ b/app/services/billing_email_service.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 
 from app.config import settings
 from app.services.aws_ses_service import AWSSESService
+from app.services.email_sender import resolve_sender_email_value
 from app.services.billing_service import (
     GRACE_PERIOD_DAYS,
     get_past_due_tenants,
@@ -149,7 +150,7 @@ async def send_grace_reminder(tenant: Dict[str, Any]) -> bool:
     )
 
     sent = await _ses.send_email(
-        from_email=settings.email_from,
+        from_email=resolve_sender_email_value(email),
         from_name="WARO Colombia",
         to_emails=[email],
         subject=subject,
@@ -313,7 +314,7 @@ async def send_payment_rejected_email(
 </html>"""
 
     sent = await _ses.send_email(
-        from_email=settings.email_from,
+        from_email=resolve_sender_email_value(tenant_email),
         from_name="WARO Colombia",
         to_emails=[tenant_email],
         subject="WARO — Tu pago fue rechazado, actualiza tu método de pago",
@@ -387,7 +388,7 @@ async def send_payment_renewed_email(
 </html>"""
 
     sent = await _ses.send_email(
-        from_email=settings.email_from,
+        from_email=resolve_sender_email_value(tenant_email),
         from_name="WARO Colombia",
         to_emails=[tenant_email],
         subject="WARO — Tu suscripción fue renovada exitosamente",

--- a/app/services/email_helpers.py
+++ b/app/services/email_helpers.py
@@ -4,8 +4,8 @@ Email helper functions for sending formatted emails
 from typing import List, Dict, Any, Optional
 from datetime import datetime
 from app.services.aws_ses_service import AWSSESService
-from app.config import settings
 from app.database import get_db_connection
+from app.services.email_sender import resolve_sender_email_for_tenant
 from app.services.aws_s3_service import AWSS3Service
 from app.templates.order_confirmation_template import (
     get_order_confirmation_text,
@@ -39,7 +39,8 @@ async def send_quotation_email(
     payment_terms: str = None,
     credit_days: int = None,
     requires_advance_payment: bool = False,
-    consolidation_group: str = None
+    consolidation_group: str = None,
+    tenant_id: Optional[str] = None,
 ) -> bool:
     """
     Send a quotation request email to a supplier
@@ -149,7 +150,7 @@ Tecnología colombiana para el mundo.
 
         ses_service = AWSSESService()
         success = await ses_service.send_email(
-            from_email=settings.email_from or "hola@warocol.com",
+            from_email=await resolve_sender_email_for_tenant(tenant_id),
             from_name="Saifer 101 de Waro Colombia",
             to_emails=[supplier_email],
             subject=f"Nueva Solicitud de Cotización - {purchase_number}",
@@ -176,7 +177,8 @@ async def send_purchase_status_notification(
     notes: str = None,
     metadata: dict = None,
     supplier_token: str = None,
-    tenant_site: str = None
+    tenant_site: str = None,
+    tenant_id: Optional[str] = None,
 ) -> bool:
     """
     Send a status update notification email to a supplier
@@ -295,7 +297,7 @@ Tecnología colombiana para el mundo.
 
         ses_service = AWSSESService()
         success = await ses_service.send_email(
-            from_email=settings.email_from or "hola@warocol.com",
+            from_email=await resolve_sender_email_for_tenant(tenant_id),
             from_name="Saifer 101 de Waro Colombia",
             to_emails=[supplier_email],
             subject=f"{purchase_number} - {info['title']}",
@@ -318,6 +320,7 @@ Tecnología colombiana para el mundo.
 async def send_negocio_welcome_email(
     owner_email: str,
     display_name: str,
+    tenant_id: Optional[str] = None,
 ) -> bool:
     """
     Send a welcome email when a negocio activates its public profile for the first time.
@@ -333,7 +336,7 @@ async def send_negocio_welcome_email(
 
         ses_service = AWSSESService()
         success = await ses_service.send_email(
-            from_email=settings.email_from or "hola@warocol.com",
+            from_email=await resolve_sender_email_for_tenant(tenant_id),
             from_name="Saifer 101 de WaRo Colombia",
             to_emails=[owner_email],
             subject=subject,
@@ -365,6 +368,7 @@ async def send_order_confirmation_email(
     delivery_instructions: Optional[str] = None,
     pickup_pin: Optional[str] = None,
     order_id: Optional[str] = None,
+    tenant_id: Optional[str] = None,
 ) -> bool:
     """
     Send a transactional order confirmation email to the customer.
@@ -392,7 +396,7 @@ async def send_order_confirmation_email(
 
         ses_service = AWSSESService()
         success = await ses_service.send_email(
-            from_email=settings.email_from or "hola@warocol.com",
+            from_email=await resolve_sender_email_for_tenant(tenant_id),
             from_name="WARO Colombia",
             to_emails=[customer_email],
             subject=subject,
@@ -420,6 +424,7 @@ async def send_order_accepted_email(
     subtotal: float,
     delivery_address: Optional[Dict[str, Any]] = None,
     order_id: Optional[str] = None,
+    tenant_id: Optional[str] = None,
 ) -> bool:
     """
     Send an order acceptance email to the customer.
@@ -444,7 +449,7 @@ async def send_order_accepted_email(
 
         ses_service = AWSSESService()
         success = await ses_service.send_email(
-            from_email=settings.email_from or "hola@warocol.com",
+            from_email=await resolve_sender_email_for_tenant(tenant_id),
             from_name="WARO Colombia",
             to_emails=[customer_email],
             subject=subject,
@@ -602,7 +607,7 @@ async def send_pos_receipt_email(
 
         if attachments:
             success = await ses_service.send_email_with_attachments(
-                from_email=settings.email_from or "hola@warocol.com",
+                from_email=await resolve_sender_email_for_tenant(tenant_id),
                 from_name=business_name or "WARO Colombia",
                 to_emails=[customer_email],
                 subject=subject,
@@ -611,7 +616,7 @@ async def send_pos_receipt_email(
             )
         else:
             success = await ses_service.send_email(
-                from_email=settings.email_from or "hola@warocol.com",
+                from_email=await resolve_sender_email_for_tenant(tenant_id),
                 from_name=business_name or "WARO Colombia",
                 to_emails=[customer_email],
                 subject=subject,

--- a/app/services/email_sender.py
+++ b/app/services/email_sender.py
@@ -1,0 +1,36 @@
+"""
+Shared sender resolution for tenant-facing transactional emails.
+"""
+from typing import Optional, Union
+from uuid import UUID
+
+from app.config import settings
+from app.database import get_db_connection
+
+
+DEFAULT_SENDER_EMAIL = "hola@warocol.com"
+
+
+def resolve_sender_email_value(sender_email: Optional[str] = None) -> str:
+    email = (sender_email or settings.email_from or DEFAULT_SENDER_EMAIL).strip()
+    return email or DEFAULT_SENDER_EMAIL
+
+
+def resolve_sender_email_from_context(tenant_context) -> str:
+    return resolve_sender_email_value(getattr(tenant_context, "tenant_email", None))
+
+
+async def resolve_sender_email_for_tenant(tenant_id: Optional[Union[str, UUID]]) -> str:
+    if not tenant_id:
+        return resolve_sender_email_value()
+
+    try:
+        tenant_uuid = tenant_id if isinstance(tenant_id, UUID) else UUID(str(tenant_id))
+        async with get_db_connection(use_transaction=False) as conn:
+            tenant_email = await conn.fetchval(
+                "SELECT email FROM tenants WHERE id = $1",
+                tenant_uuid,
+            )
+        return resolve_sender_email_value(tenant_email)
+    except Exception:
+        return resolve_sender_email_value()

--- a/app/services/leads_service.py
+++ b/app/services/leads_service.py
@@ -7,6 +7,7 @@ import json
 from typing import Optional
 
 from app.core.email_utils import normalize_email
+from app.services.email_sender import resolve_sender_email_value
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +57,7 @@ async def capture_lead(
     ip_address: Optional[str],
     user_agent: Optional[str],
     button_source: str,
+    sender_email: Optional[str] = None,
 ) -> dict:
     """
     Capture a lead from the homepage.
@@ -124,7 +126,7 @@ async def capture_lead(
     logger.info(f"📥 [capture_lead] Interaction '{interaction_type}' recorded for lead {lead_id}")
 
     # Fire-and-forget: Discord notification + email (non-blocking, always fires)
-    asyncio.create_task(_send_notifications(email, phone, button_source, ip_address, is_duplicate))
+    asyncio.create_task(_send_notifications(email, phone, button_source, ip_address, is_duplicate, sender_email))
 
     return {"profile_id": str(profile_id), "lead_id": str(lead_id), "is_duplicate": is_duplicate}
 
@@ -136,6 +138,7 @@ async def capture_access_request(
     ip_address: Optional[str],
     user_agent: Optional[str],
     button_source: str = "access_request",
+    sender_email: Optional[str] = None,
 ) -> dict:
     """
     Capture an access request from the login page.
@@ -214,7 +217,7 @@ async def capture_access_request(
     logger.info(f"📥 [capture_access_request] Interaction recorded for lead {lead_id}")
 
     # Fire-and-forget notifications (non-blocking)
-    asyncio.create_task(_send_access_request_notifications(email, phone, ip_address))
+    asyncio.create_task(_send_access_request_notifications(email, phone, ip_address, sender_email))
 
     return {"profile_id": str(profile_id), "lead_id": str(lead_id)}
 
@@ -223,11 +226,11 @@ async def _send_access_request_notifications(
     email: str,
     phone: Optional[str],
     ip_address: Optional[str],
+    sender_email: Optional[str] = None,
 ) -> None:
     """Send Discord notification and confirmation email for access requests."""
     from app.services.discord_service import discord_leads_service
     from app.services.aws_ses_service import ses_service
-    from app.config import settings
 
     tasks = []
 
@@ -253,7 +256,7 @@ async def _send_access_request_notifications(
 
     tasks.append(
         ses_service.send_email(
-            from_email=settings.email_from,
+            from_email=resolve_sender_email_value(sender_email),
             from_name="WARO Colombia",
             to_emails=[email],
             subject="¡Gracias por contactarnos! — WARO Colombia",
@@ -273,11 +276,11 @@ async def _send_notifications(
     button_source: str,
     ip_address: Optional[str],
     is_duplicate: bool = False,
+    sender_email: Optional[str] = None,
 ) -> None:
     """Send Discord notification and confirmation email without blocking the response."""
     from app.services.discord_service import discord_leads_service
     from app.services.aws_ses_service import ses_service
-    from app.config import settings
 
     tasks = []
 
@@ -314,7 +317,7 @@ async def _send_notifications(
     )
     tasks.append(
         ses_service.send_email(
-            from_email=settings.email_from,
+            from_email=resolve_sender_email_value(sender_email),
             from_name="WARO Colombia",
             to_emails=[email],
             subject=subject,

--- a/app/services/online_cart_service.py
+++ b/app/services/online_cart_service.py
@@ -928,6 +928,7 @@ async def checkout_cart(
                     delivery_instructions=cart.get('delivery_instructions'),
                     pickup_pin=cart.get('pickup_pin'),
                     order_id=str(order_id),
+                    tenant_id=str(tenant_id),
                 )
             except Exception as email_err:
                 logger.error(f"Failed to send order confirmation email for order #{order_number}: {email_err}")

--- a/app/services/online_orders_service.py
+++ b/app/services/online_orders_service.py
@@ -666,6 +666,7 @@ async def update_order_status(
                         subtotal=float(email_row["total_amount"]),
                         delivery_address=delivery_address,
                         order_id=str(order_id),
+                        tenant_id=str(tenant_id),
                     ))
 
                 # Award waros for auto-completed order (fire-and-forget — never blocks)

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -20,6 +20,7 @@ from app.services.cierre_service import (
     _post_order_gl_entry,
 )
 from app.services.email_helpers import send_pos_receipt_email
+from app.services.email_sender import resolve_sender_email_for_tenant
 from fastapi import HTTPException
 from datetime import datetime, date
 import csv
@@ -2578,7 +2579,7 @@ Tecnología colombiana para el mundo.
 
             # Send email with CSV attachment
             success = await ses_service.send_email_with_attachment(
-                from_email="hola@warocol.com",
+                from_email=await resolve_sender_email_for_tenant(tenant_id),
                 from_name="Waro Colombia - Reportes",
                 to_emails=[user_email],
                 subject=subject,

--- a/app/services/otp_service.py
+++ b/app/services/otp_service.py
@@ -10,9 +10,9 @@ from datetime import datetime, timedelta, timezone
 from fastapi import HTTPException
 from app.database import get_db_connection
 from app.services.aws_ses_service import AWSSESService
+from app.services.email_sender import resolve_sender_email_value
 from app.core.exceptions import APIError
 from app.core.email_utils import normalize_email
-from app.config import settings
 import logging
 
 logger = logging.getLogger(__name__)
@@ -31,7 +31,8 @@ def generate_otp_code() -> str:
 
 async def send_otp_email(
     email: str,
-    cart_id: Optional[UUID] = None
+    cart_id: Optional[UUID] = None,
+    sender_email: Optional[str] = None,
 ) -> dict:
     """
     Send OTP code via email for cart verification (PUBLIC)
@@ -108,7 +109,7 @@ WARO Colombia
             """.strip()
 
             email_sent = await ses_service.send_email(
-                from_email=settings.email_from or "hola@warocol.com",
+                from_email=resolve_sender_email_value(sender_email),
                 from_name="WARO Colombia",
                 to_emails=[email],
                 subject=subject,

--- a/app/services/purchases_service.py
+++ b/app/services/purchases_service.py
@@ -722,7 +722,8 @@ async def create_purchase(
                                 payment_terms=new_purchase['payment_terms'],
                                 credit_days=new_purchase['credit_days'],
                                 requires_advance_payment=new_purchase['requires_advance_payment'],
-                                consolidation_group=new_purchase['consolidation_group']
+                                consolidation_group=new_purchase['consolidation_group'],
+                                tenant_id=str(tenant_id),
                             )
                     except Exception as email_error:
                         # Log error but don't fail the purchase creation
@@ -962,4 +963,3 @@ async def extract_invoice_data(request: Request, file: UploadFile) -> dict:
             "success": False,
             "error": str(e)
         }
-

--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -430,7 +430,11 @@ async def toggle_public_profile(
                 if profile_email:
                     from app.services import email_helpers
                     asyncio.create_task(
-                        email_helpers.send_negocio_welcome_email(profile_email, profile_name)
+                        email_helpers.send_negocio_welcome_email(
+                            profile_email,
+                            profile_name,
+                            tenant_id=str(tenant_id),
+                        )
                     )
                     await conn.execute(
                         "UPDATE tenant_public_profiles SET welcome_email_sent = true WHERE tenant_id = $1",


### PR DESCRIPTION
## Summary
- Add shared sender resolution for tenant-facing SES emails
- Send public OTP using the detected tenant email, matching magic link behavior
- Route order, receipt, lead, billing, supplier, and report emails through the tenant sender fallback

## Tests
- python3 -m py_compile app/services/email_sender.py app/routers/online_verification.py app/routers/leads.py app/services/otp_service.py app/services/email_helpers.py app/services/leads_service.py app/services/billing_email_service.py app/services/orders_service.py app/services/purchases_service.py app/services/tenant_config_service.py app/services/online_cart_service.py app/services/online_orders_service.py
- pytest tests/test_magic_link_email_normalize.py tests/test_invitation_email_normalize.py tests/test_document_email.py -q

Refs uno0uno/warocol.com#1363