### PR TITLE
Allow no-tax invoicing readiness when fiscal config permits

### DIFF
--- a/app/services/invoicing_readiness_service.py
+++ b/app/services/invoicing_readiness_service.py
@@ -11,8 +11,10 @@ Five predicates must all be true:
   3. active_resolution      — at least one row in dian_resolutions with
                               is_active=true, valid date range, available numbers,
                               and document_type='invoice'
-  4. taxes_configured       — tenant_tax_config has at least one of inc_applicable
-                              or iva_applicable set to true.
+  4. tax_requirement_satisfied
+                            — tenant_tax_config has at least one of inc_applicable
+                              or iva_applicable set to true, or the issuer fiscal
+                              configuration supports no IVA/INC on sale lines.
   5. matias_company_id_configured
                             — Matias Casa de Software emissions have
                               tenant_fiscal_data.matias_company_id configured
@@ -26,9 +28,9 @@ About the no-responsable bypass that was here briefly:
   AttachedDocument when the factura has no tax line, so the customer
   email goes out without the PDF attachment — degraded UX.
 
-  Decision (issue #135): require INC or IVA always. A tenant who is
-  legitimately no-responsable can either toggle IVA at 19% or wait until
-  /status/zip polling is implemented (separate work).
+  Current decision (warocol.com#1455): API WARO readiness may allow the
+  supported no-responsable/persona-natural/no-tax scenario while #1456 keeps
+  api-facturacion and Matias artifact validation explicit.
 
 Returned shape (this is the public contract — frontend issue uno0uno/warocol.com#450
 and microservice gate uno0uno/api-facturacion#17 must consume the same JSON):
@@ -39,7 +41,8 @@ and microservice gate uno0uno/api-facturacion#17 must consume the same JSON):
         "dev_flag_enabled":     bool,
         "fiscal_data_complete": bool,
         "active_resolution":    bool,
-        "taxes_configured":     bool,
+        "taxes_configured":     bool,  # compatibility: INC or IVA active
+        "tax_requirement_satisfied": bool,
         "matias_company_id_configured": bool,
       },
       "missing": [str, ...],   # human-readable Spanish reasons
@@ -60,6 +63,9 @@ SELECT
     fd.phone                        AS phone,
     fd.email                        AS email,
     fd.matias_company_id            AS matias_company_id,
+    fd.type_organization_id         AS type_organization_id,
+    fd.tax_regime_id                AS tax_regime_id,
+    fd.tax_level_id                 AS tax_level_id,
     COALESCE(ttc.inc_applicable, false) AS inc_applicable,
     COALESCE(ttc.iva_applicable, false) AS iva_applicable,
     EXISTS (
@@ -93,6 +99,13 @@ async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
     active_resolution = bool(row['active_resolution'])
 
     taxes_configured = bool(row['inc_applicable']) or bool(row['iva_applicable'])
+    no_tax_allowed = (
+        not taxes_configured
+        and row['type_organization_id'] == 2
+        and row['tax_regime_id'] == 2
+        and row['tax_level_id'] == 5
+    )
+    tax_requirement_satisfied = taxes_configured or no_tax_allowed
     matias_company_id = row['matias_company_id']
     matias_company_id_configured = bool(
         matias_company_id and str(matias_company_id).strip()
@@ -118,8 +131,10 @@ async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
         )
     if not active_resolution:
         missing.append('No hay una resolución DIAN vigente con numeración disponible')
-    if not taxes_configured:
-        missing.append('No hay impuestos configurados (activa INC o IVA en Configuración fiscal)')
+    if not tax_requirement_satisfied:
+        missing.append(
+            'La configuración fiscal requiere INC o IVA activo para emitir'
+        )
     if not matias_company_id_configured:
         missing.append(
             'Falta UUID cliente Matias (client_uuid) para emitir con Matias'
@@ -130,7 +145,7 @@ async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
             dev_flag_enabled
             and fiscal_data_complete
             and active_resolution
-            and taxes_configured
+            and tax_requirement_satisfied
             and matias_company_id_configured
         ),
         'checks': {
@@ -138,6 +153,7 @@ async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
             'fiscal_data_complete': fiscal_data_complete,
             'active_resolution':    active_resolution,
             'taxes_configured':     taxes_configured,
+            'tax_requirement_satisfied': tax_requirement_satisfied,
             'matias_company_id_configured': matias_company_id_configured,
         },
         'missing': missing,

--- a/tests/test_invoicing_readiness.py
+++ b/tests/test_invoicing_readiness.py
@@ -26,6 +26,9 @@ def _row(
     email: str = 'contacto@acme.co',
     matias_company_id: str = '8d4f2f79-4a4e-4d7d-bf07-7bd61c9e4f37',
     active_resolution: bool = True,
+    type_organization_id: int = 1,
+    tax_regime_id: int = 2,
+    tax_level_id: int = 5,
     inc_applicable: bool = False,
     iva_applicable: bool = True,
 ):
@@ -37,6 +40,9 @@ def _row(
         'phone':             phone,
         'email':             email,
         'matias_company_id':  matias_company_id,
+        'type_organization_id': type_organization_id,
+        'tax_regime_id':     tax_regime_id,
+        'tax_level_id':      tax_level_id,
         'active_resolution': active_resolution,
         'inc_applicable':    inc_applicable,
         'iva_applicable':    iva_applicable,
@@ -78,6 +84,7 @@ class TestReadinessService:
             'fiscal_data_complete': True,
             'active_resolution':    True,
             'taxes_configured':     True,
+            'tax_requirement_satisfied': True,
             'matias_company_id_configured': True,
         }
         assert payload['missing'] == []
@@ -89,25 +96,58 @@ class TestReadinessService:
             payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
 
         assert payload['checks']['taxes_configured'] is True
+        assert payload['checks']['tax_requirement_satisfied'] is True
         assert payload['ready'] is True
 
     @pytest.mark.asyncio
     async def test_responsable_without_taxes_blocks_ready(self):
-        with _patch_db(_row(inc_applicable=False, iva_applicable=False)):
+        with _patch_db(_row(
+            type_organization_id=1,
+            tax_regime_id=1,
+            tax_level_id=48,
+            inc_applicable=False,
+            iva_applicable=False,
+        )):
             payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
 
         assert payload['checks']['taxes_configured'] is False
+        assert payload['checks']['tax_requirement_satisfied'] is False
         assert payload['ready'] is False
-        assert any('impuestos configurados' in m for m in payload['missing'])
+        assert any('requiere INC o IVA activo' in m for m in payload['missing'])
 
     @pytest.mark.asyncio
-    async def test_no_responsable_without_taxes_still_blocks_ready(self):
-        with _patch_db(_row(inc_applicable=False, iva_applicable=False)):
+    async def test_no_responsable_persona_natural_without_taxes_can_be_ready(self):
+        with _patch_db(_row(
+            type_organization_id=2,
+            tax_regime_id=2,
+            tax_level_id=5,
+            inc_applicable=False,
+            iva_applicable=False,
+        )):
             payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
 
         assert payload['checks']['taxes_configured'] is False
+        assert payload['checks']['tax_requirement_satisfied'] is True
+        assert payload['ready'] is True
+        assert payload['missing'] == []
+
+    @pytest.mark.asyncio
+    async def test_incomplete_no_responsable_persona_natural_still_blocks_ready(self):
+        with _patch_db(_row(
+            nit=None,
+            type_organization_id=2,
+            tax_regime_id=2,
+            tax_level_id=5,
+            inc_applicable=False,
+            iva_applicable=False,
+        )):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['fiscal_data_complete'] is False
+        assert payload['checks']['tax_requirement_satisfied'] is True
         assert payload['ready'] is False
-        assert any('impuestos configurados' in m for m in payload['missing'])
+        assert any('NIT' in m for m in payload['missing'])
+        assert not any('requiere INC o IVA activo' in m for m in payload['missing'])
 
     @pytest.mark.asyncio
     async def test_production_missing_matias_company_id_blocks_ready(self, monkeypatch):
@@ -252,6 +292,7 @@ class TestEmitGate:
                     'fiscal_data_complete': True,
                     'active_resolution':    True,
                     'taxes_configured':     True,
+                    'tax_requirement_satisfied': True,
                     'matias_company_id_configured': True,
                 },
                 'missing': ['Facturación electrónica deshabilitada por el equipo de WARO'],
@@ -281,6 +322,7 @@ class TestEmitGate:
                 'fiscal_data_complete': True,
                 'active_resolution':    True,
                 'taxes_configured':     True,
+                'tax_requirement_satisfied': True,
                 'matias_company_id_configured': True,
             },
             'missing': [],


### PR DESCRIPTION
## Summary
- allow API WARO readiness when the issuer is the supported persona natural/no-responsable/no-tax configuration
- keep `taxes_configured` as the IVA/INC compatibility flag and add `tax_requirement_satisfied` for readiness
- cover IVA, INC, blocked responsible no-tax, allowed no-responsable no-tax, and incomplete fiscal data cases

## Tests
- pytest tests/test_invoicing_readiness.py tests/test_tenant_fiscal_data.py

Refs uno0uno/warocol.com#1455