### PR TITLE
Bound purchase inventory decimal scales

### DIFF
--- a/migrations/091_purchase_inventory_decimal_scales.sql
+++ b/migrations/091_purchase_inventory_decimal_scales.sql
@@ -1,0 +1,60 @@
+-- 091_purchase_inventory_decimal_scales.sql
+-- warocol.com#1419 — bound purchase/inventory decimal scales.
+--
+-- Quantity, stock, conversion factor, and base-unit cost columns keep high
+-- internal precision for domain math. Money totals are rounded to currency
+-- precision so historical binary-float tails stop propagating.
+
+ALTER TABLE tenant_purchase_items
+    ALTER COLUMN quantity TYPE NUMERIC(30, 15) USING ROUND(quantity::numeric, 15),
+    ALTER COLUMN purchase_quantity TYPE NUMERIC(30, 15) USING ROUND(purchase_quantity::numeric, 15),
+    ALTER COLUMN quantity_received TYPE NUMERIC(30, 15) USING ROUND(quantity_received::numeric, 15),
+    ALTER COLUMN unit_cost TYPE NUMERIC(30, 15) USING ROUND(unit_cost::numeric, 15),
+    ALTER COLUMN total_cost TYPE NUMERIC(18, 2) USING ROUND(total_cost::numeric, 2);
+
+ALTER TABLE tenant_inventory
+    ALTER COLUMN current_stock TYPE NUMERIC(30, 15) USING ROUND(current_stock::numeric, 15),
+    ALTER COLUMN minimum_stock TYPE NUMERIC(30, 15) USING ROUND(minimum_stock::numeric, 15),
+    ALTER COLUMN maximum_stock TYPE NUMERIC(30, 15) USING ROUND(maximum_stock::numeric, 15);
+
+ALTER TABLE tenant_ingredient_movements
+    ALTER COLUMN quantity_change TYPE NUMERIC(30, 15) USING ROUND(quantity_change::numeric, 15),
+    ALTER COLUMN previous_stock TYPE NUMERIC(30, 15) USING ROUND(previous_stock::numeric, 15),
+    ALTER COLUMN new_stock TYPE NUMERIC(30, 15) USING ROUND(new_stock::numeric, 15),
+    ALTER COLUMN cost_per_unit TYPE NUMERIC(30, 15) USING ROUND(cost_per_unit::numeric, 15);
+
+ALTER TABLE ingredient_purchase_units
+    ALTER COLUMN conversion_factor TYPE NUMERIC(30, 15) USING ROUND(conversion_factor::numeric, 15),
+    ALTER COLUMN unit_cost TYPE NUMERIC(18, 2) USING ROUND(unit_cost::numeric, 2);
+
+COMMENT ON COLUMN tenant_purchase_items.quantity IS
+    'Base quantity with bounded high precision for purchase/inventory math.';
+COMMENT ON COLUMN tenant_purchase_items.purchase_quantity IS
+    'Original purchase-unit quantity with bounded high precision.';
+COMMENT ON COLUMN tenant_purchase_items.quantity_received IS
+    'Received base quantity with bounded high precision.';
+COMMENT ON COLUMN tenant_purchase_items.unit_cost IS
+    'Base-unit cost with bounded high precision; display layers format as money when needed.';
+COMMENT ON COLUMN tenant_purchase_items.total_cost IS
+    'Purchase item total rounded to currency precision.';
+
+COMMENT ON COLUMN tenant_inventory.current_stock IS
+    'Current stock with bounded high precision.';
+COMMENT ON COLUMN tenant_inventory.minimum_stock IS
+    'Minimum stock threshold with bounded high precision.';
+COMMENT ON COLUMN tenant_inventory.maximum_stock IS
+    'Maximum stock threshold with bounded high precision.';
+
+COMMENT ON COLUMN tenant_ingredient_movements.quantity_change IS
+    'Movement quantity with bounded high precision.';
+COMMENT ON COLUMN tenant_ingredient_movements.previous_stock IS
+    'Previous stock snapshot with bounded high precision.';
+COMMENT ON COLUMN tenant_ingredient_movements.new_stock IS
+    'New stock snapshot with bounded high precision.';
+COMMENT ON COLUMN tenant_ingredient_movements.cost_per_unit IS
+    'Movement base-unit cost with bounded high precision.';
+
+COMMENT ON COLUMN ingredient_purchase_units.conversion_factor IS
+    'Purchase-unit to base-unit factor with bounded high precision.';
+COMMENT ON COLUMN ingredient_purchase_units.unit_cost IS
+    'Purchase-unit money cost rounded to currency precision.';

--- a/tests/test_purchase_inventory_decimal_scales.py
+++ b/tests/test_purchase_inventory_decimal_scales.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+import re
+
+
+MIGRATION = Path(__file__).resolve().parents[1] / "migrations" / "091_purchase_inventory_decimal_scales.sql"
+
+HIGH_PRECISION_COLUMNS = {
+    "tenant_purchase_items": [
+        "quantity",
+        "purchase_quantity",
+        "quantity_received",
+        "unit_cost",
+    ],
+    "tenant_inventory": [
+        "current_stock",
+        "minimum_stock",
+        "maximum_stock",
+    ],
+    "tenant_ingredient_movements": [
+        "quantity_change",
+        "previous_stock",
+        "new_stock",
+        "cost_per_unit",
+    ],
+    "ingredient_purchase_units": [
+        "conversion_factor",
+    ],
+}
+
+MONEY_COLUMNS = {
+    "tenant_purchase_items": ["total_cost"],
+    "ingredient_purchase_units": ["unit_cost"],
+}
+
+
+def _sql() -> str:
+    return MIGRATION.read_text()
+
+
+def _assert_column_cast(sql: str, table: str, column: str, precision: str, scale: int) -> None:
+    pattern = (
+        rf"ALTER\s+COLUMN\s+{column}\s+TYPE\s+NUMERIC\({precision}\)"
+        rf"\s+USING\s+ROUND\({column}::numeric,\s*{scale}\)"
+    )
+    assert re.search(pattern, sql, re.IGNORECASE), f"{table}.{column} missing expected cast"
+
+
+def test_migration_exists_and_documents_issue_scope():
+    sql = _sql()
+
+    assert "warocol.com#1419" in sql
+    assert "tenant_purchase_items" in sql
+    assert "tenant_inventory" in sql
+    assert "tenant_ingredient_movements" in sql
+    assert "ingredient_purchase_units" in sql
+
+
+def test_high_precision_columns_are_bounded_and_rounded():
+    sql = _sql()
+
+    for table, columns in HIGH_PRECISION_COLUMNS.items():
+        assert re.search(rf"ALTER\s+TABLE\s+{table}\b", sql, re.IGNORECASE)
+        for column in columns:
+            _assert_column_cast(sql, table, column, "30, 15", 15)
+
+
+def test_money_columns_are_currency_scaled_and_rounded():
+    sql = _sql()
+
+    for table, columns in MONEY_COLUMNS.items():
+        assert re.search(rf"ALTER\s+TABLE\s+{table}\b", sql, re.IGNORECASE)
+        for column in columns:
+            _assert_column_cast(sql, table, column, "18, 2", 2)
+
+
+def test_every_target_column_has_a_comment():
+    sql = _sql()
+    all_columns = {}
+    for table, columns in HIGH_PRECISION_COLUMNS.items():
+        all_columns.setdefault(table, []).extend(columns)
+    for table, columns in MONEY_COLUMNS.items():
+        all_columns.setdefault(table, []).extend(columns)
+
+    for table, columns in all_columns.items():
+        for column in columns:
+            assert f"COMMENT ON COLUMN {table}.{column}" in sql


### PR DESCRIPTION
## Summary
- add migration 091 to bound purchase, inventory, movement, and purchase-unit numeric scales
- keep quantity/factor/base-unit-cost fields at NUMERIC(30,15) and money totals at NUMERIC(18,2)
- add SQL-text tests covering target columns, ROUND casts, and comments

## Tests
- set -a; source /Users/saifer/Documents/WEBS/WARO\ COLOMBIA/api_warocol.com/.env; set +a; pytest tests/test_purchase_inventory_decimal_scales.py
- transaction validation against local DB: BEGIN; run migrations/091_purchase_inventory_decimal_scales.sql; verify information_schema scales; ROLLBACK

Closes uno0uno/warocol.com#1419