### PR TITLE
Normalize downstream inventory precision

### DIFF
--- a/app/services/inventory_service.py
+++ b/app/services/inventory_service.py
@@ -2,6 +2,7 @@
 Inventory Service
 Handles inventory queries, movements, and stock management
 """
+from decimal import Decimal
 from typing import Optional, List, Dict, Any
 from uuid import UUID
 from fastapi import Request, Response, HTTPException
@@ -11,6 +12,19 @@ from app.core.exceptions import AuthenticationError
 import logging
 
 logger = logging.getLogger(__name__)
+
+_QUANTITY_JSON_SCALE = Decimal("0.000001")
+_MONEY_JSON_SCALE = Decimal("0.0001")
+_PERCENT_JSON_SCALE = Decimal("0.01")
+
+
+def _json_decimal(value: Any, scale: Decimal, default: Optional[float] = None) -> Optional[float]:
+    if value is None:
+        return default
+    quantized = Decimal(str(value)).quantize(scale)
+    if quantized == 0:
+        quantized = Decimal("0")
+    return float(quantized)
 
 
 async def get_inventory_stock(
@@ -209,17 +223,17 @@ async def get_inventory_stock(
                     "ingredient_name": row['ingredient_name'],
                     "unit": row['unit'],
                     "category": row['category'],
-                    "current_stock": float(row['current_stock']) if row['current_stock'] else 0,
-                    "minimum_stock": float(row['minimum_stock']) if row['minimum_stock'] else 0,
-                    "maximum_stock": float(row['maximum_stock']) if row['maximum_stock'] else None,
+                    "current_stock": _json_decimal(row['current_stock'], _QUANTITY_JSON_SCALE, 0),
+                    "minimum_stock": _json_decimal(row['minimum_stock'], _QUANTITY_JSON_SCALE, 0),
+                    "maximum_stock": _json_decimal(row['maximum_stock'], _QUANTITY_JSON_SCALE),
                     "last_updated": row['last_updated'].isoformat() if row['last_updated'] else None,
                     "location": row['location'],
                     "lote_actual": row['lote_actual'],
                     "fecha_vencimiento": row['fecha_vencimiento'].isoformat() if row['fecha_vencimiento'] else None,
                     "status": row['status'],
-                    "stock_percentage": float(row['stock_percentage']) if row['stock_percentage'] else None,
-                    "unit_cost": float(row['unit_cost']) if row['unit_cost'] else None,
-                    "total_value": float(row['total_value']) if row['total_value'] else 0
+                    "stock_percentage": _json_decimal(row['stock_percentage'], _PERCENT_JSON_SCALE),
+                    "unit_cost": _json_decimal(row['unit_cost'], _MONEY_JSON_SCALE),
+                    "total_value": _json_decimal(row['total_value'], _MONEY_JSON_SCALE, 0)
                 })
 
             return {
@@ -233,7 +247,7 @@ async def get_inventory_stock(
                     "critical_count": stats['critical_count'],
                     "low_stock_count": stats['low_stock_count'],
                     "ok_count": stats['ok_count'],
-                    "total_inventory_value": float(stats['total_inventory_value']) if stats['total_inventory_value'] else 0
+                    "total_inventory_value": _json_decimal(stats['total_inventory_value'], _MONEY_JSON_SCALE, 0)
                 },
                 "filter_options": {
                     "categories": list(filter_options['categories'] or []),
@@ -375,10 +389,10 @@ async def get_inventory_movements(
                     "ingredient_name": row['ingredient_name'],
                     "unit": row['unit'],
                     "movement_type": row['movement_type'],
-                    "quantity_change": float(row['quantity_change']),
-                    "previous_stock": float(row['previous_stock']) if row['previous_stock'] else 0,
-                    "new_stock": float(row['new_stock']) if row['new_stock'] else 0,
-                    "cost_per_unit": float(row['cost_per_unit']) if row['cost_per_unit'] else None,
+                    "quantity_change": _json_decimal(row['quantity_change'], _QUANTITY_JSON_SCALE, 0),
+                    "previous_stock": _json_decimal(row['previous_stock'], _QUANTITY_JSON_SCALE, 0),
+                    "new_stock": _json_decimal(row['new_stock'], _QUANTITY_JSON_SCALE, 0),
+                    "cost_per_unit": _json_decimal(row['cost_per_unit'], _MONEY_JSON_SCALE),
                     "reference_table": row['reference_table'],
                     "reference_id": str(row['reference_id']) if row['reference_id'] else None,
                     "reference_number": row['reference_number'],

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -41,6 +41,14 @@ def parse_date(date_str: Optional[str]) -> Optional[date]:
 
 logger = logging.getLogger(__name__)
 _BOG = ZoneInfo("America/Bogota")
+_INVENTORY_QUANTITY_SCALE = Decimal("0.000001")
+
+
+def _inventory_quantity(value: Any) -> float:
+    quantized = Decimal(str(value)).quantize(_INVENTORY_QUANTITY_SCALE)
+    if quantized == 0:
+        quantized = Decimal("0")
+    return float(quantized)
 
 def _pos_modifier_inventory_helpers():
     from app.services.pos_cart_service import (
@@ -2839,13 +2847,13 @@ async def _deduct_stock_for_status_update(conn, order_id, tenant_id, user_id, or
     for item in items:
         ingredients = await conn.fetch(_INGREDIENTS_QUERY, item["product_id"])
         for ing in ingredients:
-            qty = float(item["quantity"]) * float(ing["quantity"])
+            qty = _inventory_quantity(Decimal(str(item["quantity"])) * Decimal(str(ing["quantity"])))
             stock_row = await conn.fetchrow(
                 "SELECT current_stock FROM tenant_inventory WHERE ingredient_id = $1 AND tenant_id = $2 FOR UPDATE",
                 ing["ingredient_id"], tenant_id,
             )
             prev = float(stock_row["current_stock"]) if stock_row else 0.0
-            new = prev - qty
+            new = _inventory_quantity(Decimal(str(prev)) - Decimal(str(qty)))
             if stock_row:
                 await conn.execute(
                     "UPDATE tenant_inventory SET current_stock = $1, last_updated = NOW() WHERE ingredient_id = $2 AND tenant_id = $3",
@@ -2881,7 +2889,7 @@ async def _return_stock_for_order_cancellation(conn, order_id, tenant_id, user_i
     for item in items:
         ingredients = await conn.fetch(_INGREDIENTS_QUERY, item["product_id"])
         for ing in ingredients:
-            qty = float(item["quantity"]) * float(ing["quantity"])
+            qty = _inventory_quantity(Decimal(str(item["quantity"])) * Decimal(str(ing["quantity"])))
             await _return_ingredient_to_stock(
                 conn, tenant_id, user_id, order_id, order_number,
                 ing["ingredient_id"], qty, ing["unit"], ing["ingredient_name"],
@@ -2908,7 +2916,7 @@ async def _return_ingredient_to_stock(
     )
 
     previous_stock = float(stock_row['current_stock']) if stock_row else 0.0
-    new_stock = previous_stock + quantity
+    new_stock = _inventory_quantity(Decimal(str(previous_stock)) + Decimal(str(quantity)))
 
     # Update or create inventory record
     if stock_row:
@@ -3502,14 +3510,18 @@ async def create_manual_order(
                     )
 
                     for ingredient in ingredients:
-                        quantity_to_deduct = float(item["quantity"]) * float(ingredient["quantity"])
+                        quantity_to_deduct = _inventory_quantity(
+                            Decimal(str(item["quantity"])) * Decimal(str(ingredient["quantity"]))
+                        )
                         stock_row = await conn.fetchrow(
                             "SELECT current_stock FROM tenant_inventory WHERE ingredient_id = $1 AND tenant_id = $2",
                             ingredient["ingredient_id"],
                             tenant_id
                         )
                         previous_stock = float(stock_row["current_stock"]) if stock_row else 0.0
-                        new_stock = previous_stock - quantity_to_deduct
+                        new_stock = _inventory_quantity(
+                            Decimal(str(previous_stock)) - Decimal(str(quantity_to_deduct))
+                        )
 
                         if stock_row:
                             await conn.execute(

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -11,6 +11,13 @@ import pytest
 from httpx import AsyncClient
 from uuid import uuid4
 
+from app.services.inventory_service import _json_decimal, _QUANTITY_JSON_SCALE
+
+
+def test_inventory_json_decimal_strips_float_residue():
+    assert _json_decimal(0.1 + 0.2 - 0.3, _QUANTITY_JSON_SCALE, 0) == 0.0
+    assert _json_decimal("1.3450000000001", _QUANTITY_JSON_SCALE, 0) == 1.345
+
 
 class TestInventoryStockEndpoint:
     """Test inventory stock endpoint"""

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -10,6 +10,13 @@ import pytest
 from httpx import AsyncClient
 from uuid import uuid4
 
+from app.services.orders_service import _inventory_quantity
+
+
+def test_inventory_quantity_normalizes_consumption_residue():
+    assert _inventory_quantity(0.1 + 0.2 - 0.3) == 0.0
+    assert _inventory_quantity("1.3450000000001") == 1.345
+
 
 class TestOrdersListEndpoint:
     """Test orders list endpoint"""


### PR DESCRIPTION
## Summary
- Quantize inventory stock and movement read-model numerics before JSON output
- Normalize order inventory consumption/return quantities before movement persistence
- Cover inventory/order precision helpers

## Tests
- pytest tests/test_inventory.py tests/test_orders.py -q
- pytest tests/test_inventory.py tests/test_recipe_base_costs.py tests/test_analytics_dual_cost.py tests/test_pos_cart.py tests/test_orders.py
- clean worktree: source local API .env, then pytest tests/test_inventory.py tests/test_recipe_base_costs.py tests/test_analytics_dual_cost.py tests/test_pos_cart.py tests/test_orders.py

Refs uno0uno/warocol.com#1420