### PR TITLE
Add table session advance ledger

### DIFF
--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -8,11 +8,12 @@ from fastapi import APIRouter, Body, Depends, Request, Query
 from typing import Optional, List, Literal
 from uuid import UUID
 from datetime import date
+from decimal import Decimal
 from pydantic import BaseModel, Field
 from app.core.permissions import Module, require_module
 from app.models.table_member_assignment import OpenTableRequest
 from app.models.comanda import FireTableItemsRequest
-from app.services import tables_service
+from app.services import table_session_advances_service, tables_service
 
 router = APIRouter(tags=["Tables"])
 
@@ -217,6 +218,18 @@ class AddSessionPaymentRequest(BaseModel):
     tip_taxable: Optional[bool] = Field(None, description="Optional gravada flag for split session tip updates.")
 
 
+class CreateSessionAdvanceRequest(BaseModel):
+    amount_cop: Decimal = Field(..., gt=0, description="COP amount for this session advance")
+    payment_method: str = Field(..., description="cash | card | digital")
+    payment_method_id: Optional[UUID] = Field(None, description="UUID of the selected payment_methods row")
+    notes: Optional[str] = Field(None, max_length=500)
+    idempotency_key: Optional[str] = Field(None, max_length=128)
+
+
+class VoidSessionAdvanceRequest(BaseModel):
+    reason: Optional[str] = Field(None, max_length=500, description="Motivo opcional de anulación")
+
+
 @router.post("/{table_id}/close", dependencies=[Depends(require_module(Module.POS))])
 async def close_session(request: Request, table_id: UUID, body: CloseSessionRequest = CloseSessionRequest()):
     """
@@ -247,6 +260,43 @@ async def close_session(request: Request, table_id: UUID, body: CloseSessionRequ
         reason=body.reason,
         waros_to_redeem=body.waros_to_redeem,
         waro_reward_id=body.waro_reward_id,
+    )
+
+
+@router.get("/{table_id}/session-advances", dependencies=[Depends(require_module(Module.POS))])
+async def list_session_advances(request: Request, table_id: UUID):
+    """List session-scoped minimum-consumption advances for the open table session."""
+    return await table_session_advances_service.list_session_advances(request, table_id)
+
+
+@router.post("/{table_id}/session-advances", dependencies=[Depends(require_module(Module.POS))])
+async def create_session_advance(
+    request: Request,
+    table_id: UUID,
+    body: CreateSessionAdvanceRequest,
+):
+    """Create a session-scoped advance without customer wallet or order settlement."""
+    return await table_session_advances_service.create_session_advance(
+        request,
+        table_id,
+        body.amount_cop,
+        body.payment_method,
+        body.payment_method_id,
+        notes=body.notes,
+        idempotency_key=body.idempotency_key,
+    )
+
+
+@router.delete("/{table_id}/session-advances/{advance_id}", dependencies=[Depends(require_module(Module.POS))])
+async def void_session_advance(
+    request: Request,
+    table_id: UUID,
+    advance_id: UUID,
+    body: VoidSessionAdvanceRequest = Body(default_factory=VoidSessionAdvanceRequest),
+):
+    """Void a session advance and reverse its liability/payment GL when accounts exist."""
+    return await table_session_advances_service.void_session_advance(
+        request, table_id, advance_id, body.reason,
     )
 
 

--- a/app/services/table_session_advances_service.py
+++ b/app/services/table_session_advances_service.py
@@ -1,0 +1,519 @@
+"""
+Session-scoped advances for minimum consumption / cover.
+
+Issue: https://github.com/uno0uno/warocol.com/issues/1370
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from fastapi import Request
+
+from app.core.exceptions import APIError, AuthenticationError, NotFoundError
+from app.core.middleware import require_valid_session
+from app.database import get_db_connection
+from app.services.customer_wallet_service import (
+    DEFAULT_LIABILITY_CODE,
+    WALLET_PAYMENT_SLUG,
+    _post_two_line_gl,
+    _resolve_account_id,
+    _resolve_payment_debit_code,
+)
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_ADVANCE_TENDERS = {"cash", "card", "digital"}
+ADVANCE_RECEIVE_SOURCE = "table_session_advance_receive"
+ADVANCE_VOID_SOURCE = "table_session_advance_void"
+
+
+def _amount_decimal(amount: Decimal | float | int | str) -> Decimal:
+    try:
+        value = Decimal(str(amount))
+    except Exception as exc:
+        raise APIError("El monto del anticipo no es válido", status_code=400) from exc
+    if value <= 0:
+        raise APIError("El monto del anticipo debe ser mayor a cero", status_code=400)
+    return value.quantize(Decimal("0.01"))
+
+
+def _validate_advance_tender(payment_method: str) -> None:
+    if payment_method == WALLET_PAYMENT_SLUG:
+        raise APIError("El anticipo de mesa no usa billetera de cliente", status_code=400)
+    if payment_method not in ALLOWED_ADVANCE_TENDERS:
+        raise APIError(
+            "Use cash, card o digital como método del anticipo",
+            status_code=400,
+            details={"code": "payment_method_invalid"},
+        )
+
+
+async def _assert_payment_selection(
+    conn,
+    tenant_id: UUID,
+    payment_method: str,
+    payment_method_id: Optional[UUID],
+) -> None:
+    group_row = await conn.fetchrow(
+        """
+        SELECT id
+        FROM payment_method_groups
+        WHERE slug = $1
+          AND is_active = true
+          AND (tenant_id IS NULL OR tenant_id = $2)
+        """,
+        payment_method,
+        tenant_id,
+    )
+    if not group_row:
+        raise APIError(
+            f"Método de pago '{payment_method}' no es válido para este restaurante",
+            status_code=400,
+            details={"code": "payment_method_invalid"},
+        )
+    if not payment_method_id:
+        return
+    method_row = await conn.fetchrow(
+        """
+        SELECT id
+        FROM payment_methods
+        WHERE id = $1
+          AND tenant_id = $2
+          AND group_id = $3
+          AND is_active = true
+        """,
+        payment_method_id,
+        tenant_id,
+        group_row["id"],
+    )
+    if not method_row:
+        raise APIError(
+            "El método seleccionado no pertenece al grupo elegido",
+            status_code=400,
+            details={"code": "payment_method_id_invalid"},
+        )
+
+
+def _row_get(row, key: str, default=None):
+    try:
+        return row[key]
+    except (KeyError, TypeError):
+        return default
+
+
+async def _get_open_session(conn, tenant_id: UUID, table_id: UUID, *, lock: bool = False):
+    table_row = await conn.fetchrow(
+        """
+        SELECT id
+        FROM tables
+        WHERE id = $1
+          AND tenant_id = $2
+          AND is_active = true
+        """,
+        table_id,
+        tenant_id,
+    )
+    if not table_row:
+        raise NotFoundError("Table not found")
+    lock_sql = "FOR UPDATE" if lock else ""
+    session_row = await conn.fetchrow(
+        f"""
+        SELECT id, table_id
+        FROM table_sessions
+        WHERE table_id = $1
+          AND tenant_id = $2
+          AND closed_at IS NULL
+        {lock_sql}
+        """,
+        table_id,
+        tenant_id,
+    )
+    if not session_row:
+        raise NotFoundError("No open session for this table")
+    return session_row
+
+
+def _serialize_advance(row) -> Dict[str, Any]:
+    return {
+        "id": str(row["id"]),
+        "table_session_id": str(row["table_session_id"]),
+        "amount_cop": float(row["amount_cop"] or 0),
+        "payment_method": row["payment_method"],
+        "payment_method_id": str(row["payment_method_id"]) if row["payment_method_id"] else None,
+        "journal_entry_id": str(row["journal_entry_id"]) if row["journal_entry_id"] else None,
+        "void_journal_entry_id": (
+            str(row["void_journal_entry_id"]) if _row_get(row, "void_journal_entry_id") else None
+        ),
+        "status": row["status"],
+        "notes": _row_get(row, "notes"),
+        "void_reason": _row_get(row, "void_reason"),
+        "voided_at": row["voided_at"].isoformat() if _row_get(row, "voided_at") else None,
+        "created_at": row["created_at"].isoformat() if _row_get(row, "created_at") else None,
+    }
+
+
+def _advance_totals(rows: List[Any]) -> Dict[str, float]:
+    active = sum(
+        float(row["amount_cop"] or 0)
+        for row in rows
+        if row["status"] == "active"
+    )
+    voided = sum(
+        float(row["amount_cop"] or 0)
+        for row in rows
+        if row["status"] == "voided"
+    )
+    return {
+        "active_total_cop": active,
+        "voided_total_cop": voided,
+    }
+
+
+async def _fetch_advances(conn, tenant_id: UUID, table_session_id: UUID) -> List[Any]:
+    return await conn.fetch(
+        """
+        SELECT
+            id,
+            table_session_id,
+            amount_cop,
+            payment_method,
+            payment_method_id,
+            journal_entry_id,
+            void_journal_entry_id,
+            status,
+            notes,
+            void_reason,
+            voided_at,
+            created_at
+        FROM table_session_advances
+        WHERE tenant_id = $1
+          AND table_session_id = $2
+        ORDER BY created_at DESC, id DESC
+        """,
+        tenant_id,
+        table_session_id,
+    )
+
+
+async def get_session_advances_payload(
+    conn,
+    tenant_id: UUID,
+    table_session_id: UUID,
+) -> Dict[str, Any]:
+    rows = await _fetch_advances(conn, tenant_id, table_session_id)
+    return {
+        "advances": [_serialize_advance(row) for row in rows],
+        "advance_totals": _advance_totals(rows),
+    }
+
+
+async def _post_receive_gl(
+    conn,
+    tenant_id: UUID,
+    advance_id: UUID,
+    amount: Decimal,
+    payment_method: str,
+    payment_method_id: Optional[UUID],
+    entry_date: date,
+    created_by: Optional[UUID],
+) -> Optional[UUID]:
+    debit_code = await _resolve_payment_debit_code(conn, payment_method, payment_method_id)
+    debit_acct = await _resolve_account_id(conn, tenant_id, debit_code)
+    credit_acct = await _resolve_account_id(conn, tenant_id, DEFAULT_LIABILITY_CODE)
+    if not debit_acct or not credit_acct:
+        logger.warning(
+            "[table advance GL] Missing accounts debit=%s credit=%s tenant=%s",
+            debit_code,
+            DEFAULT_LIABILITY_CODE,
+            tenant_id,
+        )
+        return None
+    return await _post_two_line_gl(
+        conn,
+        tenant_id,
+        entry_date,
+        "Anticipo consumo mínimo mesa",
+        f"table-session-advance-{advance_id}",
+        ADVANCE_RECEIVE_SOURCE,
+        advance_id,
+        debit_acct,
+        credit_acct,
+        amount,
+        f"Dr {debit_code} — anticipo mesa",
+        f"Cr {DEFAULT_LIABILITY_CODE} — anticipos recibidos",
+        created_by,
+    )
+
+
+async def _post_void_gl(
+    conn,
+    tenant_id: UUID,
+    advance_id: UUID,
+    amount: Decimal,
+    payment_method: str,
+    payment_method_id: Optional[UUID],
+    entry_date: date,
+    created_by: Optional[UUID],
+) -> Optional[UUID]:
+    credit_code = await _resolve_payment_debit_code(conn, payment_method, payment_method_id)
+    debit_acct = await _resolve_account_id(conn, tenant_id, DEFAULT_LIABILITY_CODE)
+    credit_acct = await _resolve_account_id(conn, tenant_id, credit_code)
+    if not debit_acct or not credit_acct:
+        logger.warning(
+            "[table advance GL] Missing void accounts debit=%s credit=%s tenant=%s",
+            DEFAULT_LIABILITY_CODE,
+            credit_code,
+            tenant_id,
+        )
+        return None
+    return await _post_two_line_gl(
+        conn,
+        tenant_id,
+        entry_date,
+        "Anulación anticipo consumo mínimo mesa",
+        f"table-session-advance-void-{advance_id}",
+        ADVANCE_VOID_SOURCE,
+        advance_id,
+        debit_acct,
+        credit_acct,
+        amount,
+        f"Dr {DEFAULT_LIABILITY_CODE} — reverso anticipo mesa",
+        f"Cr {credit_code} — devolución anticipo mesa",
+        created_by,
+    )
+
+
+async def _try_post_advance_gl(conn, post_fn, advance_id: UUID, column: str) -> Optional[UUID]:
+    try:
+        async with conn.transaction():
+            journal_id = await post_fn()
+            if journal_id:
+                await conn.execute(
+                    f"""
+                    UPDATE table_session_advances
+                    SET {column} = $1,
+                        updated_at = now()
+                    WHERE id = $2
+                    """,
+                    journal_id,
+                    advance_id,
+                )
+            return journal_id
+    except Exception as exc:
+        logger.error("Table session advance GL failed: %s", exc)
+        return None
+
+
+async def create_session_advance(
+    request: Request,
+    table_id: UUID,
+    amount_cop: Decimal | float,
+    payment_method: str,
+    payment_method_id: Optional[UUID] = None,
+    notes: Optional[str] = None,
+    idempotency_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    user_id = session.user_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+    tenant_uuid = UUID(str(tenant_id))
+    user_uuid = UUID(str(user_id)) if user_id else None
+    amount = _amount_decimal(amount_cop)
+    _validate_advance_tender(payment_method)
+
+    async with get_db_connection() as conn:
+        async with conn.transaction():
+            session_row = await _get_open_session(conn, tenant_uuid, table_id, lock=True)
+            await _assert_payment_selection(conn, tenant_uuid, payment_method, payment_method_id)
+            if idempotency_key:
+                existing = await conn.fetchrow(
+                    """
+                    SELECT *
+                    FROM table_session_advances
+                    WHERE tenant_id = $1
+                      AND idempotency_key = $2
+                    """,
+                    tenant_uuid,
+                    idempotency_key,
+                )
+                if existing:
+                    payload = await get_session_advances_payload(
+                        conn,
+                        tenant_uuid,
+                        existing["table_session_id"],
+                    )
+                    return {
+                        "success": True,
+                        "data": {
+                            "advance": _serialize_advance(existing),
+                            **payload,
+                            "idempotent": True,
+                        },
+                    }
+
+            advance_row = await conn.fetchrow(
+                """
+                INSERT INTO table_session_advances (
+                    tenant_id,
+                    table_session_id,
+                    amount_cop,
+                    payment_method,
+                    payment_method_id,
+                    notes,
+                    created_by_user_id,
+                    idempotency_key
+                )
+                VALUES ($1, $2, $3, $4, $5::uuid, $6, $7::uuid, $8)
+                RETURNING *
+                """,
+                tenant_uuid,
+                session_row["id"],
+                amount,
+                payment_method,
+                str(payment_method_id) if payment_method_id else None,
+                notes,
+                str(user_uuid) if user_uuid else None,
+                idempotency_key,
+            )
+            journal_id = await _try_post_advance_gl(
+                conn,
+                lambda: _post_receive_gl(
+                    conn,
+                    tenant_uuid,
+                    advance_row["id"],
+                    amount,
+                    payment_method,
+                    payment_method_id,
+                    date.today(),
+                    user_uuid,
+                ),
+                advance_row["id"],
+                "journal_entry_id",
+            )
+            if journal_id:
+                advance_row = dict(advance_row)
+                advance_row["journal_entry_id"] = journal_id
+            payload = await get_session_advances_payload(conn, tenant_uuid, session_row["id"])
+            return {
+                "success": True,
+                "data": {
+                    "advance": _serialize_advance(advance_row),
+                    **payload,
+                },
+            }
+
+
+async def list_session_advances(request: Request, table_id: UUID) -> Dict[str, Any]:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+    tenant_uuid = UUID(str(tenant_id))
+
+    async with get_db_connection(use_transaction=False) as conn:
+        table_session = await _get_open_session(conn, tenant_uuid, table_id)
+        payload = await get_session_advances_payload(conn, tenant_uuid, table_session["id"])
+        return {
+            "success": True,
+            "data": {
+                "table_session_id": str(table_session["id"]),
+                **payload,
+            },
+        }
+
+
+async def void_session_advance(
+    request: Request,
+    table_id: UUID,
+    advance_id: UUID,
+    reason: Optional[str] = None,
+) -> Dict[str, Any]:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    user_id = session.user_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+    tenant_uuid = UUID(str(tenant_id))
+    user_uuid = UUID(str(user_id)) if user_id else None
+
+    async with get_db_connection() as conn:
+        async with conn.transaction():
+            session_row = await _get_open_session(conn, tenant_uuid, table_id, lock=True)
+            advance_row = await conn.fetchrow(
+                """
+                SELECT *
+                FROM table_session_advances
+                WHERE id = $1
+                  AND tenant_id = $2
+                  AND table_session_id = $3
+                FOR UPDATE
+                """,
+                advance_id,
+                tenant_uuid,
+                session_row["id"],
+            )
+            if not advance_row:
+                raise NotFoundError("Anticipo no encontrado")
+            if advance_row["status"] == "voided":
+                payload = await get_session_advances_payload(conn, tenant_uuid, session_row["id"])
+                return {
+                    "success": True,
+                    "data": {
+                        "advance": _serialize_advance(advance_row),
+                        **payload,
+                        "idempotent": True,
+                    },
+                }
+
+            updated_row = await conn.fetchrow(
+                """
+                UPDATE table_session_advances
+                SET status = 'voided',
+                    voided_at = now(),
+                    voided_by_user_id = $4::uuid,
+                    void_reason = $5,
+                    updated_at = now()
+                WHERE id = $1
+                  AND tenant_id = $2
+                  AND table_session_id = $3
+                  AND status = 'active'
+                RETURNING *
+                """,
+                advance_id,
+                tenant_uuid,
+                session_row["id"],
+                str(user_uuid) if user_uuid else None,
+                reason,
+            )
+            journal_id = await _try_post_advance_gl(
+                conn,
+                lambda: _post_void_gl(
+                    conn,
+                    tenant_uuid,
+                    advance_id,
+                    Decimal(str(updated_row["amount_cop"])),
+                    updated_row["payment_method"],
+                    updated_row["payment_method_id"],
+                    date.today(),
+                    user_uuid,
+                ),
+                advance_id,
+                "void_journal_entry_id",
+            )
+            if journal_id:
+                updated_row = dict(updated_row)
+                updated_row["void_journal_entry_id"] = journal_id
+            payload = await get_session_advances_payload(conn, tenant_uuid, session_row["id"])
+            return {
+                "success": True,
+                "data": {
+                    "advance": _serialize_advance(updated_row),
+                    **payload,
+                },
+            }

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -2223,6 +2223,13 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                 session_row["id"],
             )
             partial_paid_total = sum(float(r["group_amount"] or 0) for r in partial_payments_rows)
+            from app.services.table_session_advances_service import get_session_advances_payload
+
+            advances_payload = await get_session_advances_payload(
+                conn,
+                UUID(str(tenant_id)),
+                session_row["id"],
+            )
 
         return {
             "success": True,
@@ -2245,6 +2252,8 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                     "liquor_tax": float(_liq_tax),
                     "standard_tax_label": _tax_label,
                     "minimum_consumption": _minimum_consumption_state(session_row, partial_paid_total),
+                    "session_advances": advances_payload["advances"],
+                    "session_advance_totals": advances_payload["advance_totals"],
                     # Waiter attribution (warocol.com#574)
                     "attended_by_member_id": str(session_row["attended_by_member_id"]) if session_row.get("attended_by_member_id") else None,
                     "attended_by_member_name": session_row.get("attended_by_member_name"),

--- a/sql/20260617_table_session_advances.sql
+++ b/sql/20260617_table_session_advances.sql
@@ -1,0 +1,76 @@
+-- warocol.com#1370 — session-scoped advances for minimum consumption / cover.
+
+CREATE TABLE IF NOT EXISTS table_session_advances (
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id             UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    table_session_id      UUID NOT NULL REFERENCES table_sessions(id),
+    amount_cop            NUMERIC(12, 2) NOT NULL,
+    payment_method        VARCHAR(50) NOT NULL,
+    payment_method_id     UUID REFERENCES payment_methods(id) ON DELETE SET NULL,
+    journal_entry_id      UUID REFERENCES tenant_journal_entries(id) ON DELETE SET NULL,
+    void_journal_entry_id UUID REFERENCES tenant_journal_entries(id) ON DELETE SET NULL,
+    status                VARCHAR(20) NOT NULL DEFAULT 'active',
+    notes                 TEXT,
+    void_reason           TEXT,
+    voided_at             TIMESTAMPTZ,
+    voided_by_user_id     UUID REFERENCES profile(id),
+    created_by_user_id    UUID REFERENCES profile(id),
+    idempotency_key       VARCHAR(128),
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT chk_table_session_advances_amount_positive CHECK (amount_cop > 0),
+    CONSTRAINT chk_table_session_advances_status CHECK (status IN ('active', 'voided'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_table_session_advances_idempotency
+    ON table_session_advances (tenant_id, idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_table_session_advances_session_recent
+    ON table_session_advances (tenant_id, table_session_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_table_session_advances_active_session
+    ON table_session_advances (tenant_id, table_session_id)
+    WHERE status = 'active';
+
+COMMENT ON TABLE table_session_advances IS
+    'Session-scoped minimum consumption / cover advances. Collection is not an order payment or sale.';
+
+COMMENT ON COLUMN table_session_advances.table_session_id IS
+    'Open or historical table session that owns the advance; no customer/profile is required.';
+
+ALTER TABLE tenant_journal_entries
+    DROP CONSTRAINT IF EXISTS tenant_journal_entries_source_module_check;
+
+ALTER TABLE tenant_journal_entries
+    ADD CONSTRAINT tenant_journal_entries_source_module_check
+    CHECK (
+        source_module IS NULL
+        OR source_module::text = ANY (ARRAY[
+            'gastos',
+            'ventas',
+            'orden',
+            'orden_cogs',
+            'nomina',
+            'nomina_provision',
+            'nomina_ss',
+            'nomina_prima',
+            'nomina_cesantias',
+            'nomina_int_cesantias',
+            'nomina_vacaciones',
+            'nomina_dotacion',
+            'nomina_pila',
+            'nomina_horas_extras',
+            'nomina_liquidacion',
+            'inventario',
+            'cartera',
+            'arqueo',
+            'manual',
+            'system',
+            'manual_balance_adjustment',
+            'customer_wallet_recharge',
+            'customer_wallet_refund',
+            'table_session_advance_receive',
+            'table_session_advance_void'
+        ]::text[])
+    );

--- a/tests/test_table_session_advances.py
+++ b/tests/test_table_session_advances.py
@@ -1,0 +1,212 @@
+"""Tests for table-session minimum consumption advances (warocol.com#1370)."""
+from decimal import Decimal
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from app.core.exceptions import APIError
+from app.services import table_session_advances_service as svc
+
+
+class _AsyncContext:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _DbContext:
+    def __init__(self, conn):
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakeConn:
+    def __init__(self):
+        self.tenant_id = uuid4()
+        self.user_id = uuid4()
+        self.table_id = uuid4()
+        self.session_id = uuid4()
+        self.advance_id = uuid4()
+        self.payment_group_id = uuid4()
+        self.payment_method_id = uuid4()
+        self.fetchrow_queries = []
+        self.fetch_queries = []
+        self.execute_queries = []
+        self.advance_row = {
+            "id": self.advance_id,
+            "tenant_id": self.tenant_id,
+            "table_session_id": self.session_id,
+            "amount_cop": Decimal("50000.00"),
+            "payment_method": "cash",
+            "payment_method_id": self.payment_method_id,
+            "journal_entry_id": None,
+            "void_journal_entry_id": None,
+            "status": "active",
+            "notes": "cover",
+            "void_reason": None,
+            "voided_at": None,
+            "created_at": None,
+        }
+
+    def transaction(self):
+        return _AsyncContext()
+
+    async def fetchrow(self, query, *args):
+        self.fetchrow_queries.append(query)
+        compact = " ".join(query.split())
+        if "FROM tables" in compact:
+            return {"id": self.table_id}
+        if "FROM table_sessions" in compact:
+            return {"id": self.session_id, "table_id": self.table_id}
+        if "FROM payment_method_groups" in compact:
+            return {"id": self.payment_group_id}
+        if "FROM payment_methods" in compact and "WHERE id = $1" in compact:
+            return {"id": self.payment_method_id}
+        if "INSERT INTO table_session_advances" in compact:
+            return self.advance_row.copy()
+        if "idempotency_key" in compact:
+            return None
+        if "FROM tenant_accounts" in compact:
+            return None
+        return None
+
+    async def fetch(self, query, *args):
+        self.fetch_queries.append(query)
+        compact = " ".join(query.split())
+        if "FROM table_session_advances" in compact:
+            return [self.advance_row.copy()]
+        return []
+
+    async def execute(self, query, *args):
+        self.execute_queries.append(query)
+        return "OK"
+
+
+def _patch_request_context(monkeypatch, conn):
+    monkeypatch.setattr(
+        svc,
+        "require_valid_session",
+        lambda request: SimpleNamespace(
+            tenant_id=str(conn.tenant_id),
+            user_id=str(conn.user_id),
+        ),
+    )
+    monkeypatch.setattr(svc, "get_db_connection", lambda *args, **kwargs: _DbContext(conn))
+
+
+def _all_queries(conn):
+    return "\n".join(conn.fetchrow_queries + conn.fetch_queries + conn.execute_queries)
+
+
+class TestAdvanceValidation:
+    def test_rejects_customer_wallet_tender(self):
+        with pytest.raises(APIError) as exc:
+            svc._validate_advance_tender("customer_wallet")
+        assert exc.value.status_code == 400
+
+    def test_rejects_non_positive_amount(self):
+        with pytest.raises(APIError) as exc:
+            svc._amount_decimal(0)
+        assert exc.value.status_code == 400
+
+    def test_active_and_voided_totals_stay_separate(self):
+        rows = [
+            {"amount_cop": Decimal("10"), "status": "active"},
+            {"amount_cop": Decimal("20"), "status": "voided"},
+        ]
+        assert svc._advance_totals(rows) == {
+            "active_total_cop": 10.0,
+            "voided_total_cop": 20.0,
+        }
+
+
+class TestCreateSessionAdvance:
+    @pytest.mark.asyncio
+    async def test_creates_advance_without_order_payment_side_effects(self, monkeypatch):
+        conn = FakeConn()
+        _patch_request_context(monkeypatch, conn)
+
+        result = await svc.create_session_advance(
+            object(),
+            conn.table_id,
+            Decimal("50000"),
+            "cash",
+            conn.payment_method_id,
+            notes="cover",
+        )
+
+        assert result["success"] is True
+        assert result["data"]["advance"]["table_session_id"] == str(conn.session_id)
+        assert result["data"]["advance"]["payment_method_id"] == str(conn.payment_method_id)
+        assert result["data"]["advance_totals"]["active_total_cop"] == 50000.0
+        queries = _all_queries(conn)
+        assert "INSERT INTO table_session_advances" in queries
+        assert "order_payments" not in queries
+        assert "order_items" not in queries
+
+    @pytest.mark.asyncio
+    async def test_validates_payment_method_id_against_group(self, monkeypatch):
+        conn = FakeConn()
+        _patch_request_context(monkeypatch, conn)
+
+        await svc.create_session_advance(
+            object(),
+            conn.table_id,
+            Decimal("50000"),
+            "cash",
+            conn.payment_method_id,
+        )
+
+        payment_validation_queries = [
+            q for q in conn.fetchrow_queries
+            if "FROM payment_methods" in q and "group_id = $3" in q
+        ]
+        assert payment_validation_queries
+
+
+class TestVoidSessionAdvance:
+    @pytest.mark.asyncio
+    async def test_voids_advance_without_order_payment_side_effects(self, monkeypatch):
+        conn = FakeConn()
+        _patch_request_context(monkeypatch, conn)
+
+        async def fetchrow(query, *args):
+            conn.fetchrow_queries.append(query)
+            compact = " ".join(query.split())
+            if "FROM tables" in compact:
+                return {"id": conn.table_id}
+            if "FROM table_sessions" in compact:
+                return {"id": conn.session_id, "table_id": conn.table_id}
+            if "SELECT * FROM table_session_advances" in compact:
+                return conn.advance_row.copy()
+            if "UPDATE table_session_advances" in compact and "status = 'voided'" in compact:
+                row = conn.advance_row.copy()
+                row["status"] = "voided"
+                row["void_reason"] = "wrong amount"
+                return row
+            if "FROM tenant_accounts" in compact:
+                return None
+            return None
+
+        conn.fetchrow = fetchrow
+        result = await svc.void_session_advance(
+            object(),
+            conn.table_id,
+            conn.advance_id,
+            "wrong amount",
+        )
+
+        assert result["success"] is True
+        assert result["data"]["advance"]["status"] == "voided"
+        queries = _all_queries(conn)
+        assert "UPDATE table_session_advances" in queries
+        assert "order_payments" not in queries
+        assert "order_items" not in queries


### PR DESCRIPTION
## Summary
- add a table-session advance ledger for minimum-consumption prepayments without customer wallet
- add create/list/void endpoints under /tables/{table_id}/session-advances
- expose session advances separately from order partial payments in current-session payload

## Tests
- api_warocol.com/venv/bin/python -m py_compile app/services/table_session_advances_service.py app/routers/tables.py app/services/tables_service.py
- api_warocol.com/venv/bin/python -m pytest tests/test_table_session_advances.py

Closes uno0uno/warocol.com#1370