### PR TITLE
Fix minimum consumption advance accounting

### DIFF
--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -290,6 +290,7 @@ async def _post_order_gl_entry(
     order_number: Optional[int] = None,
     tip_amount: Decimal = Decimal("0"),
     tip_tax_amount: Decimal = Decimal("0"),
+    advance_amount: Decimal = Decimal("0"),
 ) -> None:
     """
     Post a double-entry GL journal entry for a single completed order (POS or domicilio).
@@ -351,16 +352,35 @@ async def _post_order_gl_entry(
         if liability_row and liability_row["customer_wallet_liability_gl_code"]:
             debit_code = str(liability_row["customer_wallet_liability_gl_code"])
 
-    debit_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, debit_code,
+    advance_debit = min(
+        Decimal(str(advance_amount or 0)).quantize(Decimal("0.01")),
+        total_amount,
     )
-    if not debit_acct:
+    payment_debit_required = advance_debit <= 0 or payment_method != "table_session_advance"
+    debit_acct = None
+    if payment_debit_required:
+        debit_acct = await conn.fetchrow(
+            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
+            tenant_id, debit_code,
+        )
+    if payment_debit_required and not debit_acct:
         logger.warning(
             f"[GL] Debit account {debit_code} not found for tenant {tenant_id} — "
             f"skip GL post for order {order_id}"
         )
         return
+    advance_acct = None
+    if advance_debit > 0:
+        advance_acct = await conn.fetchrow(
+            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
+            tenant_id, _SLUG_DEBIT_CODE["table_session_advance"],
+        )
+        if not advance_acct:
+            logger.warning(
+                f"[GL] Advance account 2810 not found for tenant {tenant_id} — "
+                f"skip GL post for order {order_id}"
+            )
+            return
 
     # ── Resolve 4135 Ingresos ──────────────────────────────────────────────
     ingresos_acct = await conn.fetchrow(
@@ -493,25 +513,45 @@ async def _post_order_gl_entry(
         )
         entry_id = entry_row["id"]
 
-        # Debit line — payment account
-        await conn.execute(
-            """INSERT INTO tenant_journal_lines
-                   (journal_entry_id, account_id, debit, credit, description, line_order)
-               VALUES ($1, $2, $3, 0, $4, 0)""",
-            entry_id, debit_acct["id"], dt, description,
-        )
+        line_order = 0
+        if advance_debit > 0 and advance_acct:
+            await conn.execute(
+                """INSERT INTO tenant_journal_lines
+                       (journal_entry_id, account_id, debit, credit, description, line_order)
+                   VALUES ($1, $2, $3, 0, $4, $5)""",
+                entry_id,
+                advance_acct["id"],
+                float(advance_debit),
+                f"{description} — aplicación anticipo mesa",
+                line_order,
+            )
+            line_order += 1
+        payment_debit = Decimal(str(debit_total)) - advance_debit
+        if payment_debit > 0 and debit_acct:
+            await conn.execute(
+                """INSERT INTO tenant_journal_lines
+                       (journal_entry_id, account_id, debit, credit, description, line_order)
+                   VALUES ($1, $2, $3, 0, $4, $5)""",
+                entry_id,
+                debit_acct["id"],
+                float(payment_debit),
+                description,
+                line_order,
+            )
+            line_order += 1
 
         # Credit line — product net revenue to 4175
         await conn.execute(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
-               VALUES ($1, $2, 0, $3, $4, 1)""",
+               VALUES ($1, $2, 0, $3, $4, $5)""",
             entry_id, ingresos_acct["id"], float(product_net_revenue),
             f"{description} — ingreso neto",
+            line_order,
         )
+        line_order += 1
 
         # Credit lines — one per active tax type (INC/IVA standard + IVA licores)
-        line_order = 2
         if standard_tax > 0 and standard_acct_id:
             await conn.execute(
                 """INSERT INTO tenant_journal_lines
@@ -1354,6 +1394,7 @@ async def _compute_preview(
             method_totals[m] = method_totals.get(m, 0.0) + float(row["total"])
 
     from app.services.customer_wallet_service import fetch_wallet_recharge_totals_for_cierre
+    from app.services.table_session_advances_service import fetch_table_session_advance_totals_for_cierre
 
     recharge_totals = await fetch_wallet_recharge_totals_for_cierre(
         conn,
@@ -1365,6 +1406,20 @@ async def _compute_preview(
     )
     for method, total in recharge_totals.items():
         method_totals[method] = method_totals.get(method, 0.0) + total
+
+    advance_totals = await fetch_table_session_advance_totals_for_cierre(
+        conn,
+        tenant_id,
+        period_start,
+        period_end,
+        period_start_time,
+        period_end_time,
+    )
+    for method, total in advance_totals["applications"].items():
+        method_totals[method] = max(method_totals.get(method, 0.0) - total, 0.0)
+    for method, total in advance_totals["collections"].items():
+        method_totals[method] = method_totals.get(method, 0.0) + total
+    minimum_cover_income = float(advance_totals.get("cover", {}).get("total", 0.0))
 
     gastos_row = await conn.fetchrow(
         f"""
@@ -1396,7 +1451,7 @@ async def _compute_preview(
     total_tips = float(tips_row["total_tips"])
     total_tip_tax = float(tips_row["total_tip_tax"])
     cash_tips = float(cash_tips_row["cash_tips"])
-    total_charged = float(sales_row["total_sales"]) + tip_settlement_total(
+    total_charged = float(sales_row["total_sales"]) + minimum_cover_income + tip_settlement_total(
         total_tips, total_tip_tax,
     )
     cash_expected = _compute_cash_expected(
@@ -1409,6 +1464,7 @@ async def _compute_preview(
 
     return {
         "totalSales":       float(sales_row["total_sales"]),
+        "minimumCoverIncome": minimum_cover_income,
         "itemsSold":        int(sales_row["items_sold"]),
         "totalTips":        total_tips,
         "totalTipTax":      total_tip_tax,
@@ -1599,6 +1655,32 @@ async def _compute_breakdown_rows(
             }
         else:
             aggregated[key]["total"] += total
+    from app.services.table_session_advances_service import fetch_table_session_advance_totals_for_cierre
+    advance_totals = await fetch_table_session_advance_totals_for_cierre(
+        conn,
+        tenant_id,
+        period_start,
+        period_end,
+        period_start_time,
+        period_end_time,
+    )
+    for method, total in advance_totals["applications"].items():
+        for key, row in aggregated.items():
+            if key[0] == method:
+                row["total"] = max(float(row["total"]) - total, 0.0)
+                break
+    for method, total in advance_totals["collections"].items():
+        if total == 0:
+            continue
+        key = (method, f"Anticipo mesa - {method}")
+        if key not in aggregated:
+            aggregated[key] = {
+                "group_slug": method,
+                "method_name": f"Anticipo mesa - {method}",
+                "total": float(total),
+            }
+        else:
+            aggregated[key]["total"] += float(total)
     return [r for r in aggregated.values() if r["total"] > 0]
 
 
@@ -2142,6 +2224,7 @@ async def create_cierre(request: Request, body: CierreCreate) -> dict:
                 "periodEndTime":        period_end_time.isoformat()   if period_end_time   else None,
                 "shiftTemplateId":      str(shift_template_id) if shift_template_id else None,
                 "totalSales":           preview["totalSales"],
+                "minimumCoverIncome":   preview.get("minimumCoverIncome", 0.0),
                 "itemsSold":            preview["itemsSold"],
                 "totalTips":            preview["totalTips"],
                 "totalTipTax":          preview["totalTipTax"],

--- a/app/services/table_session_advances_service.py
+++ b/app/services/table_session_advances_service.py
@@ -30,6 +30,8 @@ ALLOWED_ADVANCE_TENDERS = {"cash", "card", "digital"}
 TABLE_SESSION_ADVANCE_PAYMENT_SLUG = "table_session_advance"
 ADVANCE_RECEIVE_SOURCE = "table_session_advance_receive"
 ADVANCE_VOID_SOURCE = "table_session_advance_void"
+ADVANCE_COVER_SOURCE = "table_session_advance_cover"
+INGRESOS_CODE = "4175"
 
 
 def _amount_decimal(amount: Decimal | float | int | str) -> Decimal:
@@ -307,6 +309,257 @@ async def apply_session_advances_for_close(
             break
 
     return applied_total.quantize(Decimal("0.01"))
+
+
+def _standard_cover_gl_amounts(amount: Decimal, tax_config: Dict[str, Any]) -> tuple:
+    settlement = Decimal(str(amount or 0)).quantize(Decimal("0.01"))
+    tax_amount = Decimal("0")
+    tax_code = None
+    if settlement <= 0:
+        return settlement, settlement, tax_amount, tax_code
+    if tax_config.get("inc_applicable"):
+        rate = Decimal(str(tax_config["inc_rate"]))
+        tax_code = str(tax_config["inc_gl_account_code"])
+        tax_amount = settlement - (settlement / (1 + rate))
+    elif tax_config.get("iva_applicable"):
+        rate = Decimal(str(tax_config["iva_rate"]))
+        tax_code = str(tax_config["iva_gl_account_code"])
+        tax_amount = settlement - (settlement / (1 + rate))
+    return settlement, settlement - tax_amount, tax_amount, tax_code
+
+
+async def recognize_unconsumed_advance_cover_for_close(
+    conn,
+    tenant_id: UUID,
+    table_session_id: UUID,
+    amount_cop: Decimal,
+    order_ids: List[UUID],
+    tax_config: Dict[str, Any],
+    entry_date: date,
+    created_by: Optional[UUID],
+) -> Decimal:
+    cover_to_apply = Decimal(str(amount_cop or 0)).quantize(Decimal("0.01"))
+    if cover_to_apply <= 0:
+        return Decimal("0")
+
+    existing = await conn.fetchval(
+        """
+        SELECT id
+        FROM tenant_journal_entries
+        WHERE tenant_id = $1
+          AND source_module = $2
+          AND source_id = $3
+          AND status = 'posted'
+        """,
+        tenant_id,
+        ADVANCE_COVER_SOURCE,
+        table_session_id,
+    )
+    if existing:
+        logger.info("[table advance GL] Cover for session %s already posted", table_session_id)
+        return Decimal("0")
+
+    applied = await apply_session_advances_for_close(
+        conn,
+        tenant_id,
+        table_session_id,
+        cover_to_apply,
+        order_ids,
+    )
+    if applied <= 0:
+        return Decimal("0")
+
+    settlement, net_revenue, tax_amount, tax_code = _standard_cover_gl_amounts(applied, tax_config)
+    liability_acct = await _resolve_account_id(conn, tenant_id, DEFAULT_LIABILITY_CODE)
+    revenue_acct = await _resolve_account_id(conn, tenant_id, INGRESOS_CODE)
+    tax_acct = await _resolve_account_id(conn, tenant_id, tax_code) if tax_code and tax_amount > 0 else None
+    if not liability_acct or not revenue_acct:
+        logger.warning(
+            "[table advance GL] Missing cover accounts liability=%s revenue=%s tenant=%s",
+            DEFAULT_LIABILITY_CODE,
+            INGRESOS_CODE,
+            tenant_id,
+        )
+        return applied
+
+    async with conn.transaction():
+        entry_row = await conn.fetchrow(
+            """
+            INSERT INTO tenant_journal_entries
+                (tenant_id, entry_date, period_year, period_month,
+                 description, reference, source_module, source_id, status,
+                 total_debit, total_credit, created_by_user_id, posted_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'posted',
+                    $9, $9, $10::uuid, NOW())
+            RETURNING id
+            """,
+            tenant_id,
+            entry_date,
+            entry_date.year,
+            entry_date.month,
+            "Sobrante consumo mínimo mesa",
+            f"table-session-cover-{table_session_id}",
+            ADVANCE_COVER_SOURCE,
+            table_session_id,
+            float(settlement),
+            str(created_by) if created_by else None,
+        )
+        entry_id = entry_row["id"]
+        await conn.execute(
+            """
+            INSERT INTO tenant_journal_lines
+                (journal_entry_id, account_id, debit, credit, description, line_order)
+            VALUES ($1, $2, $3, 0, $4, 0)
+            """,
+            entry_id,
+            liability_acct,
+            float(settlement),
+            "Dr 2810 - aplicación sobrante consumo mínimo",
+        )
+        await conn.execute(
+            """
+            INSERT INTO tenant_journal_lines
+                (journal_entry_id, account_id, debit, credit, description, line_order)
+            VALUES ($1, $2, 0, $3, $4, 1)
+            """,
+            entry_id,
+            revenue_acct,
+            float(net_revenue),
+            "Cr 4175 - ingreso cover consumo mínimo",
+        )
+        if tax_amount > 0 and tax_acct:
+            await conn.execute(
+                """
+                INSERT INTO tenant_journal_lines
+                    (journal_entry_id, account_id, debit, credit, description, line_order)
+                VALUES ($1, $2, 0, $3, $4, 2)
+                """,
+                entry_id,
+                tax_acct,
+                float(tax_amount),
+                "Cr impuesto - cover consumo mínimo",
+            )
+
+    logger.info(
+        "[table advance GL] Posted cover for session %s amount=%s tax=%s",
+        table_session_id,
+        float(settlement),
+        float(tax_amount),
+    )
+    return applied
+
+
+async def fetch_table_session_advance_totals_for_cierre(
+    conn,
+    tenant_id: UUID,
+    period_start: date,
+    period_end: date,
+    period_start_time=None,
+    period_end_time=None,
+) -> Dict[str, Dict[str, float]]:
+    if period_start_time and period_end_time:
+        receive_filter = "created_at >= $2 AND created_at < $3"
+        void_filter = "voided_at >= $2 AND voided_at < $3"
+        params = (tenant_id, period_start_time, period_end_time)
+    else:
+        receive_filter = "created_at::date >= $2 AND created_at::date <= $3"
+        void_filter = "voided_at::date >= $2 AND voided_at::date <= $3"
+        params = (tenant_id, period_start, period_end)
+
+    collection_rows = await conn.fetch(
+        f"""
+        SELECT payment_method AS method, COALESCE(SUM(amount_cop), 0) AS total
+        FROM table_session_advances
+        WHERE tenant_id = $1
+          AND payment_method IS NOT NULL
+          AND {receive_filter}
+        GROUP BY payment_method
+
+        UNION ALL
+
+        SELECT payment_method AS method, -COALESCE(SUM(amount_cop), 0) AS total
+        FROM table_session_advances
+        WHERE tenant_id = $1
+          AND payment_method IS NOT NULL
+          AND status = 'voided'
+          AND voided_at IS NOT NULL
+          AND {void_filter}
+        GROUP BY payment_method
+        """,
+        *params,
+    )
+
+    application_rows = await conn.fetch(
+        f"""
+        SELECT
+            COALESCE(pmg.slug, first_order.payment_method, $4) AS method,
+            COALESCE(SUM(tsa.applied_amount_cop), 0) AS total
+        FROM table_session_advances tsa
+        LEFT JOIN LATERAL (
+            SELECT o.payment_method, o.payment_method_id
+            FROM orders o
+            WHERE o.id = ANY(tsa.applied_order_ids)
+            ORDER BY o.created_at, o.id
+            LIMIT 1
+        ) first_order ON true
+        LEFT JOIN payment_methods pm ON pm.id = first_order.payment_method_id
+        LEFT JOIN payment_method_groups pmg ON pmg.id = pm.group_id
+        WHERE tsa.tenant_id = $1
+          AND tsa.status = 'active'
+          AND COALESCE(tsa.applied_amount_cop, 0) > 0
+          AND tsa.applied_at IS NOT NULL
+          AND {receive_filter.replace("created_at", "tsa.applied_at")}
+        GROUP BY COALESCE(pmg.slug, first_order.payment_method, $4)
+        """,
+        *params,
+        TABLE_SESSION_ADVANCE_PAYMENT_SLUG,
+    )
+
+    if period_start_time and period_end_time:
+        cover_rows = await conn.fetch(
+            """
+            SELECT COALESCE(SUM(total_debit), 0) AS total
+            FROM tenant_journal_entries
+            WHERE tenant_id = $1
+              AND source_module = $4
+              AND status = 'posted'
+              AND entry_date >= $2::date
+              AND entry_date <= $3::date
+            """,
+            tenant_id,
+            period_start_time,
+            period_end_time,
+            ADVANCE_COVER_SOURCE,
+        )
+    else:
+        cover_rows = await conn.fetch(
+            """
+            SELECT COALESCE(SUM(total_debit), 0) AS total
+            FROM tenant_journal_entries
+            WHERE tenant_id = $1
+              AND source_module = $4
+              AND status = 'posted'
+              AND entry_date >= $2
+              AND entry_date <= $3
+            """,
+            tenant_id,
+            period_start,
+            period_end,
+            ADVANCE_COVER_SOURCE,
+        )
+
+    out = {"collections": {}, "applications": {}, "cover": {"total": 0.0}}
+    for row in collection_rows:
+        method = row["method"]
+        if method:
+            out["collections"][method] = out["collections"].get(method, 0.0) + float(row["total"])
+    for row in application_rows:
+        method = row["method"]
+        if method:
+            out["applications"][method] = out["applications"].get(method, 0.0) + float(row["total"])
+    for row in cover_rows:
+        out["cover"]["total"] += float(row["total"] or 0)
+    return out
 
 
 async def _post_receive_gl(

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -49,6 +49,7 @@ from app.services.table_session_advances_service import (
     TABLE_SESSION_ADVANCE_PAYMENT_SLUG,
     apply_session_advances_for_close,
     get_available_advance_total,
+    recognize_unconsumed_advance_cover_for_close,
 )
 import logging
 
@@ -1027,6 +1028,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                 _minimum_close_state: Optional[dict] = None
                 _advance_apply_amount = Decimal("0")
                 _advance_applied_total = Decimal("0")
+                _advance_cover_total = Decimal("0")
 
                 available_advance_total = await get_available_advance_total(
                     conn,
@@ -1406,6 +1408,21 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                                 [row["id"] for row in completed_orders],
                             )
                         tax_config = await _get_tenant_tax_config(conn, tenant_id)
+                        _advance_remaining_after_products = max(
+                            available_advance_total - _advance_applied_total,
+                            Decimal("0"),
+                        )
+                        if not split_mode and _advance_remaining_after_products > 0:
+                            _advance_cover_total = await recognize_unconsumed_advance_cover_for_close(
+                                conn,
+                                UUID(str(tenant_id)),
+                                session_row["id"],
+                                _advance_remaining_after_products,
+                                [row["id"] for row in completed_orders],
+                                tax_config,
+                                date.today(),
+                                UUID(str(user_id)) if user_id else None,
+                            )
                         first_order_id = await conn.fetchval(
                             """
                             SELECT id FROM orders
@@ -1414,9 +1431,17 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                             """,
                             session_row["id"],
                         )
+                        _advance_remaining_for_gl = _advance_applied_total
                         for ord_row in completed_orders:
                             ord_tip = Decimal("0")
                             ord_tip_tax = Decimal("0")
+                            ord_advance = Decimal("0")
+                            if not split_mode and _advance_remaining_for_gl > 0:
+                                ord_advance = min(
+                                    _advance_remaining_for_gl,
+                                    Decimal(str(ord_row["total_amount"] or 0)),
+                                )
+                                _advance_remaining_for_gl -= ord_advance
                             if not split_mode and first_order_id and ord_row["id"] == first_order_id:
                                 ord_tip = Decimal(str(tip_amount or 0))
                                 ord_tip_tax = Decimal(str(_mesa_tip_tax_amount))
@@ -1432,6 +1457,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                                 order_number=int(ord_row["order_number"]),
                                 tip_amount=ord_tip,
                                 tip_tax_amount=ord_tip_tax,
+                                advance_amount=ord_advance,
                             )
                             await _post_order_cogs_gl_entry(
                                 conn=conn,
@@ -1751,6 +1777,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                 "minimum_consumption": {
                     **(_minimum_close_state or {}),
                     "advance_applied": float(_advance_applied_total),
+                    "cover_recognized": float(_advance_cover_total),
                 } if _minimum_close_state else None,
                 "tip_amount": float(tip_amount) if tip_amount > 0 else 0,
                 "tip_source": tip_source,

--- a/sql/20260617_table_session_advances.sql
+++ b/sql/20260617_table_session_advances.sql
@@ -92,6 +92,7 @@ ALTER TABLE tenant_journal_entries
             'customer_wallet_recharge',
             'customer_wallet_refund',
             'table_session_advance_receive',
-            'table_session_advance_void'
+            'table_session_advance_void',
+            'table_session_advance_cover'
         ]::text[])
     );

--- a/tests/test_manual_order_gl_cogs.py
+++ b/tests/test_manual_order_gl_cogs.py
@@ -685,6 +685,48 @@ async def test_post_order_gl_entry_uses_selected_method_account_before_slug_fall
     assert debit_line_args[2] == debit_account_id
 
 
+@pytest.mark.asyncio
+async def test_post_order_gl_entry_splits_table_advance_to_2810():
+    tenant_id = uuid4()
+    order_id = uuid4()
+    advance_account_id = uuid4()
+    ingresos_account_id = uuid4()
+    entry_id = uuid4()
+
+    conn = AsyncMock()
+    conn.fetchval = AsyncMock(return_value=None)
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {"id": advance_account_id},
+            {"id": ingresos_account_id},
+            {"id": entry_id},
+        ]
+    )
+    conn.fetch = AsyncMock(return_value=[])
+    conn.execute = AsyncMock()
+    conn.transaction = MagicMock(return_value=_AsyncContext())
+
+    await cierre_service._post_order_gl_entry(
+        conn=conn,
+        tenant_id=tenant_id,
+        order_id=order_id,
+        order_date=date(2026, 6, 16),
+        total_amount=Decimal("70000"),
+        payment_method="table_session_advance",
+        payment_method_id=None,
+        tax_config={},
+        order_number=8522,
+        advance_amount=Decimal("70000"),
+    )
+
+    advance_lookup_args = conn.fetchrow.await_args_list[0].args
+    advance_line_args = conn.execute.await_args_list[0].args
+    assert advance_lookup_args[1:] == (tenant_id, "2810")
+    assert advance_line_args[2] == advance_account_id
+    assert advance_line_args[3] == 70000.0
+    assert "aplicación anticipo mesa" in advance_line_args[4]
+
+
 def test_manual_order_modifier_quantity_defaults_to_one():
     modifier = ManualOrderModifier(id=str(uuid4()), name="Extra queso", price=2500)
 

--- a/tests/test_table_session_advances.py
+++ b/tests/test_table_session_advances.py
@@ -141,6 +141,21 @@ class TestAdvanceValidation:
             "voided_total_cop": 0,
         }
 
+    def test_cover_gl_amounts_extract_standard_tax_from_settlement(self):
+        settlement, net, tax, tax_code = svc._standard_cover_gl_amounts(
+            Decimal("108000"),
+            {
+                "inc_applicable": True,
+                "inc_rate": Decimal("0.0800"),
+                "inc_gl_account_code": "2495",
+            },
+        )
+
+        assert settlement == Decimal("108000.00")
+        assert net.quantize(Decimal("0.01")) == Decimal("100000.00")
+        assert tax.quantize(Decimal("0.01")) == Decimal("8000.00")
+        assert tax_code == "2495"
+
 
 class TestCreateSessionAdvance:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- split table-session advance applications to debit 2810 instead of cash/bank again
- recognize unconsumed minimum-consumption advances as cover revenue with tenant tax split
- adjust cierre preview/breakdown so advance collections and applications do not double count

## Tests
- pytest tests/test_table_session_advances.py tests/test_manual_order_gl_cogs.py tests/test_cierre_preview_cash.py

Closes uno0uno/warocol.com#1372