### PR TITLE
Clarify fiscal data and tax config separation

### DIFF
--- a/app/routers/tenant_config.py
+++ b/app/routers/tenant_config.py
@@ -210,6 +210,9 @@ async def get_fiscal_data(request: Request):
     """
     Get fiscal data for the active tenant.
     Inserts defaults on first access if no row exists.
+
+    Fiscal data identifies the electronic invoice issuer. Sales tax toggles
+    such as INC/IVA live in tenant_tax_config and are handled separately.
     """
     from app.core.middleware import require_valid_session
     from app.database import get_db_connection
@@ -257,6 +260,10 @@ async def get_fiscal_data(request: Request):
 async def update_fiscal_data(request: Request, data: dict = Body(...)):
     """
     Upsert fiscal data for the active tenant.
+
+    This endpoint intentionally does not mutate tenant_tax_config. A tenant can
+    update organization type or IVA responsibility without auto-enabling INC/IVA
+    on sale lines.
     """
     from app.core.middleware import require_valid_session
     from app.database import get_db_connection

--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -622,7 +622,10 @@ async def get_tax_config(request: Request) -> dict:
 
 async def update_tax_config(request: Request, data) -> dict:
     """
-    Upsert the tax configuration for the active tenant.
+    Upsert the sale-tax configuration for the active tenant.
+
+    This controls which taxes are calculated on sales. Issuer identity fields
+    such as type_organization_id and tax_regime_id are stored via fiscal-data.
     Accepts a TaxConfigUpdate-shaped object.
     """
     try:

--- a/tests/test_tenant_fiscal_data.py
+++ b/tests/test_tenant_fiscal_data.py
@@ -167,6 +167,44 @@ def test_put_fiscal_data_normalizes_blank_matias_company_id_to_null():
     assert conn.execute.await_args.args[12] is None
 
 
+def test_put_fiscal_data_keeps_tax_config_separate_for_no_responsable_persona_natural():
+    session = _build_session()
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+
+    @asynccontextmanager
+    async def fiscal_db_ctx():
+        yield conn
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.database.get_db_connection", return_value=fiscal_db_ctx()):
+        response = TestClient(_build_app()).put(
+            "/api/tenant/fiscal-data",
+            json={
+                "nit": "123456789",
+                "business_name": "Persona Natural Test",
+                "type_organization_id": 2,
+                "tax_regime_id": 2,
+                "tax_level_id": 5,
+                "inc_applicable": True,
+                "iva_applicable": True,
+            },
+        )
+
+    assert response.status_code == 200
+    execute_args = conn.execute.await_args.args
+    sql = execute_args[0]
+    assert "tenant_fiscal_data" in sql
+    assert "tenant_tax_config" not in sql
+    assert "inc_applicable" not in sql
+    assert "iva_applicable" not in sql
+    assert execute_args[4] == 2
+    assert execute_args[5] == 2
+    assert execute_args[6] == 5
+
+
 def test_put_fiscal_data_rejects_invalid_matias_company_id():
     session = _build_session()
 


### PR DESCRIPTION
## Summary
- Document fiscal-data as issuer identity separate from sale-tax toggles
- Document tax-config as the sale-tax calculation contract
- Add regression coverage that persona natural/no responsable fiscal-data saves do not touch tenant_tax_config

## Tests
- pytest tests/test_tenant_fiscal_data.py tests/test_invoicing_readiness.py

Refs uno0uno/warocol.com#1454