### PR TITLE
Harden Matias companyId readiness

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -109,6 +109,7 @@ class Settings(BaseSettings):
     # Matias environment label for /facturacion-status (mirrors api_facturacion)
     matias_environment_id: int = Field(default=2, alias='MATIAS_ENVIRONMENT_ID')
     matias_habilitacion_tenant_ids: str = Field(default='', alias='MATIAS_HABILITACION_TENANT_IDS')
+    matias_sandbox_tenant_ids: str = Field(default='', alias='MATIAS_SANDBOX_TENANT_IDS')
 
     # warocol.com#596 — grace window for the "ya validado" short-circuit in
     # emit_invoice. A repeated emit on a rejected-as-validado order is 409'd

--- a/app/core/matias_environment.py
+++ b/app/core/matias_environment.py
@@ -16,17 +16,40 @@ def _habilitacion_tenant_keys() -> Set[str]:
     return {part.strip().lower() for part in raw.split(",") if part.strip()}
 
 
+def _sandbox_tenant_keys() -> Set[str]:
+    raw = (settings.matias_sandbox_tenant_ids or "").strip()
+    if not raw:
+        return set()
+    return {part.strip().lower() for part in raw.split(",") if part.strip()}
+
+
+def _tenant_in_keys(
+    tenant_id: Union[str, UUID],
+    keys: Set[str],
+    tenant_slug: Optional[str] = None,
+) -> bool:
+    if not keys:
+        return False
+    tenant_key = str(tenant_id).lower()
+    if tenant_key in keys:
+        return True
+    return bool(tenant_slug and tenant_slug.lower() in keys)
+
+
+def matias_sandbox_for_tenant(
+    tenant_id: Union[str, UUID],
+    tenant_slug: Optional[str] = None,
+) -> bool:
+    """True when this tenant is routed through the Matias sandbox host."""
+    return _tenant_in_keys(tenant_id, _sandbox_tenant_keys(), tenant_slug)
+
+
 def matias_environment_for_tenant(
     tenant_id: Union[str, UUID],
     tenant_slug: Optional[str] = None,
 ) -> int:
-    keys = _habilitacion_tenant_keys()
-    if keys:
-        tenant_key = str(tenant_id).lower()
-        if tenant_key in keys:
-            return _HABILITACION_ENV
-        if tenant_slug and tenant_slug.lower() in keys:
-            return _HABILITACION_ENV
+    if _tenant_in_keys(tenant_id, _habilitacion_tenant_keys(), tenant_slug):
+        return _HABILITACION_ENV
     return settings.matias_environment_id
 
 

--- a/app/services/invoicing_readiness_service.py
+++ b/app/services/invoicing_readiness_service.py
@@ -2,7 +2,7 @@
 Invoicing readiness service — issue #130
 
 Single source of truth for "can this tenant emit electronic invoices right now?"
-Four predicates must all be true:
+Five predicates must all be true:
 
   1. dev_flag_enabled       — tenants.electronic_invoicing_enabled = true
                               (dev-only kill switch, set via SQL during onboarding)
@@ -12,28 +12,23 @@ Four predicates must all be true:
                               is_active=true, valid date range, available numbers,
                               and document_type='invoice'
   4. taxes_configured       — tenant_tax_config has at least one of inc_applicable
-                              or iva_applicable set to true,
-                              OR tenant is "no responsable de IVA"
-                              (tenant_fiscal_data.tax_regime_id = 2,
-                              Art. 437 parágrafo 3 ET).
+                              or iva_applicable set to true.
+  5. matias_company_id_configured
+                            — production Matias Casa de Software emissions have
+                              tenant_fiscal_data.matias_company_id configured.
+                              Sandbox and habilitación tenants are exempt.
 
-About taxes_configured (relaxed in this iteration of #130):
+About the no-responsable bypass that was here briefly:
 
-  DIAN Resolución 000165 de 2023 + Art. 437 parágrafo 3 ET allow tenants
-  classified as "no responsable de IVA" to emit electronic invoices WITHOUT
-  any IVA line. The factura must instead carry the legal note
-  "No responsable de IVA — Art. 437 parágrafo 3 ET". For those tenants,
-  emitting without INC or IVA configured is the correct behaviour, not a
-  misconfiguration.
+  Earlier iteration relaxed taxes_configured to allow tax_regime_id=2 (no
+  responsable de IVA) to emit without INC/IVA. Empirical testing on
+  2026-04-29 (LZT-3995/3996/3997) showed Matías does NOT return PDF or
+  AttachedDocument when the factura has no tax line, so the customer
+  email goes out without the PDF attachment — degraded UX.
 
-  For tenants who ARE responsible for IVA (tax_regime_id = 1) we keep the
-  stricter check: at least one of INC or IVA must be applicable. Restaurants
-  in the hospitality sector almost always cobrar at least one of the two,
-  so emitting with both off remains a misconfiguration we want to block.
-
-  Two follow-up scenarios are tracked separately and NOT covered here:
-    - Responsable de IVA que vende solo bienes excluidos (Art. 424 ET)
-    - Bienes exentos con tarifa 0% (Art. 477 / 481 ET)
+  Decision (issue #135): require INC or IVA always. A tenant who is
+  legitimately no-responsable can either toggle IVA at 19% or wait until
+  /status/zip polling is implemented (separate work).
 
 Returned shape (this is the public contract — frontend issue uno0uno/warocol.com#450
 and microservice gate uno0uno/api-facturacion#17 must consume the same JSON):
@@ -45,6 +40,7 @@ and microservice gate uno0uno/api-facturacion#17 must consume the same JSON):
         "fiscal_data_complete": bool,
         "active_resolution":    bool,
         "taxes_configured":     bool,
+        "matias_company_id_configured": bool,
       },
       "missing": [str, ...],   # human-readable Spanish reasons
     }
@@ -52,23 +48,19 @@ and microservice gate uno0uno/api-facturacion#17 must consume the same JSON):
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
+from app.core.matias_environment import matias_environment_for_tenant, matias_sandbox_for_tenant
 from app.database import get_db_connection
-
-
-# tax_regime_id values in tenant_fiscal_data (catalog mirrored in pages/facturacion.vue):
-#   1 = Responsable de IVA
-#   2 = No responsable del impuesto (Art. 437 parágrafo 3 ET)
-TAX_REGIME_NO_RESPONSABLE = 2
 
 
 _READINESS_QUERY = """
 SELECT
     t.electronic_invoicing_enabled  AS dev_flag_enabled,
+    t.slug                          AS tenant_slug,
     fd.nit                          AS nit,
     fd.business_name                AS business_name,
     fd.phone                        AS phone,
     fd.email                        AS email,
-    fd.tax_regime_id                AS tax_regime_id,
+    fd.matias_company_id            AS matias_company_id,
     COALESCE(ttc.inc_applicable, false) AS inc_applicable,
     COALESCE(ttc.iva_applicable, false) AS iva_applicable,
     EXISTS (
@@ -101,9 +93,16 @@ async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
     dev_flag_enabled  = bool(row['dev_flag_enabled'])
     active_resolution = bool(row['active_resolution'])
 
-    is_no_responsable = row['tax_regime_id'] == TAX_REGIME_NO_RESPONSABLE
-    has_any_tax = bool(row['inc_applicable']) or bool(row['iva_applicable'])
-    taxes_configured = has_any_tax or is_no_responsable
+    taxes_configured = bool(row['inc_applicable']) or bool(row['iva_applicable'])
+    requires_matias_company_id = (
+        matias_environment_for_tenant(tenant_id, row['tenant_slug']) == 1
+        and not matias_sandbox_for_tenant(tenant_id, row['tenant_slug'])
+    )
+    matias_company_id = row['matias_company_id']
+    matias_company_id_configured = (
+        not requires_matias_company_id
+        or bool(matias_company_id and str(matias_company_id).strip())
+    )
 
     missing_fiscal_fields: List[str] = []
     if row['nit'] is None:
@@ -126,21 +125,26 @@ async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
     if not active_resolution:
         missing.append('No hay una resolución DIAN vigente con numeración disponible')
     if not taxes_configured:
-        # Only reachable when the tenant IS responsable de IVA (regime != 2)
-        # and has neither INC nor IVA applicable — that is the misconfiguration
-        # we want to block for the hospitality use case.
+        missing.append('No hay impuestos configurados (activa INC o IVA en Configuración fiscal)')
+    if not matias_company_id_configured:
         missing.append(
-            'No hay impuestos configurados (activa INC o IVA en Configuración fiscal,'
-            ' o cambia el régimen tributario a "No responsable" si aplica)'
+            'Falta UUID cliente Matias (companyId) para emitir en producción'
         )
 
     return {
-        'ready': dev_flag_enabled and fiscal_data_complete and active_resolution and taxes_configured,
+        'ready': (
+            dev_flag_enabled
+            and fiscal_data_complete
+            and active_resolution
+            and taxes_configured
+            and matias_company_id_configured
+        ),
         'checks': {
             'dev_flag_enabled':     dev_flag_enabled,
             'fiscal_data_complete': fiscal_data_complete,
             'active_resolution':    active_resolution,
             'taxes_configured':     taxes_configured,
+            'matias_company_id_configured': matias_company_id_configured,
         },
         'missing': missing,
     }

--- a/sql/20260623_matias_company_id.sql
+++ b/sql/20260623_matias_company_id.sql
@@ -1,0 +1,5 @@
+ALTER TABLE tenant_fiscal_data
+  ADD COLUMN IF NOT EXISTS matias_company_id text;
+
+COMMENT ON COLUMN tenant_fiscal_data.matias_company_id IS
+  'Matias Casa de Software customer companyId UUID for this tenant; not the WARO tenant_id.';

--- a/tests/test_invoicing_readiness.py
+++ b/tests/test_invoicing_readiness.py
@@ -19,22 +19,24 @@ _TENANT_ID = UUID('93b3e582-34fa-44a6-8d0f-bf82a3608727')
 
 def _row(
     dev_flag_enabled: bool = True,
+    tenant_slug: str = 'acme-sas',
     nit: str = '900123456',
     business_name: str = 'ACME SAS',
     phone: str = '3001234567',
     email: str = 'contacto@acme.co',
+    matias_company_id: str = '8d4f2f79-4a4e-4d7d-bf07-7bd61c9e4f37',
     active_resolution: bool = True,
     inc_applicable: bool = False,
     iva_applicable: bool = True,
-    tax_regime_id: int = 1,   # 1 = Responsable de IVA, 2 = No responsable
 ):
     return {
         'dev_flag_enabled':  dev_flag_enabled,
+        'tenant_slug':       tenant_slug,
         'nit':               nit,
         'business_name':     business_name,
         'phone':             phone,
         'email':             email,
-        'tax_regime_id':     tax_regime_id,
+        'matias_company_id':  matias_company_id,
         'active_resolution': active_resolution,
         'inc_applicable':    inc_applicable,
         'iva_applicable':    iva_applicable,
@@ -65,7 +67,7 @@ class TestReadinessService:
     """Unit tests for `invoicing_readiness_service.get_readiness`."""
 
     @pytest.mark.asyncio
-    async def test_happy_path_all_four_checks_true(self):
+    async def test_happy_path_all_five_checks_true(self):
         with _patch_db(_row()):
             payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
 
@@ -76,6 +78,7 @@ class TestReadinessService:
             'fiscal_data_complete': True,
             'active_resolution':    True,
             'taxes_configured':     True,
+            'matias_company_id_configured': True,
         }
         assert payload['missing'] == []
 
@@ -90,8 +93,7 @@ class TestReadinessService:
 
     @pytest.mark.asyncio
     async def test_responsable_without_taxes_blocks_ready(self):
-        # Responsable de IVA (regime=1) without INC and without IVA → still blocks
-        with _patch_db(_row(inc_applicable=False, iva_applicable=False, tax_regime_id=1)):
+        with _patch_db(_row(inc_applicable=False, iva_applicable=False)):
             payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
 
         assert payload['checks']['taxes_configured'] is False
@@ -99,14 +101,56 @@ class TestReadinessService:
         assert any('impuestos configurados' in m for m in payload['missing'])
 
     @pytest.mark.asyncio
-    async def test_no_responsable_passes_without_taxes(self):
-        # No responsable de IVA (regime=2) emits without INC/IVA — Art. 437 ET parágrafo 3
-        with _patch_db(_row(inc_applicable=False, iva_applicable=False, tax_regime_id=2)):
+    async def test_no_responsable_without_taxes_still_blocks_ready(self):
+        with _patch_db(_row(inc_applicable=False, iva_applicable=False)):
             payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
 
-        assert payload['checks']['taxes_configured'] is True
+        assert payload['checks']['taxes_configured'] is False
+        assert payload['ready'] is False
+        assert any('impuestos configurados' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_production_missing_matias_company_id_blocks_ready(self, monkeypatch):
+        from app import config as config_module
+
+        monkeypatch.setattr(config_module.settings, 'matias_environment_id', 1)
+        monkeypatch.setattr(config_module.settings, 'matias_habilitacion_tenant_ids', '')
+        monkeypatch.setattr(config_module.settings, 'matias_sandbox_tenant_ids', '')
+
+        with _patch_db(_row(matias_company_id='  ')):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['ready'] is False
+        assert payload['checks']['matias_company_id_configured'] is False
+        assert any('companyId' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_habilitacion_missing_matias_company_id_is_exempt(self, monkeypatch):
+        from app import config as config_module
+
+        monkeypatch.setattr(config_module.settings, 'matias_environment_id', 1)
+        monkeypatch.setattr(config_module.settings, 'matias_habilitacion_tenant_ids', str(_TENANT_ID))
+        monkeypatch.setattr(config_module.settings, 'matias_sandbox_tenant_ids', '')
+
+        with _patch_db(_row(matias_company_id=None)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
         assert payload['ready'] is True
-        assert payload['missing'] == []
+        assert payload['checks']['matias_company_id_configured'] is True
+
+    @pytest.mark.asyncio
+    async def test_sandbox_missing_matias_company_id_is_exempt(self, monkeypatch):
+        from app import config as config_module
+
+        monkeypatch.setattr(config_module.settings, 'matias_environment_id', 1)
+        monkeypatch.setattr(config_module.settings, 'matias_habilitacion_tenant_ids', '')
+        monkeypatch.setattr(config_module.settings, 'matias_sandbox_tenant_ids', 'acme-sas')
+
+        with _patch_db(_row(matias_company_id=None)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['ready'] is True
+        assert payload['checks']['matias_company_id_configured'] is True
 
     @pytest.mark.asyncio
     async def test_dev_flag_off_blocks(self):
@@ -167,7 +211,6 @@ class TestReadinessService:
             active_resolution=False,
             inc_applicable=False,
             iva_applicable=False,
-            tax_regime_id=1,   # Responsable — needs taxes; if regime were 2, taxes pass
         )):
             payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
 
@@ -207,6 +250,7 @@ class TestEmitGate:
                     'fiscal_data_complete': True,
                     'active_resolution':    True,
                     'taxes_configured':     True,
+                    'matias_company_id_configured': True,
                 },
                 'missing': ['Facturación electrónica deshabilitada por el equipo de WARO'],
             }),
@@ -235,6 +279,7 @@ class TestEmitGate:
                 'fiscal_data_complete': True,
                 'active_resolution':    True,
                 'taxes_configured':     True,
+                'matias_company_id_configured': True,
             },
             'missing': [],
         }


### PR DESCRIPTION
## Summary
- add production-only Matias companyId readiness blocking
- align upstream readiness with api-facturacion tax/companyId gates
- add idempotent tenant_fiscal_data.matias_company_id migration

## Tests
- pytest tests/test_invoicing_readiness.py tests/test_tenant_fiscal_data.py

## Manual validation
- GET /api/api/tenant/invoicing-readiness for configured and unconfigured production tenants

Closes #516