### PR TITLE
Harden POS split payment settlement

### DIFF
--- a/app/services/customer_wallet_service.py
+++ b/app/services/customer_wallet_service.py
@@ -398,6 +398,38 @@ async def apply_wallet_for_order(
     return movement_id
 
 
+async def restore_wallet_for_order_payment_void(
+    conn,
+    profile_id: UUID,
+    tenant_id: UUID,
+    amount_cop: Decimal,
+    order_id: UUID,
+    order_payment_id: UUID,
+    created_by_user_id: Optional[UUID],
+    notes: Optional[str] = None,
+) -> UUID:
+    """Restore wallet balance when a wallet tender row is voided."""
+    if amount_cop <= 0:
+        raise APIError("Monto de reversión de billetera inválido", status_code=400)
+    await assert_wallet_customer_identified(conn, profile_id)
+    current = await _lock_balance_cop(conn, profile_id, tenant_id)
+    new_balance = current + amount_cop
+    movement_id = await _insert_movement(
+        conn,
+        profile_id=profile_id,
+        tenant_id=tenant_id,
+        movement_type="void_apply",
+        amount_cop=amount_cop,
+        balance_after_cop=new_balance,
+        order_id=order_id,
+        order_payment_id=order_payment_id,
+        notes=notes,
+        created_by_user_id=created_by_user_id,
+    )
+    await _upsert_balance(conn, profile_id, tenant_id, new_balance)
+    return movement_id
+
+
 async def apply_wallet_for_session_orders(
     conn,
     profile_id: UUID,

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -36,6 +36,7 @@ from app.services.customer_wallet_service import (
     WALLET_PAYMENT_SLUG,
     apply_wallet_for_order,
     assert_wallet_customer_identified,
+    restore_wallet_for_order_payment_void,
     validate_wallet_payment_tender,
 )
 from app.services.open_priced_service import (
@@ -1274,7 +1275,8 @@ async def add_order_payment(
                 order_row = await conn.fetchrow(
                     """
                     SELECT id, total_amount, tip_amount, tip_source, tip_taxable,
-                           tip_tax_amount, status, payment_status
+                           tip_tax_amount, status, payment_status, customer_id,
+                           order_number
                     FROM orders
                     WHERE pos_cart_id = $1 AND tenant_id = $2
                     ORDER BY created_at DESC
@@ -1349,25 +1351,28 @@ async def add_order_payment(
                     resolved_tip_amount,
                     resolved_tip_tax_amount,
                 )
+                paid_before_row = await conn.fetchrow(
+                    """
+                    SELECT COALESCE(SUM(amount), 0) AS paid_total
+                    FROM order_payments
+                    WHERE order_id = $1 AND voided_at IS NULL
+                    """,
+                    order_id,
+                )
+                paid_before = float(paid_before_row["paid_total"])
+                remaining_before = max(0.0, amount_due - paid_before)
+                if amount - remaining_before > 0.01:
+                    raise APIError(
+                        f"El pago excede el saldo pendiente ({remaining_before})",
+                        status_code=400,
+                    )
 
                 user_id = session_context.user_id if hasattr(session_context, 'user_id') else None
-                if payment_method == WALLET_PAYMENT_SLUG:
-                    customer_uuid = await conn.fetchval(
-                        "SELECT customer_id FROM orders WHERE id = $1",
-                        order_id,
-                    )
-                    if not customer_uuid:
-                        raise APIError(
-                            "La billetera requiere un cliente en la orden",
-                            status_code=400,
-                        )
-                    await apply_wallet_for_order(
-                        conn,
-                        customer_uuid,
-                        UUID(str(tenant_id)),
-                        Decimal(str(amount)),
-                        order_id,
-                        UUID(str(user_id)) if user_id else None,
+                customer_uuid = order_row["customer_id"]
+                if payment_method == WALLET_PAYMENT_SLUG and not customer_uuid:
+                    raise APIError(
+                        "La billetera requiere un cliente en la orden",
+                        status_code=400,
                     )
 
                 # 3. Insert payment record
@@ -1385,6 +1390,17 @@ async def add_order_payment(
                     cash_received,
                 )
                 payment_id = str(payment_row["id"])
+
+                if payment_method == WALLET_PAYMENT_SLUG:
+                    await apply_wallet_for_order(
+                        conn,
+                        customer_uuid,
+                        UUID(str(tenant_id)),
+                        Decimal(str(amount)),
+                        order_id,
+                        UUID(str(user_id)) if user_id else None,
+                        UUID(payment_id),
+                    )
 
                 # 4. Compute paid total (warocol.com#649: ignore voided rows)
                 paid_total_row = await conn.fetchrow(
@@ -1480,6 +1496,13 @@ async def add_order_payment(
                 "tip_source": resolved_tip_source,
                 "tip_taxable": resolved_tip_taxable,
                 "tip_tax_amount": resolved_tip_tax_amount,
+                "order_id": str(order_id),
+                "order_number": int(order_row["order_number"]),
+                "total_amount": total_amount,
+                "charged_amount": amount_due,
+                "payment_method": payment_method,
+                "payment_status": "paid" if is_complete else "partial",
+                "status": "completed" if is_complete else order_row["status"],
             }
         }
 
@@ -1531,8 +1554,9 @@ async def void_order_payment(
                     """
                     SELECT op.id, op.order_id, op.amount, op.payment_method,
                            op.cash_received, op.created_by_user_id, op.voided_at,
+                           op.payment_method_id,
                            o.pos_cart_id, o.total_amount, o.tip_amount, o.tip_tax_amount,
-                           o.payment_status, o.status AS order_status
+                           o.payment_status, o.status AS order_status, o.customer_id
                     FROM order_payments op
                     JOIN orders o ON o.id = op.order_id
                     WHERE op.id = $1::uuid AND op.tenant_id = $2
@@ -1575,6 +1599,23 @@ async def void_order_payment(
                     payment_row["id"],
                     normalized_reason,
                 )
+                wallet_restore_movement_id = None
+                if payment_row["payment_method"] == WALLET_PAYMENT_SLUG:
+                    if not payment_row["customer_id"]:
+                        raise APIError(
+                            "La billetera requiere un cliente en la orden",
+                            status_code=400,
+                        )
+                    wallet_restore_movement_id = await restore_wallet_for_order_payment_void(
+                        conn,
+                        payment_row["customer_id"],
+                        UUID(str(tenant_id)),
+                        Decimal(str(payment_row["amount"])),
+                        order_id,
+                        UUID(str(payment_row["id"])),
+                        UUID(str(user_id)) if user_id else None,
+                        notes=f"Anulación pago parcial: {normalized_reason}",
+                    )
 
                 # 5. Recompute paid total ignoring voided rows.
                 paid_row = await conn.fetchrow(
@@ -1627,6 +1668,11 @@ async def void_order_payment(
                             if payment_row["cash_received"] is not None
                             else None
                         ),
+                        "wallet_restore_movement_id": (
+                            str(wallet_restore_movement_id)
+                            if wallet_restore_movement_id
+                            else None
+                        ),
                         "reopened": reopened,
                     },
                 )
@@ -1642,6 +1688,11 @@ async def void_order_payment(
                 "remaining": remaining,
                 "is_complete": is_complete,
                 "reopened": reopened,
+                "wallet_restore_movement_id": (
+                    str(wallet_restore_movement_id)
+                    if wallet_restore_movement_id
+                    else None
+                ),
             },
         }
 
@@ -2255,17 +2306,16 @@ async def complete_pos_order(
                                 f"Efectivo recibido ({split_first_cash_received}) debe ser mayor o igual al monto ({split_first_amount})",
                                 status_code=400,
                             )
+                    _amount_due = split_settlement_amount_due(
+                        float(_discounted_total), float(tip_amount), _tip_tax_amount,
+                    )
+                    if split_first_amount - _amount_due > 0.01:
+                        raise APIError(
+                            f"El pago excede el saldo pendiente ({_amount_due})",
+                            status_code=400,
+                        )
                     # Issue warocol.com#649 — RETURNING id so the frontend has a
                     # real UUID for void operations (was: None → placeholder → 422).
-                    if payment_method == WALLET_PAYMENT_SLUG:
-                        await apply_wallet_for_order(
-                            conn,
-                            customer_id,
-                            UUID(str(tenant_id)),
-                            Decimal(str(split_first_amount)),
-                            order_id,
-                            UUID(str(user_id)) if user_id else None,
-                        )
                     _split_first_payment_row = await conn.fetchrow(
                         """
                         INSERT INTO order_payments
@@ -2279,10 +2329,17 @@ async def complete_pos_order(
                         split_first_cash_received,
                     )
                     _split_first_payment_id = str(_split_first_payment_row["id"])
+                    if payment_method == WALLET_PAYMENT_SLUG:
+                        await apply_wallet_for_order(
+                            conn,
+                            customer_id,
+                            UUID(str(tenant_id)),
+                            Decimal(str(split_first_amount)),
+                            order_id,
+                            UUID(str(user_id)) if user_id else None,
+                            UUID(_split_first_payment_id),
+                        )
                     _split_paid_total = split_first_amount
-                    _amount_due = split_settlement_amount_due(
-                        float(_discounted_total), float(tip_amount), _tip_tax_amount,
-                    )
                     _split_remaining = max(0.0, _amount_due - split_first_amount)
                     _split_is_complete = _split_remaining <= 0.01
 

--- a/tests/test_payment_void_operation_events.py
+++ b/tests/test_payment_void_operation_events.py
@@ -137,6 +137,71 @@ async def test_void_order_payment_empty_reason_defaults_sin_motivo():
 
 
 @pytest.mark.asyncio
+async def test_void_wallet_order_payment_restores_wallet_balance():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    cart_id = uuid4()
+    payment_id = uuid4()
+    order_id = uuid4()
+    customer_id = uuid4()
+    movement_id = uuid4()
+    recorded = []
+
+    payment_row = {
+        "id": payment_id,
+        "order_id": order_id,
+        "amount": 25.0,
+        "payment_method": "customer_wallet",
+        "payment_method_id": None,
+        "cash_received": None,
+        "created_by_user_id": user_id,
+        "voided_at": None,
+        "pos_cart_id": cart_id,
+        "total_amount": 100.0,
+        "tip_amount": 0,
+        "tip_tax_amount": 0,
+        "payment_status": "partial",
+        "order_status": "active",
+        "customer_id": customer_id,
+    }
+
+    mock_conn, mock_cm = _txn_conn()
+    mock_conn.fetchrow = AsyncMock(side_effect=[
+        payment_row,
+        {"paid": 0},
+    ])
+    mock_conn.execute = AsyncMock()
+
+    async def capture_event(conn, tid, **kwargs):
+        recorded.append(kwargs)
+
+    with patch("app.services.pos_cart_service.require_valid_session") as mock_sess, \
+         patch("app.services.pos_cart_service.get_db_connection", return_value=mock_cm), \
+         patch("app.services.pos_cart_service.record_operation_event", side_effect=capture_event), \
+         patch(
+             "app.services.pos_cart_service.restore_wallet_for_order_payment_void",
+             new=AsyncMock(return_value=movement_id),
+         ) as restore_wallet:
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id, role="admin")
+        result = await pos_cart_service.void_order_payment(
+            MagicMock(), str(cart_id), str(payment_id), reason="Error de método",
+        )
+
+    restore_wallet.assert_awaited_once_with(
+        mock_conn,
+        customer_id,
+        tenant_id,
+        pos_cart_service.Decimal("25.0"),
+        order_id,
+        payment_id,
+        user_id,
+        notes="Anulación pago parcial: Error de método",
+    )
+    assert result["data"]["wallet_restore_movement_id"] == str(movement_id)
+    assert recorded[0]["payload"]["wallet_restore_movement_id"] == str(movement_id)
+
+
+@pytest.mark.asyncio
 async def test_void_table_payment_records_single_payment_voided_event():
     tenant_id = uuid4()
     user_id = uuid4()

--- a/tests/test_pos_cart.py
+++ b/tests/test_pos_cart.py
@@ -11,7 +11,28 @@ Endpoints tested:
 import pytest
 from httpx import AsyncClient
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
+
+from app.core.exceptions import APIError
+from app.services import pos_cart_service
+
+
+def _txn_conn():
+    mock_conn = AsyncMock()
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+    return mock_conn, mock_cm
 
 
 class TestPosCartGetEndpoint:
@@ -181,3 +202,96 @@ class TestPosWalletTenderContract:
         assert "payment_method == WALLET_PAYMENT_SLUG" in text
         assert "discount_type" in text
         assert "discount_value" in text
+
+    @pytest.mark.asyncio
+    async def test_split_payment_rejects_amount_above_remaining_before_insert(self):
+        tenant_id = uuid4()
+        user_id = uuid4()
+        cart_id = uuid4()
+        order_id = uuid4()
+        customer_id = uuid4()
+        mock_conn, mock_cm = _txn_conn()
+        mock_conn.fetchrow = AsyncMock(side_effect=[
+            {"id": cart_id, "tenant_id": tenant_id},
+            {
+                "id": order_id,
+                "total_amount": 100.0,
+                "tip_amount": 0,
+                "tip_source": "none",
+                "tip_taxable": False,
+                "tip_tax_amount": 0,
+                "status": "active",
+                "payment_status": "partial",
+                "customer_id": customer_id,
+                "order_number": 77,
+            },
+            {"paid_total": 80.0},
+        ])
+
+        with patch("app.services.pos_cart_service.require_valid_session") as mock_sess, \
+             patch("app.services.pos_cart_service.get_db_connection", return_value=mock_cm):
+            mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+            with pytest.raises(APIError) as exc:
+                await pos_cart_service.add_order_payment(
+                    MagicMock(),
+                    str(cart_id),
+                    amount=25.0,
+                    payment_method="card",
+                )
+
+        assert exc.value.status_code == 400
+        assert "excede el saldo pendiente" in str(exc.value)
+        assert mock_conn.fetchrow.await_count == 3
+        mock_conn.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_wallet_split_payment_links_wallet_movement_to_payment_row(self):
+        tenant_id = uuid4()
+        user_id = uuid4()
+        cart_id = uuid4()
+        order_id = uuid4()
+        payment_id = uuid4()
+        customer_id = uuid4()
+        mock_conn, mock_cm = _txn_conn()
+        mock_conn.fetchrow = AsyncMock(side_effect=[
+            {"id": cart_id, "tenant_id": tenant_id},
+            {
+                "id": order_id,
+                "total_amount": 100.0,
+                "tip_amount": 0,
+                "tip_source": "none",
+                "tip_taxable": False,
+                "tip_tax_amount": 0,
+                "status": "active",
+                "payment_status": "partial",
+                "customer_id": customer_id,
+                "order_number": 78,
+            },
+            {"paid_total": 20.0},
+            {"id": payment_id},
+            {"paid_total": 50.0},
+        ])
+        mock_conn.execute = AsyncMock()
+
+        with patch("app.services.pos_cart_service.require_valid_session") as mock_sess, \
+             patch("app.services.pos_cart_service.get_db_connection", return_value=mock_cm), \
+             patch("app.services.pos_cart_service.apply_wallet_for_order", new=AsyncMock()) as apply_wallet:
+            mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+            result = await pos_cart_service.add_order_payment(
+                MagicMock(),
+                str(cart_id),
+                amount=30.0,
+                payment_method="customer_wallet",
+            )
+
+        assert result["data"]["payment_id"] == str(payment_id)
+        assert result["data"]["remaining"] == 50.0
+        apply_wallet.assert_awaited_once_with(
+            mock_conn,
+            customer_id,
+            tenant_id,
+            pos_cart_service.Decimal("30.0"),
+            order_id,
+            user_id,
+            payment_id,
+        )


### PR DESCRIPTION
## Summary
- reject split tenders that exceed remaining balance before persistence
- link wallet split movements to order_payments rows
- restore wallet balance when a wallet split payment is voided

## Tests
- python3 -m py_compile app/services/pos_cart_service.py app/services/customer_wallet_service.py
- pytest tests/test_pos_cart.py tests/test_waro_wallet_checkout.py tests/test_payment_void_operation_events.py
- git diff --check

Refs uno0uno/warocol.com#1401