### PR TITLE
test: add decimal policy regression coverage

### DIFF
--- a/tests/test_ingredient_purchase_units.py
+++ b/tests/test_ingredient_purchase_units.py
@@ -9,7 +9,7 @@ import pytest
 from fastapi import Request
 
 from app.core.middleware import SessionContext
-from app.models.ingredient import IngredientPurchaseUnitCreate
+from app.models.ingredient import IngredientPurchaseUnitCreate, IngredientPurchaseUnitUpdate
 from app.routers.ingredient_purchase_units import router
 from app.services.ingredient_purchase_units_service import (
     create_purchase_unit,
@@ -27,6 +27,27 @@ def _session():
         "expires_at": None,
         "is_active": True,
     })
+
+
+def test_purchase_unit_models_keep_decimal_field_roles():
+    ingredient_id = uuid4()
+
+    data = IngredientPurchaseUnitCreate(
+        ingredient_id=ingredient_id,
+        purchase_unit="paquete",
+        purchase_unit_label="Paquete precision",
+        conversion_factor="1.345678",
+        unit_cost="250.123456",
+    )
+    update = IngredientPurchaseUnitUpdate(
+        conversion_factor="0.333333",
+        unit_cost="6.617100",
+    )
+
+    assert data.conversion_factor == Decimal("1.345678")
+    assert data.unit_cost == Decimal("250.123456")
+    assert update.conversion_factor == Decimal("0.333333")
+    assert update.unit_cost == Decimal("6.617100")
 
 
 @pytest.mark.asyncio
@@ -112,6 +133,29 @@ async def test_resolve_to_base_unit_preserves_six_decimal_conversion():
     )
 
     assert base_qty == Decimal("2.691356")
+    assert base_unit == "gr"
+
+
+@pytest.mark.asyncio
+async def test_resolve_to_base_unit_rounds_to_six_without_float_tail():
+    ingredient_id = uuid4()
+    conn = MagicMock()
+
+    async def _fetchrow(query, *args):
+        if "SELECT unit FROM ingredients" in query:
+            return {"unit": "gr"}
+        return {"conversion_factor": Decimal("0.333333")}
+
+    conn.fetchrow = AsyncMock(side_effect=_fetchrow)
+
+    base_qty, base_unit = await resolve_to_base_unit(
+        conn,
+        ingredient_id,
+        Decimal("3"),
+        "porcion",
+    )
+
+    assert base_qty == Decimal("0.999999")
     assert base_unit == "gr"
 
 

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -21,10 +21,12 @@ from app.services.inventory_service import (
 def test_inventory_json_decimal_strips_float_residue():
     assert _json_decimal(0.1 + 0.2 - 0.3, _QUANTITY_JSON_SCALE, 0) == 0.0
     assert _json_decimal("1.3450000000001", _QUANTITY_JSON_SCALE, 0) == 1.345
+    assert _json_decimal("0.3333334", _QUANTITY_JSON_SCALE, 0) == 0.333333
 
 
 def test_inventory_json_decimal_preserves_technical_unit_cost_precision():
     assert _json_decimal("6.617100371747212", _TECHNICAL_COST_JSON_SCALE, 0) == 6.6171
+    assert _json_decimal("250.1234564", _TECHNICAL_COST_JSON_SCALE, 0) == 250.123456
 
 
 class TestInventoryStockEndpoint:

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -266,6 +266,32 @@ class TestProductCreateModel:
         assert len(product.ingredients) == 1
         assert product.ingredients[0].quantity == Decimal("100")
 
+    def test_recipe_quantities_preserve_six_decimal_precision(self):
+        from app.models.product import ProductCreate, RecipeBaseLink, RecipeIngredientBase
+
+        product = ProductCreate(
+            name="Salsa precision",
+            price=12000,
+            category_id=uuid4(),
+            ingredients=[
+                RecipeIngredientBase(
+                    ingredient_id=uuid4(),
+                    quantity="0.333333",
+                    unit="kg",
+                )
+            ],
+            recipe_bases=[
+                RecipeBaseLink(
+                    recipe_base_id=uuid4(),
+                    quantity="1.345678",
+                )
+            ],
+            tenant_id=uuid4(),
+        )
+
+        assert product.ingredients[0].quantity == Decimal("0.333333")
+        assert product.recipe_bases[0].quantity == Decimal("1.345678")
+
     def test_create_with_only_recipe_bases_succeeds(self):
         """ProductCreate accepts only recipe bases (no direct ingredients) — pre-existing behavior preserved."""
         from app.models.product import ProductCreate


### PR DESCRIPTION
## Summary
- Add API regression coverage for Decimal purchase-unit models and six-decimal unit conversion.
- Extend inventory and product model tests for quantity/technical-cost precision without long float tails.

## Tests
- pytest tests/test_direct_purchase_decimal.py tests/test_ingredient_purchase_units.py tests/test_purchase_inventory_decimal_scales.py tests/test_inventory.py tests/test_products.py tests/test_recipe_base_costs.py

No build run per request.

Refs uno0uno/warocol.com#1430