### PR TITLE
Add signed AI agent SSE proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,12 @@ FRONTEND_BASE_URL=https://warocol.com
 # Ollama Extract API
 OLLAMA_API_URL=https://chat.warocol.com
 
+# Internal WARO agent-api proxy
+AGENT_API_URL=http://agent-api:8100
+INTERNAL_SIGNATURE_SECRET=replace_with_shared_internal_secret
+AGENT_API_CONNECT_TIMEOUT_SECONDS=5
+AGENT_API_READ_TIMEOUT_SECONDS=300
+
 # MercadoPago — pagos recurrentes (issue #60)
 MP_ACCESS_TOKEN=APP_USR-xxxx-xxxx-xxxx-xxxx
 MP_PUBLIC_KEY=APP_USR-xxxx-xxxx-xxxx-xxxx

--- a/app/config.py
+++ b/app/config.py
@@ -53,6 +53,12 @@ class Settings(BaseSettings):
 
     # Ollama Extract API
     ollama_api_url: str = Field(default="https://chat.warocol.com", alias='OLLAMA_API_URL')
+
+    # Internal WARO agent-api proxy
+    agent_api_url: Optional[str] = Field(default=None, alias='AGENT_API_URL')
+    agent_internal_signature_secret: Optional[str] = Field(default=None, alias='INTERNAL_SIGNATURE_SECRET')
+    agent_api_connect_timeout_seconds: float = Field(default=5.0, alias='AGENT_API_CONNECT_TIMEOUT_SECONDS')
+    agent_api_read_timeout_seconds: Optional[float] = Field(default=300.0, alias='AGENT_API_READ_TIMEOUT_SECONDS')
     
     # Google Gemini API
     google_api_key: Optional[str] = Field(default=None, alias='GOOGLE_API_KEY')

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, customer_portal, leads, waros, billing, legal, payments_webhook, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
+from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, ai_agents, customer_portal, leads, waros, billing, legal, payments_webhook, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
 from app.config import settings
 from app.core.logging import setup_logging
 from app.core.exceptions import api_exception_handler, general_exception_handler, APIError
@@ -176,6 +176,7 @@ app.include_router(operaciones_operation_events.router)  # Bitácora POS events 
 app.include_router(online_cart.router)  # Public online ordering cart
 app.include_router(online_orders.router)  # Authenticated online orders management
 app.include_router(notifications.router)  # Authenticated notifications management
+app.include_router(ai_agents.router)      # Authenticated AI agent SSE proxy
 app.include_router(online_verification.router)  # Public OTP verification
 app.include_router(online_verification.customer_router)  # Public customer validation
 app.include_router(address_profile.router)  # Public address management

--- a/app/routers/ai_agents.py
+++ b/app/routers/ai_agents.py
@@ -1,0 +1,245 @@
+import hashlib
+import hmac
+import logging
+from typing import AsyncIterator, Dict, Optional, Sequence
+from uuid import uuid4
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import StreamingResponse
+
+from app.config import settings
+from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
+from app.core.middleware import require_valid_session
+from app.core.permissions import Module, require_module
+from app.database import get_db_connection
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/ai", tags=["ai-agents"])
+
+SALES_SCOPES = ("orders:read",)
+FOOD_COST_SCOPES = ("analytics:read", "menu:read", "financial:read")
+
+
+def _agent_api_base_url() -> str:
+    base_url = (settings.agent_api_url or "").strip().rstrip("/")
+    if not base_url:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Agent API URL is not configured",
+        )
+    return base_url
+
+
+def _internal_signature_secret() -> str:
+    secret = (settings.agent_internal_signature_secret or "").strip()
+    if not secret:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Agent API internal signature is not configured",
+        )
+    return secret
+
+
+def _timeout() -> httpx.Timeout:
+    connect_timeout = settings.agent_api_connect_timeout_seconds
+    read_timeout = settings.agent_api_read_timeout_seconds
+    return httpx.Timeout(
+        connect=connect_timeout,
+        read=read_timeout,
+        write=connect_timeout,
+        pool=connect_timeout,
+    )
+
+
+def _sign_internal_request(
+    method: str,
+    path: str,
+    request_id: str,
+    tenant_id: str,
+    profile_id: str,
+    member_id: Optional[str],
+    scopes: str,
+    body: bytes,
+) -> str:
+    body_digest = hashlib.sha256(body).hexdigest()
+    canonical = "\n".join(
+        [
+            method.upper(),
+            path,
+            request_id,
+            tenant_id,
+            profile_id,
+            member_id or "",
+            scopes,
+            body_digest,
+        ]
+    )
+    return hmac.new(
+        _internal_signature_secret().encode("utf-8"),
+        canonical.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+async def _resolve_member_id(profile_id: str, tenant_id: str) -> Optional[str]:
+    async with get_db_connection() as conn:
+        member_id = await conn.fetchval(
+            """
+            SELECT id
+            FROM tenant_members
+            WHERE user_id = $1
+              AND tenant_id = $2
+              AND is_active = true
+            ORDER BY CASE
+                WHEN role = ANY($3::text[]) THEN 0
+                ELSE 1
+            END
+            LIMIT 1
+            """,
+            profile_id,
+            tenant_id,
+            list(LEGACY_INTERNAL_TEAM_ROLES),
+        )
+    return str(member_id) if member_id else None
+
+
+def _build_internal_headers(
+    path: str,
+    request_id: str,
+    tenant_id: str,
+    profile_id: str,
+    member_id: Optional[str],
+    scopes: str,
+    body: bytes,
+) -> Dict[str, str]:
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+        "x-waro-tenant-id": tenant_id,
+        "x-waro-profile-id": profile_id,
+        "x-waro-request-id": request_id,
+        "x-waro-scopes": scopes,
+    }
+    if member_id:
+        headers["x-waro-member-id"] = member_id
+    headers["x-waro-internal-signature"] = _sign_internal_request(
+        method="POST",
+        path=path,
+        request_id=request_id,
+        tenant_id=tenant_id,
+        profile_id=profile_id,
+        member_id=member_id,
+        scopes=scopes,
+        body=body,
+    )
+    return headers
+
+
+async def _iter_upstream_bytes(
+    response: httpx.Response,
+    client: httpx.AsyncClient,
+) -> AsyncIterator[bytes]:
+    try:
+        async for chunk in response.aiter_bytes():
+            if chunk:
+                yield chunk
+    finally:
+        await response.aclose()
+        await client.aclose()
+
+
+async def _proxy_agent_stream(
+    request: Request,
+    upstream_path: str,
+    scopes: Sequence[str],
+) -> StreamingResponse:
+    session = require_valid_session(request)
+    if not session.user_id or not session.tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Valid user and tenant session required",
+        )
+
+    body = await request.body()
+    request_id = request.headers.get("x-waro-request-id") or str(uuid4())
+    tenant_id = str(session.tenant_id)
+    profile_id = str(session.user_id)
+    member_id = await _resolve_member_id(profile_id, tenant_id)
+    scope_header = ",".join(scopes)
+    base_url = _agent_api_base_url()
+    upstream_url = f"{base_url}{upstream_path}"
+    headers = _build_internal_headers(
+        path=upstream_path,
+        request_id=request_id,
+        tenant_id=tenant_id,
+        profile_id=profile_id,
+        member_id=member_id,
+        scopes=scope_header,
+        body=body,
+    )
+
+    client = httpx.AsyncClient(timeout=_timeout())
+    try:
+        upstream_request = client.build_request(
+            "POST",
+            upstream_url,
+            content=body,
+            headers=headers,
+        )
+        response = await client.send(upstream_request, stream=True)
+    except httpx.RequestError as exc:
+        await client.aclose()
+        logger.warning("Agent API stream setup failed request_id=%s error=%s", request_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Agent API stream setup failed",
+        ) from exc
+
+    if response.status_code >= 400:
+        await response.aread()
+        await response.aclose()
+        await client.aclose()
+        logger.warning(
+            "Agent API rejected stream setup request_id=%s status=%s",
+            request_id,
+            response.status_code,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Agent API rejected stream setup",
+        )
+
+    return StreamingResponse(
+        _iter_upstream_bytes(response, client),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+            "x-waro-request-id": request_id,
+        },
+    )
+
+
+@router.post("/sales/messages/stream", dependencies=[Depends(require_module(Module.VENTAS))])
+async def stream_sales_agent(request: Request) -> StreamingResponse:
+    return await _proxy_agent_stream(
+        request=request,
+        upstream_path="/internal/ai/sales/messages/stream",
+        scopes=SALES_SCOPES,
+    )
+
+
+@router.post(
+    "/food-cost/messages/stream",
+    dependencies=[Depends(require_module(Module.ANALITICA))],
+)
+async def stream_food_cost_agent(request: Request) -> StreamingResponse:
+    return await _proxy_agent_stream(
+        request=request,
+        upstream_path="/internal/ai/food-cost/messages/stream",
+        scopes=FOOD_COST_SCOPES,
+    )

--- a/tests/test_ai_agents_proxy.py
+++ b/tests/test_ai_agents_proxy.py
@@ -1,0 +1,255 @@
+import hashlib
+import hmac
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.core.permissions import Module
+from app.routers import ai_agents
+
+
+BODY = b'{"message":"ventas de hoy"}'
+TENANT_ID = uuid4()
+PROFILE_ID = uuid4()
+MEMBER_ID = uuid4()
+
+
+@pytest.fixture(autouse=True)
+def _clear_permission_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_session(role="owner", tenant_id=TENANT_ID):
+    return SessionContext({
+        "user_id": PROFILE_ID,
+        "tenant_id": tenant_id,
+        "email": "owner@example.com",
+        "name": "Owner",
+        "expires_at": None,
+        "is_active": True,
+        "role": role,
+    })
+
+
+def _enforce_db_ctx():
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+    return _ctx
+
+
+class FakeUpstreamResponse:
+    def __init__(self, status_code=200, chunks=None, body=b""):
+        self.status_code = status_code
+        self._chunks = chunks or []
+        self._body = body
+        self.closed = False
+
+    async def aiter_bytes(self):
+        for chunk in self._chunks:
+            yield chunk
+
+    async def aread(self):
+        return self._body
+
+    async def aclose(self):
+        self.closed = True
+
+
+class FakeAsyncClient:
+    instances = []
+    response = FakeUpstreamResponse()
+
+    def __init__(self, timeout=None):
+        self.timeout = timeout
+        self.closed = False
+        self.sent_request = None
+        FakeAsyncClient.instances.append(self)
+
+    def build_request(self, method, url, content=None, headers=None):
+        return {
+            "method": method,
+            "url": url,
+            "content": content,
+            "headers": headers or {},
+        }
+
+    async def send(self, request, stream=False):
+        self.sent_request = request
+        self.sent_stream = stream
+        return FakeAsyncClient.response
+
+    async def aclose(self):
+        self.closed = True
+
+
+def _client():
+    app = FastAPI()
+    app.include_router(ai_agents.router)
+    return TestClient(app)
+
+
+def test_sign_internal_request_matches_agent_api_contract():
+    with patch.object(ai_agents.settings, "agent_internal_signature_secret", "secret"):
+        signature = ai_agents._sign_internal_request(
+            method="POST",
+            path="/internal/ai/sales/messages/stream",
+            request_id="req-1",
+            tenant_id="tenant-1",
+            profile_id="profile-1",
+            member_id=None,
+            scopes="orders:read",
+            body=BODY,
+        )
+
+    canonical = "\n".join([
+        "POST",
+        "/internal/ai/sales/messages/stream",
+        "req-1",
+        "tenant-1",
+        "profile-1",
+        "",
+        "orders:read",
+        hashlib.sha256(BODY).hexdigest(),
+    ])
+    expected = hmac.new(b"secret", canonical.encode("utf-8"), hashlib.sha256).hexdigest()
+    assert signature == expected
+
+
+def test_sales_proxy_streams_frames_and_preserves_request_id():
+    session = _build_session(role="owner")
+    FakeAsyncClient.instances = []
+    FakeAsyncClient.response = FakeUpstreamResponse(
+        chunks=[b"event: token\ndata: uno\n\n", b"event: final\ndata: done\n\n"],
+    )
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.ai_agents.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.routers.ai_agents._resolve_member_id", AsyncMock(return_value=str(MEMBER_ID))), \
+         patch.object(ai_agents.settings, "agent_api_url", "http://agent-api:8100"), \
+         patch.object(ai_agents.settings, "agent_internal_signature_secret", "secret"), \
+         patch("app.routers.ai_agents.httpx.AsyncClient", FakeAsyncClient):
+        response = _client().post(
+            "/ai/sales/messages/stream",
+            content=BODY,
+            headers={
+                "Content-Type": "application/json",
+                "x-waro-request-id": "req-preserved",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.headers["x-waro-request-id"] == "req-preserved"
+    assert response.content == b"event: token\ndata: uno\n\nevent: final\ndata: done\n\n"
+
+    sent = FakeAsyncClient.instances[0].sent_request
+    assert sent["method"] == "POST"
+    assert sent["url"] == "http://agent-api:8100/internal/ai/sales/messages/stream"
+    assert sent["content"] == BODY
+    assert sent["headers"]["x-waro-tenant-id"] == str(TENANT_ID)
+    assert sent["headers"]["x-waro-profile-id"] == str(PROFILE_ID)
+    assert sent["headers"]["x-waro-member-id"] == str(MEMBER_ID)
+    assert sent["headers"]["x-waro-request-id"] == "req-preserved"
+    assert sent["headers"]["x-waro-scopes"] == "orders:read"
+    assert sent["headers"]["x-waro-internal-signature"]
+    assert FakeAsyncClient.instances[0].closed is True
+    assert FakeAsyncClient.response.closed is True
+
+
+def test_food_cost_proxy_uses_analytics_menu_financial_scopes():
+    session = _build_session(role="owner")
+    FakeAsyncClient.instances = []
+    FakeAsyncClient.response = FakeUpstreamResponse(chunks=[b"event: final\ndata: done\n\n"])
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.ai_agents.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.routers.ai_agents._resolve_member_id", AsyncMock(return_value=None)), \
+         patch.object(ai_agents.settings, "agent_api_url", "http://agent-api:8100"), \
+         patch.object(ai_agents.settings, "agent_internal_signature_secret", "secret"), \
+         patch("app.routers.ai_agents.httpx.AsyncClient", FakeAsyncClient):
+        response = _client().post("/ai/food-cost/messages/stream", content=BODY)
+
+    assert response.status_code == 200
+    sent = FakeAsyncClient.instances[0].sent_request
+    assert sent["url"] == "http://agent-api:8100/internal/ai/food-cost/messages/stream"
+    assert sent["headers"]["x-waro-scopes"] == "analytics:read,menu:read,financial:read"
+    assert "x-waro-member-id" not in sent["headers"]
+
+
+def test_missing_tenant_rejects_before_upstream_call():
+    session = _build_session(role="owner", tenant_id=None)
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.ai_agents.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.routers.ai_agents._resolve_member_id", AsyncMock()) as resolve_member, \
+         patch("app.routers.ai_agents.httpx.AsyncClient", FakeAsyncClient):
+        response = _client().post("/ai/sales/messages/stream", content=BODY)
+
+    assert response.status_code == 401
+    resolve_member.assert_not_awaited()
+
+
+def test_missing_agent_config_rejects_before_upstream_call():
+    session = _build_session(role="owner")
+    FakeAsyncClient.instances = []
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.ai_agents.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.routers.ai_agents._resolve_member_id", AsyncMock(return_value=None)), \
+         patch.object(ai_agents.settings, "agent_api_url", None), \
+         patch.object(ai_agents.settings, "agent_internal_signature_secret", "secret"), \
+         patch("app.routers.ai_agents.httpx.AsyncClient", FakeAsyncClient):
+        response = _client().post("/ai/sales/messages/stream", content=BODY)
+
+    assert response.status_code == 503
+    assert FakeAsyncClient.instances == []
+
+
+def test_module_gates_block_kitchen_role_before_upstream_call():
+    session = _build_session(role="kitchen")
+    kitchen_modules = frozenset({Module.DESPACHO})
+    FakeAsyncClient.instances = []
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.core.permissions.get_role_modules", AsyncMock(return_value=kitchen_modules)), \
+         patch("app.routers.ai_agents.httpx.AsyncClient", FakeAsyncClient):
+        response = _client().post("/ai/sales/messages/stream", content=BODY)
+
+    assert response.status_code == 403
+    assert "ventas" in response.json()["detail"].lower()
+    assert FakeAsyncClient.instances == []
+
+
+def test_build_headers_generates_request_id_signature_and_content_headers():
+    with patch.object(ai_agents.settings, "agent_internal_signature_secret", "secret"):
+        headers = ai_agents._build_internal_headers(
+            path="/internal/ai/food-cost/messages/stream",
+            request_id="req-generated",
+            tenant_id=str(TENANT_ID),
+            profile_id=str(PROFILE_ID),
+            member_id=None,
+            scopes="analytics:read,menu:read,financial:read",
+            body=BODY,
+        )
+
+    assert headers["Content-Type"] == "application/json"
+    assert headers["Accept"] == "text/event-stream"
+    assert headers["x-waro-request-id"] == "req-generated"
+    assert headers["x-waro-internal-signature"]


### PR DESCRIPTION
## Summary
- add authenticated sales and food-cost AI SSE proxy routes
- sign agent-api requests with WARO context headers and preserve request IDs
- add focused proxy/signing/RBAC streaming tests

## Tests
- pytest -q tests/test_ai_agents_proxy.py
- python3 -m py_compile app/main.py app/routers/ai_agents.py app/config.py
- python3 -m py_compile app/routers/ai_agents.py app/config.py && git diff --check

Refs waro-labs/waro-ai-agents#33