### PR TITLE
Attach WARO API to agent runtime network

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,7 @@ AGENT_API_URL=http://agent-api:8100
 INTERNAL_SIGNATURE_SECRET=replace_with_shared_internal_secret
 AGENT_API_CONNECT_TIMEOUT_SECONDS=5
 AGENT_API_READ_TIMEOUT_SECONDS=300
+WARO_RUNTIME_NETWORK=waro-network
 
 # MercadoPago — pagos recurrentes (issue #60)
 MP_ACCESS_TOKEN=APP_USR-xxxx-xxxx-xxxx-xxxx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,12 @@ services:
       - JWT_SECRET=${NUXT_PRIVATE_JWT_SECRET}
     networks:
       - default
+      - waro_runtime
       - postgresqlwarolabs_default
 
 networks:
+  waro_runtime:
+    name: ${WARO_RUNTIME_NETWORK:-waro-network}
+    external: true
   postgresqlwarolabs_default:
     external: true


### PR DESCRIPTION
Summary
- attach api_warocol web to the shared WARO runtime Docker network
- add WARO_RUNTIME_NETWORK to the env example so AGENT_API_URL=http://agent-api:8100 resolves over container DNS

Tests
- docker-compose -f docker-compose.yml -f docker-compose.prod.yml config --quiet
- git diff --check

Refs waro-labs/waro-ai-agents#34