### PR TITLE
Add inventory and purchase QuerySpec datasets

### DIFF
--- a/app/models/api_token.py
+++ b/app/models/api_token.py
@@ -88,6 +88,7 @@ AVAILABLE_SCOPES = [
     "products:write",  # Crear/modificar productos
     "inventory:read",  # Leer inventario
     "inventory:write", # Modificar inventario
+    "purchases:read",  # Leer compras
     "customers:read",  # Leer clientes
     "customers:write", # Crear/modificar clientes
     "analytics:read",  # Leer analytics (menu BCG, food cost, alertas, calidad de datos)

--- a/app/routers/api_tokens.py
+++ b/app/routers/api_tokens.py
@@ -60,6 +60,7 @@ async def get_available_scopes():
             "products:write": "Crear y modificar productos",
             "inventory:read": "Leer inventario",
             "inventory:write": "Modificar inventario",
+            "purchases:read": "Leer compras",
             "customers:read": "Leer clientes",
             "customers:write": "Crear y modificar clientes"
         }

--- a/app/routers/public_api.py
+++ b/app/routers/public_api.py
@@ -120,7 +120,7 @@ class QueryOrderByRequest(BaseModel):
 
 class QuerySpecRequest(BaseModel):
     """Safe analytical QuerySpec; never accepts SQL"""
-    dataset: str = Field(description="Dataset name: sales_items | customers | product_profitability")
+    dataset: str = Field(description="Dataset name from /v1/queries/schema")
     measures: List[str] = Field(default_factory=list, description="Allowlisted measure names")
     dimensions: List[str] = Field(default_factory=list, description="Allowlisted dimension names")
     filters: Dict[str, Any] = Field(default_factory=dict, description="Allowlisted filters")

--- a/app/services/inventory_service.py
+++ b/app/services/inventory_service.py
@@ -34,9 +34,9 @@ def _json_decimal(value: Any, scale: Decimal, default: Optional[float] = None) -
     return float(quantized)
 
 
-async def get_inventory_stock(
-    request: Request,
-    response: Response,
+async def _get_inventory_stock_for_tenant(
+    tenant_id: str,
+    *,
     limit: int = 250,
     offset: int = 0,
     search: Optional[str] = None,
@@ -47,11 +47,10 @@ async def get_inventory_stock(
     sort_direction: str = "desc"
 ) -> Dict[str, Any]:
     """
-    Get current inventory stock with stats
+    Get current inventory stock with stats for a tenant.
 
     Args:
-        request: FastAPI request
-        response: FastAPI response
+        tenant_id: Tenant to query
         limit: Number of records to return
         offset: Number of records to skip
         search: Search term for ingredient name
@@ -65,9 +64,6 @@ async def get_inventory_stock(
         Dictionary with inventory data and stats
     """
     try:
-        session_context = require_valid_session(request)
-        tenant_id = session_context.tenant_id
-
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
 
@@ -269,9 +265,40 @@ async def get_inventory_stock(
         raise HTTPException(status_code=500, detail="Error interno del servidor")
 
 
-async def get_inventory_movements(
+async def get_inventory_stock(
     request: Request,
     response: Response,
+    limit: int = 250,
+    offset: int = 0,
+    search: Optional[str] = None,
+    status_filter: Optional[str] = None,  # 'low', 'critical', 'ok', 'all'
+    category: Optional[str] = None,
+    unit: Optional[str] = None,
+    sort_field: str = "current_stock",
+    sort_direction: str = "desc"
+) -> Dict[str, Any]:
+    """
+    Get current inventory stock with stats for the current session tenant.
+    """
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+
+    return await _get_inventory_stock_for_tenant(
+        tenant_id,
+        limit=limit,
+        offset=offset,
+        search=search,
+        status_filter=status_filter,
+        category=category,
+        unit=unit,
+        sort_field=sort_field,
+        sort_direction=sort_direction
+    )
+
+
+async def _get_inventory_movements_for_tenant(
+    tenant_id: str,
+    *,
     limit: int = 100,
     offset: int = 0,
     ingredient_id: Optional[UUID] = None,
@@ -281,11 +308,10 @@ async def get_inventory_movements(
     end_date: Optional[str] = None
 ) -> Dict[str, Any]:
     """
-    Get inventory movements history
+    Get inventory movements history for a tenant.
 
     Args:
-        request: FastAPI request
-        response: FastAPI response
+        tenant_id: Tenant to query
         limit: Number of records to return
         offset: Number of records to skip
         ingredient_id: Filter by specific ingredient
@@ -298,9 +324,6 @@ async def get_inventory_movements(
         Dictionary with movements data
     """
     try:
-        session_context = require_valid_session(request)
-        tenant_id = session_context.tenant_id
-
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
 
@@ -423,6 +446,35 @@ async def get_inventory_movements(
     except Exception as e:
         logger.error(f"Error getting inventory movements: {str(e)}")
         raise HTTPException(status_code=500, detail="Error interno del servidor")
+
+
+async def get_inventory_movements(
+    request: Request,
+    response: Response,
+    limit: int = 100,
+    offset: int = 0,
+    ingredient_id: Optional[UUID] = None,
+    movement_type: Optional[str] = None,  # 'purchase', 'consumption', 'adjustment', etc.
+    quantity_direction: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None
+) -> Dict[str, Any]:
+    """
+    Get inventory movements history for the current session tenant.
+    """
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+
+    return await _get_inventory_movements_for_tenant(
+        tenant_id,
+        limit=limit,
+        offset=offset,
+        ingredient_id=ingredient_id,
+        movement_type=movement_type,
+        quantity_direction=quantity_direction,
+        start_date=start_date,
+        end_date=end_date
+    )
 
 
 async def get_stock_by_ingredient(

--- a/app/services/queries_service.py
+++ b/app/services/queries_service.py
@@ -21,6 +21,18 @@ DEFAULT_TIMEOUT_SECONDS = 5
 DEFAULT_TIMEZONE = "America/Bogota"
 MAX_LIMIT = 100
 
+_INVENTORY_LATEST_COSTS_CTE = """
+latest_costs AS (
+    SELECT DISTINCT ON (ingredient_id)
+        ingredient_id,
+        cost_per_unit
+    FROM tenant_ingredient_movements
+    WHERE tenant_id = $1
+      AND cost_per_unit IS NOT NULL
+    ORDER BY ingredient_id, created_at DESC
+)
+"""
+
 
 @dataclass(frozen=True)
 class QueryField:
@@ -44,6 +56,7 @@ class DatasetSpec:
     base_conditions: tuple[str, ...]
     cte_sql: Optional[str] = None
     extra_group_by: tuple[str, ...] = ()
+    limitations: tuple[str, ...] = ()
 
 
 DATASETS: dict[str, DatasetSpec] = {
@@ -185,6 +198,176 @@ DATASETS: dict[str, DatasetSpec] = {
         cte_sql=_PRODUCT_COSTS_CTE,
         extra_group_by=("pc.price", "pc.effective_cost", "pc.estimated_cost", "pc.costo_percibido", "pc.cost_used_for_classification"),
     ),
+    "inventory_stock": DatasetSpec(
+        name="inventory_stock",
+        label="Inventory stock",
+        description="Current ingredient stock grouped by ingredient, category, unit, or stock status.",
+        required_scope="inventory:read",
+        dimensions={
+            "ingredient": QueryField("i.name", "string", "Ingredient", groupable=True),
+            "ingredient_id": QueryField("ti.ingredient_id", "uuid", "Ingredient ID", groupable=True),
+            "category": QueryField("i.category", "string", "Category", groupable=True),
+            "unit": QueryField("i.unit", "string", "Unit", groupable=True),
+            "status": QueryField(
+                "CASE "
+                "WHEN ti.current_stock < 0 THEN 'negative' "
+                "WHEN ti.current_stock > 0 AND ti.current_stock <= ti.minimum_stock THEN 'low' "
+                "ELSE 'ok' END",
+                "string",
+                "Status",
+                groupable=True,
+            ),
+        },
+        measures={
+            "current_stock": QueryField("COALESCE(SUM(ti.current_stock), 0)", "number", "Current stock"),
+            "minimum_stock": QueryField("COALESCE(SUM(ti.minimum_stock), 0)", "number", "Minimum stock"),
+            "maximum_stock": QueryField("COALESCE(SUM(ti.maximum_stock), 0)", "number", "Maximum stock"),
+            "unit_cost": QueryField("COALESCE(AVG(lc.cost_per_unit), 0)", "currency", "Average unit cost"),
+            "stock_value": QueryField("COALESCE(SUM(ti.current_stock * COALESCE(lc.cost_per_unit, 0)), 0)", "currency", "Stock value"),
+        },
+        filters={
+            "category": {"type": "string", "field": "i.category"},
+            "unit": {"type": "string", "field": "i.unit"},
+            "status": {
+                "type": "string",
+                "field": (
+                    "CASE "
+                    "WHEN ti.current_stock < 0 THEN 'negative' "
+                    "WHEN ti.current_stock > 0 AND ti.current_stock <= ti.minimum_stock THEN 'low' "
+                    "ELSE 'ok' END"
+                ),
+            },
+        },
+        sortable={
+            "ingredient",
+            "category",
+            "unit",
+            "status",
+            "current_stock",
+            "minimum_stock",
+            "maximum_stock",
+            "unit_cost",
+            "stock_value",
+        },
+        from_sql="""
+            FROM tenant_inventory ti
+            JOIN ingredients i ON ti.ingredient_id = i.id
+            LEFT JOIN latest_costs lc ON lc.ingredient_id = ti.ingredient_id
+        """,
+        base_conditions=("ti.tenant_id = $1",),
+        cte_sql=_INVENTORY_LATEST_COSTS_CTE,
+        limitations=("Uses the latest inventory movement cost per ingredient when available.",),
+    ),
+    "inventory_movements": DatasetSpec(
+        name="inventory_movements",
+        label="Inventory movements",
+        description="Ingredient stock movements grouped by ingredient, movement type, day, or reference.",
+        required_scope="inventory:read",
+        dimensions={
+            "ingredient": QueryField("i.name", "string", "Ingredient", groupable=True),
+            "ingredient_id": QueryField("tim.ingredient_id", "uuid", "Ingredient ID", groupable=True),
+            "movement_type": QueryField("tim.movement_type", "string", "Movement type", groupable=True),
+            "day": QueryField("DATE(tim.created_at AT TIME ZONE {tz})", "date", "Day", groupable=True),
+            "reference_table": QueryField("tim.reference_table", "string", "Reference table", groupable=True),
+            "reference_number": QueryField(
+                "COALESCE(tp.purchase_number, o.order_number::text)",
+                "string",
+                "Reference number",
+                groupable=True,
+            ),
+        },
+        measures={
+            "quantity_in": QueryField("COALESCE(SUM(GREATEST(tim.quantity_change, 0)), 0)", "number", "Quantity in"),
+            "quantity_out": QueryField("COALESCE(SUM(ABS(LEAST(tim.quantity_change, 0))), 0)", "number", "Quantity out"),
+            "net_quantity": QueryField("COALESCE(SUM(tim.quantity_change), 0)", "number", "Net quantity"),
+            "movement_count": QueryField("COUNT(tim.id)", "integer", "Movement count"),
+            "avg_cost_per_unit": QueryField("COALESCE(AVG(tim.cost_per_unit), 0)", "currency", "Average cost per unit"),
+        },
+        filters={
+            "date_range": {"type": "date_range", "field": "tim.created_at"},
+            "ingredient": {"type": "string", "field": "i.name"},
+            "movement_type": {"type": "string", "field": "tim.movement_type"},
+            "reference_table": {"type": "string", "field": "tim.reference_table"},
+        },
+        sortable={
+            "ingredient",
+            "movement_type",
+            "day",
+            "reference_table",
+            "reference_number",
+            "quantity_in",
+            "quantity_out",
+            "net_quantity",
+            "movement_count",
+            "avg_cost_per_unit",
+        },
+        from_sql="""
+            FROM tenant_ingredient_movements tim
+            JOIN ingredients i ON tim.ingredient_id = i.id
+            LEFT JOIN tenant_purchases tp
+                ON tim.reference_table = 'tenant_purchases'
+                AND tp.id = tim.reference_id
+                AND tp.tenant_id = tim.tenant_id
+            LEFT JOIN orders o
+                ON tim.reference_table = 'orders'
+                AND o.id = tim.reference_id
+                AND o.tenant_id = tim.tenant_id
+        """,
+        base_conditions=("tim.tenant_id = $1",),
+    ),
+    "purchase_items": DatasetSpec(
+        name="purchase_items",
+        label="Purchase items",
+        description="Purchased ingredient items grouped by supplier, ingredient, day, purchase number, or status.",
+        required_scope="purchases:read",
+        dimensions={
+            "supplier": QueryField("COALESCE(ts.name, 'Sin proveedor')", "string", "Supplier", groupable=True),
+            "supplier_id": QueryField("tp.supplier_id", "uuid", "Supplier ID", groupable=True),
+            "ingredient": QueryField("i.name", "string", "Ingredient", groupable=True),
+            "ingredient_id": QueryField("tpi.ingredient_id", "uuid", "Ingredient ID", groupable=True),
+            "category": QueryField("i.category", "string", "Category", groupable=True),
+            "day": QueryField("DATE(tp.purchase_date AT TIME ZONE {tz})", "date", "Day", groupable=True),
+            "purchase_number": QueryField("tp.purchase_number", "string", "Purchase number", groupable=True),
+            "status": QueryField("tp.status", "string", "Status", groupable=True),
+            "is_direct_entry": QueryField("tp.is_direct_entry", "boolean", "Is direct entry", groupable=True),
+        },
+        measures={
+            "quantity_purchased": QueryField("COALESCE(SUM(tpi.quantity), 0)", "number", "Quantity purchased"),
+            "quantity_received": QueryField("COALESCE(SUM(tpi.quantity_received), 0)", "number", "Quantity received"),
+            "total_cost": QueryField("COALESCE(SUM(tpi.total_cost), 0)", "currency", "Total cost"),
+            "avg_unit_cost": QueryField("COALESCE(AVG(tpi.unit_cost), 0)", "currency", "Average unit cost"),
+            "purchase_count": QueryField("COUNT(DISTINCT tp.id)", "integer", "Purchase count"),
+        },
+        filters={
+            "date_range": {"type": "date_range", "field": "tp.purchase_date"},
+            "supplier": {"type": "string", "field": "COALESCE(ts.name, 'Sin proveedor')"},
+            "ingredient": {"type": "string", "field": "i.name"},
+            "status": {"type": "string", "field": "tp.status"},
+            "is_direct_entry": {"type": "boolean", "field": "tp.is_direct_entry"},
+        },
+        sortable={
+            "supplier",
+            "ingredient",
+            "category",
+            "day",
+            "purchase_number",
+            "status",
+            "is_direct_entry",
+            "quantity_purchased",
+            "quantity_received",
+            "total_cost",
+            "avg_unit_cost",
+            "purchase_count",
+        },
+        from_sql="""
+            FROM tenant_purchase_items tpi
+            JOIN tenant_purchases tp ON tpi.purchase_id = tp.id
+            JOIN ingredients i ON tpi.ingredient_id = i.id
+            LEFT JOIN tenant_suppliers ts ON tp.supplier_id = ts.id AND ts.tenant_id = tp.tenant_id
+        """,
+        base_conditions=("tp.tenant_id = $1",),
+        limitations=("Purchase item costs reflect stored purchase records and do not forecast replenishment needs.",),
+    ),
 }
 
 
@@ -204,6 +387,7 @@ def get_queries_schema() -> dict[str, Any]:
                     "measures": _schema_fields(dataset.measures),
                     "filters": dataset.filters,
                     "sortable_fields": sorted(dataset.sortable),
+                    "limitations": list(dataset.limitations),
                 }
                 for dataset in DATASETS.values()
             ]
@@ -277,7 +461,7 @@ async def run_queryspec(request, spec: dict[str, Any]) -> dict[str, Any]:
                 "limit": compiled["limit"],
                 "row_count": len(rows),
             },
-            "limitations": [],
+            "limitations": list(dataset.limitations),
         },
     }
 
@@ -403,10 +587,16 @@ def _apply_filters(
     for key, value in filters.items():
         if key == "date_range" or value is None:
             continue
-        field = dataset.filters[key]["field"]
-        if not isinstance(value, str) or not value.strip():
-            raise ValidationError(f"{key} filter must be a non-empty string", {"field": f"filters.{key}"})
-        params.append(value.strip())
+        filter_spec = dataset.filters[key]
+        field = filter_spec["field"]
+        if filter_spec["type"] == "boolean":
+            if not isinstance(value, bool):
+                raise ValidationError(f"{key} filter must be a boolean", {"field": f"filters.{key}"})
+            params.append(value)
+        else:
+            if not isinstance(value, str) or not value.strip():
+                raise ValidationError(f"{key} filter must be a non-empty string", {"field": f"filters.{key}"})
+            params.append(value.strip())
         where_parts.append(f"{field} = ${len(params) + 1}")
 
 

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -7,14 +7,22 @@ Endpoints tested:
 - GET /inventory/stock/{ingredient_id}
 - POST /inventory/adjustments
 """
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from httpx import AsyncClient
 from uuid import uuid4
 
 from app.services.inventory_service import (
+    _get_inventory_movements_for_tenant,
+    _get_inventory_stock_for_tenant,
     _json_decimal,
     _QUANTITY_JSON_SCALE,
     _TECHNICAL_COST_JSON_SCALE,
+    get_inventory_movements,
+    get_inventory_stock,
 )
 
 
@@ -27,6 +35,203 @@ def test_inventory_json_decimal_strips_float_residue():
 def test_inventory_json_decimal_preserves_technical_unit_cost_precision():
     assert _json_decimal("6.617100371747212", _TECHNICAL_COST_JSON_SCALE, 0) == 6.6171
     assert _json_decimal("250.1234564", _TECHNICAL_COST_JSON_SCALE, 0) == 250.123456
+
+
+class _FakeInventoryConnection:
+    def __init__(self, *, fetch_rows=None, fetchrow_rows=None):
+        self.fetch_rows = fetch_rows or []
+        self.fetchrow_rows = list(fetchrow_rows or [])
+        self.fetch_calls = []
+        self.fetchrow_calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def fetch(self, query, *params):
+        self.fetch_calls.append((query, params))
+        return self.fetch_rows
+
+    async def fetchrow(self, query, *params):
+        self.fetchrow_calls.append((query, params))
+        return self.fetchrow_rows.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_inventory_stock_core_uses_explicit_tenant_without_session():
+    tenant_id = "tenant-core-stock"
+    conn = _FakeInventoryConnection(
+        fetch_rows=[
+            {
+                "id": uuid4(),
+                "ingredient_id": uuid4(),
+                "ingredient_name": "Tomate",
+                "unit": "gr",
+                "category": "Verduras",
+                "current_stock": "12.5",
+                "minimum_stock": "5",
+                "maximum_stock": "20",
+                "last_updated": datetime(2026, 1, 1, 12, 0),
+                "location": "Bodega",
+                "lote_actual": "L1",
+                "fecha_vencimiento": datetime(2026, 2, 1, 12, 0),
+                "status": "ok",
+                "stock_percentage": "62.5",
+                "unit_cost": "100.25",
+                "total_value": "1253.125",
+            }
+        ],
+        fetchrow_rows=[
+            {"total": 1},
+            {
+                "total_ingredients": 1,
+                "critical_count": 0,
+                "low_stock_count": 0,
+                "ok_count": 1,
+                "total_inventory_value": "1253.125",
+            },
+            {"categories": ["Verduras"], "units": ["gr"]},
+        ],
+    )
+
+    with patch("app.services.inventory_service.require_valid_session", side_effect=AssertionError), \
+         patch("app.services.inventory_service.get_db_connection", return_value=conn):
+        result = await _get_inventory_stock_for_tenant(
+            tenant_id,
+            limit=10,
+            offset=5,
+            search="tom",
+            status_filter="ok",
+            category="Verduras",
+            unit="gr",
+            sort_field="ingredient_name",
+            sort_direction="asc",
+        )
+
+    assert result["success"] is True
+    assert result["total"] == 1
+    assert result["data"][0]["ingredient_name"] == "Tomate"
+    assert conn.fetch_calls[0][1][0] == tenant_id
+    assert conn.fetch_calls[0][1][-2:] == (10, 5)
+
+
+@pytest.mark.asyncio
+async def test_inventory_movements_core_uses_explicit_tenant_without_session():
+    tenant_id = "tenant-core-movements"
+    ingredient_id = uuid4()
+    conn = _FakeInventoryConnection(
+        fetch_rows=[
+            {
+                "id": uuid4(),
+                "ingredient_id": ingredient_id,
+                "ingredient_name": "Tomate",
+                "unit": "gr",
+                "movement_type": "purchase",
+                "quantity_change": "3.5",
+                "previous_stock": "1",
+                "new_stock": "4.5",
+                "cost_per_unit": "10.25",
+                "reference_table": "tenant_purchases",
+                "reference_id": uuid4(),
+                "reference_number": "CP-1",
+                "reason": "Compra",
+                "notes": None,
+                "created_by": uuid4(),
+                "created_by_name": "Ana",
+                "created_at": datetime(2026, 1, 1, 12, 0),
+            }
+        ],
+        fetchrow_rows=[{"total": 1}],
+    )
+
+    with patch("app.services.inventory_service.require_valid_session", side_effect=AssertionError), \
+         patch("app.services.inventory_service.get_db_connection", return_value=conn):
+        result = await _get_inventory_movements_for_tenant(
+            tenant_id,
+            limit=20,
+            offset=2,
+            ingredient_id=ingredient_id,
+            movement_type="purchase",
+            quantity_direction="positive",
+            start_date="2026-01-01",
+            end_date="2026-01-31",
+        )
+
+    assert result["success"] is True
+    assert result["data"][0]["ingredient_name"] == "Tomate"
+    assert conn.fetch_calls[0][1][0] == tenant_id
+    assert conn.fetch_calls[0][1][-2:] == (20, 2)
+
+
+@pytest.mark.asyncio
+async def test_inventory_stock_wrapper_resolves_tenant_before_core():
+    session = SimpleNamespace(tenant_id="tenant-wrapper-stock")
+
+    with patch("app.services.inventory_service.require_valid_session", return_value=session), \
+         patch("app.services.inventory_service._get_inventory_stock_for_tenant", new_callable=AsyncMock) as core:
+        core.return_value = {"success": True, "data": []}
+
+        result = await get_inventory_stock(
+            object(),
+            object(),
+            limit=10,
+            offset=1,
+            search="tom",
+            status_filter="low",
+            category="Verduras",
+            unit="gr",
+            sort_field="ingredient_name",
+            sort_direction="asc",
+        )
+
+    assert result == {"success": True, "data": []}
+    core.assert_awaited_once_with(
+        "tenant-wrapper-stock",
+        limit=10,
+        offset=1,
+        search="tom",
+        status_filter="low",
+        category="Verduras",
+        unit="gr",
+        sort_field="ingredient_name",
+        sort_direction="asc",
+    )
+
+
+@pytest.mark.asyncio
+async def test_inventory_movements_wrapper_resolves_tenant_before_core():
+    session = SimpleNamespace(tenant_id="tenant-wrapper-movements")
+    ingredient_id = uuid4()
+
+    with patch("app.services.inventory_service.require_valid_session", return_value=session), \
+         patch("app.services.inventory_service._get_inventory_movements_for_tenant", new_callable=AsyncMock) as core:
+        core.return_value = {"success": True, "data": []}
+
+        result = await get_inventory_movements(
+            object(),
+            object(),
+            limit=20,
+            offset=2,
+            ingredient_id=ingredient_id,
+            movement_type="purchase",
+            quantity_direction="positive",
+            start_date="2026-01-01",
+            end_date="2026-01-31",
+        )
+
+    assert result == {"success": True, "data": []}
+    core.assert_awaited_once_with(
+        "tenant-wrapper-movements",
+        limit=20,
+        offset=2,
+        ingredient_id=ingredient_id,
+        movement_type="purchase",
+        quantity_direction="positive",
+        start_date="2026-01-01",
+        end_date="2026-01-31",
+    )
 
 
 class TestInventoryStockEndpoint:

--- a/tests/test_queries_service.py
+++ b/tests/test_queries_service.py
@@ -37,12 +37,26 @@ def test_queries_schema_lists_mvp_datasets():
     schema = queries_service.get_queries_schema()
     datasets = {item["name"]: item for item in schema["data"]["datasets"]}
 
-    assert set(datasets) == {"sales_items", "customers", "product_profitability"}
+    assert set(datasets) == {
+        "sales_items",
+        "customers",
+        "product_profitability",
+        "inventory_stock",
+        "inventory_movements",
+        "purchase_items",
+    }
     assert "revenue" in {field["name"] for field in datasets["sales_items"]["measures"]}
     assert "total_spent" in {field["name"] for field in datasets["customers"]["measures"]}
     assert "profit_margin_operativo_pct" in {
         field["name"] for field in datasets["product_profitability"]["measures"]
     }
+    assert datasets["inventory_stock"]["required_scope"] == "inventory:read"
+    assert datasets["inventory_movements"]["required_scope"] == "inventory:read"
+    assert datasets["purchase_items"]["required_scope"] == "purchases:read"
+    assert "stock_value" in {field["name"] for field in datasets["inventory_stock"]["measures"]}
+    assert "net_quantity" in {field["name"] for field in datasets["inventory_movements"]["measures"]}
+    assert "total_cost" in {field["name"] for field in datasets["purchase_items"]["measures"]}
+    assert datasets["purchase_items"]["limitations"]
 
 
 @pytest.mark.parametrize(
@@ -146,6 +160,129 @@ def test_compile_product_profitability_accepts_cost_source_dimension():
     assert compiled["columns"][1]["role"] == "dimension"
     assert "pc.cost_used_for_classification AS cost_source" in compiled["sql"]
     assert "pc.cost_used_for_classification" in compiled["sql"]
+
+
+def test_compile_inventory_stock_queryspec_uses_tenant_scope_and_latest_costs():
+    compiled = queries_service.compile_queryspec(
+        {
+            "dataset": "inventory_stock",
+            "measures": ["current_stock", "stock_value"],
+            "dimensions": ["ingredient", "category", "status"],
+            "filters": {"category": "Bebidas"},
+            "order_by": [{"field": "stock_value", "direction": "desc"}],
+            "limit": 25,
+        }
+    )
+
+    sql = compiled["sql"]
+    assert "WITH" in sql
+    assert "latest_costs AS" in sql
+    assert "FROM tenant_inventory ti" in sql
+    assert "JOIN ingredients i ON ti.ingredient_id = i.id" in sql
+    assert "ti.tenant_id = $1" in sql
+    assert "i.category = $2" in sql
+    assert "Bebidas" not in sql
+    assert "ORDER BY stock_value DESC NULLS LAST" in sql
+    assert "LIMIT $3" in sql
+    assert compiled["params"] == ["Bebidas", 25]
+
+
+def test_compile_inventory_movements_queryspec_parameterizes_dates_and_filters():
+    compiled = queries_service.compile_queryspec(
+        {
+            "dataset": "inventory_movements",
+            "measures": ["quantity_in", "quantity_out", "net_quantity", "movement_count"],
+            "dimensions": ["ingredient", "movement_type", "day"],
+            "filters": {
+                "date_range": {"from": "2026-02-01", "to": "2026-02-28"},
+                "movement_type": "purchase",
+            },
+            "order_by": [{"field": "net_quantity", "direction": "desc"}],
+            "limit": 30,
+        }
+    )
+
+    sql = compiled["sql"]
+    assert "FROM tenant_ingredient_movements tim" in sql
+    assert "LEFT JOIN tenant_purchases tp" in sql
+    assert "tim.tenant_id = $1" in sql
+    assert "tim.created_at >= ($2::timestamp AT TIME ZONE $3)" in sql
+    assert "tim.created_at < (($4::timestamp + interval '1 day') AT TIME ZONE $5)" in sql
+    assert "tim.movement_type = $6" in sql
+    assert "tim.movement_type = 'purchase'" not in sql
+    assert "LIMIT $7" in sql
+    assert compiled["params"] == [
+        date(2026, 2, 1),
+        "America/Bogota",
+        date(2026, 2, 28),
+        "America/Bogota",
+        "purchase",
+        30,
+    ]
+
+
+def test_compile_purchase_items_queryspec_uses_purchase_scope_and_boolean_filter():
+    compiled = queries_service.compile_queryspec(
+        {
+            "dataset": "purchase_items",
+            "measures": ["quantity_purchased", "total_cost", "avg_unit_cost"],
+            "dimensions": ["supplier", "ingredient", "is_direct_entry"],
+            "filters": {"is_direct_entry": True},
+            "order_by": [{"field": "total_cost", "direction": "desc"}],
+            "limit": 10,
+        }
+    )
+
+    sql = compiled["sql"]
+    assert "FROM tenant_purchase_items tpi" in sql
+    assert "JOIN tenant_purchases tp ON tpi.purchase_id = tp.id" in sql
+    assert "LEFT JOIN tenant_suppliers ts ON tp.supplier_id = ts.id AND ts.tenant_id = tp.tenant_id" in sql
+    assert "tp.tenant_id = $1" in sql
+    assert "tp.is_direct_entry = $2" in sql
+    assert "True" not in sql
+    assert "LIMIT $3" in sql
+    assert compiled["params"] == [True, 10]
+
+
+def test_compile_new_queryspec_datasets_reject_invalid_surface():
+    with pytest.raises(ValidationError) as invalid_field:
+        queries_service.compile_queryspec(
+            {
+                "dataset": "inventory_stock",
+                "measures": ["current_stock"],
+                "dimensions": ["raw_table"],
+                "filters": {},
+                "order_by": [{"field": "current_stock", "direction": "desc"}],
+                "limit": 10,
+            }
+        )
+    assert "dimensions" in str(invalid_field.value.details)
+
+    with pytest.raises(ValidationError) as invalid_bool:
+        queries_service.compile_queryspec(
+            {
+                "dataset": "purchase_items",
+                "measures": ["total_cost"],
+                "dimensions": ["supplier"],
+                "filters": {"is_direct_entry": "true"},
+                "order_by": [{"field": "total_cost", "direction": "desc"}],
+                "limit": 10,
+            }
+        )
+    assert "filters.is_direct_entry" in str(invalid_bool.value.details)
+
+    with pytest.raises(ValidationError) as invalid_order:
+        queries_service.compile_queryspec(
+            {
+                "dataset": "inventory_movements",
+                "measures": ["movement_count"],
+                "dimensions": ["ingredient"],
+                "filters": {},
+                "order_by": [{"field": "net_quantity", "direction": "desc"}],
+                "limit": 10,
+            }
+        )
+    assert "order_by.0.field" in str(invalid_order.value.details)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add inventory_stock, inventory_movements, and purchase_items QuerySpec datasets
- expose dataset limitations and purchases:read scope
- cover schema, allowlist rejection, tenant isolation, and parameterized SQL tests

## Tests
- pytest tests/test_queries_service.py
- pytest tests/test_public_api_queries.py

Closes #503