### PR TITLE
Persist Matias companyId in tenant fiscal config

### DIFF
--- a/app/routers/tenant_config.py
+++ b/app/routers/tenant_config.py
@@ -3,6 +3,7 @@ Tenant configuration router - admin endpoints for managing public profiles
 Authentication required
 """
 from datetime import date as _date
+from uuid import UUID
 from asyncpg.exceptions import UniqueViolationError
 from fastapi import APIRouter, Depends, Request, Body, HTTPException
 from fastapi.responses import JSONResponse
@@ -182,6 +183,26 @@ def _normalize_receipt_tip_label(raw) -> str:
     return label
 
 
+def _normalize_matias_company_id(data: dict) -> Optional[str]:
+    raw = data.get('matias_company_id')
+    if raw is None and 'companyId' in data:
+        raw = data.get('companyId')
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        raise HTTPException(status_code=400, detail='Matias companyId must be a valid UUID string')
+
+    value = raw.strip()
+    if not value:
+        return None
+
+    try:
+        UUID(value)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail='Matias companyId must be a valid UUID') from exc
+    return value
+
+
 @router.get("/fiscal-data", dependencies=[Depends(require_module(Module.MI_NEGOCIO))])
 async def get_fiscal_data(request: Request):
     """
@@ -220,6 +241,7 @@ async def get_fiscal_data(request: Request):
             'city_id': row['city_id'],
             'phone': row['phone'],
             'email': row['email'],
+            'matias_company_id': row['matias_company_id'],
             'receipt_document_label': _normalize_receipt_document_label(row['receipt_document_label']),
             'receipt_tip_label': _normalize_receipt_tip_label(row.get('receipt_tip_label')),
             'show_logo_on_receipts': row['show_logo_on_receipts']
@@ -243,14 +265,16 @@ async def update_fiscal_data(request: Request, data: dict = Body(...)):
     document_label = _normalize_receipt_document_label(data.get('receipt_document_label'))
     tip_label = _normalize_receipt_tip_label(data.get('receipt_tip_label'))
     show_logo = bool(data.get('show_logo_on_receipts', True))
+    matias_company_id = _normalize_matias_company_id(data)
 
     async with get_db_connection() as conn:
         await conn.execute(
             """INSERT INTO tenant_fiscal_data (tenant_id, nit, business_name,
                    type_organization_id, tax_regime_id, tax_level_id,
                    fiscal_address, city, city_id, phone, email,
-                   receipt_document_label, receipt_tip_label, show_logo_on_receipts, updated_at)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, now())
+                   matias_company_id, receipt_document_label, receipt_tip_label,
+                   show_logo_on_receipts, updated_at)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, now())
                ON CONFLICT (tenant_id) DO UPDATE SET
                    nit = EXCLUDED.nit,
                    business_name = EXCLUDED.business_name,
@@ -262,6 +286,7 @@ async def update_fiscal_data(request: Request, data: dict = Body(...)):
                    city_id = EXCLUDED.city_id,
                    phone = EXCLUDED.phone,
                    email = EXCLUDED.email,
+                   matias_company_id = EXCLUDED.matias_company_id,
                    receipt_document_label = EXCLUDED.receipt_document_label,
                    receipt_tip_label = EXCLUDED.receipt_tip_label,
                    show_logo_on_receipts = EXCLUDED.show_logo_on_receipts,
@@ -277,6 +302,7 @@ async def update_fiscal_data(request: Request, data: dict = Body(...)):
             data.get('city_id', 149),
             data.get('phone'),
             data.get('email'),
+            matias_company_id,
             document_label,
             tip_label,
             show_logo,

--- a/dbdoc/public.tenant_fiscal_data.md
+++ b/dbdoc/public.tenant_fiscal_data.md
@@ -16,6 +16,7 @@
 | city_id | integer | 149 | true |  |  |  |
 | phone | varchar(20) |  | true |  |  |  |
 | email | varchar(200) |  | true |  |  |  |
+| matias_company_id | text |  | true |  |  | Matias Casa de Software customer companyId UUID for this tenant; not the WARO tenant_id. |
 | created_at | timestamp with time zone | now() | false |  |  |  |
 | updated_at | timestamp with time zone | now() | false |  |  |  |
 

--- a/migrations/093_matias_company_id.sql
+++ b/migrations/093_matias_company_id.sql
@@ -1,0 +1,7 @@
+-- Migration 093: persist Matias Casa de Software companyId per tenant
+
+ALTER TABLE tenant_fiscal_data
+    ADD COLUMN IF NOT EXISTS matias_company_id TEXT NULL;
+
+COMMENT ON COLUMN tenant_fiscal_data.matias_company_id IS
+    'Matias Casa de Software customer companyId UUID for this tenant; not the WARO tenant_id.';

--- a/tests/test_mi_negocio_permissions.py
+++ b/tests/test_mi_negocio_permissions.py
@@ -115,7 +115,7 @@ def test_admin_role_denied_mi_negocio_under_enforce():
         Module.POS, Module.VENTAS, Module.DESPACHO, Module.MENU,
         Module.OPERACIONES, Module.ABASTECIMIENTO, Module.ANALITICA,
         Module.FINANZAS, Module.FACTURACION, Module.INTEGRACIONES,
-        Module.MI_PLAN, Module.EVENTOS,
+        Module.MI_PLAN,
     })
 
     with patch("app.core.middleware.get_session_context", return_value=session), \

--- a/tests/test_tenant_fiscal_data.py
+++ b/tests/test_tenant_fiscal_data.py
@@ -1,0 +1,154 @@
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.routers.tenant_config import router as tenant_config_router
+
+
+@pytest.fixture(autouse=True)
+def _clear_permission_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_session():
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "owner@example.com",
+        "name": "Owner",
+        "expires_at": None,
+        "is_active": True,
+        "role": "owner",
+    })
+
+
+def _enforce_db_ctx():
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+    return _ctx
+
+
+def _fiscal_row(**overrides):
+    row = {
+        "nit": "900123456",
+        "business_name": "Waro Test SAS",
+        "type_organization_id": 1,
+        "tax_regime_id": 2,
+        "tax_level_id": 5,
+        "fiscal_address": "Cra 1 # 2-3",
+        "city": "Bogota",
+        "city_id": 149,
+        "phone": "3001234567",
+        "email": "facturacion@example.com",
+        "matias_company_id": None,
+        "receipt_document_label": "Prefactura",
+        "receipt_tip_label": "Propina",
+        "show_logo_on_receipts": True,
+    }
+    row.update(overrides)
+    return row
+
+
+def _build_app():
+    app = FastAPI()
+    app.include_router(tenant_config_router, prefix="/api/tenant")
+    return app
+
+
+def test_get_fiscal_data_returns_nullable_matias_company_id():
+    session = _build_session()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_fiscal_row(matias_company_id=None))
+
+    @asynccontextmanager
+    async def fiscal_db_ctx():
+        yield conn
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.database.get_db_connection", return_value=fiscal_db_ctx()):
+        response = TestClient(_build_app()).get("/api/tenant/fiscal-data")
+
+    assert response.status_code == 200
+    assert response.json()["data"]["matias_company_id"] is None
+
+
+def test_put_fiscal_data_persists_company_id_alias():
+    session = _build_session()
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    company_id = "8d4f2f79-4a4e-4d7d-bf07-7bd61c9e4f37"
+
+    @asynccontextmanager
+    async def fiscal_db_ctx():
+        yield conn
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.database.get_db_connection", return_value=fiscal_db_ctx()):
+        response = TestClient(_build_app()).put(
+            "/api/tenant/fiscal-data",
+            json={
+                "nit": "900123456",
+                "business_name": "Waro Test SAS",
+                "companyId": f"  {company_id}  ",
+            },
+        )
+
+    assert response.status_code == 200
+    execute_args = conn.execute.await_args.args
+    assert "matias_company_id" in execute_args[0]
+    assert execute_args[12] == company_id
+
+
+def test_put_fiscal_data_normalizes_blank_matias_company_id_to_null():
+    session = _build_session()
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+
+    @asynccontextmanager
+    async def fiscal_db_ctx():
+        yield conn
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.database.get_db_connection", return_value=fiscal_db_ctx()):
+        response = TestClient(_build_app()).put(
+            "/api/tenant/fiscal-data",
+            json={"nit": "900123456", "matias_company_id": "   "},
+        )
+
+    assert response.status_code == 200
+    assert conn.execute.await_args.args[12] is None
+
+
+def test_put_fiscal_data_rejects_invalid_matias_company_id():
+    session = _build_session()
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()):
+        response = TestClient(_build_app()).put(
+            "/api/tenant/fiscal-data",
+            json={"matias_company_id": "not-a-waro-tenant-id"},
+        )
+
+    assert response.status_code == 400
+    assert "Matias companyId" in response.json()["detail"]


### PR DESCRIPTION
## Summary
- add nullable tenant_fiscal_data.matias_company_id migration and dbdoc entry
- expose matias_company_id through GET/PUT /api/tenant/fiscal-data with optional UUID validation
- add focused fiscal-data API tests and repair stale MI_NEGOCIO enum fixture

## Tests
- pytest tests/test_tenant_fiscal_data.py
- pytest tests/test_mi_negocio_permissions.py

Closes #513