### PR TITLE
Mark table QR notifications read on accept/reject

### DIFF
--- a/app/services/notifications_service.py
+++ b/app/services/notifications_service.py
@@ -49,6 +49,26 @@ async def create_comanda_ready_notification(
     await conn.execute("SELECT pg_notify($1, $2)", channel, json.dumps(notify_payload))
 
 
+async def mark_table_qr_notifications_read(
+    conn,
+    tenant_id: UUID,
+    request_id: UUID,
+) -> None:
+    """Mark staff notifications for a Table QR request as read (accept/reject)."""
+    await conn.execute(
+        """
+        UPDATE notifications
+        SET read_at = NOW()
+        WHERE tenant_id = $1
+          AND type = 'table_qr_request'
+          AND payload->>'request_id' = $2
+          AND read_at IS NULL
+        """,
+        tenant_id,
+        str(request_id),
+    )
+
+
 async def create_table_qr_notification(
     conn, tenant_id: UUID, request_id: UUID, payload: dict
 ) -> None:

--- a/app/services/table_qr_requests_service.py
+++ b/app/services/table_qr_requests_service.py
@@ -9,6 +9,7 @@ from fastapi import Request
 from app.core.exceptions import APIError, AuthenticationError, NotFoundError
 from app.core.middleware import require_valid_session
 from app.database import get_db_connection
+from app.services import notifications_service
 from app.services.tables_service import _add_tab_items_core, fire_table_items
 
 logger = logging.getLogger(__name__)
@@ -258,6 +259,10 @@ async def reject_request(request: Request, request_id: UUID) -> dict:
                 status_code=404,
             )
 
+        await notifications_service.mark_table_qr_notifications_read(
+            conn, tenant_id, request_id
+        )
+
     return {
         "success": True,
         "data": {
@@ -383,6 +388,11 @@ async def accept_requests(
             accepted_ids = [r["id"] for r in updated]
             if len(accepted_ids) != len(request_ids):
                 raise APIError("Failed to mark all requests as accepted", status_code=500)
+
+            for rid in accepted_ids:
+                await notifications_service.mark_table_qr_notifications_read(
+                    conn, tenant_id, rid
+                )
 
     try:
         await fire_table_items(request, table_id)

--- a/tests/test_table_qr_requests.py
+++ b/tests/test_table_qr_requests.py
@@ -62,12 +62,17 @@ async def test_reject_request_marks_rejected():
     conn.fetchrow = AsyncMock(return_value={"id": request_id, "table_id": table_id})
 
     with patch("app.services.table_qr_requests_service.require_valid_session", return_value=session), \
-         patch("app.services.table_qr_requests_service.get_db_connection") as mock_conn:
+         patch("app.services.table_qr_requests_service.get_db_connection") as mock_conn, \
+         patch(
+             "app.services.table_qr_requests_service.notifications_service.mark_table_qr_notifications_read",
+             new_callable=AsyncMock,
+         ) as mark_read_mock:
         mock_conn.return_value.__aenter__ = AsyncMock(return_value=conn)
         mock_conn.return_value.__aexit__ = AsyncMock(return_value=False)
 
         result = await table_qr_requests_service.reject_request(MagicMock(), request_id)
         assert result["data"]["status"] == "rejected"
+        mark_read_mock.assert_awaited_once_with(conn, session.tenant_id, request_id)
 
 
 @pytest.mark.asyncio
@@ -223,7 +228,10 @@ async def test_accept_requests_passes_persisted_modifier_quantity_to_tab_core():
     ) as add_tab_mock, patch(
         "app.services.table_qr_requests_service.fire_table_items",
         new=AsyncMock(),
-    ):
+    ), patch(
+        "app.services.table_qr_requests_service.notifications_service.mark_table_qr_notifications_read",
+        new_callable=AsyncMock,
+    ) as mark_read_mock:
         mock_conn.return_value.__aenter__ = AsyncMock(return_value=conn)
         mock_conn.return_value.__aexit__ = AsyncMock(return_value=False)
 
@@ -235,6 +243,7 @@ async def test_accept_requests_passes_persisted_modifier_quantity_to_tab_core():
     assert result["success"] is True
     forwarded_items = add_tab_mock.await_args.args[4]
     assert forwarded_items[0]["modifiers"][0]["quantity"] == 3
+    mark_read_mock.assert_awaited_once_with(conn, session.tenant_id, request_id)
 
 
 def test_list_endpoint_delegates():


### PR DESCRIPTION
## Summary
- Mark `table_qr_request` notifications as read when staff accepts or rejects a pending QR order.
- Prevents stale bell alerts for orders already processed (reported at Armelo Perro).

## Test plan
- [ ] Accept a pending table QR request → related notification has `read_at` set in DB.
- [ ] Reject a pending table QR request → same behavior.
- [ ] `pytest tests/test_table_qr_requests.py` passes.

Made with [Cursor](https://cursor.com)