### PR TITLE
Label manual discounts on POS receipts

### DIFF
--- a/app/templates/pos_receipt_template.py
+++ b/app/templates/pos_receipt_template.py
@@ -129,7 +129,7 @@ def get_pos_receipt_text(
     elif promo_savings > 0:
         totals_lines.append(f"Promoción: -{_format_cop(promo_savings)}")
     if discount_amount > 0:
-        totals_lines.append(f"Descuento: -{_format_cop(discount_amount)}")
+        totals_lines.append(f"Descuento manual: -{_format_cop(discount_amount)}")
     if _waro_breakdown:
         for entry in _waro_breakdown:
             cop = float(entry.get("cop_discount") or 0)

--- a/tests/test_pos_receipt_template.py
+++ b/tests/test_pos_receipt_template.py
@@ -53,3 +53,25 @@ def test_pos_receipt_renders_waro_redemption_line():
     )
     assert "Subtotal: $50.000" in text
     assert "Canje WaRo (Empanada gratis): -$5.000" in text
+
+
+def test_pos_receipt_labels_manual_discount_separately_from_promotions():
+    text = get_pos_receipt_text(
+        order_number=45,
+        total_amount=82000,
+        payment_method="card",
+        items=[{"quantity": 1, "subtotal": 100000, "product": {"name": "Combo"}}],
+        order_date=datetime(2026, 6, 19, 12, 0, tzinfo=timezone.utc),
+        subtotal=100000,
+        promo_breakdown=[
+            {
+                "promotion_name": "Promo almuerzo",
+                "promo_type": "percentage",
+                "savings": 8000,
+            },
+        ],
+        discount_amount=10000,
+    )
+    assert "Promo almuerzo: -$8.000" in text
+    assert "Descuento manual: -$10.000" in text
+    assert "Descuento: -$10.000" not in text


### PR DESCRIPTION
## Summary
- Label manual order discounts as "Descuento manual" in POS receipt email/plain-text output
- Add receipt template coverage so manual discounts stay distinct from automatic promotion lines

## Tests
- pytest tests/test_pos_receipt_template.py
- pytest (interrupted after unrelated existing failures outside receipt scope: cierre/data quality/invoicing/manual GL/online cart)

Refs uno0uno/warocol.com#1399