### PR TITLE
Apply decimal precision policy to API serialization

### DIFF
--- a/app/models/ingredient.py
+++ b/app/models/ingredient.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field
 from typing import Optional, List
 from uuid import UUID
 from datetime import datetime
+from decimal import Decimal
 
 class IngredientBase(BaseModel):
     name: str = Field(..., min_length=1, max_length=255, description="Name of the ingredient")
@@ -108,8 +109,8 @@ class IngredientPurchaseUnitBase(BaseModel):
     ingredient_id: UUID = Field(..., description="ID of the ingredient")
     purchase_unit: str = Field(..., min_length=1, max_length=50, description="Purchase unit type (paquete, caja, docena, bulto)")
     purchase_unit_label: str = Field(..., min_length=1, max_length=100, description="Display label (e.g., 'Paquete x18', 'Caja x144')")
-    conversion_factor: float = Field(..., gt=0, description="Number of base units in 1 purchase unit")
-    unit_cost: Optional[float] = Field(None, ge=0, description="Cost per purchase unit")
+    conversion_factor: Decimal = Field(..., gt=0, description="Number of base units in 1 purchase unit")
+    unit_cost: Optional[Decimal] = Field(None, ge=0, description="Cost per purchase unit")
     is_default: bool = Field(default=False, description="Default purchase unit for this ingredient")
     is_active: bool = Field(default=True, description="Whether this purchase unit is active")
     notes: Optional[str] = Field(None, description="Additional notes")
@@ -124,8 +125,8 @@ class IngredientPurchaseUnitUpdate(BaseModel):
     """Update ingredient purchase unit"""
     purchase_unit: Optional[str] = Field(None, min_length=1, max_length=50)
     purchase_unit_label: Optional[str] = Field(None, min_length=1, max_length=100)
-    conversion_factor: Optional[float] = Field(None, gt=0)
-    unit_cost: Optional[float] = Field(None, ge=0)
+    conversion_factor: Optional[Decimal] = Field(None, gt=0)
+    unit_cost: Optional[Decimal] = Field(None, ge=0)
     is_default: Optional[bool] = None
     is_active: Optional[bool] = None
     notes: Optional[str] = None

--- a/app/models/product.py
+++ b/app/models/product.py
@@ -34,7 +34,7 @@ class ModifierGroup(BaseModel):
 class RecipeIngredientBase(BaseModel):
     """Ingredient in a product recipe"""
     ingredient_id: UUID = Field(..., description="ID of the ingredient")
-    quantity: float = Field(..., gt=0, description="Quantity of ingredient needed")
+    quantity: Decimal = Field(..., gt=0, description="Quantity of ingredient needed")
     unit: str = Field(..., min_length=1, max_length=50, description="Unit of measure (g, ml, kg, l, u)")
 
 class RecipeBaseLink(BaseModel):

--- a/app/models/purchase.py
+++ b/app/models/purchase.py
@@ -470,13 +470,13 @@ class DirectPurchaseCreate(BaseModel):
     payment_terms: Optional[str] = None
     notes: Optional[str] = None
     invoice_number: Optional[str] = None
-    invoice_amount: Optional[float] = None
+    invoice_amount: Optional[Decimal] = None
     purchase_date: Optional[str] = None
     invoice_date: Optional[str] = None
     payment_method: Optional[str] = None
     payment_method_id: Optional[str] = None
     payment_reference: Optional[str] = None
-    payment_amount: Optional[float] = None
+    payment_amount: Optional[Decimal] = None
     payment_date: Optional[str] = None
 
     class Config:
@@ -491,7 +491,7 @@ class DirectPurchaseUpdate(BaseModel):
     payment_method: Optional[str] = None
     payment_method_id: Optional[str] = None
     payment_reference: Optional[str] = None
-    payment_amount: Optional[float] = None
+    payment_amount: Optional[Decimal] = None
     payment_date: Optional[str] = None
 
     class Config:

--- a/app/services/ingredient_purchase_units_service.py
+++ b/app/services/ingredient_purchase_units_service.py
@@ -1,4 +1,5 @@
-from typing import List, Optional
+from decimal import Decimal
+from typing import Any, List, Optional
 from uuid import UUID
 from fastapi import Request, Response, HTTPException
 from app.database import get_db_connection
@@ -27,12 +28,26 @@ from app.models.ingredient import (
 )
 
 logger = logging.getLogger(__name__)
+_QUANTITY_SCALE = Decimal("0.000001")
+
+
+def _decimal_value(value: Any, default: Decimal = Decimal("0")) -> Decimal:
+    if value is None:
+        return default
+    return Decimal(str(value))
+
+
+def _quantity_decimal(value: Any) -> Decimal:
+    quantized = _decimal_value(value).quantize(_QUANTITY_SCALE)
+    if quantized == 0:
+        return Decimal("0")
+    return quantized
 
 
 async def resolve_to_base_unit(
     conn,
     ingredient_id: UUID,
-    quantity: float,
+    quantity: Any,
     unit: str
 ) -> tuple:
     """
@@ -42,19 +57,20 @@ async def resolve_to_base_unit(
     - If a matching entry exists in ingredient_purchase_units → applies conversion_factor.
     - If no conversion found → logs a warning and returns original values unchanged.
 
-    Returns: (base_quantity: float, base_unit: str)
+    Returns: (base_quantity: Decimal, base_unit: str)
     """
+    quantity_decimal = _quantity_decimal(quantity)
     ing_row = await conn.fetchrow(
         "SELECT unit FROM ingredients WHERE id = $1",
         ingredient_id
     )
     if not ing_row:
-        return float(quantity), unit
+        return quantity_decimal, unit
 
     base_unit = ing_row['unit']
 
     if unit == base_unit:
-        return float(quantity), base_unit
+        return quantity_decimal, base_unit
 
     conv_row = await conn.fetchrow(
         """
@@ -71,10 +87,11 @@ async def resolve_to_base_unit(
     )
 
     if conv_row and conv_row['conversion_factor']:
-        base_quantity = float(quantity) * float(conv_row['conversion_factor'])
+        conversion_factor = _decimal_value(conv_row['conversion_factor'])
+        base_quantity = _quantity_decimal(quantity_decimal * conversion_factor)
         logger.info(
             f"Unit conversion: {quantity} {unit} → {base_quantity} {base_unit} "
-            f"(factor={conv_row['conversion_factor']}, ingredient={ingredient_id})"
+            f"(factor={conversion_factor}, ingredient={ingredient_id})"
         )
         return base_quantity, base_unit
 
@@ -82,13 +99,13 @@ async def resolve_to_base_unit(
         f"No conversion found for unit '{unit}' on ingredient {ingredient_id} "
         f"(base_unit='{base_unit}'). Saving without conversion."
     )
-    return float(quantity), unit
+    return quantity_decimal, unit
 
 
 async def resolve_recipe_quantity_to_base_unit(
     conn,
     ingredient_id: UUID,
-    recipe_qty: float,
+    recipe_qty: Any,
     recipe_unit: str,
 ) -> float:
     """
@@ -104,46 +121,47 @@ async def resolve_recipe_quantity_to_base_unit(
         "SELECT unit, unit_weight_gr FROM ingredients WHERE id = $1",
         ingredient_id
     )
+    recipe_quantity = _quantity_decimal(recipe_qty)
     if not row:
-        return recipe_qty
+        return float(recipe_quantity)
     base_unit = row["unit"]
     if recipe_unit == base_unit:
-        return recipe_qty
+        return float(recipe_quantity)
     weight = row["unit_weight_gr"]
-    if weight and float(weight) > 0:
-        w = float(weight)
+    if weight and _decimal_value(weight) > 0:
+        w = _decimal_value(weight)
         if recipe_unit in ("gr", "ml") and base_unit == "und":
-            converted = recipe_qty / w
+            converted = _quantity_decimal(recipe_quantity / w)
             logger.info(
-                f"Recipe unit conversion: {recipe_qty} {recipe_unit} → {converted:.4f} und "
+                f"Recipe unit conversion: {recipe_qty} {recipe_unit} → {converted} und "
                 f"(unit_weight_gr={weight}, ingredient={ingredient_id})"
             )
-            return converted
+            return float(converted)
         if recipe_unit == "und" and base_unit in ("gr", "ml"):
-            converted = recipe_qty * w
+            converted = _quantity_decimal(recipe_quantity * w)
             logger.info(
-                f"Recipe unit conversion: {recipe_qty} und → {converted:.4f} {base_unit} "
+                f"Recipe unit conversion: {recipe_qty} und → {converted} {base_unit} "
                 f"(unit_weight_gr={weight}, ingredient={ingredient_id})"
             )
-            return converted
+            return float(converted)
         # Two-step: catalog unit (lt, kg, botella…) → gr/ml → und
         # e.g. 2 lt on a und ingredient with unit_weight_gr=750 ml/und
         #      → 2 * 1000 ml = 2000 ml → 2000 / 750 = 2.667 und
         catalog_entry = _CATALOG_TO_BASE.get(recipe_unit)
         if catalog_entry and base_unit == "und" and catalog_entry["base"] in ("gr", "ml"):
-            qty_base = recipe_qty * catalog_entry["factor"]
-            converted = qty_base / w
+            qty_base = recipe_quantity * Decimal(str(catalog_entry["factor"]))
+            converted = _quantity_decimal(qty_base / w)
             logger.info(
                 f"Recipe unit conversion (2-step): {recipe_qty} {recipe_unit} "
-                f"→ {qty_base} {catalog_entry['base']} → {converted:.4f} und "
+                f"→ {qty_base} {catalog_entry['base']} → {converted} und "
                 f"(catalog_factor={catalog_entry['factor']}, unit_weight_gr={weight}, ingredient={ingredient_id})"
             )
-            return converted
+            return float(converted)
     logger.warning(
         f"No recipe unit conversion for '{recipe_unit}' → '{base_unit}' on ingredient {ingredient_id}. "
         f"Returning recipe_qty unchanged."
     )
-    return recipe_qty
+    return float(recipe_quantity)
 
 
 async def get_purchase_units_by_ingredient(
@@ -169,8 +187,8 @@ async def get_purchase_units_by_ingredient(
                     ipu.ingredient_id,
                     ipu.purchase_unit,
                     ipu.purchase_unit_label,
-                    CAST(ipu.conversion_factor AS float) as conversion_factor,
-                    CAST(ipu.unit_cost AS float) as unit_cost,
+                    ipu.conversion_factor,
+                    ipu.unit_cost,
                     ipu.is_default,
                     ipu.is_active,
                     ipu.notes,
@@ -229,8 +247,8 @@ async def get_purchase_unit_by_id(
                     ipu.ingredient_id,
                     ipu.purchase_unit,
                     ipu.purchase_unit_label,
-                    CAST(ipu.conversion_factor AS float) as conversion_factor,
-                    CAST(ipu.unit_cost AS float) as unit_cost,
+                    ipu.conversion_factor,
+                    ipu.unit_cost,
                     ipu.is_default,
                     ipu.is_active,
                     ipu.notes,
@@ -318,8 +336,8 @@ async def create_purchase_unit(
                     ingredient_id,
                     purchase_unit,
                     purchase_unit_label,
-                    CAST(conversion_factor AS float) as conversion_factor,
-                    CAST(unit_cost AS float) as unit_cost,
+                    conversion_factor,
+                    unit_cost,
                     is_default,
                     is_active,
                     notes,
@@ -502,8 +520,8 @@ async def get_all_purchase_units(
                     ipu.ingredient_id,
                     ipu.purchase_unit,
                     ipu.purchase_unit_label,
-                    CAST(ipu.conversion_factor AS float) as conversion_factor,
-                    CAST(ipu.unit_cost AS float) as unit_cost,
+                    ipu.conversion_factor,
+                    ipu.unit_cost,
                     ipu.is_default,
                     ipu.is_active,
                     ipu.notes,

--- a/app/services/inventory_service.py
+++ b/app/services/inventory_service.py
@@ -15,7 +15,14 @@ logger = logging.getLogger(__name__)
 
 _QUANTITY_JSON_SCALE = Decimal("0.000001")
 _MONEY_JSON_SCALE = Decimal("0.0001")
+_TECHNICAL_COST_JSON_SCALE = Decimal("0.000001")
 _PERCENT_JSON_SCALE = Decimal("0.01")
+
+
+def _decimal_value(value: Any, default: Decimal = Decimal("0")) -> Decimal:
+    if value is None:
+        return default
+    return Decimal(str(value))
 
 
 def _json_decimal(value: Any, scale: Decimal, default: Optional[float] = None) -> Optional[float]:
@@ -493,14 +500,14 @@ async def get_stock_by_ingredient(
                 "ingredient_name": stock_data['ingredient_name'],
                 "unit": stock_data['unit'],
                 "category": stock_data['category'],
-                "current_stock": float(stock_data['current_stock']) if stock_data['current_stock'] else 0,
-                "minimum_stock": float(stock_data['minimum_stock']) if stock_data['minimum_stock'] else 0,
-                "maximum_stock": float(stock_data['maximum_stock']) if stock_data['maximum_stock'] else None,
+                "current_stock": _json_decimal(stock_data['current_stock'], _QUANTITY_JSON_SCALE, 0),
+                "minimum_stock": _json_decimal(stock_data['minimum_stock'], _QUANTITY_JSON_SCALE, 0),
+                "maximum_stock": _json_decimal(stock_data['maximum_stock'], _QUANTITY_JSON_SCALE),
                 "last_updated": stock_data['last_updated'].isoformat() if stock_data['last_updated'] else None,
                 "location": stock_data['location'],
                 "lote_actual": stock_data['lote_actual'],
                 "fecha_vencimiento": stock_data['fecha_vencimiento'].isoformat() if stock_data['fecha_vencimiento'] else None,
-                "unit_cost": float(stock_data['unit_cost']) if stock_data['unit_cost'] else None
+                "unit_cost": _json_decimal(stock_data['unit_cost'], _TECHNICAL_COST_JSON_SCALE)
             }
 
     except AuthenticationError:
@@ -539,7 +546,7 @@ async def create_adjustment(
         # Get request body
         body = await request.json()
         ingredient_id = UUID(body.get('ingredient_id'))
-        quantity_change = float(body.get('quantity_change'))
+        quantity_change = _decimal_value(body.get('quantity_change'))
         reason = body.get('reason', 'Manual adjustment')
         source = body.get('source', 'manual_adjustment')
         # New fields for enhanced adjustments
@@ -566,7 +573,7 @@ async def create_adjustment(
                 base_unit = ingredient_row['unit']
 
                 # If a purchase unit is provided, get conversion factor
-                conversion_factor = 1.0
+                conversion_factor = Decimal("1")
                 unit_for_movement = base_unit
 
                 if purchase_unit and purchase_unit != base_unit:
@@ -578,7 +585,7 @@ async def create_adjustment(
                     conversion_row = await conn.fetchrow(conversion_query, ingredient_id, purchase_unit)
 
                     if conversion_row:
-                        conversion_factor = float(conversion_row['conversion_factor'])
+                        conversion_factor = _decimal_value(conversion_row['conversion_factor'])
                         unit_for_movement = conversion_row['purchase_unit']
                     else:
                         # If no conversion found, use base unit
@@ -586,7 +593,7 @@ async def create_adjustment(
                         unit_for_movement = base_unit
 
                 # Convert quantity to base unit
-                quantity_in_base_unit = quantity_change * conversion_factor
+                quantity_in_base_unit = (quantity_change * conversion_factor).quantize(_QUANTITY_JSON_SCALE)
 
                 # Get current stock
                 stock_query = """
@@ -604,9 +611,9 @@ async def create_adjustment(
                         VALUES ($1, $2, 0, 0)
                     """
                     await conn.execute(insert_query, tenant_id, ingredient_id)
-                    previous_stock = 0
+                    previous_stock = Decimal("0")
                 else:
-                    previous_stock = float(stock_row['current_stock']) if stock_row['current_stock'] else 0
+                    previous_stock = _decimal_value(stock_row['current_stock'])
 
                 # Idempotent: "set to current stock" (e.g. confirm 0 when already 0).
                 if quantity_change == 0:
@@ -616,15 +623,15 @@ async def create_adjustment(
                         "data": {
                             "ingredient_id": str(ingredient_id),
                             "quantity_change": 0,
-                            "previous_stock": previous_stock,
-                            "new_stock": previous_stock,
+                            "previous_stock": _json_decimal(previous_stock, _QUANTITY_JSON_SCALE, 0),
+                            "new_stock": _json_decimal(previous_stock, _QUANTITY_JSON_SCALE, 0),
                             "reason": reason,
                             "created_at": None,
                         },
                     }
 
                 # Calculate new stock (using converted quantity)
-                new_stock = max(0, previous_stock + quantity_in_base_unit)
+                new_stock = max(Decimal("0"), previous_stock + quantity_in_base_unit).quantize(_QUANTITY_JSON_SCALE)
 
                 # Update stock
                 update_query = """
@@ -639,7 +646,12 @@ async def create_adjustment(
                 if cost_per_unit:
                     # If cost is provided with a purchase unit, convert it to base unit cost
                     # Example: $30,000 per kg → $30 per gr (30000 / 1000)
-                    cost_in_base_unit = float(cost_per_unit) / conversion_factor if conversion_factor > 0 else float(cost_per_unit)
+                    cost_decimal = _decimal_value(cost_per_unit)
+                    cost_in_base_unit = (
+                        cost_decimal / conversion_factor
+                        if conversion_factor > 0
+                        else cost_decimal
+                    ).quantize(_TECHNICAL_COST_JSON_SCALE)
 
                 # Create movement record with optional cost
                 movement_query = """
@@ -686,9 +698,9 @@ async def create_adjustment(
                     "data": {
                         "id": str(movement_row['id']),
                         "ingredient_id": str(ingredient_id),
-                        "quantity_change": quantity_change,
-                        "previous_stock": previous_stock,
-                        "new_stock": new_stock,
+                        "quantity_change": _json_decimal(quantity_in_base_unit, _QUANTITY_JSON_SCALE, 0),
+                        "previous_stock": _json_decimal(previous_stock, _QUANTITY_JSON_SCALE, 0),
+                        "new_stock": _json_decimal(new_stock, _QUANTITY_JSON_SCALE, 0),
                         "reason": reason,
                         "created_at": movement_row['created_at'].isoformat()
                     }

--- a/migrations/092_recipe_decimal_scales.sql
+++ b/migrations/092_recipe_decimal_scales.sql
@@ -1,0 +1,18 @@
+-- 092_recipe_decimal_scales.sql
+-- warocol.com#1429 — preserve recipe quantities with API decimal policy.
+--
+-- Physical recipe quantities and recipe-base multipliers must keep at least
+-- 6 decimals. Purchase/inventory quantity scales are already covered by
+-- 091_purchase_inventory_decimal_scales.sql.
+
+ALTER TABLE product_recipes
+    ALTER COLUMN quantity TYPE NUMERIC(30, 15) USING ROUND(quantity::numeric, 15);
+
+ALTER TABLE product_base_recipes
+    ALTER COLUMN quantity TYPE NUMERIC(30, 15) USING ROUND(quantity::numeric, 15);
+
+COMMENT ON COLUMN product_recipes.quantity IS
+    'Ingredient quantity per product recipe with bounded high precision.';
+
+COMMENT ON COLUMN product_base_recipes.quantity IS
+    'Recipe-base multiplier per product with bounded high precision.';

--- a/tests/test_ingredient_purchase_units.py
+++ b/tests/test_ingredient_purchase_units.py
@@ -1,6 +1,7 @@
 """Ingredient purchase-unit creation edge cases."""
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -10,7 +11,11 @@ from fastapi import Request
 from app.core.middleware import SessionContext
 from app.models.ingredient import IngredientPurchaseUnitCreate
 from app.routers.ingredient_purchase_units import router
-from app.services.ingredient_purchase_units_service import create_purchase_unit
+from app.services.ingredient_purchase_units_service import (
+    create_purchase_unit,
+    resolve_recipe_quantity_to_base_unit,
+    resolve_to_base_unit,
+)
 
 
 def _session():
@@ -85,3 +90,42 @@ def test_purchase_unit_router_accepts_trailing_slash_post():
 
     assert slash_routes
     assert slash_routes[0].include_in_schema is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_to_base_unit_preserves_six_decimal_conversion():
+    ingredient_id = uuid4()
+    conn = MagicMock()
+
+    async def _fetchrow(query, *args):
+        if "SELECT unit FROM ingredients" in query:
+            return {"unit": "gr"}
+        return {"conversion_factor": Decimal("1.345678")}
+
+    conn.fetchrow = AsyncMock(side_effect=_fetchrow)
+
+    base_qty, base_unit = await resolve_to_base_unit(
+        conn,
+        ingredient_id,
+        Decimal("2.000000"),
+        "paquete",
+    )
+
+    assert base_qty == Decimal("2.691356")
+    assert base_unit == "gr"
+
+
+@pytest.mark.asyncio
+async def test_resolve_recipe_quantity_to_base_unit_preserves_fractional_units():
+    ingredient_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={"unit": "und", "unit_weight_gr": Decimal("1.345")})
+
+    converted = await resolve_recipe_quantity_to_base_unit(
+        conn,
+        ingredient_id,
+        Decimal("8900"),
+        "gr",
+    )
+
+    assert converted == 6617.100372

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -11,12 +11,20 @@ import pytest
 from httpx import AsyncClient
 from uuid import uuid4
 
-from app.services.inventory_service import _json_decimal, _QUANTITY_JSON_SCALE
+from app.services.inventory_service import (
+    _json_decimal,
+    _QUANTITY_JSON_SCALE,
+    _TECHNICAL_COST_JSON_SCALE,
+)
 
 
 def test_inventory_json_decimal_strips_float_residue():
     assert _json_decimal(0.1 + 0.2 - 0.3, _QUANTITY_JSON_SCALE, 0) == 0.0
     assert _json_decimal("1.3450000000001", _QUANTITY_JSON_SCALE, 0) == 1.345
+
+
+def test_inventory_json_decimal_preserves_technical_unit_cost_precision():
+    assert _json_decimal("6.617100371747212", _TECHNICAL_COST_JSON_SCALE, 0) == 6.6171
 
 
 class TestInventoryStockEndpoint:

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -9,6 +9,7 @@ Endpoints tested:
 import pytest
 from httpx import AsyncClient
 from uuid import uuid4
+from decimal import Decimal
 
 
 class TestProductsListEndpoint:
@@ -263,6 +264,7 @@ class TestProductCreateModel:
             tenant_id=uuid4(),
         )
         assert len(product.ingredients) == 1
+        assert product.ingredients[0].quantity == Decimal("100")
 
     def test_create_with_only_recipe_bases_succeeds(self):
         """ProductCreate accepts only recipe bases (no direct ingredients) — pre-existing behavior preserved."""


### PR DESCRIPTION
## Summary
- Use Decimal for purchase-unit and product recipe quantity models plus purchase-unit conversion math
- Serialize inventory quantities and technical unit costs with decimal-domain scales
- Add recipe quantity scale migration and precision tests for 6-decimal conversions

## Tests
- pytest tests/test_direct_purchase_decimal.py tests/test_ingredient_purchase_units.py tests/test_inventory.py tests/test_products.py tests/test_modifier_ingredients.py

Closes uno0uno/warocol.com#1429