### PR TITLE
Add minimum consumption tenant config

### DIFF
--- a/app/models/tenant_public_profile.py
+++ b/app/models/tenant_public_profile.py
@@ -105,6 +105,23 @@ class TenantPublicProfileBase(BaseModel):
                     "without touching the KDS. Requires comandas_enabled=true."
     )
 
+    # Minimum consumption / cover config (warocol.com#1368).
+    # This batch only persists tenant config. Later batches snapshot/apply it to
+    # sessions, deposits, close enforcement, accounting and reports.
+    minimum_consumption_enabled: bool = Field(
+        False,
+        description="When true, table sessions may use tenant minimum consumption / cover rules.",
+    )
+    minimum_consumption_amount: Decimal = Field(
+        Decimal('0'),
+        ge=0,
+        description="Minimum consumption / cover amount in COP for table sessions.",
+    )
+    minimum_consumption_restrictive: bool = Field(
+        False,
+        description="When true, later close-session logic may block closing below the minimum.",
+    )
+
     # Waiter attribution family feature flag (warocol.com#573)
     waiter_attribution_enabled: bool = Field(
         False,
@@ -233,6 +250,9 @@ class TenantPublicProfileUpdate(BaseModel):
     kds_enabled: Optional[bool] = None
     auto_select_generic_enabled: Optional[bool] = None
     expediter_enabled: Optional[bool] = None
+    minimum_consumption_enabled: Optional[bool] = None
+    minimum_consumption_amount: Optional[Decimal] = Field(None, ge=0)
+    minimum_consumption_restrictive: Optional[bool] = None
     waiter_attribution_enabled: Optional[bool] = None
 
     # Custom mesa label (warocol.com#614)

--- a/app/routers/operaciones_context.py
+++ b/app/routers/operaciones_context.py
@@ -24,6 +24,7 @@ from app.services import table_assignments_service
 from app.services.operaciones_context_service import (
     get_operaciones_context,
     set_open_sale_enabled,
+    update_minimum_consumption_config,
     update_promo_conflict_config,
     update_tables_label,
     update_tip_config,
@@ -88,6 +89,14 @@ class TipConfigRequest(BaseModel):
                 f"percentages of length {len(self.percentages)}"
             )
         return self
+
+
+class MinimumConsumptionConfigRequest(BaseModel):
+    """Payload for PATCH /operaciones/minimum-consumption/config (#1368)."""
+
+    enabled: bool = False
+    amount: Decimal = Field(Decimal("0"), ge=0)
+    restrictive: bool = False
 
 
 class PromoConflictConfigRequest(BaseModel):
@@ -254,6 +263,24 @@ async def toggle_promo_line_opt_out(request: Request, body: ToggleRequest):
     """Toggle per-line promotion opt-out at POS checkout (warocol.com#1003)."""
     session = require_valid_session(request)
     return await update_toggle(session.tenant_id, "allow_promo_line_opt_out", body.enabled)
+
+
+@router.patch(
+    "/minimum-consumption/config",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def patch_minimum_consumption_config(
+    request: Request,
+    body: MinimumConsumptionConfigRequest,
+):
+    """Persist tenant-level minimum consumption / cover config (#1368)."""
+    session = require_valid_session(request)
+    return await update_minimum_consumption_config(
+        session.tenant_id,
+        body.enabled,
+        body.amount,
+        body.restrictive,
+    )
 
 
 @router.patch(

--- a/app/services/operaciones_context_service.py
+++ b/app/services/operaciones_context_service.py
@@ -14,6 +14,7 @@ The toggle writer parameterizes the column name dynamically; the
 `ALLOWED_TOGGLES` whitelist prevents SQL injection.
 """
 import json
+from decimal import Decimal
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
@@ -226,6 +227,61 @@ async def update_tip_config(
         "data": {
             "tip_default_percentages": [float(p) for p in row["tip_default_percentages"] or []],
             "tip_preselect_index": row["tip_preselect_index"],
+        },
+    }
+
+
+async def update_minimum_consumption_config(
+    tenant_id: UUID,
+    enabled: bool,
+    amount: Decimal,
+    restrictive: bool,
+) -> Dict[str, Any]:
+    """Persist minimum consumption / cover config (warocol.com#1368).
+
+    This is tenant config only. Later epic batches snapshot and enforce it on
+    table sessions. Mirrors the fresh-tenant UPSERT pattern used by other
+    non-boolean operaciones config writers.
+    """
+    if amount < 0:
+        raise HTTPException(status_code=422, detail="amount must be greater than or equal to 0")
+
+    query = """
+        INSERT INTO tenant_public_profiles
+            (
+                tenant_id,
+                slug,
+                display_name,
+                minimum_consumption_enabled,
+                minimum_consumption_amount,
+                minimum_consumption_restrictive
+            )
+        SELECT t.id, t.slug, t.name, $2, $3, $4
+        FROM tenants t
+        WHERE t.id = $1
+        ON CONFLICT (tenant_id) DO UPDATE
+            SET minimum_consumption_enabled     = EXCLUDED.minimum_consumption_enabled,
+                minimum_consumption_amount      = EXCLUDED.minimum_consumption_amount,
+                minimum_consumption_restrictive = EXCLUDED.minimum_consumption_restrictive,
+                updated_at                      = now()
+        RETURNING
+            minimum_consumption_enabled,
+            minimum_consumption_amount,
+            minimum_consumption_restrictive
+    """
+
+    async with get_db_connection() as conn:
+        row = await conn.fetchrow(query, tenant_id, enabled, amount, restrictive)
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+
+    return {
+        "success": True,
+        "data": {
+            "minimum_consumption_enabled": bool(row["minimum_consumption_enabled"]),
+            "minimum_consumption_amount": float(row["minimum_consumption_amount"] or 0),
+            "minimum_consumption_restrictive": bool(row["minimum_consumption_restrictive"]),
         },
     }
 

--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -31,6 +31,9 @@ SELECT
     tpp.accepts_online_orders,
     tpp.auto_select_generic_enabled,
     tpp.open_sale_enabled,
+    tpp.minimum_consumption_enabled,
+    tpp.minimum_consumption_amount,
+    tpp.minimum_consumption_restrictive,
     tpp.waiter_attribution_enabled,
     tpp.tables_label_singular,
     tpp.tables_label_plural,
@@ -114,6 +117,17 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
         'accepts_online_orders': bool(row['accepts_online_orders']) if row['accepts_online_orders'] is not None else False,
         'auto_select_generic_enabled': bool(row['auto_select_generic_enabled']) if row['auto_select_generic_enabled'] is not None else False,
         'open_sale_enabled': bool(row['open_sale_enabled']) if row['open_sale_enabled'] is not None else False,
+        'minimum_consumption_enabled': bool(row['minimum_consumption_enabled'])
+        if row['minimum_consumption_enabled'] is not None
+        else False,
+        'minimum_consumption_amount': (
+            float(row['minimum_consumption_amount'])
+            if row['minimum_consumption_amount'] is not None
+            else 0.0
+        ),
+        'minimum_consumption_restrictive': bool(row['minimum_consumption_restrictive'])
+        if row['minimum_consumption_restrictive'] is not None
+        else False,
         'waiter_attribution_enabled': bool(row['waiter_attribution_enabled']) if row['waiter_attribution_enabled'] is not None else False,
         'tables_label_singular': row['tables_label_singular'],
         'tables_label_plural': row['tables_label_plural'],

--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -72,9 +72,10 @@ async def upsert_public_profile(
                         comandas_enabled, kds_enabled,
                         auto_select_generic_enabled,
                         expediter_enabled,
+                        minimum_consumption_enabled, minimum_consumption_amount, minimum_consumption_restrictive,
                         updated_at
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, CURRENT_TIMESTAMP)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, CURRENT_TIMESTAMP)
                     ON CONFLICT (tenant_id)
                     DO UPDATE SET
                         slug = EXCLUDED.slug,
@@ -103,6 +104,9 @@ async def upsert_public_profile(
                         kds_enabled = EXCLUDED.kds_enabled,
                         auto_select_generic_enabled = EXCLUDED.auto_select_generic_enabled,
                         expediter_enabled = EXCLUDED.expediter_enabled,
+                        minimum_consumption_enabled = EXCLUDED.minimum_consumption_enabled,
+                        minimum_consumption_amount = EXCLUDED.minimum_consumption_amount,
+                        minimum_consumption_restrictive = EXCLUDED.minimum_consumption_restrictive,
                         updated_at = CURRENT_TIMESTAMP
                     RETURNING *
                 """
@@ -135,7 +139,10 @@ async def upsert_public_profile(
                     profile_data.comandas_enabled,
                     profile_data.kds_enabled,
                     profile_data.auto_select_generic_enabled,
-                    profile_data.expediter_enabled
+                    profile_data.expediter_enabled,
+                    profile_data.minimum_consumption_enabled,
+                    profile_data.minimum_consumption_amount,
+                    profile_data.minimum_consumption_restrictive
                 )
 
                 profile = TenantPublicProfile(**dict(result))
@@ -217,8 +224,9 @@ async def update_public_profile(
                         is_manually_open,
                         comandas_enabled, kds_enabled,
                         auto_select_generic_enabled,
-                        expediter_enabled
-                    ) VALUES ($1, $2, $3, FALSE, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)
+                        expediter_enabled,
+                        minimum_consumption_enabled, minimum_consumption_amount, minimum_consumption_restrictive
+                    ) VALUES ($1, $2, $3, FALSE, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27)
                     RETURNING *
                 """
                 result = await conn.fetchrow(
@@ -252,6 +260,9 @@ async def update_public_profile(
                     data_dict.get('kds_enabled', False),
                     data_dict.get('auto_select_generic_enabled', False),
                     data_dict.get('expediter_enabled', False),
+                    data_dict.get('minimum_consumption_enabled', False),
+                    data_dict.get('minimum_consumption_amount', 0),
+                    data_dict.get('minimum_consumption_restrictive', False),
                 )
 
                 profile_data_dict = dict(result)

--- a/migrations/089_minimum_consumption_config.sql
+++ b/migrations/089_minimum_consumption_config.sql
@@ -1,0 +1,25 @@
+-- 089_minimum_consumption_config.sql
+-- warocol.com#1368 — tenant-level minimum consumption / cover config.
+-- Config only: session snapshots, deposits, close blocking, accounting and
+-- reporting are handled by later epic batches.
+
+ALTER TABLE tenant_public_profiles
+    ADD COLUMN IF NOT EXISTS minimum_consumption_enabled BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS minimum_consumption_amount NUMERIC(12,2) NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS minimum_consumption_restrictive BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE tenant_public_profiles
+    DROP CONSTRAINT IF EXISTS tenant_public_profiles_minimum_consumption_amount_check;
+
+ALTER TABLE tenant_public_profiles
+    ADD CONSTRAINT tenant_public_profiles_minimum_consumption_amount_check
+    CHECK (minimum_consumption_amount >= 0);
+
+COMMENT ON COLUMN tenant_public_profiles.minimum_consumption_enabled IS
+    'When true, table sessions may use tenant minimum consumption / cover rules. Config only in #1368.';
+
+COMMENT ON COLUMN tenant_public_profiles.minimum_consumption_amount IS
+    'Tenant minimum consumption / cover amount in COP for table sessions. Config only in #1368.';
+
+COMMENT ON COLUMN tenant_public_profiles.minimum_consumption_restrictive IS
+    'When true, later close-session batches may block closing below the configured minimum. No enforcement in #1368.';

--- a/sql/20260617_minimum_consumption_config.sql
+++ b/sql/20260617_minimum_consumption_config.sql
@@ -1,0 +1,23 @@
+-- warocol.com#1368 — tenant-level minimum consumption / cover config.
+-- Config only: no session, payment, accounting or close behavior in this batch.
+
+ALTER TABLE tenant_public_profiles
+    ADD COLUMN IF NOT EXISTS minimum_consumption_enabled BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS minimum_consumption_amount NUMERIC(12,2) NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS minimum_consumption_restrictive BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE tenant_public_profiles
+    DROP CONSTRAINT IF EXISTS tenant_public_profiles_minimum_consumption_amount_check;
+
+ALTER TABLE tenant_public_profiles
+    ADD CONSTRAINT tenant_public_profiles_minimum_consumption_amount_check
+    CHECK (minimum_consumption_amount >= 0);
+
+COMMENT ON COLUMN tenant_public_profiles.minimum_consumption_enabled IS
+    'When true, table sessions may use tenant minimum consumption / cover rules. Config only in #1368.';
+
+COMMENT ON COLUMN tenant_public_profiles.minimum_consumption_amount IS
+    'Tenant minimum consumption / cover amount in COP for table sessions. Config only in #1368.';
+
+COMMENT ON COLUMN tenant_public_profiles.minimum_consumption_restrictive IS
+    'When true, later close-session batches may block closing below the configured minimum. No enforcement in #1368.';


### PR DESCRIPTION
## Summary
- add tenant_public_profiles fields for minimum consumption config
- expose config in shared POS/operaciones restaurant context
- add operaciones PATCH endpoint for saving enabled/amount/restrictive

## Tests
- python3 -m py_compile app/models/tenant_public_profile.py app/services/pos_context_service.py app/services/operaciones_context_service.py app/routers/operaciones_context.py app/services/tenant_config_service.py

Refs uno0uno/warocol.com#1368