### PR TITLE
Gate Kali by tenant flag

### DIFF
--- a/app/models/me.py
+++ b/app/models/me.py
@@ -1,5 +1,5 @@
-from typing import List, Optional
-from pydantic import BaseModel
+from typing import Dict, List, Optional
+from pydantic import BaseModel, Field
 
 
 class AccessResponse(BaseModel):
@@ -15,7 +15,11 @@ class AccessResponse(BaseModel):
       already accounting for tenant-specific overrides.
     - `enforcement_mode`: the tenant's current permissions mode, one of
       'disabled' | 'shadow' | 'enforce'.
+    - `features`: tenant feature capabilities that are not RBAC modules.
     """
     role: Optional[str] = None
     modules: List[str] = []
     enforcement_mode: str = "disabled"
+    features: Dict[str, bool] = Field(
+        default_factory=lambda: {"kali_enabled": False}
+    )

--- a/app/models/tenant_public_profile.py
+++ b/app/models/tenant_public_profile.py
@@ -86,6 +86,13 @@ class TenantPublicProfileBase(BaseModel):
     comandas_enabled: bool = Field(False, description="Whether the comandas/KDS module is enabled. When false, system behaves exactly as today.")
     kds_enabled: bool = Field(False, description="Whether KDS station screens (/cocina/[id]) are enabled. Requires comandas_enabled=true.")
 
+    # Internal Kali assistant feature flag. This is intentionally controlled
+    # by SQL/config only, not exposed through tenant-facing toggle endpoints.
+    kali_enabled: bool = Field(
+        False,
+        description="Internal-only flag: whether the Kali AI assistant is enabled for this tenant.",
+    )
+
     # POS personalization (issue #529)
     auto_select_generic_enabled: bool = Field(
         False,

--- a/app/routers/ai_agents.py
+++ b/app/routers/ai_agents.py
@@ -13,6 +13,7 @@ from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
 from app.core.middleware import require_valid_session
 from app.core.permissions import Module, require_module
 from app.database import get_db_connection
+from app.services.kali_access_service import is_kali_enabled
 
 
 logger = logging.getLogger(__name__)
@@ -161,6 +162,12 @@ async def _proxy_agent_stream(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Valid user and tenant session required",
+        )
+
+    if not await is_kali_enabled(session.tenant_id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Kali is not enabled for this tenant",
         )
 
     body = await request.body()

--- a/app/routers/me.py
+++ b/app/routers/me.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, Request
 from app.core.middleware import SessionContext, require_valid_session
 from app.core.permissions import get_enforcement_mode, get_role_modules
 from app.models.me import AccessResponse
+from app.services.kali_access_service import get_kali_access_features
 
 router = APIRouter()
 
@@ -27,15 +28,18 @@ async def get_my_access(
             role=session.role,
             modules=[],
             enforcement_mode="disabled",
+            features={"kali_enabled": False},
         )
 
     enforcement_mode = await get_enforcement_mode(session.tenant_id)
+    features = await get_kali_access_features(session.tenant_id)
 
     if session.role is None:
         return AccessResponse(
             role=None,
             modules=[],
             enforcement_mode=enforcement_mode,
+            features=features,
         )
 
     modules = await get_role_modules(session.tenant_id, session.role)
@@ -43,4 +47,5 @@ async def get_my_access(
         role=session.role,
         modules=sorted(m.value for m in modules),
         enforcement_mode=enforcement_mode,
+        features=features,
     )

--- a/app/services/kali_access_service.py
+++ b/app/services/kali_access_service.py
@@ -1,0 +1,33 @@
+"""Internal Kali feature availability by tenant."""
+from typing import Dict, Optional
+from uuid import UUID
+
+from app.database import get_db_connection
+
+
+async def is_kali_enabled(tenant_id: Optional[UUID]) -> bool:
+    """Return whether Kali is enabled for a tenant.
+
+    Missing tenant IDs, missing tenants, and missing public-profile rows are
+    treated as disabled. Kali is intentionally not a RBAC module.
+    """
+    if tenant_id is None:
+        return False
+
+    async with get_db_connection() as conn:
+        enabled = await conn.fetchval(
+            """
+            SELECT COALESCE(tpp.kali_enabled, false)
+            FROM tenants t
+            LEFT JOIN tenant_public_profiles tpp ON tpp.tenant_id = t.id
+            WHERE t.id = $1
+            """,
+            tenant_id,
+        )
+
+    return bool(enabled)
+
+
+async def get_kali_access_features(tenant_id: Optional[UUID]) -> Dict[str, bool]:
+    """Capability payload consumed by /me/access and frontend route gates."""
+    return {"kali_enabled": await is_kali_enabled(tenant_id)}

--- a/migrations/090_kali_enabled.sql
+++ b/migrations/090_kali_enabled.sql
@@ -1,0 +1,21 @@
+-- 090_kali_enabled.sql
+-- api-warolabs#483 — internal tenant gate for Kali.
+--
+-- Kali is not a RBAC module and must not have a tenant-facing toggle. This
+-- flag is controlled by internal SQL/config only. Default false keeps every
+-- tenant disabled unless explicitly enabled.
+
+ALTER TABLE tenant_public_profiles
+    ADD COLUMN IF NOT EXISTS kali_enabled BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN tenant_public_profiles.kali_enabled IS
+    'Internal-only feature flag for Kali AI assistant availability. No UI toggle; default false.';
+
+-- First release: enable Kali only for WARO Colombia.
+INSERT INTO tenant_public_profiles (tenant_id, slug, display_name, kali_enabled)
+SELECT t.id, t.slug, t.name, true
+FROM tenants t
+WHERE t.slug = 'warocolombia'
+ON CONFLICT (tenant_id) DO UPDATE
+    SET kali_enabled = true,
+        updated_at = now();

--- a/sql/20260619_kali_enabled.sql
+++ b/sql/20260619_kali_enabled.sql
@@ -1,0 +1,19 @@
+-- api-warolabs#483 — internal tenant gate for Kali.
+--
+-- Kali is controlled internally only. Do not expose this flag through tenant
+-- UI, operaciones toggles, or public administration endpoints.
+
+ALTER TABLE tenant_public_profiles
+    ADD COLUMN IF NOT EXISTS kali_enabled BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN tenant_public_profiles.kali_enabled IS
+    'Internal-only feature flag for Kali AI assistant availability. No UI toggle; default false.';
+
+-- First release: enable Kali only for WARO Colombia.
+INSERT INTO tenant_public_profiles (tenant_id, slug, display_name, kali_enabled)
+SELECT t.id, t.slug, t.name, true
+FROM tenants t
+WHERE t.slug = 'warocolombia'
+ON CONFLICT (tenant_id) DO UPDATE
+    SET kali_enabled = true,
+        updated_at = now();

--- a/tests/test_ai_agents_proxy.py
+++ b/tests/test_ai_agents_proxy.py
@@ -139,6 +139,7 @@ def test_sales_proxy_streams_frames_and_preserves_request_id():
     with patch("app.core.middleware.get_session_context", return_value=session), \
          patch("app.routers.ai_agents.require_valid_session", return_value=session), \
          patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.routers.ai_agents.is_kali_enabled", AsyncMock(return_value=True)), \
          patch("app.routers.ai_agents._resolve_member_id", AsyncMock(return_value=str(MEMBER_ID))), \
          patch.object(ai_agents.settings, "agent_api_url", "http://agent-api:8100"), \
          patch.object(ai_agents.settings, "agent_internal_signature_secret", "secret"), \
@@ -178,6 +179,7 @@ def test_food_cost_proxy_uses_analytics_menu_financial_scopes():
     with patch("app.core.middleware.get_session_context", return_value=session), \
          patch("app.routers.ai_agents.require_valid_session", return_value=session), \
          patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.routers.ai_agents.is_kali_enabled", AsyncMock(return_value=True)), \
          patch("app.routers.ai_agents._resolve_member_id", AsyncMock(return_value=None)), \
          patch.object(ai_agents.settings, "agent_api_url", "http://agent-api:8100"), \
          patch.object(ai_agents.settings, "agent_internal_signature_secret", "secret"), \
@@ -204,6 +206,41 @@ def test_missing_tenant_rejects_before_upstream_call():
     resolve_member.assert_not_awaited()
 
 
+def test_disabled_kali_tenant_rejects_before_upstream_setup():
+    session = _build_session(role="owner")
+    FakeAsyncClient.instances = []
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.ai_agents.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.routers.ai_agents.is_kali_enabled", AsyncMock(return_value=False)), \
+         patch("app.routers.ai_agents._resolve_member_id", AsyncMock()) as resolve_member, \
+         patch("app.routers.ai_agents.httpx.AsyncClient", FakeAsyncClient):
+        response = _client().post("/ai/sales/messages/stream", content=BODY)
+
+    assert response.status_code == 403
+    assert "kali" in response.json()["detail"].lower()
+    resolve_member.assert_not_awaited()
+    assert FakeAsyncClient.instances == []
+
+
+def test_disabled_kali_tenant_blocks_food_cost_before_upstream_setup():
+    session = _build_session(role="owner")
+    FakeAsyncClient.instances = []
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.ai_agents.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.routers.ai_agents.is_kali_enabled", AsyncMock(return_value=False)), \
+         patch("app.routers.ai_agents._resolve_member_id", AsyncMock()) as resolve_member, \
+         patch("app.routers.ai_agents.httpx.AsyncClient", FakeAsyncClient):
+        response = _client().post("/ai/food-cost/messages/stream", content=BODY)
+
+    assert response.status_code == 403
+    resolve_member.assert_not_awaited()
+    assert FakeAsyncClient.instances == []
+
+
 def test_missing_agent_config_rejects_before_upstream_call():
     session = _build_session(role="owner")
     FakeAsyncClient.instances = []
@@ -211,6 +248,7 @@ def test_missing_agent_config_rejects_before_upstream_call():
     with patch("app.core.middleware.get_session_context", return_value=session), \
          patch("app.routers.ai_agents.require_valid_session", return_value=session), \
          patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.routers.ai_agents.is_kali_enabled", AsyncMock(return_value=True)), \
          patch("app.routers.ai_agents._resolve_member_id", AsyncMock(return_value=None)), \
          patch.object(ai_agents.settings, "agent_api_url", None), \
          patch.object(ai_agents.settings, "agent_internal_signature_secret", "secret"), \

--- a/tests/test_me_access.py
+++ b/tests/test_me_access.py
@@ -71,7 +71,11 @@ def test_owner_returns_all_modules():
 
     with patch("app.core.middleware.get_session_context", return_value=session), \
          patch("app.routers.me.require_valid_session", return_value=session), \
-         patch("app.core.permissions.get_db_connection", side_effect=_mock_db_ctx("disabled")):
+         patch("app.core.permissions.get_db_connection", side_effect=_mock_db_ctx("disabled")), \
+         patch(
+             "app.routers.me.get_kali_access_features",
+             new=AsyncMock(return_value={"kali_enabled": True}),
+         ):
         client = TestClient(app)
         response = client.get("/me/access")
 
@@ -82,6 +86,7 @@ def test_owner_returns_all_modules():
     expected = sorted(m.value for m in Module)
     assert body["modules"] == expected
     assert body["enforcement_mode"] == "disabled"
+    assert body["features"]["kali_enabled"] is True
 
 
 def test_cashier_returns_pos_ventas_only():
@@ -96,6 +101,10 @@ def test_cashier_returns_pos_ventas_only():
          patch("app.routers.me.require_valid_session", return_value=session), \
          patch("app.core.permissions.get_db_connection", side_effect=_mock_db_ctx("disabled")), \
          patch(
+             "app.routers.me.get_kali_access_features",
+             new=AsyncMock(return_value={"kali_enabled": False}),
+         ), \
+         patch(
              "app.routers.me.get_role_modules",
              new=AsyncMock(return_value=cashier_modules),
          ):
@@ -106,6 +115,7 @@ def test_cashier_returns_pos_ventas_only():
     body = response.json()
     assert body["role"] == "cashier"
     assert body["modules"] == ["pos", "ventas"]
+    assert body["features"]["kali_enabled"] is False
 
 
 def test_null_role_returns_empty_modules():
@@ -116,7 +126,11 @@ def test_null_role_returns_empty_modules():
 
     with patch("app.core.middleware.get_session_context", return_value=session), \
          patch("app.routers.me.require_valid_session", return_value=session), \
-         patch("app.core.permissions.get_db_connection", side_effect=_mock_db_ctx("shadow")):
+         patch("app.core.permissions.get_db_connection", side_effect=_mock_db_ctx("shadow")), \
+         patch(
+             "app.routers.me.get_kali_access_features",
+             new=AsyncMock(return_value={"kali_enabled": True}),
+         ):
         client = TestClient(app)
         response = client.get("/me/access")
 
@@ -126,6 +140,35 @@ def test_null_role_returns_empty_modules():
     assert body["modules"] == []
     # enforcement_mode still reported — tenant_id was present, only role was None.
     assert body["enforcement_mode"] == "shadow"
+    assert body["features"]["kali_enabled"] is True
+
+
+def test_null_tenant_returns_kali_disabled_feature():
+    """Session without tenant reports safe disabled feature defaults."""
+    session = SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": None,
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": "owner",
+    })
+    app = FastAPI()
+    app.include_router(me_router, prefix="/me")
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.me.require_valid_session", return_value=session), \
+         patch("app.routers.me.get_kali_access_features", new=AsyncMock()) as features:
+        client = TestClient(app)
+        response = client.get("/me/access")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["modules"] == []
+    assert body["enforcement_mode"] == "disabled"
+    assert body["features"]["kali_enabled"] is False
+    features.assert_not_awaited()
 
 
 def test_enforcement_mode_disabled_reported():
@@ -139,6 +182,10 @@ def test_enforcement_mode_disabled_reported():
     with patch("app.core.middleware.get_session_context", return_value=session), \
          patch("app.routers.me.require_valid_session", return_value=session), \
          patch("app.core.permissions.get_db_connection", side_effect=_mock_db_ctx("disabled")), \
+         patch(
+             "app.routers.me.get_kali_access_features",
+             new=AsyncMock(return_value={"kali_enabled": False}),
+         ), \
          patch(
              "app.routers.me.get_role_modules",
              new=AsyncMock(return_value=admin_modules),
@@ -161,6 +208,10 @@ def test_enforcement_mode_enforce_reported():
     with patch("app.core.middleware.get_session_context", return_value=session), \
          patch("app.routers.me.require_valid_session", return_value=session), \
          patch("app.core.permissions.get_db_connection", side_effect=_mock_db_ctx("enforce")), \
+         patch(
+             "app.routers.me.get_kali_access_features",
+             new=AsyncMock(return_value={"kali_enabled": False}),
+         ), \
          patch(
              "app.routers.me.get_role_modules",
              new=AsyncMock(return_value=admin_modules),


### PR DESCRIPTION
## Summary
- add internal tenant-level `kali_enabled` capability with WARO Colombia seeded on
- expose `features.kali_enabled` from `/me/access` for frontend gating
- block AI SSE proxy endpoints before upstream setup when Kali is disabled

## Tests
- pytest tests/test_ai_agents_proxy.py tests/test_me_access.py
- git diff --check

Closes #483