### PR TITLE
Allow table cash close after advances

### DIFF
--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -195,7 +195,7 @@ class CloseSessionRequest(BaseModel):
     split_mode: bool = Field(False, description="True when using split payment — keeps session open, marks orders as partial")
     split_first_amount: float = Field(0.0, description="Amount for the first split payment (used only when split_mode=True)")
     split_first_cash_received: Optional[float] = Field(None, description="Issue #524 — cash handed over for the first split payment when payment_method='cash'. Must be >= split_first_amount.")
-    cash_received: Optional[float] = Field(None, description="Issue #524 — cash handed over for a single (non-split) cash close. Must be >= total session amount.")
+    cash_received: Optional[float] = Field(None, description="Issue #524 — cash handed over for a single (non-split) cash close. Must be >= amount due after table-session advances.")
     tip_amount: float = Field(0, ge=0, description="warocol.com#639 — total tip for the mesa session. Applied to the first completed order in the session (like cash_received). Rejected when tip_enabled=false. Allowed with split_mode.")
     tip_source: Literal['preset', 'custom', 'none'] = Field('none', description="warocol.com#639 — how the tip was chosen. Must agree with tip_amount.")
     tip_taxable: bool = Field(False, description="warocol.com#740 — apply consumption tax to tip_amount when true (gravada).")

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -1790,7 +1790,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                         - float(_advance_applied_total),
                     )
                     + tip_settlement_total(float(tip_amount), _mesa_tip_tax_amount)
-                ) if tip_amount > 0 else None,
+                ) if tip_amount > 0 or _advance_applied_total > 0 else None,
             },
         }
 

--- a/sql/20260617_orders_cash_received_table_advance.sql
+++ b/sql/20260617_orders_cash_received_table_advance.sql
@@ -1,0 +1,18 @@
+ALTER TABLE orders
+    DROP CONSTRAINT IF EXISTS chk_orders_cash_received_gte_total;
+
+ALTER TABLE orders
+    ADD CONSTRAINT chk_orders_cash_received_gte_total
+    CHECK (
+        cash_received IS NULL
+        OR (
+            cash_received >= 0
+            AND (
+                cash_received >= total_amount
+                OR table_session_id IS NOT NULL
+            )
+        )
+    );
+
+COMMENT ON CONSTRAINT chk_orders_cash_received_gte_total ON orders IS
+    'Single cash tender must cover total_amount for counter/online orders. Table sessions may store only the cash balance collected after an applied table-session advance; service validation enforces the close amount.';


### PR DESCRIPTION
## Summary
- Adjusts the orders cash_received constraint so table sessions can store only the cash balance collected after an applied table advance.
- Keeps the stricter cash_received >= total_amount rule for non-table orders.
- Returns charged_amount when a table advance is applied, even without tip.

## Tests
- python3 -m py_compile app/services/tables_service.py app/routers/tables.py
- git diff --check -- app/routers/tables.py app/services/tables_service.py sql/20260617_orders_cash_received_table_advance.sql
- Applied sql/20260617_orders_cash_received_table_advance.sql against local/tunneled DATABASE_URL and verified constraint definition

Refs uno0uno/warocol.com#1378