### PR TITLE
Clarify no-tax readiness error copy

### DIFF
--- a/app/services/invoicing_readiness_service.py
+++ b/app/services/invoicing_readiness_service.py
@@ -133,7 +133,7 @@ async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
         missing.append('No hay una resolución DIAN vigente con numeración disponible')
     if not tax_requirement_satisfied:
         missing.append(
-            'La configuración fiscal requiere INC o IVA activo para emitir'
+            'La configuración fiscal requiere INC/IVA activo o un escenario sin impuesto válido para emitir'
         )
     if not matias_company_id_configured:
         missing.append(

--- a/tests/test_invoicing_readiness.py
+++ b/tests/test_invoicing_readiness.py
@@ -113,7 +113,7 @@ class TestReadinessService:
         assert payload['checks']['taxes_configured'] is False
         assert payload['checks']['tax_requirement_satisfied'] is False
         assert payload['ready'] is False
-        assert any('requiere INC o IVA activo' in m for m in payload['missing'])
+        assert any('requiere INC/IVA activo o un escenario sin impuesto válido' in m for m in payload['missing'])
 
     @pytest.mark.asyncio
     async def test_no_responsable_persona_natural_without_taxes_can_be_ready(self):
@@ -147,7 +147,7 @@ class TestReadinessService:
         assert payload['checks']['tax_requirement_satisfied'] is True
         assert payload['ready'] is False
         assert any('NIT' in m for m in payload['missing'])
-        assert not any('requiere INC o IVA activo' in m for m in payload['missing'])
+        assert not any('requiere INC/IVA activo o un escenario sin impuesto válido' in m for m in payload['missing'])
 
     @pytest.mark.asyncio
     async def test_production_missing_matias_company_id_blocks_ready(self, monkeypatch):


### PR DESCRIPTION
## Summary
- Clarify readiness error copy for tenants that need either active IVA/INC or a valid no-tax scenario.
- Update readiness assertions for the new message.

## Tests
- pytest tests/test_emit_short_circuit.py tests/test_document_email.py tests/test_pos_receipt_template.py tests/test_invoicing_readiness.py

Refs uno0uno/warocol.com#1457