### PR TITLE
Expose procurement read wrappers

### DIFF
--- a/app/models/api_token.py
+++ b/app/models/api_token.py
@@ -89,6 +89,7 @@ AVAILABLE_SCOPES = [
     "inventory:read",  # Leer inventario
     "inventory:write", # Modificar inventario
     "purchases:read",  # Leer compras
+    "suppliers:read",  # Leer proveedores
     "customers:read",  # Leer clientes
     "customers:write", # Crear/modificar clientes
     "analytics:read",  # Leer analytics (menu BCG, food cost, alertas, calidad de datos)

--- a/app/routers/public_api.py
+++ b/app/routers/public_api.py
@@ -4,7 +4,7 @@ Endpoints for external integrations authenticated via API tokens
 """
 from fastapi import APIRouter, Depends, HTTPException, Request, Query
 from pydantic import BaseModel, Field
-from typing import List, Optional, Dict, Any
+from typing import Any, Dict, List, Literal, Optional
 from uuid import UUID
 from app.core.permissions import Module, require_module
 from app.services import public_api_service, public_restaurant_service, queries_service
@@ -127,6 +127,49 @@ class QuerySpecRequest(BaseModel):
     order_by: Optional[List[QueryOrderByRequest]] = Field(default=None, description="Allowlisted ordering")
     limit: Optional[int] = Field(default=None, description="Required row limit")
     timezone: str = Field(default="America/Bogota", description="Timezone for date filters")
+
+
+class ProcurementInventoryStockRequest(BaseModel):
+    """Request body for public inventory stock listing"""
+    limit: int = Field(default=250, ge=1, le=500, description="Items per page")
+    offset: int = Field(default=0, ge=0, description="Number of items to skip")
+    search: Optional[str] = Field(default=None, description="Search by ingredient name")
+    statusFilter: Optional[str] = Field(default="all", description="Filter by status: low, negative, ok, all")
+    category: Optional[str] = Field(default=None, description="Filter by ingredient category")
+    unit: Optional[str] = Field(default=None, description="Filter by ingredient unit")
+    sortField: str = Field(default="current_stock", description="Sort field")
+    sortDirection: Literal["asc", "desc"] = Field(default="desc", description="Sort direction")
+
+
+class ProcurementInventoryMovementsRequest(BaseModel):
+    """Request body for public inventory movements listing"""
+    limit: int = Field(default=100, ge=1, le=500, description="Items per page")
+    offset: int = Field(default=0, ge=0, description="Number of items to skip")
+    ingredientId: Optional[str] = Field(default=None, description="Filter by ingredient UUID")
+    movementType: Optional[str] = Field(default=None, description="Filter by movement type")
+    quantityDirection: Optional[Literal["positive", "negative"]] = Field(default=None, description="Filter by quantity sign")
+    startDate: Optional[str] = Field(default=None, description="Filter by start date (ISO)")
+    endDate: Optional[str] = Field(default=None, description="Filter by end date (ISO)")
+
+
+class ProcurementDirectPurchasesRequest(BaseModel):
+    """Request body for public direct purchases listing"""
+    page: int = Field(default=1, ge=1, description="Page number")
+    limit: int = Field(default=50, ge=1, le=250, description="Items per page")
+    search: Optional[str] = Field(default=None, description="Search by purchase, invoice, or supplier")
+    status: Optional[str] = Field(default=None, description="Filter by purchase status")
+    supplierId: Optional[str] = Field(default=None, description="Filter by supplier UUID")
+    dateFilter: Optional[Literal["today", "yesterday", "last_week", "15_days", "1_month", "3_months"]] = Field(default=None, description="Relative date filter")
+
+
+class ProcurementSuppliersRequest(BaseModel):
+    """Request body for public suppliers listing"""
+    page: int = Field(default=1, ge=1, description="Page number")
+    limit: int = Field(default=50, ge=1, le=250, description="Items per page")
+    search: Optional[str] = Field(default=None, description="Search by supplier fields")
+    searchField: Optional[Literal["name", "tax_id", "email", "phone"]] = Field(default=None, description="Field to search")
+    isActive: Optional[bool] = Field(default=None, description="Filter by active status")
+    paymentTerms: Optional[str] = Field(default=None, description="Filter by payment terms")
 
 
 @router.get("/restaurant", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
@@ -427,6 +470,82 @@ async def run_queryspec(request: Request, body: QuerySpecRequest):
     """
     return await queries_service.run_queryspec(request, body.dict())
 
+
+@router.post("/inventory/stock", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
+async def get_procurement_inventory_stock(request: Request, body: ProcurementInventoryStockRequest):
+    """
+    Obtiene stock actual de inventario del tenant autenticado por API key.
+
+    **Scope requerido:** `inventory:read` o `read`
+    """
+    return await public_api_service.get_procurement_inventory_stock(
+        request,
+        limit=body.limit,
+        offset=body.offset,
+        search=body.search,
+        status_filter=body.statusFilter,
+        category=body.category,
+        unit=body.unit,
+        sort_field=body.sortField,
+        sort_direction=body.sortDirection,
+    )
+
+
+@router.post("/inventory/movements", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
+async def get_procurement_inventory_movements(request: Request, body: ProcurementInventoryMovementsRequest):
+    """
+    Obtiene movimientos de inventario del tenant autenticado por API key.
+
+    **Scope requerido:** `inventory:read` o `read`
+    """
+    ingredient_id = UUID(body.ingredientId) if body.ingredientId else None
+    return await public_api_service.get_procurement_inventory_movements(
+        request,
+        limit=body.limit,
+        offset=body.offset,
+        ingredient_id=ingredient_id,
+        movement_type=body.movementType,
+        quantity_direction=body.quantityDirection,
+        start_date=body.startDate,
+        end_date=body.endDate,
+    )
+
+
+@router.post("/purchases/direct", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
+async def get_procurement_direct_purchases(request: Request, body: ProcurementDirectPurchasesRequest):
+    """
+    Obtiene compras directas del tenant autenticado por API key.
+
+    **Scope requerido:** `purchases:read` o `read`
+    """
+    supplier_id = UUID(body.supplierId) if body.supplierId else None
+    return await public_api_service.get_procurement_direct_purchases(
+        request,
+        page=body.page,
+        limit=body.limit,
+        search=body.search,
+        status=body.status,
+        supplier_id=supplier_id,
+        date_filter=body.dateFilter,
+    )
+
+
+@router.post("/suppliers", dependencies=[Depends(require_module(Module.INTEGRACIONES))])
+async def get_procurement_suppliers(request: Request, body: ProcurementSuppliersRequest):
+    """
+    Obtiene proveedores del tenant autenticado por API key.
+
+    **Scope requerido:** `suppliers:read` o `read`
+    """
+    return await public_api_service.get_procurement_suppliers(
+        request,
+        page=body.page,
+        limit=body.limit,
+        search=body.search,
+        search_field=body.searchField,
+        is_active=body.isActive,
+        payment_terms=body.paymentTerms,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/direct_purchase_service.py
+++ b/app/services/direct_purchase_service.py
@@ -753,9 +753,9 @@ async def create_direct_purchase(
         )
 
 
-async def get_direct_purchases_list(
-    request: Request,
-    response: Response,
+async def _get_direct_purchases_for_tenant(
+    tenant_id: str,
+    *,
     page: int = 1,
     limit: int = 50,
     search: Optional[str] = None,
@@ -767,9 +767,6 @@ async def get_direct_purchases_list(
     Get list of direct purchases (is_direct_entry = TRUE) with tenant isolation
     """
     try:
-        session_context = require_valid_session(request)
-        tenant_id = session_context.tenant_id
-
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
 
@@ -889,6 +886,33 @@ async def get_direct_purchases_list(
         logger.error(f"Error in get_direct_purchases_list: {str(e)}")
         logger.exception(e)
         raise HTTPException(status_code=500, detail="Error interno del servidor")
+
+
+async def get_direct_purchases_list(
+    request: Request,
+    response: Response,
+    page: int = 1,
+    limit: int = 50,
+    search: Optional[str] = None,
+    status: Optional[str] = None,
+    supplier_id: Optional[UUID] = None,
+    date_filter: Optional[str] = None
+) -> Dict[str, Any]:
+    """
+    Get list of direct purchases for the current session tenant.
+    """
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+
+    return await _get_direct_purchases_for_tenant(
+        tenant_id,
+        page=page,
+        limit=limit,
+        search=search,
+        status=status,
+        supplier_id=supplier_id,
+        date_filter=date_filter
+    )
 
 
 async def get_direct_purchase_by_id(

--- a/app/services/public_api_service.py
+++ b/app/services/public_api_service.py
@@ -2,9 +2,10 @@
 Public API Service
 Handles data access for external integrations via API tokens
 """
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 from fastapi import Request
+from fastapi.encoders import jsonable_encoder
 from app.database import get_db_connection
 from app.core.middleware import get_api_key_context
 from app.core.exceptions import AuthenticationError, AuthorizationError, APIError
@@ -49,6 +50,28 @@ def validate_api_key_auth(request: Request, required_scope: str) -> tuple[str, s
         raise AuthorizationError(f"API key no tiene el permiso requerido: {required_scope}")
 
     return api_key_context.tenant_id, api_key_context.token_id
+
+
+def _with_procurement_metadata(
+    result: Any,
+    *,
+    resource: str,
+    required_scope: str,
+    filters: Dict[str, Any],
+    limitations: List[str],
+) -> Dict[str, Any]:
+    payload = jsonable_encoder(result)
+    if not isinstance(payload, dict):
+        payload = {"success": True, "data": payload}
+
+    payload["metadata"] = {
+        **payload.get("metadata", {}),
+        "resource": resource,
+        "required_scope": required_scope,
+        "filters": {key: value for key, value in filters.items() if value is not None},
+        "limitations": limitations,
+    }
+    return payload
 
 
 async def get_sales_list(
@@ -2189,6 +2212,187 @@ async def _customer_metrics_by_month(conn, where_clause, params, param_count, ti
         }
         for row in rows
     ]
+
+
+# ---------------------------------------------------------------------------
+# Procurement endpoints (read-only, API-key auth)
+# ---------------------------------------------------------------------------
+
+async def get_procurement_inventory_stock(
+    request: Request,
+    *,
+    limit: int = 250,
+    offset: int = 0,
+    search: Optional[str] = None,
+    status_filter: Optional[str] = None,
+    category: Optional[str] = None,
+    unit: Optional[str] = None,
+    sort_field: str = "current_stock",
+    sort_direction: str = "desc",
+) -> dict:
+    """Public API: current inventory stock (inventory:read)."""
+    from app.services.inventory_service import _get_inventory_stock_for_tenant
+
+    tenant_id, _ = validate_api_key_auth(request, "inventory:read")
+    result = await _get_inventory_stock_for_tenant(
+        tenant_id,
+        limit=limit,
+        offset=offset,
+        search=search,
+        status_filter=status_filter,
+        category=category,
+        unit=unit,
+        sort_field=sort_field,
+        sort_direction=sort_direction,
+    )
+    return _with_procurement_metadata(
+        result,
+        resource="inventory_stock",
+        required_scope="inventory:read",
+        filters={
+            "limit": limit,
+            "offset": offset,
+            "search": search,
+            "status_filter": status_filter,
+            "category": category,
+            "unit": unit,
+            "sort_field": sort_field,
+            "sort_direction": sort_direction,
+        },
+        limitations=[
+            "Operational stock listing only; use /v1/queries/run inventory_stock for flexible aggregations.",
+            "Read-only; does not reserve, adjust, or purchase inventory.",
+        ],
+    )
+
+
+async def get_procurement_inventory_movements(
+    request: Request,
+    *,
+    limit: int = 100,
+    offset: int = 0,
+    ingredient_id: Optional[UUID] = None,
+    movement_type: Optional[str] = None,
+    quantity_direction: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> dict:
+    """Public API: inventory movement history (inventory:read)."""
+    from app.services.inventory_service import _get_inventory_movements_for_tenant
+
+    tenant_id, _ = validate_api_key_auth(request, "inventory:read")
+    result = await _get_inventory_movements_for_tenant(
+        tenant_id,
+        limit=limit,
+        offset=offset,
+        ingredient_id=ingredient_id,
+        movement_type=movement_type,
+        quantity_direction=quantity_direction,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    return _with_procurement_metadata(
+        result,
+        resource="inventory_movements",
+        required_scope="inventory:read",
+        filters={
+            "limit": limit,
+            "offset": offset,
+            "ingredient_id": str(ingredient_id) if ingredient_id else None,
+            "movement_type": movement_type,
+            "quantity_direction": quantity_direction,
+            "start_date": start_date,
+            "end_date": end_date,
+        },
+        limitations=[
+            "Operational movement listing only; use /v1/queries/run inventory_movements for aggregations.",
+            "Read-only; movement adjustments are not available through public API keys.",
+        ],
+    )
+
+
+async def get_procurement_direct_purchases(
+    request: Request,
+    *,
+    page: int = 1,
+    limit: int = 50,
+    search: Optional[str] = None,
+    status: Optional[str] = None,
+    supplier_id: Optional[UUID] = None,
+    date_filter: Optional[str] = None,
+) -> dict:
+    """Public API: direct purchases listing (purchases:read)."""
+    from app.services.direct_purchase_service import _get_direct_purchases_for_tenant
+
+    tenant_id, _ = validate_api_key_auth(request, "purchases:read")
+    result = await _get_direct_purchases_for_tenant(
+        tenant_id,
+        page=page,
+        limit=limit,
+        search=search,
+        status=status,
+        supplier_id=supplier_id,
+        date_filter=date_filter,
+    )
+    return _with_procurement_metadata(
+        result,
+        resource="direct_purchases",
+        required_scope="purchases:read",
+        filters={
+            "page": page,
+            "limit": limit,
+            "search": search,
+            "status": status,
+            "supplier_id": str(supplier_id) if supplier_id else None,
+            "date_filter": date_filter,
+        },
+        limitations=[
+            "Direct purchase headers only; use /v1/queries/run purchase_items for item-level aggregations.",
+            "Read-only; purchase creation and receiving are not available through public API keys.",
+        ],
+    )
+
+
+async def get_procurement_suppliers(
+    request: Request,
+    *,
+    page: int = 1,
+    limit: int = 50,
+    search: Optional[str] = None,
+    search_field: Optional[str] = None,
+    is_active: Optional[bool] = None,
+    payment_terms: Optional[str] = None,
+) -> dict:
+    """Public API: suppliers listing (suppliers:read)."""
+    from app.services.suppliers_service import _get_suppliers_for_tenant
+
+    tenant_id, _ = validate_api_key_auth(request, "suppliers:read")
+    result = await _get_suppliers_for_tenant(
+        tenant_id,
+        page=page,
+        limit=limit,
+        search=search,
+        search_field=search_field,
+        is_active=is_active,
+        payment_terms=payment_terms,
+    )
+    return _with_procurement_metadata(
+        result,
+        resource="suppliers",
+        required_scope="suppliers:read",
+        filters={
+            "page": page,
+            "limit": limit,
+            "search": search,
+            "search_field": search_field,
+            "is_active": is_active,
+            "payment_terms": payment_terms,
+        },
+        limitations=[
+            "Supplier listing only; supplier creation and updates are not available through public API keys.",
+            "Commercial supplier details are tenant-scoped and require suppliers:read.",
+        ],
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/suppliers_service.py
+++ b/app/services/suppliers_service.py
@@ -18,9 +18,9 @@ from app.models.supplier import (
 
 logger = logging.getLogger(__name__)
 
-async def get_suppliers_list(
-    request: Request,
-    response: Response,
+async def _get_suppliers_for_tenant(
+    tenant_id: str,
+    *,
     page: int = 1,
     limit: int = 50,
     search: Optional[str] = None,
@@ -32,9 +32,6 @@ async def get_suppliers_list(
     Get suppliers list with tenant isolation following database governance
     """
     try:
-        session_context = require_valid_session(request)
-        tenant_id = session_context.tenant_id
-
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
 
@@ -171,6 +168,32 @@ async def get_suppliers_list(
     except Exception as e:
         logger.error(f"❌ Error fetching suppliers: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Error interno del servidor")
+
+async def get_suppliers_list(
+    request: Request,
+    response: Response,
+    page: int = 1,
+    limit: int = 50,
+    search: Optional[str] = None,
+    search_field: Optional[str] = None,
+    is_active: Optional[bool] = None,
+    payment_terms: Optional[str] = None
+) -> SuppliersListResponse:
+    """
+    Get suppliers list for the current session tenant.
+    """
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+
+    return await _get_suppliers_for_tenant(
+        tenant_id,
+        page=page,
+        limit=limit,
+        search=search,
+        search_field=search_field,
+        is_active=is_active,
+        payment_terms=payment_terms
+    )
 
 async def get_supplier_by_id(
     request: Request,

--- a/tests/test_public_api_queries.py
+++ b/tests/test_public_api_queries.py
@@ -1,9 +1,12 @@
 from unittest.mock import AsyncMock, patch
+from uuid import uuid4
 
 import pytest
 from fastapi import Request
 
 from app.routers import public_api
+from app.models.api_token import AVAILABLE_SCOPES
+from app.services import public_api_service
 
 
 def _request():
@@ -15,6 +18,16 @@ def test_public_api_registers_queries_routes():
 
     assert "/v1/queries/schema" in paths
     assert "/v1/queries/run" in paths
+
+
+def test_public_api_registers_procurement_routes():
+    paths = {route.path for route in public_api.router.routes}
+
+    assert "/v1/inventory/stock" in paths
+    assert "/v1/inventory/movements" in paths
+    assert "/v1/purchases/direct" in paths
+    assert "/v1/suppliers" in paths
+    assert "suppliers:read" in AVAILABLE_SCOPES
 
 
 @pytest.mark.asyncio
@@ -51,3 +64,157 @@ async def test_queries_run_endpoint_delegates_to_queries_service():
 
     run.assert_awaited_once_with(request, body.dict())
     assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_public_inventory_stock_uses_api_key_scope_without_session():
+    request = _request()
+    expected = {"success": True, "data": [], "total": 0}
+
+    with patch(
+        "app.services.public_api_service.validate_api_key_auth",
+        return_value=("tenant-1", "token-1"),
+    ) as auth, patch(
+        "app.services.inventory_service.require_valid_session",
+        side_effect=AssertionError("session auth should not be used"),
+    ), patch(
+        "app.services.inventory_service._get_inventory_stock_for_tenant",
+        new=AsyncMock(return_value=expected),
+    ) as core:
+        result = await public_api_service.get_procurement_inventory_stock(
+            request,
+            limit=25,
+            offset=5,
+            search="tom",
+            status_filter="low",
+            category="Verduras",
+            unit="gr",
+            sort_field="ingredient_name",
+            sort_direction="asc",
+        )
+
+    auth.assert_called_once_with(request, "inventory:read")
+    core.assert_awaited_once_with(
+        "tenant-1",
+        limit=25,
+        offset=5,
+        search="tom",
+        status_filter="low",
+        category="Verduras",
+        unit="gr",
+        sort_field="ingredient_name",
+        sort_direction="asc",
+    )
+    assert result["metadata"]["required_scope"] == "inventory:read"
+    assert result["metadata"]["resource"] == "inventory_stock"
+
+
+@pytest.mark.asyncio
+async def test_public_inventory_movements_route_delegates_stable_body():
+    ingredient_id = uuid4()
+    body = public_api.ProcurementInventoryMovementsRequest(
+        limit=30,
+        offset=2,
+        ingredientId=str(ingredient_id),
+        movementType="purchase",
+        quantityDirection="positive",
+        startDate="2026-01-01",
+        endDate="2026-01-31",
+    )
+    expected = {"success": True, "data": [], "metadata": {}}
+
+    with patch(
+        "app.routers.public_api.public_api_service.get_procurement_inventory_movements",
+        new=AsyncMock(return_value=expected),
+    ) as service:
+        request = _request()
+        result = await public_api.get_procurement_inventory_movements(request, body)
+
+    service.assert_awaited_once_with(
+        request,
+        limit=30,
+        offset=2,
+        ingredient_id=ingredient_id,
+        movement_type="purchase",
+        quantity_direction="positive",
+        start_date="2026-01-01",
+        end_date="2026-01-31",
+    )
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_public_direct_purchases_uses_api_key_scope_without_session():
+    request = _request()
+    supplier_id = uuid4()
+
+    with patch(
+        "app.services.public_api_service.validate_api_key_auth",
+        return_value=("tenant-1", "token-1"),
+    ) as auth, patch(
+        "app.services.direct_purchase_service.require_valid_session",
+        side_effect=AssertionError("session auth should not be used"),
+    ), patch(
+        "app.services.direct_purchase_service._get_direct_purchases_for_tenant",
+        new=AsyncMock(return_value={"success": True, "data": [], "total": 0}),
+    ) as core:
+        result = await public_api_service.get_procurement_direct_purchases(
+            request,
+            page=2,
+            limit=10,
+            search="fact",
+            status="received",
+            supplier_id=supplier_id,
+            date_filter="last_week",
+        )
+
+    auth.assert_called_once_with(request, "purchases:read")
+    core.assert_awaited_once_with(
+        "tenant-1",
+        page=2,
+        limit=10,
+        search="fact",
+        status="received",
+        supplier_id=supplier_id,
+        date_filter="last_week",
+    )
+    assert result["metadata"]["required_scope"] == "purchases:read"
+    assert result["metadata"]["resource"] == "direct_purchases"
+
+
+@pytest.mark.asyncio
+async def test_public_suppliers_uses_api_key_scope_without_session():
+    request = _request()
+
+    with patch(
+        "app.services.public_api_service.validate_api_key_auth",
+        return_value=("tenant-1", "token-1"),
+    ) as auth, patch(
+        "app.services.suppliers_service.require_valid_session",
+        side_effect=AssertionError("session auth should not be used"),
+    ), patch(
+        "app.services.suppliers_service._get_suppliers_for_tenant",
+        new=AsyncMock(return_value={"success": True, "data": [], "total": 0}),
+    ) as core:
+        result = await public_api_service.get_procurement_suppliers(
+            request,
+            page=1,
+            limit=20,
+            search="acme",
+            search_field="name",
+            is_active=True,
+            payment_terms="30 dias",
+        )
+
+    auth.assert_called_once_with(request, "suppliers:read")
+    core.assert_awaited_once_with(
+        "tenant-1",
+        page=1,
+        limit=20,
+        search="acme",
+        search_field="name",
+        is_active=True,
+        payment_terms="30 dias",
+    )
+    assert result["metadata"]["required_scope"] == "suppliers:read"
+    assert result["metadata"]["resource"] == "suppliers"


### PR DESCRIPTION
## Summary
- add API-key-only /v1 wrappers for inventory stock, inventory movements, direct purchases, and suppliers
- extract tenant-core list functions for direct purchases and suppliers while preserving session wrappers
- add suppliers:read scope and focused auth/route tests

## Tests
- pytest tests/test_inventory.py tests/test_public_api_queries.py tests/test_queries_service.py

Closes #504