### PR TITLE
Document POS manual checkout API contract

### DIFF
--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -202,6 +202,15 @@ async def clear_cart(
 
 
 class CompleteOrderRequest(BaseModel):
+    """POS manual checkout contract.
+
+    The checkout stack is: automatic promotions, then manual discount, then
+    WaRo redemption, then payment tender. Single-payment payloads send
+    payment_method/payment_method_id plus optional discount_type/discount_value.
+    Split-payment payloads create the order with split_mode=true and
+    split_first_amount; later tenders use AddPaymentRequest.
+    """
+
     payment_method: Optional[str] = Field(None, description="Payment method: cash, card, digital, credit. May be omitted only for delivery orders that remain pending until payment is known.")
     customer_id: UUID = Field(..., description="Customer ID to associate with the order")
     credit_due_date: Optional[date] = Field(None, description="Optional due date for credit orders (only used when payment_method='credit')")
@@ -307,6 +316,13 @@ class SendReceiptRequest(BaseModel):
 
 
 class AddPaymentRequest(BaseModel):
+    """Subsequent split-payment tender.
+
+    amount is one tender against the remaining settlement total. Wallet uses
+    payment_method='customer_wallet' and never sends cash_received; cash sends
+    cash_received only when the cashier needs change calculation.
+    """
+
     amount: float = Field(..., gt=0, description="Amount for this payment")
     payment_method: str = Field(..., description="cash | card | digital | credit or custom slug")
     payment_method_id: Optional[str] = Field(None, description="UUID of payment_methods row")

--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -209,6 +209,21 @@ class CompleteOrderRequest(BaseModel):
     payment_method/payment_method_id plus optional discount_type/discount_value.
     Split-payment payloads create the order with split_mode=true and
     split_first_amount; later tenders use AddPaymentRequest.
+
+    Canonical examples:
+    - cash + 10% manual discount:
+      {payment_method: "cash", discount_type: "percent", discount_value: 10,
+       cash_received: 50000}
+    - wallet tender:
+      {payment_method: "customer_wallet", customer_id: "<profile_uuid>",
+       discount_type: "fixed", discount_value: 5000}
+    - first split tender:
+      {payment_method: "cash", split_mode: true, split_first_amount: 20000,
+       split_first_cash_received: 20000}
+
+    Backward compatibility: clients that do not use manual discounts, wallet,
+    WaRo redemption, or split payments may keep sending only the legacy
+    single-payment fields.
     """
 
     payment_method: Optional[str] = Field(None, description="Payment method: cash, card, digital, credit. May be omitted only for delivery orders that remain pending until payment is known.")
@@ -321,6 +336,9 @@ class AddPaymentRequest(BaseModel):
     amount is one tender against the remaining settlement total. Wallet uses
     payment_method='customer_wallet' and never sends cash_received; cash sends
     cash_received only when the cashier needs change calculation.
+
+    Example wallet partial tender:
+    {amount: 15000, payment_method: "customer_wallet", payment_method_id: null}
     """
 
     amount: float = Field(..., gt=0, description="Amount for this payment")

--- a/app/services/customer_wallet_service.py
+++ b/app/services/customer_wallet_service.py
@@ -74,6 +74,8 @@ async def _resolve_payment_debit_code(
 
 
 async def assert_wallet_customer_identified(conn, profile_id: UUID) -> None:
+    """Wallet tender is only valid for an identified, non-anonymous customer."""
+
     row = await conn.fetchrow(
         "SELECT phone_number FROM profile WHERE id = $1",
         profile_id,
@@ -96,6 +98,8 @@ def validate_wallet_payment_tender(
     payment_method: str,
     cash_received: Optional[float] = None,
 ) -> None:
+    """Reject cash-change fields for wallet payments."""
+
     if payment_method != WALLET_PAYMENT_SLUG:
         return
     if cash_received is not None:
@@ -363,7 +367,12 @@ async def apply_wallet_for_order(
     created_by_user_id: Optional[UUID],
     order_payment_id: Optional[UUID] = None,
 ) -> UUID:
-    """Debit wallet within an existing transaction. Caller must have validated customer."""
+    """Debit wallet within the checkout transaction.
+
+    Wallet is a payment tender, not a discount. The balance lock and
+    insufficient-balance error stay backend-authoritative for both single and
+    split payments.
+    """
     if amount_cop <= 0:
         raise APIError("Monto de billetera inválido", status_code=400)
     await assert_wallet_customer_identified(conn, profile_id)

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -1679,7 +1679,15 @@ async def complete_pos_order(
     waro_reward_id: Optional[UUID] = None,
 ) -> dict:
     """
-    Complete a POS order:
+    Complete a POS order.
+
+    Manual checkout contract:
+    automatic promotions -> manual discount -> WaRo redemption -> payment
+    tender. Wallet is recorded as payment_method='customer_wallet', not as a
+    discount. Split payments create order_payments rows; orders.payment_method
+    remains a legacy/single-payment compatibility field.
+
+    Flow:
     1. Associate customer with cart
     2. Create order record
     3. Copy cart items to order_items

--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -1486,7 +1486,12 @@ def apply_manual_discount_to_evaluated_lines(
     evaluated: Dict[str, Any],
     manual_discount_amount: float,
 ) -> Dict[str, Any]:
-    """Apply manual order discount on promo-adjusted subtotals (stacking contract)."""
+    """Apply manual order discount on promo-adjusted subtotals.
+
+    Manual checkout discounts stack after automatic promotions. Percent
+    discounts therefore use subtotal_after_promos as their base; fixed discounts
+    are capped at that same post-promo base.
+    """
     manual_discount = max(0.0, float(manual_discount_amount or 0))
     lines = evaluated["lines"]
     base_total = float(evaluated["subtotal_after_promos"])
@@ -1524,7 +1529,7 @@ def apply_waro_redemption_to_evaluated_lines(
     evaluated: Dict[str, Any],
     waro_discount_cop: float,
 ) -> Dict[str, Any]:
-    """Apply WaRo COP discount on promo+manual-adjusted subtotals (checkout layer 4)."""
+    """Apply WaRo COP discount after promo and manual discounts."""
     waro_discount = max(0.0, float(waro_discount_cop or 0))
     lines = evaluated["lines"]
     base_total = float(evaluated["total_amount"])
@@ -1632,7 +1637,7 @@ async def evaluate_checkout_promotions(
     discount_value: Optional[float] = None,
     preserve_persisted_promos: bool = False,
 ) -> Dict[str, Any]:
-    """DB-backed promo evaluation + optional manual discount stacking."""
+    """DB-backed promo evaluation plus optional manual discount stacking."""
     evaluation_at = at or default_at_bogota()
     promotions = await load_promotions_for_evaluation(conn, tenant_id, evaluation_at)
     profile_row = await conn.fetchrow(

--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -1659,6 +1659,8 @@ async def evaluate_checkout_promotions(
     )
     manual_discount = float(manual_discount_amount or 0)
     if discount_type and discount_value is not None and discount_value > 0:
+        # Contract: automatic line promotions are evaluated first; the manual
+        # order discount is capped against subtotal_after_promos.
         if discount_type == "percent":
             manual_discount = round(evaluated["subtotal_after_promos"] * discount_value / 100)
         else:


### PR DESCRIPTION
Summary
- Add concrete POS manual checkout payload examples to the API request model docs.
- Document compatibility for legacy single-payment clients.
- Clarify the backend calculation/tender contract: automatic promos, manual discount, WaRo redemption, then payment tender.

Tests
- pytest tests/test_pos_cart.py tests/test_customer_wallet.py tests/test_order_promo_persist.py tests/test_waro_wallet_checkout.py (34 passed).
- Full pytest: 1033 passed, 23 failed, 11 skipped; failures are unrelated pre-existing areas outside this comment/docstring-only change.

Refs uno0uno/warocol.com#1397