### PR TITLE
Support manual order discounts and split payments

### DIFF
--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -226,6 +226,13 @@ class ManualOrderItem(BaseModel):
     modifiers: List[ManualOrderModifier] = []
 
 
+class ManualOrderPayment(BaseModel):
+    amount: float = Field(gt=0)
+    payment_method: str
+    payment_method_id: Optional[str] = None
+    cash_received: Optional[float] = None
+
+
 class CreateManualOrderRequest(BaseModel):
     order_date: str
     payment_method: str
@@ -235,6 +242,9 @@ class CreateManualOrderRequest(BaseModel):
     # group slug). Optional for backward compatibility.
     payment_method_id: Optional[str] = None
     customer_id: Optional[str] = None
+    discount_type: Optional[str] = None
+    discount_value: Optional[float] = None
+    payments: Optional[List[ManualOrderPayment]] = None
     items: List[ManualOrderItem] = Field(min_length=1)
 
 
@@ -253,7 +263,10 @@ async def create_manual_order(
         payment_method=data.payment_method,
         payment_method_id=data.payment_method_id,
         items=[item.model_dump() for item in data.items],
-        customer_id=data.customer_id
+        customer_id=data.customer_id,
+        discount_type=data.discount_type,
+        discount_value=data.discount_value,
+        payments=[payment.model_dump() for payment in data.payments] if data.payments else None,
     )
 
 

--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -291,6 +291,7 @@ async def _post_order_gl_entry(
     tip_amount: Decimal = Decimal("0"),
     tip_tax_amount: Decimal = Decimal("0"),
     advance_amount: Decimal = Decimal("0"),
+    payment_splits: Optional[List[Dict[str, Any]]] = None,
 ) -> None:
     """
     Post a double-entry GL journal entry for a single completed order (POS or domicilio).
@@ -326,32 +327,68 @@ async def _post_order_gl_entry(
         logger.info(f"[GL] Order {order_id}: zero amount — skip GL post")
         return
 
-    # ── Resolve debit account: specific method → group → slug fallback ────
-    debit_code = None
-    if payment_method_id:
-        pm_row = await conn.fetchrow(
-            """SELECT COALESCE(pm.gl_account_code, pmg.gl_account_code) AS code
-               FROM payment_methods pm
-               JOIN payment_method_groups pmg ON pm.group_id = pmg.id
-               WHERE pm.id = $1""",
-            payment_method_id,
-        )
-        if pm_row and pm_row["code"]:
-            debit_code = pm_row["code"]
-    if not debit_code:
-        debit_code = _SLUG_DEBIT_CODE.get(payment_method or "", "1105")
-    if payment_method == "customer_wallet":
-        liability_row = await conn.fetchrow(
-            """
-            SELECT customer_wallet_liability_gl_code
-            FROM tenant_public_profiles
-            WHERE tenant_id = $1
-            """,
-            tenant_id,
-        )
-        if liability_row and liability_row["customer_wallet_liability_gl_code"]:
-            debit_code = str(liability_row["customer_wallet_liability_gl_code"])
+    async def resolve_debit_code(method: str, method_id: Optional[UUID]) -> str:
+        debit_code = None
+        if method_id:
+            pm_row = await conn.fetchrow(
+                """SELECT COALESCE(pm.gl_account_code, pmg.gl_account_code) AS code
+                   FROM payment_methods pm
+                   JOIN payment_method_groups pmg ON pm.group_id = pmg.id
+                   WHERE pm.id = $1""",
+                method_id,
+            )
+            if pm_row and pm_row["code"]:
+                debit_code = pm_row["code"]
+        if not debit_code:
+            debit_code = _SLUG_DEBIT_CODE.get(method or "", "1105")
+        if method == "customer_wallet":
+            liability_row = await conn.fetchrow(
+                """
+                SELECT customer_wallet_liability_gl_code
+                FROM tenant_public_profiles
+                WHERE tenant_id = $1
+                """,
+                tenant_id,
+            )
+            if liability_row and liability_row["customer_wallet_liability_gl_code"]:
+                debit_code = str(liability_row["customer_wallet_liability_gl_code"])
+        return str(debit_code)
 
+    async def resolve_debit_account(code: str):
+        debit_acct = await conn.fetchrow(
+            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
+            tenant_id,
+            code,
+        )
+        if not debit_acct:
+            logger.warning(
+                f"[GL] Debit account {code} not found for tenant {tenant_id} — "
+                f"skip GL post for order {order_id}"
+            )
+            return None
+        return debit_acct
+
+    # ── Resolve debit account: specific method → group → slug fallback ────
+    debit_code = await resolve_debit_code(payment_method, payment_method_id)
+    split_debits: List[Dict[str, Any]] = []
+    if payment_splits:
+        split_total = sum(Decimal(str(split.get("amount") or 0)) for split in payment_splits)
+        if split_total > 0:
+            for split in payment_splits:
+                split_method_id = split.get("payment_method_id")
+                if split_method_id and not isinstance(split_method_id, UUID):
+                    split_method_id = UUID(str(split_method_id))
+                split_debits.append(
+                    {
+                        "amount": Decimal(str(split.get("amount") or 0)),
+                        "payment_method": split.get("payment_method") or "",
+                        "payment_method_id": split_method_id,
+                        "code": await resolve_debit_code(
+                            split.get("payment_method") or "",
+                            split_method_id,
+                        ),
+                    }
+                )
     # ── Resolve 4135 Ingresos ──────────────────────────────────────────────
     ingresos_acct = await conn.fetchrow(
         "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
@@ -471,17 +508,35 @@ async def _post_order_gl_entry(
     )
     payment_debit = debit_total - advance_debit
     debit_acct = None
+    split_debit_lines: List[Dict[str, Any]] = []
     if payment_debit > 0:
-        debit_acct = await conn.fetchrow(
-            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-            tenant_id, debit_code,
-        )
-        if not debit_acct:
-            logger.warning(
-                f"[GL] Debit account {debit_code} not found for tenant {tenant_id} — "
-                f"skip GL post for order {order_id}"
-            )
-            return
+        if split_debits:
+            split_total = sum(split["amount"] for split in split_debits)
+            remaining_debit = payment_debit
+            for idx, split in enumerate(split_debits):
+                if split["amount"] <= 0:
+                    continue
+                if idx == len(split_debits) - 1:
+                    debit_amount = remaining_debit
+                else:
+                    debit_amount = (payment_debit * split["amount"] / split_total).quantize(Decimal("0.01"))
+                    remaining_debit -= debit_amount
+                if debit_amount <= 0:
+                    continue
+                split_acct = await resolve_debit_account(split["code"])
+                if not split_acct:
+                    return
+                split_debit_lines.append(
+                    {
+                        "account_id": split_acct["id"],
+                        "amount": debit_amount,
+                        "payment_method": split["payment_method"],
+                    }
+                )
+        else:
+            debit_acct = await resolve_debit_account(debit_code)
+            if not debit_acct:
+                return
     advance_acct = None
     if advance_debit > 0:
         advance_acct = await conn.fetchrow(
@@ -526,7 +581,20 @@ async def _post_order_gl_entry(
                 line_order,
             )
             line_order += 1
-        if payment_debit > 0 and debit_acct:
+        if split_debit_lines:
+            for split in split_debit_lines:
+                await conn.execute(
+                    """INSERT INTO tenant_journal_lines
+                           (journal_entry_id, account_id, debit, credit, description, line_order)
+                       VALUES ($1, $2, $3, 0, $4, $5)""",
+                    entry_id,
+                    split["account_id"],
+                    float(split["amount"]),
+                    f"{description} — {split['payment_method']}",
+                    line_order,
+                )
+                line_order += 1
+        elif payment_debit > 0 and debit_acct:
             await conn.execute(
                 """INSERT INTO tenant_journal_lines
                        (journal_entry_id, account_id, debit, credit, description, line_order)

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -3348,6 +3348,9 @@ async def create_manual_order(
     items: List[dict],
     customer_id: Optional[str] = None,
     payment_method_id: Optional[str] = None,
+    discount_type: Optional[str] = None,
+    discount_value: Optional[float] = None,
+    payments: Optional[List[dict]] = None,
 ) -> dict:
     """
     Create an order manually with a custom date, bypassing the POS cart.
@@ -3374,12 +3377,33 @@ async def create_manual_order(
 
         customer_uuid = UUID(customer_id) if customer_id else None
         payment_method_uuid = UUID(payment_method_id) if payment_method_id else None
+        split_payments = payments or []
 
         if payment_method == "customer_wallet":
             if not customer_uuid:
                 raise APIError("La billetera requiere un cliente identificado", status_code=400)
             if payment_method_uuid:
                 raise APIError("payment_method_id no aplica al método billetera del cliente", status_code=400)
+
+        for payment in split_payments:
+            if payment.get("payment_method") == "customer_wallet" and not customer_uuid:
+                raise APIError("La billetera requiere un cliente identificado", status_code=400)
+            if payment.get("payment_method") == "customer_wallet" and payment.get("payment_method_id"):
+                raise APIError("payment_method_id no aplica al método billetera del cliente", status_code=400)
+            if payment.get("cash_received") is not None:
+                if payment.get("payment_method") != "cash":
+                    raise APIError("cash_received solo aplica a pagos en efectivo", status_code=400)
+                if float(payment["cash_received"]) < float(payment["amount"]):
+                    raise APIError("Efectivo recibido debe ser mayor o igual al monto", status_code=400)
+            if payment.get("payment_method_id"):
+                try:
+                    UUID(payment["payment_method_id"])
+                except ValueError:
+                    raise APIError(
+                        "payment_method_id no es un UUID válido",
+                        status_code=400,
+                        details={"code": "payment_method_id_invalid"},
+                    )
 
         async with get_db_connection() as conn:
             async with conn.transaction():
@@ -3398,21 +3422,52 @@ async def create_manual_order(
                     return float(modifier.get("price", 0)) * modifier_quantity(modifier)
 
                 # Compute total server-side — never trust client total
-                total_amount = sum(
+                gross_total = sum(
                     float(item["quantity"]) * (
                         float(item["unit_price"])
                         + sum(modifier_unit_total(m) for m in item.get("modifiers", []))
                     )
                     for item in items
                 )
+                if gross_total < 0:
+                    raise APIError("Total de venta inválido", status_code=400)
+
+                normalized_discount_type = discount_type if discount_value is not None else None
+                normalized_discount_value = float(discount_value) if discount_value is not None else None
+                discount_amount = 0.0
+                if normalized_discount_type:
+                    if normalized_discount_type not in ("percent", "fixed"):
+                        raise APIError("discount_type debe ser 'percent' o 'fixed'", status_code=400)
+                    if normalized_discount_value is None or normalized_discount_value <= 0:
+                        raise APIError("discount_value debe ser mayor a 0", status_code=400)
+                    if normalized_discount_type == "percent":
+                        if normalized_discount_value > 100:
+                            raise APIError("El descuento porcentual no puede superar el 100%", status_code=400)
+                        discount_amount = gross_total * normalized_discount_value / 100
+                    else:
+                        discount_amount = normalized_discount_value
+                    if discount_amount - gross_total > 0.01:
+                        raise APIError("El descuento no puede superar el subtotal", status_code=400)
+                    discount_amount = round(discount_amount, 2)
+
+                total_amount = round(max(0.0, gross_total - discount_amount), 2)
+
+                if split_payments:
+                    paid_total = round(sum(float(p["amount"]) for p in split_payments), 2)
+                    if abs(paid_total - total_amount) > 0.01:
+                        raise APIError(
+                            f"Los pagos divididos ({paid_total}) deben sumar el total ({total_amount})",
+                            status_code=400,
+                        )
 
                 order_row = await conn.fetchrow(
                     """
                     INSERT INTO orders (
                         tenant_id, customer_id, payment_method, payment_method_id,
-                        order_date, total_amount, status, extra_attributes
+                        order_date, total_amount, status, payment_status,
+                        discount_type, discount_value, discount_amount, extra_attributes
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, 'completed', $7)
+                    VALUES ($1, $2, $3, $4, $5, $6, 'completed', 'paid', $7, $8, $9, $10)
                     RETURNING id, order_number, order_date, created_at
                     """,
                     tenant_id,
@@ -3421,6 +3476,9 @@ async def create_manual_order(
                     payment_method_uuid,
                     order_datetime,
                     total_amount,
+                    normalized_discount_type,
+                    normalized_discount_value,
+                    discount_amount or None,
                     json.dumps({"source": "manual"})
                 )
 
@@ -3551,7 +3609,42 @@ async def create_manual_order(
                         str(tenant_id),
                     )
 
-                if payment_method == "customer_wallet" and customer_uuid:
+                if split_payments:
+                    from app.services.customer_wallet_service import apply_wallet_for_order
+
+                    for payment in split_payments:
+                        payment_method_for_row = payment["payment_method"]
+                        payment_method_id_for_row = payment.get("payment_method_id")
+                        payment_method_uuid_for_row = (
+                            UUID(payment_method_id_for_row) if payment_method_id_for_row else None
+                        )
+                        payment_amount = round(float(payment["amount"]), 2)
+                        payment_row = await conn.fetchrow(
+                            """
+                            INSERT INTO order_payments
+                                (order_id, tenant_id, amount, payment_method, payment_method_id, created_by_user_id, cash_received)
+                            VALUES ($1, $2, $3, $4, $5::uuid, $6::uuid, $7)
+                            RETURNING id
+                            """,
+                            order_id,
+                            tenant_id,
+                            payment_amount,
+                            payment_method_for_row,
+                            str(payment_method_uuid_for_row) if payment_method_uuid_for_row else None,
+                            str(user_id) if user_id else None,
+                            payment.get("cash_received"),
+                        )
+                        if payment_method_for_row == "customer_wallet":
+                            await apply_wallet_for_order(
+                                conn,
+                                customer_uuid,
+                                tenant_id,
+                                Decimal(str(payment_amount)),
+                                order_id,
+                                user_id,
+                                payment_row["id"],
+                            )
+                elif payment_method == "customer_wallet" and customer_uuid:
                     from app.services.customer_wallet_service import apply_wallet_for_order
 
                     await apply_wallet_for_order(
@@ -3582,6 +3675,7 @@ async def create_manual_order(
                         payment_method_id=gl_payment_method_id,
                         tax_config=tax_config,
                         order_number=int(order_row["order_number"]),
+                        payment_splits=split_payments or None,
                     )
                 except Exception as e:
                     logger.error(f"GL entry failed for manual order {order_id}: {e}")
@@ -3615,6 +3709,10 @@ async def create_manual_order(
                 "total_amount": float(total_amount),
                 "status": "completed",
                 "payment_method": payment_method,
+                "payment_method_id": str(payment_method_uuid) if payment_method_uuid else None,
+                "discount_type": normalized_discount_type,
+                "discount_value": normalized_discount_value,
+                "discount_amount": float(discount_amount),
             }
         }
 

--- a/tests/test_manual_order_gl_cogs.py
+++ b/tests/test_manual_order_gl_cogs.py
@@ -653,14 +653,18 @@ async def test_post_order_gl_entry_uses_selected_method_account_before_slug_fall
 
     conn = AsyncMock()
     conn.fetchval = AsyncMock(return_value=None)
-    conn.fetchrow = AsyncMock(
-        side_effect=[
-            {"code": "1120"},
-            {"id": debit_account_id},
-            {"id": ingresos_account_id},
-            {"id": entry_id},
-        ]
-    )
+    async def fetchrow_side_effect(query, *args):
+        if "FROM payment_methods pm" in query:
+            return {"code": "1120"}
+        if "FROM tenant_accounts" in query and len(args) >= 2 and args[1] == "1120":
+            return {"id": debit_account_id}
+        if "FROM tenant_accounts" in query and len(args) >= 2 and args[1] == "4175":
+            return {"id": ingresos_account_id}
+        if "INSERT INTO tenant_journal_entries" in query:
+            return {"id": entry_id}
+        return None
+
+    conn.fetchrow = AsyncMock(side_effect=fetchrow_side_effect)
     conn.fetch = AsyncMock(return_value=[])
     conn.execute = AsyncMock()
     conn.transaction = MagicMock(return_value=_AsyncContext())
@@ -678,7 +682,10 @@ async def test_post_order_gl_entry_uses_selected_method_account_before_slug_fall
     )
 
     method_lookup_args = conn.fetchrow.await_args_list[0].args
-    debit_lookup_args = conn.fetchrow.await_args_list[1].args
+    debit_lookup_args = next(
+        call.args for call in conn.fetchrow.await_args_list
+        if len(call.args) >= 3 and call.args[1:] == (tenant_id, "1120")
+    )
     debit_line_args = conn.execute.await_args_list[0].args
     assert method_lookup_args[1] == method_id
     assert debit_lookup_args[1:] == (tenant_id, "1120")
@@ -695,13 +702,16 @@ async def test_post_order_gl_entry_splits_table_advance_to_2810():
 
     conn = AsyncMock()
     conn.fetchval = AsyncMock(return_value=None)
-    conn.fetchrow = AsyncMock(
-        side_effect=[
-            {"id": advance_account_id},
-            {"id": ingresos_account_id},
-            {"id": entry_id},
-        ]
-    )
+    async def fetchrow_side_effect(query, *args):
+        if "FROM tenant_accounts" in query and len(args) >= 2 and args[1] == "2810":
+            return {"id": advance_account_id}
+        if "FROM tenant_accounts" in query and len(args) >= 2 and args[1] == "4175":
+            return {"id": ingresos_account_id}
+        if "INSERT INTO tenant_journal_entries" in query:
+            return {"id": entry_id}
+        return None
+
+    conn.fetchrow = AsyncMock(side_effect=fetchrow_side_effect)
     conn.fetch = AsyncMock(return_value=[])
     conn.execute = AsyncMock()
     conn.transaction = MagicMock(return_value=_AsyncContext())
@@ -719,12 +729,83 @@ async def test_post_order_gl_entry_splits_table_advance_to_2810():
         advance_amount=Decimal("70000"),
     )
 
-    advance_lookup_args = conn.fetchrow.await_args_list[0].args
+    advance_lookup_args = next(
+        call.args for call in conn.fetchrow.await_args_list
+        if len(call.args) >= 3 and call.args[1:] == (tenant_id, "2810")
+    )
     advance_line_args = conn.execute.await_args_list[0].args
     assert advance_lookup_args[1:] == (tenant_id, "2810")
     assert advance_line_args[2] == advance_account_id
     assert advance_line_args[3] == 70000.0
     assert "aplicación anticipo mesa" in advance_line_args[4]
+
+
+@pytest.mark.asyncio
+async def test_post_order_gl_entry_splits_debits_by_payment_puc():
+    tenant_id = uuid4()
+    order_id = uuid4()
+    digital_method_id = uuid4()
+    card_method_id = uuid4()
+    digital_account_id = uuid4()
+    card_account_id = uuid4()
+    ingresos_account_id = uuid4()
+    entry_id = uuid4()
+
+    conn = AsyncMock()
+    conn.fetchval = AsyncMock(return_value=None)
+
+    async def fetchrow_side_effect(query, *args):
+        if "FROM payment_methods pm" in query and args[0] == digital_method_id:
+            return {"code": "111025"}
+        if "FROM payment_methods pm" in query and args[0] == card_method_id:
+            return {"code": "111040"}
+        if "FROM tenant_accounts" in query and len(args) >= 2 and args[1] == "111025":
+            return {"id": digital_account_id}
+        if "FROM tenant_accounts" in query and len(args) >= 2 and args[1] == "111040":
+            return {"id": card_account_id}
+        if "FROM tenant_accounts" in query and len(args) >= 2 and args[1] == "4175":
+            return {"id": ingresos_account_id}
+        if "INSERT INTO tenant_journal_entries" in query:
+            return {"id": entry_id}
+        return None
+
+    conn.fetchrow = AsyncMock(side_effect=fetchrow_side_effect)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.execute = AsyncMock()
+    conn.transaction = MagicMock(return_value=_AsyncContext())
+
+    await cierre_service._post_order_gl_entry(
+        conn=conn,
+        tenant_id=tenant_id,
+        order_id=order_id,
+        order_date=date(2026, 6, 19),
+        total_amount=Decimal("45000"),
+        payment_method="card",
+        payment_method_id=card_method_id,
+        tax_config={},
+        order_number=15342,
+        payment_splits=[
+            {
+                "amount": Decimal("42000"),
+                "payment_method": "digital",
+                "payment_method_id": digital_method_id,
+            },
+            {
+                "amount": Decimal("3000"),
+                "payment_method": "card",
+                "payment_method_id": card_method_id,
+            },
+        ],
+    )
+
+    debit_lines = [
+        call.args for call in conn.execute.await_args_list
+        if "INSERT INTO tenant_journal_lines" in call.args[0] and call.args[2] in (digital_account_id, card_account_id)
+    ]
+    assert debit_lines[0][2] == digital_account_id
+    assert debit_lines[0][3] == 42000.0
+    assert debit_lines[1][2] == card_account_id
+    assert debit_lines[1][3] == 3000.0
 
 
 def test_manual_order_modifier_quantity_defaults_to_one():

--- a/tests/test_manual_order_payments.py
+++ b/tests/test_manual_order_payments.py
@@ -1,0 +1,223 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import Request
+
+from app.core.exceptions import APIError
+from app.services import orders_service
+
+
+class _AsyncContext:
+    def __init__(self, value=None):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _conn_for_manual_order(*, order_id, order_item_id, order_date, payment_ids=()):
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {
+                "id": order_id,
+                "order_number": 41010,
+                "order_date": order_date,
+                "created_at": order_date,
+            },
+            {"id": order_item_id},
+            *[{"id": payment_id} for payment_id in payment_ids],
+        ]
+    )
+    conn.fetch = AsyncMock(return_value=[])
+    conn.execute = AsyncMock()
+    conn.transaction = MagicMock(return_value=_AsyncContext())
+    return conn
+
+
+def _patch_manual_order(conn, tenant_id, user_id):
+    return (
+        patch(
+            "app.services.orders_service.require_valid_session",
+            return_value=SimpleNamespace(tenant_id=tenant_id, user_id=user_id),
+        ),
+        patch("app.services.orders_service.get_db_connection", return_value=_AsyncContext(conn)),
+        patch("app.services.orders_service.assert_order_not_in_closed_monthly_period", new=AsyncMock()),
+        patch("app.services.orders_service._pos_modifier_inventory_helpers", return_value=(AsyncMock(), None, None)),
+        patch("app.services.orders_service._pos_order_item_ingredient_snapshot_helper", return_value=AsyncMock()),
+        patch("app.services.orders_service._get_tenant_tax_config", new=AsyncMock(return_value={"inc_enabled": True})),
+        patch("app.services.orders_service._post_order_gl_entry", new=AsyncMock()),
+        patch("app.services.orders_service._post_order_cogs_gl_entry", new=AsyncMock()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_manual_order_persists_percent_discount_server_side():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    order_id = uuid4()
+    order_item_id = uuid4()
+    product_id = uuid4()
+    order_date = datetime(2026, 6, 19, 9, 0)
+    conn = _conn_for_manual_order(
+        order_id=order_id,
+        order_item_id=order_item_id,
+        order_date=order_date,
+    )
+
+    patches = _patch_manual_order(conn, tenant_id, user_id)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6], patches[7]:
+        result = await orders_service.create_manual_order(
+            Request({"type": "http"}),
+            order_date="2026-06-19T09:00:00",
+            payment_method="cash",
+            items=[
+                {
+                    "product_id": str(product_id),
+                    "quantity": 2,
+                    "unit_price": 5000,
+                    "modifiers": [],
+                }
+            ],
+            discount_type="percent",
+            discount_value=10,
+        )
+
+    order_insert_args = conn.fetchrow.await_args_list[0].args
+    assert result["data"]["total_amount"] == 9000
+    assert result["data"]["discount_amount"] == 1000
+    assert order_insert_args[6] == 9000
+    assert order_insert_args[7] == "percent"
+    assert order_insert_args[8] == 10
+    assert order_insert_args[9] == 1000
+
+
+@pytest.mark.asyncio
+async def test_create_manual_order_persists_split_payments_and_wallet_debit():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    customer_id = uuid4()
+    order_id = uuid4()
+    order_item_id = uuid4()
+    first_payment_id = uuid4()
+    wallet_payment_id = uuid4()
+    product_id = uuid4()
+    order_date = datetime(2026, 6, 19, 9, 0)
+    conn = _conn_for_manual_order(
+        order_id=order_id,
+        order_item_id=order_item_id,
+        order_date=order_date,
+        payment_ids=(first_payment_id, wallet_payment_id),
+    )
+    apply_wallet = AsyncMock()
+
+    patches = _patch_manual_order(conn, tenant_id, user_id)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6], patches[7], patch(
+        "app.services.customer_wallet_service.apply_wallet_for_order",
+        new=apply_wallet,
+    ), patch(
+        "app.services.orders_service.evaluate_and_award",
+        new=MagicMock(return_value=object()),
+    ), patch(
+        "app.services.orders_service.asyncio.create_task",
+        new=MagicMock(),
+    ):
+        result = await orders_service.create_manual_order(
+            Request({"type": "http"}),
+            order_date="2026-06-19T09:00:00",
+            payment_method="cash",
+            items=[
+                {
+                    "product_id": str(product_id),
+                    "quantity": 1,
+                    "unit_price": 30000,
+                    "modifiers": [],
+                }
+            ],
+            customer_id=str(customer_id),
+            payments=[
+                {"amount": 20000, "payment_method": "cash", "payment_method_id": None},
+                {"amount": 10000, "payment_method": "customer_wallet", "payment_method_id": None},
+            ],
+        )
+
+    payment_inserts = [
+        call.args for call in conn.fetchrow.await_args_list
+        if "INSERT INTO order_payments" in call.args[0]
+    ]
+    assert result["success"] is True
+    assert len(payment_inserts) == 2
+    assert payment_inserts[0][3] == 20000
+    assert payment_inserts[0][4] == "cash"
+    assert payment_inserts[1][3] == 10000
+    assert payment_inserts[1][4] == "customer_wallet"
+    apply_wallet.assert_awaited_once()
+    assert apply_wallet.await_args.args[1] == customer_id
+    assert apply_wallet.await_args.args[3].to_integral_value() == 10000
+    assert apply_wallet.await_args.args[6] == wallet_payment_id
+
+
+@pytest.mark.asyncio
+async def test_create_manual_order_rejects_split_total_mismatch():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    order_id = uuid4()
+    order_item_id = uuid4()
+    product_id = uuid4()
+    order_date = datetime(2026, 6, 19, 9, 0)
+    conn = _conn_for_manual_order(
+        order_id=order_id,
+        order_item_id=order_item_id,
+        order_date=order_date,
+    )
+
+    patches = _patch_manual_order(conn, tenant_id, user_id)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6], patches[7]:
+        with pytest.raises(APIError, match="pagos divididos"):
+            await orders_service.create_manual_order(
+                Request({"type": "http"}),
+                order_date="2026-06-19T09:00:00",
+                payment_method="cash",
+                items=[
+                    {
+                        "product_id": str(product_id),
+                        "quantity": 1,
+                        "unit_price": 30000,
+                        "modifiers": [],
+                    }
+                ],
+                payments=[
+                    {"amount": 10000, "payment_method": "cash", "payment_method_id": None},
+                ],
+            )
+
+
+@pytest.mark.asyncio
+async def test_create_manual_order_rejects_wallet_without_customer_before_db():
+    with patch(
+        "app.services.orders_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=uuid4(), user_id=uuid4()),
+    ):
+        with pytest.raises(APIError, match="cliente identificado"):
+            await orders_service.create_manual_order(
+                Request({"type": "http", "headers": []}),
+                order_date="2026-06-19T09:00:00",
+                payment_method="cash",
+                items=[
+                    {
+                        "product_id": str(uuid4()),
+                        "quantity": 1,
+                        "unit_price": 10000,
+                        "modifiers": [],
+                    }
+                ],
+                payments=[
+                    {"amount": 10000, "payment_method": "customer_wallet", "payment_method_id": None},
+                ],
+            )


### PR DESCRIPTION
## Summary\n- Extend /api/orders/manual with manual discount fields and optional split payment rows\n- Persist split payments in order_payments and debit wallet only for wallet tender amounts\n- Add focused manual order payment tests and make GL mocks order-independent\n\n## Tests\n- pytest tests/test_manual_order_payments.py tests/test_manual_order_gl_cogs.py tests/test_waro_wallet_checkout.py tests/test_promo_cart_evaluation.py\n- python3 -m py_compile app/routers/orders.py app/services/orders_service.py tests/test_manual_order_payments.py tests/test_manual_order_gl_cogs.py\n\nRefs uno0uno/warocol.com#1410