### PR TITLE
Prefer internal role for duplicate tenant memberships

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -5,7 +5,7 @@ from urllib.parse import unquote
 from uuid import UUID
 from fastapi import Request, HTTPException, Response
 from app.config import settings
-from app.core.internal_roles import is_legacy_internal_team_role
+from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES, is_legacy_internal_team_role
 from typing import List, Optional
 
 logger = logging.getLogger(__name__)
@@ -365,7 +365,8 @@ async def get_session_from_request(request: Request) -> Optional[dict]:
 
             # Get valid session data + the user's role on this tenant.
             # LEFT JOIN tenant_members so a session whose user has no
-            # active membership row still resolves (role becomes None).
+            # active membership row still resolves (role becomes None). When
+            # duplicate active rows exist, prefer internal roles over customer.
             # Epic 2 (#164) — required by the require_module() dependency
             # so it can decide log/allow/deny without an extra DB hit.
             session_query = """
@@ -374,16 +375,25 @@ async def get_session_from_request(request: Request) -> Optional[dict]:
                        tm.role AS role
                 FROM sessions s
                 JOIN profile p ON s.user_id = p.id
-                LEFT JOIN tenant_members tm
-                  ON tm.user_id = s.user_id
-                 AND tm.tenant_id = s.tenant_id
-                 AND tm.is_active = true
+                LEFT JOIN LATERAL (
+                    SELECT role
+                    FROM tenant_members tm
+                    WHERE tm.user_id = s.user_id
+                      AND tm.tenant_id = s.tenant_id
+                      AND tm.is_active = true
+                    ORDER BY CASE WHEN tm.role = ANY($2::text[]) THEN 0 ELSE 1 END
+                    LIMIT 1
+                ) tm ON true
                 WHERE s.id = $1
                   AND s.expires_at > NOW()
                   AND s.is_active = true
                 LIMIT 1
             """
-            session_result = await conn.fetchrow(session_query, session_token)
+            session_result = await conn.fetchrow(
+                session_query,
+                session_token,
+                list(LEGACY_INTERNAL_TEAM_ROLES),
+            )
 
             if not session_result:
                 return None

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -53,8 +53,18 @@ async def get_session_data(request: Request, response: Response) -> SessionRespo
                 # Only read role from ACTIVE memberships (#201). Customer rows
                 # are active memberships, but they are not internal team access.
                 role_result = await conn.fetchrow(
-                    "SELECT role FROM tenant_members WHERE tenant_id = $1 AND user_id = $2 AND is_active = true LIMIT 1",
-                    session_result['tenant_id'], session_result['user_id']
+                    """
+                    SELECT role
+                    FROM tenant_members
+                    WHERE tenant_id = $1
+                      AND user_id = $2
+                      AND is_active = true
+                    ORDER BY CASE WHEN role = ANY($3::text[]) THEN 0 ELSE 1 END
+                    LIMIT 1
+                    """,
+                    session_result['tenant_id'],
+                    session_result['user_id'],
+                    list(LEGACY_INTERNAL_TEAM_ROLES),
                 )
                 if role_result:
                     user_role = role_result['role']

--- a/tests/test_customer_team_migration_regression.py
+++ b/tests/test_customer_team_migration_regression.py
@@ -126,6 +126,53 @@ async def test_karen_tijuana_customer_admin_coexistence_stays_visible_in_custome
 
 
 @pytest.mark.asyncio
+async def test_karen_tijuana_admin_customer_session_resolves_internal_role():
+    from app.core.security import get_session_from_request
+
+    session_token = str(uuid4())
+    tenant_id = uuid4()
+    profile_id = uuid4()
+    expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {"id": session_token, "expires_at": expires_at, "is_active": True, "ended_at": None},
+            {
+                "user_id": profile_id,
+                "tenant_id": tenant_id,
+                "expires_at": expires_at,
+                "is_active": True,
+                "email": "karen@example.com",
+                "name": "Karen Tijuana",
+                "role": "admin",
+            },
+        ]
+    )
+    conn.fetch = AsyncMock(return_value=[])
+    conn.execute = AsyncMock(return_value=None)
+
+    with patch("app.database.get_db_connection", side_effect=_db_context(conn)), patch(
+        "app.core.security.get_session_token",
+        new=AsyncMock(return_value=session_token),
+    ):
+        result = await get_session_from_request(_request())
+
+    assert result["role"] == "admin"
+    session_query = conn.fetchrow.await_args_list[1].args[0]
+    assert "LEFT JOIN LATERAL" in session_query
+    assert "ORDER BY CASE WHEN tm.role = ANY($2::text[])" in session_query
+    assert conn.fetchrow.await_args_list[1].args[2] == [
+        "superuser",
+        "admin",
+        "employee",
+        "member",
+        "promotor",
+    ]
+    conn.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_karen_tijuana_legacy_customer_role_session_is_denied_after_migration():
     from app.core.security import get_session_from_request
 

--- a/tests/test_switch_tenant_membership.py
+++ b/tests/test_switch_tenant_membership.py
@@ -260,6 +260,51 @@ async def test_get_session_data_role_null_when_terminated():
 
 
 @pytest.mark.asyncio
+async def test_get_session_data_prefers_internal_role_when_customer_duplicate_exists():
+    """Regression: active admin + customer rows must resolve as admin, not customer."""
+    from app.services.auth_service import get_session_data
+
+    user_id = uuid4()
+    tenant_id = uuid4()
+    session_token = "fake-token"
+    request = MagicMock()
+    request.cookies = {"session-token": session_token}
+    request.headers = {}
+    response = _build_response()
+
+    fetchrow_responses = [
+        {
+            "user_id": user_id,
+            "email": "karen@example.com",
+            "name": "Karen Tijuana",
+            "user_created_at": "2024-01-01T00:00:00Z",
+            "tenant_id": tenant_id,
+            "expires_at": "2030-01-01T00:00:00Z",
+            "created_at": "2025-01-01T00:00:00Z",
+            "ip_address": "127.0.0.1",
+            "login_method": "magic-link",
+        },
+        {"id": tenant_id, "name": "Tijuana cafe Bar", "slug": "tijuana-cafe-bar"},
+        {"role": "admin"},
+    ]
+
+    db_ctx, conn = _build_db_mock(fetchrow_side_effect=fetchrow_responses)
+
+    with patch("app.services.auth_service.get_db_connection", side_effect=db_ctx), \
+         patch("app.services.auth_service.get_session_token", new=AsyncMock(return_value=session_token)), \
+         patch("app.services.auth_service.clear_session_cookie", new=AsyncMock(return_value=None)) as clear_cookie:
+        result = await get_session_data(request, response)
+
+    assert result.user.role == "admin"
+    assert result.has_internal_access is True
+    role_query = conn.fetchrow.await_args_list[2].args[0]
+    assert "ORDER BY CASE WHEN role = ANY($3::text[])" in role_query
+    assert conn.fetchrow.await_args_list[2].args[3] == ["superuser", "admin", "employee", "member", "promotor"]
+    conn.execute.assert_not_awaited()
+    clear_cookie.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_get_session_data_denies_customer_role_and_clears_cookie():
     """Existing active internal sessions with role=customer are invalidated."""
     from app.services.auth_service import get_session_data


### PR DESCRIPTION
## Summary
- Prefer active internal tenant roles over customer when duplicate active memberships exist.
- Apply the same role resolution rule to /auth/session and require_valid_session session loading.
- Add regression coverage for admin + customer coexistence and preserve customer-only denial.

## Tests
- python3 -m py_compile app/services/auth_service.py app/core/security.py app/core/internal_roles.py && git diff --check
- pytest -q tests/test_switch_tenant_membership.py tests/test_customer_team_migration_regression.py

Closes #479