### PR TITLE
Add customer invoicing request flag

### DIFF
--- a/app/routers/tenant_config.py
+++ b/app/routers/tenant_config.py
@@ -246,6 +246,7 @@ async def get_fiscal_data(request: Request):
             'city_id': row['city_id'],
             'phone': row['phone'],
             'email': row['email'],
+            'electronic_invoicing_requested': bool(row['electronic_invoicing_requested']),
             'matias_company_id': row['matias_company_id'],
             'receipt_document_label': _normalize_receipt_document_label(row['receipt_document_label']),
             'receipt_tip_label': _normalize_receipt_tip_label(row.get('receipt_tip_label')),
@@ -275,15 +276,17 @@ async def update_fiscal_data(request: Request, data: dict = Body(...)):
     tip_label = _normalize_receipt_tip_label(data.get('receipt_tip_label'))
     show_logo = bool(data.get('show_logo_on_receipts', True))
     matias_company_id = _normalize_matias_company_id(data)
+    electronic_invoicing_requested = bool(data.get('electronic_invoicing_requested', False))
 
     async with get_db_connection() as conn:
         await conn.execute(
             """INSERT INTO tenant_fiscal_data (tenant_id, nit, business_name,
                    type_organization_id, tax_regime_id, tax_level_id,
                    fiscal_address, city, city_id, phone, email,
-                   matias_company_id, receipt_document_label, receipt_tip_label,
-                   show_logo_on_receipts, updated_at)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, now())
+                   electronic_invoicing_requested, matias_company_id,
+                   receipt_document_label, receipt_tip_label, show_logo_on_receipts,
+                   updated_at)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, now())
                ON CONFLICT (tenant_id) DO UPDATE SET
                    nit = EXCLUDED.nit,
                    business_name = EXCLUDED.business_name,
@@ -295,6 +298,7 @@ async def update_fiscal_data(request: Request, data: dict = Body(...)):
                    city_id = EXCLUDED.city_id,
                    phone = EXCLUDED.phone,
                    email = EXCLUDED.email,
+                   electronic_invoicing_requested = EXCLUDED.electronic_invoicing_requested,
                    matias_company_id = EXCLUDED.matias_company_id,
                    receipt_document_label = EXCLUDED.receipt_document_label,
                    receipt_tip_label = EXCLUDED.receipt_tip_label,
@@ -311,6 +315,7 @@ async def update_fiscal_data(request: Request, data: dict = Body(...)):
             data.get('city_id', 149),
             data.get('phone'),
             data.get('email'),
+            electronic_invoicing_requested,
             matias_company_id,
             document_label,
             tip_label,

--- a/app/services/invoicing_readiness_service.py
+++ b/app/services/invoicing_readiness_service.py
@@ -2,20 +2,22 @@
 Invoicing readiness service — issue #130
 
 Single source of truth for "can this tenant emit electronic invoices right now?"
-Five predicates must all be true:
+Six predicates must all be true:
 
-  1. dev_flag_enabled       — tenants.electronic_invoicing_enabled = true
+  1. customer_requested     — tenant_fiscal_data.electronic_invoicing_requested
+                              = true (customer intent from /facturacion)
+  2. dev_flag_enabled       — tenants.electronic_invoicing_enabled = true
                               (dev-only kill switch, set via SQL during onboarding)
-  2. fiscal_data_complete   — tenant_fiscal_data has non-null nit, business_name,
+  3. fiscal_data_complete   — tenant_fiscal_data has non-null nit, business_name,
                               phone, email
-  3. active_resolution      — at least one row in dian_resolutions with
+  4. active_resolution      — at least one row in dian_resolutions with
                               is_active=true, valid date range, available numbers,
                               and document_type='invoice'
-  4. tax_requirement_satisfied
+  5. tax_requirement_satisfied
                             — tenant_tax_config has at least one of inc_applicable
                               or iva_applicable set to true, or the issuer fiscal
                               configuration supports no IVA/INC on sale lines.
-  5. matias_company_id_configured
+  6. matias_company_id_configured
                             — Matias Casa de Software emissions have
                               tenant_fiscal_data.matias_company_id configured
                               for the outbound Matias client_uuid.
@@ -38,6 +40,7 @@ and microservice gate uno0uno/api-facturacion#17 must consume the same JSON):
     {
       "ready": bool,
       "checks": {
+        "customer_requested": bool,
         "dev_flag_enabled":     bool,
         "fiscal_data_complete": bool,
         "active_resolution":    bool,
@@ -62,6 +65,8 @@ SELECT
     fd.business_name                AS business_name,
     fd.phone                        AS phone,
     fd.email                        AS email,
+    COALESCE(fd.electronic_invoicing_requested, false)
+                                    AS customer_requested,
     fd.matias_company_id            AS matias_company_id,
     fd.type_organization_id         AS type_organization_id,
     fd.tax_regime_id                AS tax_regime_id,
@@ -95,6 +100,7 @@ async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
     if row is None:
         return None
 
+    customer_requested = bool(row['customer_requested'])
     dev_flag_enabled  = bool(row['dev_flag_enabled'])
     active_resolution = bool(row['active_resolution'])
 
@@ -123,8 +129,10 @@ async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
     fiscal_data_complete = len(missing_fiscal_fields) == 0
 
     missing: List[str] = []
+    if not customer_requested:
+        missing.append('Solicita la activación de facturación electrónica desde la configuración fiscal')
     if not dev_flag_enabled:
-        missing.append('Facturación electrónica deshabilitada por el equipo de WARO')
+        missing.append('Facturación electrónica pendiente de habilitación interna por WARO/Matias')
     if not fiscal_data_complete:
         missing.append(
             'Faltan datos fiscales: ' + ', '.join(missing_fiscal_fields)
@@ -142,13 +150,15 @@ async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
 
     return {
         'ready': (
-            dev_flag_enabled
+            customer_requested
+            and dev_flag_enabled
             and fiscal_data_complete
             and active_resolution
             and tax_requirement_satisfied
             and matias_company_id_configured
         ),
         'checks': {
+            'customer_requested':   customer_requested,
             'dev_flag_enabled':     dev_flag_enabled,
             'fiscal_data_complete': fiscal_data_complete,
             'active_resolution':    active_resolution,

--- a/migrations/094_electronic_invoicing_requested.sql
+++ b/migrations/094_electronic_invoicing_requested.sql
@@ -1,0 +1,10 @@
+-- Migration 094: customer-controlled electronic invoicing request
+--
+-- Separates the customer's intent to use electronic invoicing from WARO's
+-- internal Matias/DIAN enablement switch on tenants.electronic_invoicing_enabled.
+
+ALTER TABLE tenant_fiscal_data
+    ADD COLUMN IF NOT EXISTS electronic_invoicing_requested BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN tenant_fiscal_data.electronic_invoicing_requested IS
+    'Customer-controlled request/intent to use electronic invoicing; does not enable DIAN/Matias emission by itself.';

--- a/tests/test_invoicing_readiness.py
+++ b/tests/test_invoicing_readiness.py
@@ -25,6 +25,7 @@ def _row(
     phone: str = '3001234567',
     email: str = 'contacto@acme.co',
     matias_company_id: str = '8d4f2f79-4a4e-4d7d-bf07-7bd61c9e4f37',
+    customer_requested: bool = True,
     active_resolution: bool = True,
     type_organization_id: int = 1,
     tax_regime_id: int = 2,
@@ -39,6 +40,7 @@ def _row(
         'business_name':     business_name,
         'phone':             phone,
         'email':             email,
+        'customer_requested': customer_requested,
         'matias_company_id':  matias_company_id,
         'type_organization_id': type_organization_id,
         'tax_regime_id':     tax_regime_id,
@@ -80,6 +82,7 @@ class TestReadinessService:
         assert payload is not None
         assert payload['ready'] is True
         assert payload['checks'] == {
+            'customer_requested':   True,
             'dev_flag_enabled':     True,
             'fiscal_data_complete': True,
             'active_resolution':    True,
@@ -88,6 +91,26 @@ class TestReadinessService:
             'matias_company_id_configured': True,
         }
         assert payload['missing'] == []
+
+    @pytest.mark.asyncio
+    async def test_customer_request_is_required_before_internal_enablement_can_be_ready(self):
+        with _patch_db(_row(customer_requested=False, dev_flag_enabled=True)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['customer_requested'] is False
+        assert payload['checks']['dev_flag_enabled'] is True
+        assert payload['ready'] is False
+        assert any('Solicita la activación' in m for m in payload['missing'])
+
+    @pytest.mark.asyncio
+    async def test_internal_enablement_is_still_required_after_customer_request(self):
+        with _patch_db(_row(customer_requested=True, dev_flag_enabled=False)):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['checks']['customer_requested'] is True
+        assert payload['checks']['dev_flag_enabled'] is False
+        assert payload['ready'] is False
+        assert any('habilitación interna' in m for m in payload['missing'])
 
     @pytest.mark.asyncio
     async def test_taxes_configured_via_inc_alone(self):
@@ -201,7 +224,7 @@ class TestReadinessService:
 
         assert payload['ready'] is False
         assert payload['checks']['dev_flag_enabled'] is False
-        assert any('deshabilitada por el equipo' in m for m in payload['missing'])
+        assert any('habilitación interna' in m for m in payload['missing'])
 
     @pytest.mark.asyncio
     async def test_missing_nit_marks_fiscal_incomplete(self):

--- a/tests/test_tenant_fiscal_data.py
+++ b/tests/test_tenant_fiscal_data.py
@@ -54,6 +54,7 @@ def _fiscal_row(**overrides):
         "city_id": 149,
         "phone": "3001234567",
         "email": "facturacion@example.com",
+        "electronic_invoicing_requested": False,
         "matias_company_id": None,
         "receipt_document_label": "Prefactura",
         "receipt_tip_label": "Propina",
@@ -86,6 +87,7 @@ def test_get_fiscal_data_returns_nullable_matias_company_id():
 
     assert response.status_code == 200
     assert response.json()["data"]["matias_company_id"] is None
+    assert response.json()["data"]["electronic_invoicing_requested"] is False
 
 
 def test_put_fiscal_data_persists_company_id_alias():
@@ -114,7 +116,8 @@ def test_put_fiscal_data_persists_company_id_alias():
     assert response.status_code == 200
     execute_args = conn.execute.await_args.args
     assert "matias_company_id" in execute_args[0]
-    assert execute_args[12] == company_id
+    assert execute_args[12] is False
+    assert execute_args[13] == company_id
 
 
 def test_put_fiscal_data_persists_client_uuid_alias():
@@ -142,7 +145,8 @@ def test_put_fiscal_data_persists_client_uuid_alias():
 
     assert response.status_code == 200
     execute_args = conn.execute.await_args.args
-    assert execute_args[12] == company_id
+    assert execute_args[12] is False
+    assert execute_args[13] == company_id
 
 
 def test_put_fiscal_data_normalizes_blank_matias_company_id_to_null():
@@ -164,7 +168,38 @@ def test_put_fiscal_data_normalizes_blank_matias_company_id_to_null():
         )
 
     assert response.status_code == 200
-    assert conn.execute.await_args.args[12] is None
+    assert conn.execute.await_args.args[13] is None
+
+
+def test_put_fiscal_data_persists_electronic_invoicing_request_without_internal_flag():
+    session = _build_session()
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+
+    @asynccontextmanager
+    async def fiscal_db_ctx():
+        yield conn
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.database.get_db_connection", return_value=fiscal_db_ctx()):
+        response = TestClient(_build_app()).put(
+            "/api/tenant/fiscal-data",
+            json={
+                "nit": "900123456",
+                "business_name": "Waro Test SAS",
+                "electronic_invoicing_requested": True,
+                "electronic_invoicing_enabled": True,
+            },
+        )
+
+    assert response.status_code == 200
+    execute_args = conn.execute.await_args.args
+    sql = execute_args[0]
+    assert "electronic_invoicing_requested" in sql
+    assert "electronic_invoicing_enabled" not in sql
+    assert execute_args[12] is True
 
 
 def test_put_fiscal_data_keeps_tax_config_separate_for_no_responsable_persona_natural():


### PR DESCRIPTION
## Summary\n- add tenant_fiscal_data.electronic_invoicing_requested migration\n- expose/persist the customer request via fiscal-data\n- require customer request separately from internal WARO/Matias enablement in readiness\n\n## Tests\n- pytest tests/test_tenant_fiscal_data.py tests/test_invoicing_readiness.py\n\nRefs uno0uno/warocol.com#1461