### PR TITLE
Post order GL when table advance covers balance

### DIFF
--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -352,36 +352,6 @@ async def _post_order_gl_entry(
         if liability_row and liability_row["customer_wallet_liability_gl_code"]:
             debit_code = str(liability_row["customer_wallet_liability_gl_code"])
 
-    advance_debit = min(
-        Decimal(str(advance_amount or 0)).quantize(Decimal("0.01")),
-        total_amount,
-    )
-    payment_debit_required = advance_debit <= 0 or payment_method != "table_session_advance"
-    debit_acct = None
-    if payment_debit_required:
-        debit_acct = await conn.fetchrow(
-            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-            tenant_id, debit_code,
-        )
-    if payment_debit_required and not debit_acct:
-        logger.warning(
-            f"[GL] Debit account {debit_code} not found for tenant {tenant_id} — "
-            f"skip GL post for order {order_id}"
-        )
-        return
-    advance_acct = None
-    if advance_debit > 0:
-        advance_acct = await conn.fetchrow(
-            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-            tenant_id, _SLUG_DEBIT_CODE["table_session_advance"],
-        )
-        if not advance_acct:
-            logger.warning(
-                f"[GL] Advance account 2810 not found for tenant {tenant_id} — "
-                f"skip GL post for order {order_id}"
-            )
-            return
-
     # ── Resolve 4135 Ingresos ──────────────────────────────────────────────
     ingresos_acct = await conn.fetchrow(
         "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
@@ -495,6 +465,36 @@ async def _post_order_gl_entry(
     if tip_settlement > 0:
         debit_total += tip_settlement
 
+    advance_debit = min(
+        Decimal(str(advance_amount or 0)).quantize(Decimal("0.01")),
+        debit_total,
+    )
+    payment_debit = debit_total - advance_debit
+    debit_acct = None
+    if payment_debit > 0:
+        debit_acct = await conn.fetchrow(
+            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
+            tenant_id, debit_code,
+        )
+        if not debit_acct:
+            logger.warning(
+                f"[GL] Debit account {debit_code} not found for tenant {tenant_id} — "
+                f"skip GL post for order {order_id}"
+            )
+            return
+    advance_acct = None
+    if advance_debit > 0:
+        advance_acct = await conn.fetchrow(
+            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
+            tenant_id, _SLUG_DEBIT_CODE["table_session_advance"],
+        )
+        if not advance_acct:
+            logger.warning(
+                f"[GL] Advance account 2810 not found for tenant {tenant_id} — "
+                f"skip GL post for order {order_id}"
+            )
+            return
+
     dt = float(debit_total)
     description = f"#{order_number}" if order_number else f"Venta {order_date.isoformat()} — orden {order_id}"
     tip_description = f"{description} — propina"
@@ -526,7 +526,6 @@ async def _post_order_gl_entry(
                 line_order,
             )
             line_order += 1
-        payment_debit = Decimal(str(debit_total)) - advance_debit
         if payment_debit > 0 and debit_acct:
             await conn.execute(
                 """INSERT INTO tenant_journal_lines

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -1028,6 +1028,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                 _minimum_close_state: Optional[dict] = None
                 _advance_apply_amount = Decimal("0")
                 _advance_applied_total = Decimal("0")
+                _advance_tip_applied_total = Decimal("0")
                 _advance_cover_total = Decimal("0")
 
                 available_advance_total = await get_available_advance_total(
@@ -1422,16 +1423,35 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                                 [row["id"] for row in completed_orders],
                             )
                         tax_config = await _get_tenant_tax_config(conn, tenant_id)
+                        _tip_settlement_decimal = Decimal(str(
+                            tip_settlement_total(float(tip_amount), _mesa_tip_tax_amount)
+                        )).quantize(Decimal("0.01"))
                         _advance_remaining_after_products = max(
                             available_advance_total - _advance_applied_total,
                             Decimal("0"),
                         )
-                        if not split_mode and _advance_remaining_after_products > 0:
+                        if not split_mode and _advance_remaining_after_products > 0 and _tip_settlement_decimal > 0:
+                            _advance_tip_apply_amount = min(
+                                _advance_remaining_after_products,
+                                _tip_settlement_decimal,
+                            )
+                            _advance_tip_applied_total = await apply_session_advances_for_close(
+                                conn,
+                                UUID(str(tenant_id)),
+                                session_row["id"],
+                                _advance_tip_apply_amount,
+                                [row["id"] for row in completed_orders],
+                            )
+                        _advance_remaining_after_settlement = max(
+                            _advance_remaining_after_products - _advance_tip_applied_total,
+                            Decimal("0"),
+                        )
+                        if not split_mode and _advance_remaining_after_settlement > 0:
                             _advance_cover_total = await recognize_unconsumed_advance_cover_for_close(
                                 conn,
                                 UUID(str(tenant_id)),
                                 session_row["id"],
-                                _advance_remaining_after_products,
+                                _advance_remaining_after_settlement,
                                 [row["id"] for row in completed_orders],
                                 tax_config,
                                 date.today(),
@@ -1445,20 +1465,22 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                             """,
                             session_row["id"],
                         )
-                        _advance_remaining_for_gl = _advance_applied_total
+                        _advance_remaining_for_gl = _advance_applied_total + _advance_tip_applied_total
                         for ord_row in completed_orders:
                             ord_tip = Decimal("0")
                             ord_tip_tax = Decimal("0")
                             ord_advance = Decimal("0")
-                            if not split_mode and _advance_remaining_for_gl > 0:
-                                ord_advance = min(
-                                    _advance_remaining_for_gl,
-                                    Decimal(str(ord_row["total_amount"] or 0)),
-                                )
-                                _advance_remaining_for_gl -= ord_advance
                             if not split_mode and first_order_id and ord_row["id"] == first_order_id:
                                 ord_tip = Decimal(str(tip_amount or 0))
                                 ord_tip_tax = Decimal(str(_mesa_tip_tax_amount))
+                            if not split_mode and _advance_remaining_for_gl > 0:
+                                ord_settlement = (
+                                    Decimal(str(ord_row["total_amount"] or 0))
+                                    + ord_tip
+                                    + ord_tip_tax
+                                )
+                                ord_advance = min(_advance_remaining_for_gl, ord_settlement)
+                                _advance_remaining_for_gl -= ord_advance
                             await _post_order_gl_entry(
                                 conn=conn,
                                 tenant_id=tenant_id,
@@ -1770,7 +1792,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
         )
         advance_settlement_applied = min(
             settlement_total,
-            float(_advance_applied_total + _advance_cover_total),
+            float(_advance_applied_total + _advance_tip_applied_total),
         )
         charged_amount = max(0.0, settlement_total - advance_settlement_applied)
 
@@ -1804,6 +1826,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                 "minimum_consumption": {
                     **(_minimum_close_state or {}),
                     "advance_applied": float(_advance_applied_total),
+                    "advance_tip_applied": float(_advance_tip_applied_total),
                     "cover_recognized": float(_advance_cover_total),
                 } if _minimum_close_state else None,
                 "tip_amount": float(tip_amount) if tip_amount > 0 else 0,


### PR DESCRIPTION
## Summary
- Let order GL debit 2810 up to full order settlement, including tips/taxes, when a table advance covers the balance
- Apply advance to product total first, then tip settlement, and only recognize true leftover as cover
- Keep COGS behavior unchanged and independent of advance settlement

## Tests
- `python3 -m py_compile app/services/tables_service.py app/services/cierre_service.py`
- `git diff --check -- app/services/tables_service.py app/services/cierre_service.py .wr/475.yaml`

Closes #475

Sensitive accounting change: recommend `/wr-review` before merge.
