### PR TITLE
Allow invoice email without local PDF

### DIFF
--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -3,8 +3,8 @@ Documents Router — bridge to api-facturacion (issue #129)
 
 Document management: list, PDF/XML download, and email send.
 
-GET  /  and GET /{track_id}/pdf and GET /{track_id}/xml are live —
-they read electronic_invoices directly from DB and generate R2 presigned URLs.
+GET  /  and GET /{track_id}/xml read electronic_invoices directly from DB.
+GET  /{track_id}/pdf uses R2 first and can fall back to Matias via api-facturacion.
 
 POST /{track_id}/resend-email and POST /{track_id}/send-email-to proxy
 to api-facturacion which talks to Matias. Both enforce tenant ownership

--- a/app/services/facturacion_service.py
+++ b/app/services/facturacion_service.py
@@ -8,11 +8,13 @@ Endpoints proxied:
   POST /invoice/emit          → emit_invoice()
   GET  electronic_invoices DB → get_order_invoice(), get_dian_status()
   GET  electronic_invoices DB → get_documents_list()
-  GET  R2 presigned URL       → get_document_pdf_url(), get_document_xml_url()
+  GET  R2/Matias PDF URL      → get_document_pdf_url()
+  GET  R2 presigned XML URL   → get_document_xml_url()
   Generic proxy helper        → proxy_to_facturacion()
 
-DB-only functions do NOT call api-facturacion — they read electronic_invoices
-directly and generate R2 presigned URLs locally (api-warolabs has R2 credentials).
+Most read functions use electronic_invoices directly and generate R2 presigned URLs
+locally. PDF download may ask api-facturacion for its Matias fallback when R2 has
+not stored the artifact yet.
 """
 import httpx
 import logging
@@ -311,10 +313,11 @@ async def get_document_pdf_url(
     tenant_id: str,
 ) -> Optional[str]:
     """
-    Return a fresh R2 presigned URL for the PDF of an invoice.
+    Return a fresh URL for the PDF of an invoice.
 
     track_id maps to electronic_invoices.id (UUID primary key).
-    Returns None if the invoice has no PDF yet.
+    Uses R2 first, then api-facturacion's Matias fallback when R2 has no PDF yet.
+    Returns None if neither source can provide a URL.
     Raises HTTPException 404 if the invoice record does not exist.
     """
     async with get_db_connection(use_transaction=False) as conn:
@@ -328,15 +331,27 @@ async def get_document_pdf_url(
     if not row:
         raise HTTPException(status_code=404, detail="Invoice not found")
 
-    if not row['r2_pdf_key']:
-        return None
+    if row['r2_pdf_key']:
+        try:
+            s3 = AWSS3Service()
+            return await s3.get_presigned_url(row['r2_pdf_key'], expiration=3600)
+        except Exception as exc:
+            logger.warning(f"Could not generate PDF presigned URL for invoice {track_id}: {exc}")
 
     try:
-        s3 = AWSS3Service()
-        return await s3.get_presigned_url(row['r2_pdf_key'], expiration=3600)
-    except Exception as exc:
-        logger.warning(f"Could not generate PDF presigned URL for invoice {track_id}: {exc}")
-        return None
+        fallback = await proxy_to_facturacion(
+            method='GET',
+            path=f'/documents/{track_id}/pdf',
+            timeout=30.0,
+        )
+    except HTTPException as exc:
+        if exc.status_code in (404, 422):
+            logger.info(f"PDF fallback unavailable for invoice {track_id}: {exc.detail}")
+            return None
+        raise
+
+    pdf_url = fallback.get('pdf_url') or fallback.get('url')
+    return str(pdf_url) if pdf_url else None
 
 
 async def get_document_xml_url(

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -3765,13 +3765,13 @@ async def send_invoice_email(
     Send the WARO-branded receipt email for an order's accepted invoice (warocol.com#603).
 
     Loads the order header + items + invoice + tenant business profile from DB
-    (single connection, sequential reads), validates the invoice is accepted and
-    has a PDF available in R2, then dispatches the existing `send_pos_receipt_email`
-    helper which handles SES + template + PDF/XML attachment.
+    (single connection, sequential reads), validates the invoice is accepted,
+    then dispatches the existing `send_pos_receipt_email` helper which handles
+    SES + template + optional PDF/XML attachment.
 
     Raises:
         HTTPException 404 — order not found for the session tenant
-        HTTPException 422 — no invoice / invoice not accepted / PDF not available
+        HTTPException 422 — no invoice / invoice not accepted
         HTTPException 502 — SES rejected the send
     """
     session_context = require_valid_session(request)
@@ -3791,7 +3791,8 @@ async def send_invoice_email(
         if not order_row:
             raise HTTPException(status_code=404, detail="Order not found")
 
-        # 2. Invoice header — must exist, be accepted, and have a PDF available.
+        # 2. Invoice header — must exist and be accepted. PDF attachment is optional:
+        # accepted Matias invoices may exist before the local R2 PDF key is stored.
         invoice_row = await conn.fetchrow(
             """SELECT prefix, invoice_number, cufe, status, r2_pdf_key
                FROM electronic_invoices
@@ -3809,11 +3810,6 @@ async def send_invoice_email(
             raise HTTPException(
                 status_code=422,
                 detail="La factura debe estar aceptada por DIAN para poder enviarla por correo.",
-            )
-        if not invoice_row['r2_pdf_key']:
-            raise HTTPException(
-                status_code=422,
-                detail="El PDF de la factura aún no está disponible. Reintentá en unos segundos.",
             )
 
         # 3. Tax breakdown — net line base matches GL / cierre_service.

--- a/tests/test_document_email.py
+++ b/tests/test_document_email.py
@@ -20,6 +20,7 @@ import pytest
 from fastapi import HTTPException
 
 from app.routers import documents as documents_router
+from app.services import facturacion_service
 
 
 _TENANT_ID = UUID('93b3e582-34fa-44a6-8d0f-bf82a3608727')
@@ -44,6 +45,13 @@ class _ConnCtx:
 def _patch_db_returns(row):
     return patch(
         'app.routers.documents.get_db_connection',
+        lambda *args, **kwargs: _ConnCtx(row),
+    )
+
+
+def _patch_facturacion_db_returns(row):
+    return patch(
+        'app.services.facturacion_service.get_db_connection',
         lambda *args, **kwargs: _ConnCtx(row),
     )
 
@@ -74,6 +82,48 @@ def _patch_httpx(status_code: int = 200, body: dict = None):
         'app.services.facturacion_service.httpx.AsyncClient',
         return_value=client,
     ), client
+
+
+# ── PDF fallback ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_document_pdf_uses_matias_fallback_when_r2_missing():
+    """Owned invoice without R2 PDF → gateway returns api-facturacion fallback URL."""
+    with _patch_facturacion_db_returns({'status': 'accepted', 'r2_pdf_key': None}), patch(
+        'app.services.facturacion_service.proxy_to_facturacion',
+        new=AsyncMock(return_value={
+            'pdf_url': 'https://matias.example/document.pdf',
+            'source': 'matias',
+            'expires_in': None,
+        }),
+    ) as proxy_mock:
+        pdf_url = await facturacion_service.get_document_pdf_url(
+            str(_TRACK_ID),
+            str(_TENANT_ID),
+        )
+
+    assert pdf_url == 'https://matias.example/document.pdf'
+    proxy_mock.assert_awaited_once_with(
+        method='GET',
+        path=f'/documents/{_TRACK_ID}/pdf',
+        timeout=30.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_document_pdf_returns_none_when_fallback_has_no_url():
+    """Owned invoice without R2 PDF and no Matias URL → existing 404 route behavior remains."""
+    with _patch_facturacion_db_returns({'status': 'accepted', 'r2_pdf_key': None}), patch(
+        'app.services.facturacion_service.proxy_to_facturacion',
+        new=AsyncMock(return_value={'pdf_url': None, 'source': 'matias'}),
+    ):
+        pdf_url = await facturacion_service.get_document_pdf_url(
+            str(_TRACK_ID),
+            str(_TENANT_ID),
+        )
+
+    assert pdf_url is None
 
 
 # ── resend-email ─────────────────────────────────────────────────────────────

--- a/tests/test_invoice_send_email.py
+++ b/tests/test_invoice_send_email.py
@@ -219,24 +219,55 @@ async def test_send_invoice_email_rejects_non_accepted():
 # ── Missing PDF (r2_pdf_key is null) ─────────────────────────────────────────
 
 @pytest.mark.asyncio
-async def test_send_invoice_email_rejects_missing_pdf():
-    """Invoice accepted but r2_pdf_key is NULL → 422, no email sent."""
+async def test_send_invoice_email_allows_missing_pdf():
+    """Invoice accepted but r2_pdf_key is NULL → email still sends."""
     request = MagicMock()
     helper_mock = AsyncMock(return_value=True)
 
     with _patch_session(), _patch_db(
-        fetchrow=[_order_row(), _invoice_row(r2_pdf_key=None)],
-        fetch=[],
-    ), patch(
+        fetchrow=[_order_row(), _invoice_row(r2_pdf_key=None), _waro_inferred_row(), _profile_row()],
+        fetch=[
+            [],
+            [],
+            [],
+            [{'id': uuid4(), 'quantity': 1, 'subtotal': 200.0, 'product_name': 'tomate barranca'}],
+            [],
+        ],
+    ), _patch_tax(), patch(
         'app.services.orders_service.send_pos_receipt_email',
         new=helper_mock,
+    ):
+        result = await orders_service.send_invoice_email(request, _ORDER_ID, _RECIPIENT)
+
+    assert result == {'success': True, 'sent_to': _RECIPIENT}
+    helper_mock.assert_awaited_once()
+    assert helper_mock.await_args.kwargs['invoice_prefix'] == 'LZT'
+    assert helper_mock.await_args.kwargs['invoice_number'] == 5462
+
+
+@pytest.mark.asyncio
+async def test_send_invoice_email_missing_pdf_still_surfaces_ses_failure():
+    """Missing local PDF does not mask real SES/provider failures."""
+    request = MagicMock()
+
+    with _patch_session(), _patch_db(
+        fetchrow=[_order_row(), _invoice_row(r2_pdf_key=None), _waro_inferred_row(), _profile_row()],
+        fetch=[
+            [],
+            [],
+            [],
+            [{'id': uuid4(), 'quantity': 1, 'subtotal': 200.0, 'product_name': 'tomate barranca'}],
+            [],
+        ],
+    ), _patch_tax(), patch(
+        'app.services.orders_service.send_pos_receipt_email',
+        new=AsyncMock(return_value=False),
     ):
         with pytest.raises(HTTPException) as exc_info:
             await orders_service.send_invoice_email(request, _ORDER_ID, _RECIPIENT)
 
-    assert exc_info.value.status_code == 422
-    assert 'pdf' in exc_info.value.detail.lower()
-    helper_mock.assert_not_awaited()
+    assert exc_info.value.status_code == 502
+    assert 'no se pudo' in exc_info.value.detail.lower()
 
 
 # ── SES failure ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- allow accepted invoice emails to send when the local R2 PDF key is missing
- add Matias fallback resolution for document PDF URLs through api-facturacion
- update regression coverage for missing-PDF invoice email and PDF fallback behavior

## Tests
- pytest tests/test_invoice_send_email.py
- pytest tests/test_document_email.py

Refs uno0uno/warocol.com#1441