### PR TITLE
Use configured SES sender for emails

### DIFF
--- a/app/routers/leads.py
+++ b/app/routers/leads.py
@@ -9,7 +9,6 @@ from fastapi import APIRouter, Request
 from pydantic import BaseModel, EmailStr, field_validator
 from app.database import get_db_connection
 from app.services import leads_service
-from app.core.middleware import get_tenant_context
 from app.core.email_utils import normalize_email
 
 logger = logging.getLogger(__name__)
@@ -73,7 +72,6 @@ async def capture_lead(body: LeadCaptureRequest, request: Request):
     user_agent = request.headers.get("user-agent")
 
     logger.info(f"📥 [leads/capture] email={body.email} source={body.button_source} ip={ip_address}")
-    tenant_context = get_tenant_context(request)
 
     async with get_db_connection() as conn:
         result = await leads_service.capture_lead(
@@ -83,7 +81,6 @@ async def capture_lead(body: LeadCaptureRequest, request: Request):
             ip_address=ip_address,
             user_agent=user_agent,
             button_source=body.button_source,
-            sender_email=tenant_context.tenant_email,
         )
 
     return {
@@ -108,7 +105,6 @@ async def capture_access_request(body: AccessRequestBody, request: Request):
     user_agent = request.headers.get("user-agent")
 
     logger.info(f"📥 [leads/access-request] email={body.email} source={body.button_source} ip={ip_address}")
-    tenant_context = get_tenant_context(request)
 
     async with get_db_connection() as conn:
         await leads_service.capture_access_request(
@@ -118,7 +114,6 @@ async def capture_access_request(body: AccessRequestBody, request: Request):
             ip_address=ip_address,
             user_agent=user_agent,
             button_source=body.button_source,
-            sender_email=tenant_context.tenant_email,
         )
 
     return {"success": True, "message": "¡Solicitud enviada! Nos pondremos en contacto contigo pronto."}

--- a/app/routers/online_verification.py
+++ b/app/routers/online_verification.py
@@ -2,12 +2,11 @@
 Online Verification Router
 PUBLIC endpoints for OTP verification and customer validation (NO authentication required)
 """
-from fastapi import APIRouter, Request, Response
+from fastapi import APIRouter, Response
 from typing import Optional
 from uuid import UUID
 from pydantic import BaseModel, EmailStr
 from app.services import otp_service
-from app.core.middleware import get_tenant_context
 from app.core.security import create_customer_jwt, set_customer_cookie
 
 router = APIRouter(prefix="/online/otp", tags=["Online Verification (Public)"])
@@ -40,7 +39,7 @@ class ValidateCustomerRequest(BaseModel):
 
 
 @router.post("/send")
-async def send_otp(payload: SendOTPRequest, request: Request):
+async def send_otp(payload: SendOTPRequest):
     """
     Send OTP code via email (PUBLIC - no auth).
 
@@ -51,11 +50,9 @@ async def send_otp(payload: SendOTPRequest, request: Request):
 
     **Public endpoint - no authentication required**
     """
-    tenant_context = get_tenant_context(request)
     return await otp_service.send_otp_email(
         email=payload.email,
         cart_id=payload.cart_id,
-        sender_email=tenant_context.tenant_email,
     )
 
 
@@ -92,7 +89,7 @@ async def verify_otp(payload: VerifyOTPRequest, response: Response):
 
 
 @router.post("/resend")
-async def resend_otp(payload: ResendOTPRequest, request: Request):
+async def resend_otp(payload: ResendOTPRequest):
     """
     Resend OTP code (PUBLIC - no auth).
 
@@ -103,12 +100,10 @@ async def resend_otp(payload: ResendOTPRequest, request: Request):
 
     **Public endpoint - no authentication required**
     """
-    tenant_context = get_tenant_context(request)
     # Uses the same send_otp_email function which handles cooldown
     return await otp_service.send_otp_email(
         email=payload.email,
         cart_id=payload.cart_id,
-        sender_email=tenant_context.tenant_email,
     )
 
 

--- a/app/services/email_sender.py
+++ b/app/services/email_sender.py
@@ -1,36 +1,16 @@
-"""
-Shared sender resolution for tenant-facing transactional emails.
-"""
-from typing import Optional, Union
-from uuid import UUID
+"""Shared sender resolution for SES transactional emails."""
+from typing import Optional
 
 from app.config import settings
-from app.database import get_db_connection
 
 
 DEFAULT_SENDER_EMAIL = "hola@warocol.com"
 
 
-def resolve_sender_email_value(sender_email: Optional[str] = None) -> str:
-    email = (sender_email or settings.email_from or DEFAULT_SENDER_EMAIL).strip()
+def resolve_sender_email_value(fallback_email: Optional[str] = None) -> str:
+    email = (settings.email_from or fallback_email or DEFAULT_SENDER_EMAIL).strip()
     return email or DEFAULT_SENDER_EMAIL
 
 
-def resolve_sender_email_from_context(tenant_context) -> str:
-    return resolve_sender_email_value(getattr(tenant_context, "tenant_email", None))
-
-
-async def resolve_sender_email_for_tenant(tenant_id: Optional[Union[str, UUID]]) -> str:
-    if not tenant_id:
-        return resolve_sender_email_value()
-
-    try:
-        tenant_uuid = tenant_id if isinstance(tenant_id, UUID) else UUID(str(tenant_id))
-        async with get_db_connection(use_transaction=False) as conn:
-            tenant_email = await conn.fetchval(
-                "SELECT email FROM tenants WHERE id = $1",
-                tenant_uuid,
-            )
-        return resolve_sender_email_value(tenant_email)
-    except Exception:
-        return resolve_sender_email_value()
+async def resolve_sender_email_for_tenant(_tenant_id=None) -> str:
+    return resolve_sender_email_value()

--- a/app/services/invitation_service.py
+++ b/app/services/invitation_service.py
@@ -167,6 +167,7 @@ async def send_invitation(request: Request, payload: SendInvitationRequest) -> S
 
             # Send invitation email
             from app.services.aws_ses_service import ses_service
+            from app.services.email_sender import resolve_sender_email_value
             from app.templates.invitation_template import get_invitation_template, get_invitation_subject
             from app.config import settings
 
@@ -202,7 +203,7 @@ async def send_invitation(request: Request, payload: SendInvitationRequest) -> S
 
             # Send email
             email_sent = await ses_service.send_email(
-                from_email=tenant_email,
+                from_email=resolve_sender_email_value(tenant_email),
                 from_name=from_name,
                 to_emails=[payload.email],
                 subject=subject,

--- a/app/services/leads_service.py
+++ b/app/services/leads_service.py
@@ -57,7 +57,6 @@ async def capture_lead(
     ip_address: Optional[str],
     user_agent: Optional[str],
     button_source: str,
-    sender_email: Optional[str] = None,
 ) -> dict:
     """
     Capture a lead from the homepage.
@@ -126,7 +125,7 @@ async def capture_lead(
     logger.info(f"📥 [capture_lead] Interaction '{interaction_type}' recorded for lead {lead_id}")
 
     # Fire-and-forget: Discord notification + email (non-blocking, always fires)
-    asyncio.create_task(_send_notifications(email, phone, button_source, ip_address, is_duplicate, sender_email))
+    asyncio.create_task(_send_notifications(email, phone, button_source, ip_address, is_duplicate))
 
     return {"profile_id": str(profile_id), "lead_id": str(lead_id), "is_duplicate": is_duplicate}
 
@@ -138,7 +137,6 @@ async def capture_access_request(
     ip_address: Optional[str],
     user_agent: Optional[str],
     button_source: str = "access_request",
-    sender_email: Optional[str] = None,
 ) -> dict:
     """
     Capture an access request from the login page.
@@ -217,7 +215,7 @@ async def capture_access_request(
     logger.info(f"📥 [capture_access_request] Interaction recorded for lead {lead_id}")
 
     # Fire-and-forget notifications (non-blocking)
-    asyncio.create_task(_send_access_request_notifications(email, phone, ip_address, sender_email))
+    asyncio.create_task(_send_access_request_notifications(email, phone, ip_address))
 
     return {"profile_id": str(profile_id), "lead_id": str(lead_id)}
 
@@ -226,7 +224,6 @@ async def _send_access_request_notifications(
     email: str,
     phone: Optional[str],
     ip_address: Optional[str],
-    sender_email: Optional[str] = None,
 ) -> None:
     """Send Discord notification and confirmation email for access requests."""
     from app.services.discord_service import discord_leads_service
@@ -256,7 +253,7 @@ async def _send_access_request_notifications(
 
     tasks.append(
         ses_service.send_email(
-            from_email=resolve_sender_email_value(sender_email),
+            from_email=resolve_sender_email_value(),
             from_name="WARO Colombia",
             to_emails=[email],
             subject="¡Gracias por contactarnos! — WARO Colombia",
@@ -276,7 +273,6 @@ async def _send_notifications(
     button_source: str,
     ip_address: Optional[str],
     is_duplicate: bool = False,
-    sender_email: Optional[str] = None,
 ) -> None:
     """Send Discord notification and confirmation email without blocking the response."""
     from app.services.discord_service import discord_leads_service
@@ -317,7 +313,7 @@ async def _send_notifications(
     )
     tasks.append(
         ses_service.send_email(
-            from_email=resolve_sender_email_value(sender_email),
+            from_email=resolve_sender_email_value(),
             from_name="WARO Colombia",
             to_emails=[email],
             subject=subject,

--- a/app/services/magic_link_service.py
+++ b/app/services/magic_link_service.py
@@ -77,6 +77,7 @@ async def send_magic_link(request: Request, email: str, redirect: Optional[str] 
             
             # Send magic link email using AWS SES
             from app.services.aws_ses_service import ses_service
+            from app.services.email_sender import resolve_sender_email_value
             from app.templates.magic_link_template import get_magic_link_template, get_magic_link_subject
             from app.config import settings
             
@@ -112,7 +113,7 @@ async def send_magic_link(request: Request, email: str, redirect: Optional[str] 
             
             # Send email via AWS SES
             email_sent = await ses_service.send_email(
-                from_email=tenant_context.tenant_email,
+                from_email=resolve_sender_email_value(tenant_context.tenant_email),
                 from_name=from_name,
                 to_emails=[email],
                 subject=subject,
@@ -120,7 +121,7 @@ async def send_magic_link(request: Request, email: str, redirect: Optional[str] 
             )
             
             if email_sent:
-                logger.info(f"✅ Magic link email sent to {email} from {tenant_context.tenant_email}")
+                logger.info(f"✅ Magic link email sent to {email} from configured SES sender")
                 logger.info(f"🔗 Magic link URL: {magic_link_url}")
             else:
                 logger.error(f"❌ Failed to send magic link email to {email}")

--- a/app/services/otp_service.py
+++ b/app/services/otp_service.py
@@ -32,7 +32,6 @@ def generate_otp_code() -> str:
 async def send_otp_email(
     email: str,
     cart_id: Optional[UUID] = None,
-    sender_email: Optional[str] = None,
 ) -> dict:
     """
     Send OTP code via email for cart verification (PUBLIC)
@@ -109,7 +108,7 @@ WARO Colombia
             """.strip()
 
             email_sent = await ses_service.send_email(
-                from_email=resolve_sender_email_value(sender_email),
+                from_email=resolve_sender_email_value(),
                 from_name="WARO Colombia",
                 to_emails=[email],
                 subject=subject,


### PR DESCRIPTION
## Summary
- Centralizes transactional SES sender resolution on NUXT_PRIVATE_EMAIL_FROM.
- Keeps tenant/origin emails only as fallback values when the env var is missing.
- Updates OTP, magic link, invitations, and lead/access request emails to use the configured sender.

## Validation
- python3 -m py_compile app/services/email_sender.py app/services/otp_service.py app/routers/online_verification.py app/services/magic_link_service.py app/services/invitation_service.py app/services/email_helpers.py app/services/leads_service.py app/routers/leads.py app/services/billing_email_service.py app/services/orders_service.py
- pytest tests/test_magic_link_email_normalize.py tests/test_invitation_email_normalize.py tests/test_document_email.py -q
- git diff --check

## Deployment note
Set NUXT_PRIVATE_EMAIL_FROM=anderson.arevalo@warocol.com on the server environment. Local .env.prod is ignored by git and is not included in this PR.

Refs uno0uno/warocol.com#1365