### PR TITLE
Accept Matias client_uuid alias

### DIFF
--- a/app/routers/tenant_config.py
+++ b/app/routers/tenant_config.py
@@ -185,6 +185,8 @@ def _normalize_receipt_tip_label(raw) -> str:
 
 def _normalize_matias_company_id(data: dict) -> Optional[str]:
     raw = data.get('matias_company_id')
+    if raw is None and 'client_uuid' in data:
+        raw = data.get('client_uuid')
     if raw is None and 'companyId' in data:
         raw = data.get('companyId')
     if raw is None:

--- a/app/services/invoicing_readiness_service.py
+++ b/app/services/invoicing_readiness_service.py
@@ -15,7 +15,8 @@ Five predicates must all be true:
                               or iva_applicable set to true.
   5. matias_company_id_configured
                             — production Matias Casa de Software emissions have
-                              tenant_fiscal_data.matias_company_id configured.
+                              tenant_fiscal_data.matias_company_id configured
+                              for the outbound Matias client_uuid.
                               Sandbox and habilitación tenants are exempt.
 
 About the no-responsable bypass that was here briefly:
@@ -128,7 +129,7 @@ async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
         missing.append('No hay impuestos configurados (activa INC o IVA en Configuración fiscal)')
     if not matias_company_id_configured:
         missing.append(
-            'Falta UUID cliente Matias (companyId) para emitir en producción'
+            'Falta UUID cliente Matias (client_uuid) para emitir en producción'
         )
 
     return {

--- a/dbdoc/public.tenant_fiscal_data.md
+++ b/dbdoc/public.tenant_fiscal_data.md
@@ -16,7 +16,7 @@
 | city_id | integer | 149 | true |  |  |  |
 | phone | varchar(20) |  | true |  |  |  |
 | email | varchar(200) |  | true |  |  |  |
-| matias_company_id | text |  | true |  |  | Matias Casa de Software customer companyId UUID for this tenant; not the WARO tenant_id. |
+| matias_company_id | text |  | true |  |  | Matias Casa de Software customer client_uuid for this tenant; not the WARO tenant_id. |
 | created_at | timestamp with time zone | now() | false |  |  |  |
 | updated_at | timestamp with time zone | now() | false |  |  |  |
 

--- a/sql/20260623_matias_company_id.sql
+++ b/sql/20260623_matias_company_id.sql
@@ -2,4 +2,4 @@ ALTER TABLE tenant_fiscal_data
   ADD COLUMN IF NOT EXISTS matias_company_id text;
 
 COMMENT ON COLUMN tenant_fiscal_data.matias_company_id IS
-  'Matias Casa de Software customer companyId UUID for this tenant; not the WARO tenant_id.';
+  'Matias Casa de Software customer client_uuid for this tenant; not the WARO tenant_id.';

--- a/tests/test_invoicing_readiness.py
+++ b/tests/test_invoicing_readiness.py
@@ -122,7 +122,7 @@ class TestReadinessService:
 
         assert payload['ready'] is False
         assert payload['checks']['matias_company_id_configured'] is False
-        assert any('companyId' in m for m in payload['missing'])
+        assert any('client_uuid' in m for m in payload['missing'])
 
     @pytest.mark.asyncio
     async def test_habilitacion_missing_matias_company_id_is_exempt(self, monkeypatch):

--- a/tests/test_tenant_fiscal_data.py
+++ b/tests/test_tenant_fiscal_data.py
@@ -117,6 +117,34 @@ def test_put_fiscal_data_persists_company_id_alias():
     assert execute_args[12] == company_id
 
 
+def test_put_fiscal_data_persists_client_uuid_alias():
+    session = _build_session()
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    company_id = "8d4f2f79-4a4e-4d7d-bf07-7bd61c9e4f37"
+
+    @asynccontextmanager
+    async def fiscal_db_ctx():
+        yield conn
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.database.get_db_connection", return_value=fiscal_db_ctx()):
+        response = TestClient(_build_app()).put(
+            "/api/tenant/fiscal-data",
+            json={
+                "nit": "900123456",
+                "business_name": "Waro Test SAS",
+                "client_uuid": f"  {company_id}  ",
+            },
+        )
+
+    assert response.status_code == 200
+    execute_args = conn.execute.await_args.args
+    assert execute_args[12] == company_id
+
+
 def test_put_fiscal_data_normalizes_blank_matias_company_id_to_null():
     session = _build_session()
     conn = MagicMock()


### PR DESCRIPTION
## Summary
- accept client_uuid as an API alias for the stored Matias customer UUID
- update readiness/migration docs to name Matias client_uuid
- keep companyId accepted as backward-compatible input alias

## Tests
- pytest tests/test_tenant_fiscal_data.py tests/test_invoicing_readiness.py

Refs #516