### PR TITLE
Validate table advances in cierre totals

### DIFF
--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -1223,6 +1223,39 @@ def _compute_cash_expected(
     return opening_cash + total_cash + cash_tips - gastos_efectivo
 
 
+def _sum_advance_bucket(bucket: Dict[str, float]) -> float:
+    return sum(float(total or 0.0) for total in bucket.values())
+
+
+def _advance_audit_totals(advance_totals: Dict[str, Dict[str, float]]) -> Dict[str, float]:
+    """Audit values used by cierre to explain table-session advance reconciliation."""
+    return {
+        "tableAdvanceCollections": _sum_advance_bucket(advance_totals.get("collections", {})),
+        "tableAdvanceApplications": _sum_advance_bucket(advance_totals.get("applications", {})),
+        "tableAdvanceCover": float(advance_totals.get("cover", {}).get("total", 0.0)),
+    }
+
+
+def _apply_table_session_advances_to_methods(
+    method_totals: Dict[str, float],
+    advance_totals: Dict[str, Dict[str, float]],
+) -> Dict[str, float]:
+    """Move table advances from order settlement methods to their tender methods.
+
+    Example: with a 60k digital advance and a 100k cash close, the order can
+    carry 100k cash settlement. Cierre subtracts the 60k applied advance from
+    cash and then adds the 60k digital collection, leaving cash=40k,
+    digital=60k. Exact/full-advance closes settle against table_session_advance
+    and are reduced to zero before adding the original tender collection.
+    """
+    adjusted = dict(method_totals)
+    for method, total in advance_totals.get("applications", {}).items():
+        adjusted[method] = max(adjusted.get(method, 0.0) - float(total or 0.0), 0.0)
+    for method, total in advance_totals.get("collections", {}).items():
+        adjusted[method] = adjusted.get(method, 0.0) + float(total or 0.0)
+    return adjusted
+
+
 async def _compute_preview(
     conn,
     tenant_id: UUID,
@@ -1414,10 +1447,8 @@ async def _compute_preview(
         period_start_time,
         period_end_time,
     )
-    for method, total in advance_totals["applications"].items():
-        method_totals[method] = max(method_totals.get(method, 0.0) - total, 0.0)
-    for method, total in advance_totals["collections"].items():
-        method_totals[method] = method_totals.get(method, 0.0) + total
+    method_totals = _apply_table_session_advances_to_methods(method_totals, advance_totals)
+    advance_audit = _advance_audit_totals(advance_totals)
     minimum_cover_income = float(advance_totals.get("cover", {}).get("total", 0.0))
 
     gastos_row = await conn.fetchrow(
@@ -1468,6 +1499,7 @@ async def _compute_preview(
         "totalTips":        total_tips,
         "totalTipTax":      total_tip_tax,
         "totalCharged":     total_charged,
+        **advance_audit,
         "cashTips":         cash_tips,
         "openingCash":      float(opening_cash),
         "totalCash":        total_cash,
@@ -1663,12 +1695,12 @@ async def _compute_breakdown_rows(
         period_start_time,
         period_end_time,
     )
-    for method, total in advance_totals["applications"].items():
+    for method, total in advance_totals.get("applications", {}).items():
         for key, row in aggregated.items():
             if key[0] == method:
-                row["total"] = max(float(row["total"]) - total, 0.0)
+                row["total"] = max(float(row["total"]) - float(total or 0.0), 0.0)
                 break
-    for method, total in advance_totals["collections"].items():
+    for method, total in advance_totals.get("collections", {}).items():
         if total == 0:
             continue
         key = (method, f"Anticipo mesa - {method}")
@@ -2228,6 +2260,9 @@ async def create_cierre(request: Request, body: CierreCreate) -> dict:
                 "totalTips":            preview["totalTips"],
                 "totalTipTax":          preview["totalTipTax"],
                 "totalCharged":         preview["totalCharged"],
+                "tableAdvanceCollections": preview.get("tableAdvanceCollections", 0.0),
+                "tableAdvanceApplications": preview.get("tableAdvanceApplications", 0.0),
+                "tableAdvanceCover":     preview.get("tableAdvanceCover", 0.0),
                 "cashTips":             preview["cashTips"],
                 "openingCash":          opening_cash,
                 "totalCash":            preview["totalCash"],

--- a/tests/test_cierre_preview_cash.py
+++ b/tests/test_cierre_preview_cash.py
@@ -1,5 +1,9 @@
 """Unit tests for cierre preview cashExpected (warocol.com#948)."""
-from app.services.cierre_service import _compute_cash_expected
+from app.services.cierre_service import (
+    _advance_audit_totals,
+    _apply_table_session_advances_to_methods,
+    _compute_cash_expected,
+)
 
 
 def test_cash_expected_all_cash_tips_embedded_in_total_cash():
@@ -47,3 +51,52 @@ def test_cash_expected_additive_when_cash_tips_not_embedded():
         gastos_efectivo=0.0,
     )
     assert result == 330_000.0
+
+
+def test_table_advance_partial_close_moves_amount_to_advance_tender():
+    adjusted = _apply_table_session_advances_to_methods(
+        {"cash": 100_000.0},
+        {
+            "applications": {"cash": 60_000.0},
+            "collections": {"digital": 60_000.0},
+            "cover": {"total": 0.0},
+        },
+    )
+
+    assert adjusted["cash"] == 40_000.0
+    assert adjusted["digital"] == 60_000.0
+
+
+def test_table_advance_exact_close_zeroes_synthetic_settlement_method():
+    adjusted = _apply_table_session_advances_to_methods(
+        {"table_session_advance": 60_000.0},
+        {
+            "applications": {"table_session_advance": 60_000.0},
+            "collections": {"cash": 60_000.0},
+            "cover": {"total": 0.0},
+        },
+    )
+
+    assert adjusted["table_session_advance"] == 0.0
+    assert adjusted["cash"] == 60_000.0
+
+
+def test_table_advance_overage_keeps_collection_and_reports_cover():
+    advance_totals = {
+        "applications": {"table_session_advance": 28_000.0},
+        "collections": {"digital": 60_000.0},
+        "cover": {"total": 32_000.0},
+    }
+    adjusted = _apply_table_session_advances_to_methods(
+        {"table_session_advance": 28_000.0},
+        advance_totals,
+    )
+    audit = _advance_audit_totals(advance_totals)
+
+    assert adjusted["table_session_advance"] == 0.0
+    assert adjusted["digital"] == 60_000.0
+    assert audit == {
+        "tableAdvanceCollections": 60_000.0,
+        "tableAdvanceApplications": 28_000.0,
+        "tableAdvanceCover": 32_000.0,
+    }


### PR DESCRIPTION
## Summary
- Centralizes table-session advance reconciliation for cierre method totals.
- Exposes audit totals for advance collections, applications, and cover in cierre preview/create responses.
- Adds unit coverage for partial, exact, and over-advance arqueo scenarios.

## Tests
- python3 -m py_compile app/services/cierre_service.py app/services/table_session_advances_service.py app/services/tables_service.py && git diff --check
- pytest -q tests/test_cierre_preview_cash.py
- pytest -q tests/test_table_session_advances.py tests/test_cierre_preview_cash.py

Closes #477