### PR TITLE
Add wallet tender regression tests

### DIFF
--- a/tests/test_customer_wallet.py
+++ b/tests/test_customer_wallet.py
@@ -23,6 +23,9 @@ class TestWalletTenderValidation:
     def test_cash_allows_cash_received(self):
         validate_wallet_payment_tender("cash", cash_received=100.0)
 
+    def test_wallet_allows_missing_cash_received(self):
+        validate_wallet_payment_tender(WALLET_PAYMENT_SLUG)
+
 
 class TestAnonymousGuard:
     @pytest.mark.asyncio
@@ -84,3 +87,53 @@ class TestApplyWalletInsufficientBalance:
                 None,
             )
         assert "insuficiente" in str(exc.value).lower()
+
+
+class TestApplyWalletForOrder:
+    @pytest.mark.asyncio
+    async def test_debits_balance_and_links_order_payment(self):
+        conn = AsyncMock()
+        profile_id = uuid4()
+        tenant_id = uuid4()
+        order_id = uuid4()
+        order_payment_id = uuid4()
+        movement_id = uuid4()
+        inserts = []
+        upserts = []
+
+        async def fetchrow_side_effect(query, *args):
+            q = " ".join(query.split())
+            if "phone_number" in q:
+                return {"phone_number": "3001234567"}
+            if "FOR UPDATE" in q and "customer_wallet_balances" in q:
+                return {"balance_cop": Decimal("50000")}
+            if "INSERT INTO customer_wallet_movements" in q:
+                inserts.append(args)
+                return {"id": movement_id}
+            return None
+
+        async def execute_side_effect(query, *args):
+            q = " ".join(query.split())
+            if "INSERT INTO customer_wallet_balances" in q:
+                upserts.append(args)
+
+        conn.fetchrow = AsyncMock(side_effect=fetchrow_side_effect)
+        conn.execute = AsyncMock(side_effect=execute_side_effect)
+
+        result = await apply_wallet_for_order(
+            conn,
+            profile_id,
+            tenant_id,
+            Decimal("12500"),
+            order_id,
+            None,
+            order_payment_id=order_payment_id,
+        )
+
+        assert result == movement_id
+        assert inserts
+        assert inserts[0][7] == order_id
+        assert inserts[0][8] == order_payment_id
+        assert inserts[0][3] == Decimal("-12500")
+        assert inserts[0][4] == Decimal("37500")
+        assert upserts[0] == (profile_id, tenant_id, Decimal("37500"))

--- a/tests/test_pos_cart.py
+++ b/tests/test_pos_cart.py
@@ -10,6 +10,7 @@ Endpoints tested:
 """
 import pytest
 from httpx import AsyncClient
+from pathlib import Path
 from uuid import uuid4
 
 
@@ -167,3 +168,16 @@ class TestPosCartCompleteEndpoint:
             json={"payment_method": "digital"}
         )
         assert response.status_code in [404, 401, 403, 500]
+
+
+class TestPosWalletTenderContract:
+    def test_service_keeps_customer_wallet_as_payment_tender(self):
+        src = Path(__file__).resolve().parents[1] / "app/services/pos_cart_service.py"
+        text = src.read_text()
+
+        assert "Wallet is recorded as payment_method='customer_wallet'" in text
+        assert "validate_wallet_payment_tender(payment_method, cash_received)" in text
+        assert "if not split_mode and payment_method == WALLET_PAYMENT_SLUG" in text
+        assert "payment_method == WALLET_PAYMENT_SLUG" in text
+        assert "discount_type" in text
+        assert "discount_value" in text


### PR DESCRIPTION
## Summary\n- cover wallet tender without cash_received\n- cover wallet debit movement details and order payment linkage\n- pin POS wallet tender contract in service tests\n\n## Tests\n- pytest tests/test_customer_wallet.py tests/test_waro_wallet_checkout.py tests/test_pos_cart.py -q\n\nRefs uno0uno/warocol.com#1400