### PR TITLE
Expose table advance totals on order detail

### DIFF
--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -667,6 +667,7 @@ async def get_order_by_id(
                     o.delivery_instructions,
                     o.tip_amount,
                     o.tip_source,
+                    o.tip_tax_amount,
                     t_meta2.is_bar as is_bar,
                     o.served_by_member_id,
                     p_served.name as served_by_member_name,
@@ -748,6 +749,51 @@ async def get_order_by_id(
 
             _promo_summary = await _get_order_promo_summary(conn, order_id)
             _waro_summary = await _get_order_waro_redemption_summary(conn, order_id)
+            advance_gl_row = await conn.fetchrow(
+                """
+                SELECT COALESCE(SUM(jl.debit), 0) AS advance_applied
+                FROM tenant_journal_entries je
+                JOIN tenant_journal_lines jl ON jl.journal_entry_id = je.id
+                JOIN tenant_accounts ta ON ta.id = jl.account_id
+                WHERE je.tenant_id = $1
+                  AND je.source_module = 'orden'
+                  AND je.source_id = $2
+                  AND je.status = 'posted'
+                  AND ta.code = '2810'
+                  AND jl.debit > 0
+                  AND jl.description ILIKE '%anticipo mesa%'
+                """,
+                tenant_id,
+                order_id,
+            )
+            _tip_amount = float(order_row['tip_amount']) if order_row['tip_amount'] is not None else 0.0
+            _tip_tax_amount = float(order_row['tip_tax_amount']) if order_row['tip_tax_amount'] is not None else 0.0
+            _settlement_amount = float(order_row['total_amount']) + _tip_amount + _tip_tax_amount
+            _advance_applied = float(advance_gl_row["advance_applied"] or 0) if advance_gl_row else 0.0
+            if _advance_applied <= 0:
+                advance_direct_row = await conn.fetchrow(
+                    """
+                    SELECT COALESCE(SUM(applied_amount_cop), 0) AS advance_applied
+                    FROM table_session_advances
+                    WHERE tenant_id = $1
+                      AND status = 'active'
+                      AND $2 = ANY(applied_order_ids)
+                      AND cardinality(applied_order_ids) = 1
+                    """,
+                    tenant_id,
+                    order_id,
+                )
+                _advance_applied = (
+                    float(advance_direct_row["advance_applied"] or 0)
+                    if advance_direct_row else 0.0
+                )
+            _advance_applied = min(_settlement_amount, _advance_applied)
+            _charged_amount = None
+            if _tip_amount > 0 or _advance_applied > 0:
+                _charged_amount = max(
+                    0.0,
+                    _settlement_amount - _advance_applied,
+                )
 
             # Hydrate delivery address inline (None if not a delivery, or address was soft-deleted)
             delivery_address = None
@@ -801,8 +847,11 @@ async def get_order_by_id(
                     },
                     "served_by_member_id": str(order_row['served_by_member_id']) if order_row['served_by_member_id'] else None,
                     "served_by_member_name": order_row['served_by_member_name'],
-                    "tip_amount": float(order_row['tip_amount']) if order_row['tip_amount'] is not None else 0.0,
+                    "tip_amount": _tip_amount,
                     "tip_source": order_row['tip_source'] or 'none',
+                    "tip_tax_amount": _tip_tax_amount,
+                    "advance_applied": _advance_applied,
+                    "charged_amount": _charged_amount,
                     "items_count": order_row['items_count'],
                     "split_payments": split_payments,
                     "standard_tax": _std_tax,

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -1179,6 +1179,17 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                         consumed_total,
                         available_advance_total,
                     )
+                    if tip_amount > 0:
+                        tax_config = await _get_tenant_tax_config(conn, tenant_id)
+                        _mesa_tip_tax_amount = compute_tip_tax_amount(
+                            float(tip_amount), bool(tip_taxable), tax_config,
+                        )
+                    _settlement_due_after_advance = max(
+                        Decimal("0"),
+                        consumed_total
+                        + Decimal(str(tip_settlement_total(float(tip_amount), _mesa_tip_tax_amount)))
+                        - available_advance_total,
+                    )
                     if (
                         not split_mode
                         and _minimum_close_state["enabled"]
@@ -1199,17 +1210,17 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                         )
                     if not split_mode and available_advance_total > 0:
                         _advance_apply_amount = Decimal(str(_minimum_close_state["apply_amount"]))
-                        if Decimal(str(_minimum_close_state["overage_due"])) <= Decimal("0.01"):
+                        if _settlement_due_after_advance <= Decimal("0.01"):
                             payment_method = TABLE_SESSION_ADVANCE_PAYMENT_SLUG
                             payment_method_id = None
                             cash_received = None
                         elif payment_method == TABLE_SESSION_ADVANCE_PAYMENT_SLUG:
                             raise APIError(
-                                "Selecciona un método de pago para cobrar el excedente del consumo mínimo",
+                                "Selecciona un método de pago para cobrar el saldo pendiente",
                                 status_code=400,
                                 details={
                                     "code": "minimum_consumption_overage_payment_required",
-                                    "overage_due": _minimum_close_state["overage_due"],
+                                    "overage_due": float(_settlement_due_after_advance),
                                 },
                             )
 
@@ -1336,8 +1347,11 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                                 float(tip_amount), _mesa_tip_tax_amount,
                             )
                             if _minimum_close_state and _minimum_close_state["advance_total"] > 0:
-                                _required_cash = float(_minimum_close_state["overage_due"]) + tip_settlement_total(
-                                    float(tip_amount), _mesa_tip_tax_amount,
+                                _required_cash = max(
+                                    0.0,
+                                    float(session_total_with_tip or 0)
+                                    + tip_settlement_total(float(tip_amount), _mesa_tip_tax_amount)
+                                    - float(_minimum_close_state["advance_total"]),
                                 )
                             if cash_received < _required_cash:
                                 raise APIError(
@@ -1750,6 +1764,15 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                 logger.warning(f"Tax breakdown failed for mesa close (table {table_id}): {_e}")
         order_ids = [str(r["id"]) for r in order_rows]
         order_numbers = [int(r["order_number"]) for r in order_rows if r["order_number"] is not None]
+        settlement_total = (
+            float(sum(float(r.get("total_amount", 0)) for r in order_rows))
+            + tip_settlement_total(float(tip_amount), _mesa_tip_tax_amount)
+        )
+        advance_settlement_applied = min(
+            settlement_total,
+            float(_advance_applied_total + _advance_cover_total),
+        )
+        charged_amount = max(0.0, settlement_total - advance_settlement_applied)
 
         # Defensive: keep alignment even if order_number is unexpectedly null
         if len(order_numbers) != len(order_ids):
@@ -1774,6 +1797,10 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                 "standard_tax_label": _tax_label,
                 "promo_savings": float(_promo_savings),
                 "promo_breakdown": _promo_breakdown,
+                "payment_method": payment_method,
+                "payment_method_id": str(payment_method_id) if payment_method_id else None,
+                "advance_applied": advance_settlement_applied,
+                "advance_cover_recognized": float(_advance_cover_total),
                 "minimum_consumption": {
                     **(_minimum_close_state or {}),
                     "advance_applied": float(_advance_applied_total),
@@ -1783,14 +1810,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                 "tip_source": tip_source,
                 "tip_taxable": _mesa_tip_taxable if tip_amount > 0 else False,
                 "tip_tax_amount": float(_mesa_tip_tax_amount) if tip_amount > 0 else 0,
-                "charged_amount": (
-                    max(
-                        0.0,
-                        float(sum(float(r.get("total_amount", 0)) for r in order_rows))
-                        - float(_advance_applied_total),
-                    )
-                    + tip_settlement_total(float(tip_amount), _mesa_tip_tax_amount)
-                ) if tip_amount > 0 or _advance_applied_total > 0 else None,
+                "charged_amount": charged_amount if tip_amount > 0 or advance_settlement_applied > 0 else None,
             },
         }
 


### PR DESCRIPTION
## Summary
- Return readonly table advance totals from order detail
- Return final payment method, advance applied, and charged amount from table close
- Keep settlement/accounting mutation logic unchanged beyond response values already calculated during close

## Tests
- `python3 -m py_compile app/services/orders_service.py app/services/tables_service.py`
- `git diff --check -- app/services/orders_service.py app/services/tables_service.py`

Refs uno0uno/warocol.com#1380
