### PR TITLE
Cover manual checkout QA invariants

### DIFF
--- a/tests/test_pos_cart.py
+++ b/tests/test_pos_cart.py
@@ -192,6 +192,11 @@ class TestPosCartCompleteEndpoint:
 
 
 class TestPosWalletTenderContract:
+    def test_manual_discount_amount_uses_promo_adjusted_subtotal(self):
+        assert pos_cart_service._manual_discount_amount(80_000, "percent", 10) == 8_000
+        assert pos_cart_service._manual_discount_amount(80_000, "fixed", 90_000) == 80_000
+        assert pos_cart_service._manual_discount_amount(80_000, None, 10) == 0
+
     def test_service_keeps_customer_wallet_as_payment_tender(self):
         src = Path(__file__).resolve().parents[1] / "app/services/pos_cart_service.py"
         text = src.read_text()
@@ -202,6 +207,7 @@ class TestPosWalletTenderContract:
         assert "payment_method == WALLET_PAYMENT_SLUG" in text
         assert "discount_type" in text
         assert "discount_value" in text
+        assert "UUID(_split_first_payment_id)" in text
 
     @pytest.mark.asyncio
     async def test_split_payment_rejects_amount_above_remaining_before_insert(self):

--- a/tests/test_pos_receipt_template.py
+++ b/tests/test_pos_receipt_template.py
@@ -75,3 +75,43 @@ def test_pos_receipt_labels_manual_discount_separately_from_promotions():
     assert "Promo almuerzo: -$8.000" in text
     assert "Descuento manual: -$10.000" in text
     assert "Descuento: -$10.000" not in text
+
+
+def test_pos_receipt_keeps_checkout_discount_stack_separate():
+    text = get_pos_receipt_text(
+        order_number=46,
+        total_amount=83000,
+        payment_method="customer_wallet",
+        items=[{"quantity": 1, "subtotal": 120000, "product": {"name": "Cena"}}],
+        order_date=datetime(2026, 6, 19, 18, 30, tzinfo=timezone.utc),
+        subtotal=120000,
+        promo_breakdown=[
+            {
+                "promotion_name": "Promo noche",
+                "promo_type": "fixed_off",
+                "savings": 12000,
+            },
+        ],
+        discount_amount=15000,
+        standard_tax=3000,
+        standard_tax_label="IVA",
+        tip_amount=7000,
+        waro_redemption_summary={
+            "waro_discount_cop": 10000,
+            "waro_breakdown": [
+                {
+                    "redemption_type": "reward_fixed_cop",
+                    "cop_discount": 10000,
+                    "reward_name": "Bono fidelidad",
+                },
+            ],
+        },
+    )
+
+    assert "Subtotal: $120.000" in text
+    assert "Promo noche: -$12.000" in text
+    assert "Descuento manual: -$15.000" in text
+    assert "Canje WaRo (Bono fidelidad): -$10.000" in text
+    assert "IVA: $3.000" in text
+    assert "Propina: $7.000" in text
+    assert "TOTAL COBRADO: $90.000" in text


### PR DESCRIPTION
## Summary
- Add coverage for promo-adjusted manual discount math and first wallet split tender linkage
- Add receipt coverage for promo, manual discount, WaRo, tax, and tip as separate lines

## Tests
- pytest tests/test_pos_cart.py tests/test_payment_void_operation_events.py tests/test_customer_wallet.py tests/test_pos_receipt_template.py

Refs uno0uno/warocol.com#1402