### PR TITLE
Expose cost source in QuerySpec product profitability

### DIFF
--- a/app/routers/ai_agents.py
+++ b/app/routers/ai_agents.py
@@ -26,6 +26,7 @@ SALES_SCOPES = (
     "analytics:read",
     "menu:read",
     "customers:read",
+    "dataset_scope",
 )
 FOOD_COST_SCOPES = ("analytics:read", "menu:read", "financial:read")
 

--- a/app/services/analytics_service.py
+++ b/app/services/analytics_service.py
@@ -35,7 +35,8 @@ _PRODUCT_COSTS_CTE = """
             END AS effective_cost,
             CASE
                 WHEN p.costo_percibido IS NOT NULL AND p.costo_percibido > 0 THEN 'operativo'
-                ELSE 'real'
+                WHEN COALESCE(p.costo_calculado, 0) > 0 THEN 'real'
+                ELSE 'estimado_40pct_precio'
             END AS cost_used_for_classification
         FROM product p
         WHERE p.tenant_id = $1

--- a/app/services/queries_service.py
+++ b/app/services/queries_service.py
@@ -5,6 +5,7 @@ This module exposes semantic datasets, not SQL. Clients can only reference
 allowlisted dataset fields; SQL fragments remain owned by the API.
 """
 import asyncio
+import json
 from dataclasses import dataclass
 from datetime import datetime, date
 from typing import Any, Optional
@@ -103,7 +104,12 @@ DATASETS: dict[str, DatasetSpec] = {
             LEFT JOIN profile p ON o.customer_id = p.id
             LEFT JOIN waros_wallets ww ON ww.profile_id = o.customer_id AND ww.tenant_id = o.tenant_id
         """,
-        base_conditions=("o.tenant_id = $1", POS_LIKE_FILTER_ALIAS_O, "o.status = 'completed'", "o.customer_id IS NOT NULL"),
+        base_conditions=(
+            "o.tenant_id = $1",
+            POS_LIKE_FILTER_ALIAS_O,
+            "o.status = 'completed'",
+            "o.customer_id IS NOT NULL",
+        ),
     ),
     "product_profitability": DatasetSpec(
         name="product_profitability",
@@ -114,6 +120,12 @@ DATASETS: dict[str, DatasetSpec] = {
             "product": QueryField("p.name", "string", "Product", groupable=True),
             "product_id": QueryField("p.id", "uuid", "Product ID", groupable=True),
             "category": QueryField("c.name", "string", "Category", groupable=True),
+            "cost_source": QueryField(
+                "pc.cost_used_for_classification",
+                "string",
+                "Cost source",
+                groupable=True,
+            ),
             "classification": QueryField(
                 "CASE "
                 "WHEN COALESCE(SUM(oi.quantity), 0) >= 20 "
@@ -152,6 +164,7 @@ DATASETS: dict[str, DatasetSpec] = {
         sortable={
             "product",
             "category",
+            "cost_source",
             "classification",
             "quantity_sold",
             "revenue",
@@ -170,7 +183,7 @@ DATASETS: dict[str, DatasetSpec] = {
         """,
         base_conditions=("p.tenant_id = $1", "o.tenant_id = $1", POS_LIKE_FILTER_ALIAS_O, "o.status = 'completed'"),
         cte_sql=_PRODUCT_COSTS_CTE,
-        extra_group_by=("pc.price", "pc.effective_cost", "pc.estimated_cost", "pc.costo_percibido"),
+        extra_group_by=("pc.price", "pc.effective_cost", "pc.estimated_cost", "pc.costo_percibido", "pc.cost_used_for_classification"),
     ),
 }
 
@@ -201,7 +214,41 @@ def get_queries_schema() -> dict[str, Any]:
 async def run_queryspec(request, spec: dict[str, Any]) -> dict[str, Any]:
     dataset = _get_dataset(spec.get("dataset"))
     tenant_id, _ = validate_api_key_auth(request, dataset.required_scope)
+    print(
+        "[api:queryspec] received "
+        + json.dumps(
+            {
+                "tenant_id": tenant_id,
+                "dataset": spec.get("dataset"),
+                "measures": spec.get("measures"),
+                "dimensions": spec.get("dimensions"),
+                "filters": spec.get("filters"),
+                "order_by": spec.get("order_by"),
+                "limit": spec.get("limit"),
+            },
+            ensure_ascii=False,
+            default=str,
+        ),
+        flush=True,
+    )
     compiled = compile_queryspec(spec)
+    print(
+        "[api:queryspec] compiled "
+        + json.dumps(
+            {
+                "dataset": dataset.name,
+                "dimensions": compiled["dimensions"],
+                "measures": compiled["measures"],
+                "columns": [column["name"] for column in compiled["columns"]],
+                "order_by": compiled["order_by"],
+                "limit": compiled["limit"],
+                "params_count": len(compiled["params"]),
+            },
+            ensure_ascii=False,
+            default=str,
+        ),
+        flush=True,
+    )
 
     try:
         async with get_db_connection(use_transaction=False) as conn:

--- a/tests/test_queries_service.py
+++ b/tests/test_queries_service.py
@@ -123,6 +123,31 @@ def test_compile_product_profitability_uses_product_costs_cte():
     assert "JOIN product_costs pc" in compiled["sql"]
 
 
+def test_compile_product_profitability_accepts_cost_source_dimension():
+    compiled = queries_service.compile_queryspec(
+        {
+            "dataset": "product_profitability",
+            "measures": ["quantity_sold", "profit_margin_pct", "profit_margin_real_pct", "revenue"],
+            "dimensions": ["product", "cost_source"],
+            "filters": {},
+            "order_by": [{"field": "quantity_sold", "direction": "desc"}],
+            "limit": 20,
+        }
+    )
+
+    assert [column["name"] for column in compiled["columns"]] == [
+        "product",
+        "cost_source",
+        "quantity_sold",
+        "profit_margin_pct",
+        "profit_margin_real_pct",
+        "revenue",
+    ]
+    assert compiled["columns"][1]["role"] == "dimension"
+    assert "pc.cost_used_for_classification AS cost_source" in compiled["sql"]
+    assert "pc.cost_used_for_classification" in compiled["sql"]
+
+
 @pytest.mark.asyncio
 async def test_run_queryspec_passes_tenant_and_returns_normalized_rows():
     fake_row = {


### PR DESCRIPTION
## Summary
- Add dataset_scope to the sales agent scopes.
- Expose cost_source for product_profitability QuerySpec requests.
- Preserve estimated-cost labeling only when the 40% fallback is actually used.
- Add coverage for cost_source QuerySpec compilation.

## Tests
- venv/bin/python -m pytest tests/test_queries_service.py -q