### PR TITLE
Add tenant timezone contract

### DIFF
--- a/app/core/timezones.py
+++ b/app/core/timezones.py
@@ -1,0 +1,58 @@
+"""Tenant operational timezone helpers.
+
+Operational tenant time controls local business dates, schedules, and report
+boundaries. Fiscal/legal Colombia time should use a separate named helper.
+"""
+from datetime import date, datetime, time, timedelta, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+DEFAULT_TENANT_TIMEZONE = "America/Bogota"
+
+
+def validate_timezone(value: str | None) -> str:
+    """Return a normalized IANA timezone or raise ValueError for user input."""
+    if value is None or not isinstance(value, str) or not value.strip():
+        raise ValueError("timezone must be a valid IANA timezone")
+
+    timezone_name = value.strip()
+    try:
+        ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError("timezone must be a valid IANA timezone") from exc
+    return timezone_name
+
+
+def normalize_timezone(value: str | None) -> str:
+    """Return a safe tenant timezone, falling back for legacy/invalid values."""
+    try:
+        return validate_timezone(value)
+    except ValueError:
+        return DEFAULT_TENANT_TIMEZONE
+
+
+def get_zoneinfo(value: str | None) -> ZoneInfo:
+    """Return ZoneInfo for a tenant timezone, using the safe default if needed."""
+    return ZoneInfo(normalize_timezone(value))
+
+
+def tenant_today(value: str | None, now: datetime | None = None) -> date:
+    """Return today's local date in the tenant operational timezone."""
+    zone = get_zoneinfo(value)
+    instant = now or datetime.now(timezone.utc)
+    if instant.tzinfo is None:
+        instant = instant.replace(tzinfo=timezone.utc)
+    return instant.astimezone(zone).date()
+
+
+def local_day_utc_range(
+    day: date,
+    value: str | None,
+) -> tuple[datetime, datetime]:
+    """Return [start, end) UTC datetimes for a tenant-local calendar day."""
+    zone = get_zoneinfo(value)
+    local_start = datetime.combine(day, time.min, tzinfo=zone)
+    local_end = local_start + timedelta(days=1)
+    return (
+        local_start.astimezone(timezone.utc),
+        local_end.astimezone(timezone.utc),
+    )

--- a/app/models/tenant_public_profile.py
+++ b/app/models/tenant_public_profile.py
@@ -4,6 +4,7 @@ from typing import Optional, Dict, Any
 from uuid import UUID
 from datetime import datetime
 from decimal import Decimal
+from app.core.timezones import DEFAULT_TENANT_TIMEZONE, validate_timezone
 
 class BusinessHours(BaseModel):
     """Business hours for a single day"""
@@ -46,6 +47,10 @@ class TenantPublicProfileBase(BaseModel):
     neighborhood: Optional[str] = Field(None, max_length=255)
     latitude: Optional[Decimal] = Field(None, description="Latitude coordinate")
     longitude: Optional[Decimal] = Field(None, description="Longitude coordinate")
+    timezone: str = Field(
+        DEFAULT_TENANT_TIMEZONE,
+        description="IANA timezone for tenant operational dates and business hours",
+    )
 
     # Business hours (JSONB)
     business_hours: Optional[Dict[str, Any]] = Field(
@@ -180,6 +185,11 @@ class TenantPublicProfileBase(BaseModel):
                     "checkout. NULL = nothing pre-selected (Ley 1935 voluntariness).",
     )
 
+    @field_validator('timezone')
+    @classmethod
+    def _validate_timezone(cls, v):
+        return validate_timezone(v)
+
     @field_validator('tip_default_percentages')
     @classmethod
     def _validate_tip_presets(cls, v):
@@ -238,6 +248,7 @@ class TenantPublicProfileUpdate(BaseModel):
     neighborhood: Optional[str] = Field(None, max_length=255)
     latitude: Optional[Decimal] = None
     longitude: Optional[Decimal] = None
+    timezone: Optional[str] = None
 
     business_hours: Optional[Dict[str, Any]] = None
     social_media: Optional[Dict[str, str]] = None
@@ -271,6 +282,13 @@ class TenantPublicProfileUpdate(BaseModel):
     tip_taxable_default: Optional[bool] = None
     tip_default_percentages: Optional[list[Decimal]] = None
     tip_preselect_index: Optional[int] = None
+
+    @field_validator('timezone')
+    @classmethod
+    def _validate_timezone_update(cls, v):
+        if v is None:
+            return v
+        return validate_timezone(v)
 
     @field_validator('tip_default_percentages')
     @classmethod

--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Optional
 from uuid import UUID
 
 from app.database import get_db_connection
+from app.core.timezones import normalize_timezone
 from app.services.invoicing_readiness_service import get_readiness
 from app.services.open_priced_service import fetch_open_sale_product
 from app.services.promotions_service import (
@@ -23,6 +24,7 @@ from app.services.promotions_service import (
 _CONTEXT_QUERY = """
 SELECT
     tpp.display_name,
+    tpp.timezone,
     tpp.kds_enabled,
     tpp.comandas_enabled,
     tpp.expediter_enabled,
@@ -109,6 +111,7 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
 
     return {
         'display_name': row['display_name'],
+        'timezone': normalize_timezone(row['timezone']),
         'kds_enabled': bool(row['kds_enabled']) if row['kds_enabled'] is not None else False,
         'comandas_enabled': bool(row['comandas_enabled']) if row['comandas_enabled'] is not None else False,
         'expediter_enabled': bool(row['expediter_enabled']) if row['expediter_enabled'] is not None else False,

--- a/app/services/public_restaurant_service.py
+++ b/app/services/public_restaurant_service.py
@@ -5,13 +5,11 @@ No authentication required - these are public endpoints
 from typing import Optional, Dict, Any, List
 from uuid import UUID
 from datetime import datetime, time
-from zoneinfo import ZoneInfo
 from fastapi import HTTPException
+from app.core.timezones import get_zoneinfo, normalize_timezone
 from app.database import get_db_connection
 import json
 import logging
-
-BOGOTA_TZ = ZoneInfo("America/Bogota")
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +38,7 @@ async def get_profile_by_slug(slug: str) -> Optional[Dict[str, Any]]:
                     tpp.display_name, tpp.description, tpp.logo_url, tpp.banner_url,
                     tpp.phone_number, tpp.email, tpp.address,
                     tpp.city, tpp.neighborhood, tpp.latitude, tpp.longitude,
+                    tpp.timezone,
                     tpp.business_hours, tpp.social_media,
                     tpp.seo_title, tpp.seo_description,
                     tpp.accepts_online_orders, tpp.min_order_amount, tpp.estimated_preparation_time,
@@ -84,11 +83,13 @@ async def get_profile_by_slug(slug: str) -> Optional[Dict[str, Any]]:
                 [float(p) for p in tip_presets] if tip_presets else [10.0]
             )
             profile['tip_enabled'] = bool(profile.get('tip_enabled'))
+            profile['timezone'] = normalize_timezone(profile.get('timezone'))
 
             # Calculate if currently open — manual toggle takes priority
             profile['is_currently_open'] = is_currently_open(
                 profile.get('business_hours'),
-                profile.get('is_manually_open', True)
+                profile.get('is_manually_open', True),
+                profile.get('timezone'),
             )
 
             return profile
@@ -207,6 +208,7 @@ async def get_profile_by_tenant_id(tenant_id: UUID) -> Optional[Dict[str, Any]]:
                     display_name, description, logo_url, banner_url,
                     phone_number, email, address,
                     city, neighborhood, latitude, longitude,
+                    timezone,
                     business_hours, social_media,
                     seo_title, seo_description,
                     accepts_online_orders, min_order_amount, estimated_preparation_time,
@@ -233,10 +235,12 @@ async def get_profile_by_tenant_id(tenant_id: UUID) -> Optional[Dict[str, Any]]:
                     profile['social_media'] = json.loads(profile['social_media'])
                 except (json.JSONDecodeError, TypeError):
                     profile['social_media'] = {}
+            profile['timezone'] = normalize_timezone(profile.get('timezone'))
 
             profile['is_currently_open'] = is_currently_open(
                 profile.get('business_hours'),
-                profile.get('is_manually_open', True)
+                profile.get('is_manually_open', True),
+                profile.get('timezone'),
             )
 
             return profile
@@ -518,7 +522,11 @@ async def get_product_detail(slug: str, product_id: UUID) -> Dict[str, Any]:
         raise HTTPException(status_code=500, detail="Error fetching product details")
 
 
-def is_currently_open(business_hours: Optional[Dict[str, Any]], is_manually_open: bool = True) -> bool:
+def is_currently_open(
+    business_hours: Optional[Dict[str, Any]],
+    is_manually_open: bool = True,
+    timezone_name: str | None = None,
+) -> bool:
     """
     Calculate if restaurant is currently open based on business hours and manual toggle.
 
@@ -528,6 +536,7 @@ def is_currently_open(business_hours: Optional[Dict[str, Any]], is_manually_open
             ...
         }
         is_manually_open: Operator manual override. False = closed regardless of schedule.
+        timezone_name: IANA timezone for evaluating the current local time.
 
     Returns:
         True if currently open, False otherwise
@@ -540,7 +549,7 @@ def is_currently_open(business_hours: Optional[Dict[str, Any]], is_manually_open
         return False
 
     try:
-        now = datetime.now(tz=BOGOTA_TZ)
+        now = datetime.now(tz=get_zoneinfo(timezone_name))
         current_day = now.strftime('%A').lower()  # 'monday', 'tuesday', etc.
         current_time = now.time()
 
@@ -635,6 +644,7 @@ async def list_restaurants(
                     tpp.display_name, tpp.description, tpp.logo_url, tpp.banner_url,
                     tpp.phone_number, tpp.email, tpp.address,
                     tpp.city, tpp.city_slug, tpp.country, tpp.neighborhood,
+                    tpp.timezone,
                     tpp.is_manually_open, tpp.business_hours,
                     tpp.created_at, tpp.updated_at
                 FROM tenant_public_profiles tpp
@@ -671,6 +681,8 @@ async def list_restaurants(
                     except (json.JSONDecodeError, TypeError):
                         business_hours = {}
 
+                timezone_name = normalize_timezone(row["timezone"])
+
                 restaurants.append({
                     "id": str(row["id"]),
                     "tenant_id": str(row["tenant_id"]),
@@ -687,7 +699,12 @@ async def list_restaurants(
                     "city": row["city"],
                     "city_slug": row["city_slug"],
                     "neighborhood": row["neighborhood"],
-                    "is_currently_open": is_currently_open(business_hours, row["is_manually_open"]),
+                    "timezone": timezone_name,
+                    "is_currently_open": is_currently_open(
+                        business_hours,
+                        row["is_manually_open"],
+                        timezone_name,
+                    ),
                     "created_at": row["created_at"].isoformat() if row["created_at"] else None,
                     "updated_at": row["updated_at"].isoformat() if row["updated_at"] else None
                 })

--- a/app/services/queries_service.py
+++ b/app/services/queries_service.py
@@ -12,13 +12,14 @@ from typing import Any, Optional
 from uuid import UUID
 
 from app.core.exceptions import APIError, AuthenticationError, AuthorizationError, ValidationError
+from app.core.timezones import DEFAULT_TENANT_TIMEZONE, normalize_timezone
 from app.database import get_db_connection
 from app.services.analytics_service import _PRODUCT_COSTS_CTE
 from app.services.public_api_service import POS_LIKE_FILTER_ALIAS_O, validate_api_key_auth
 
 
 DEFAULT_TIMEOUT_SECONDS = 5
-DEFAULT_TIMEZONE = "America/Bogota"
+DEFAULT_TIMEZONE = DEFAULT_TENANT_TIMEZONE
 MAX_LIMIT = 100
 
 _INVENTORY_LATEST_COSTS_CTE = """
@@ -483,7 +484,7 @@ def compile_queryspec(spec: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1 or limit > MAX_LIMIT:
         raise ValidationError("QuerySpec limit must be an integer between 1 and 100", {"field": "limit", "max": MAX_LIMIT})
 
-    timezone = spec.get("timezone") or DEFAULT_TIMEZONE
+    timezone = normalize_timezone(spec.get("timezone"))
     select_parts: list[str] = []
     group_parts: list[str] = []
     columns: list[dict[str, str]] = []

--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -9,6 +9,7 @@ from fastapi import Request, HTTPException
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError
+from app.core.timezones import DEFAULT_TENANT_TIMEZONE, normalize_timezone, validate_timezone
 from app.models.tenant_public_profile import (
     TenantPublicProfile,
     TenantPublicProfileCreate,
@@ -21,6 +22,22 @@ from app.services.aws_s3_service import AWSS3Service
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def _profile_from_row(row) -> TenantPublicProfile:
+    profile_data = dict(row)
+    if isinstance(profile_data.get('business_hours'), str):
+        try:
+            profile_data['business_hours'] = json.loads(profile_data['business_hours'])
+        except Exception:
+            profile_data['business_hours'] = None
+    if isinstance(profile_data.get('social_media'), str):
+        try:
+            profile_data['social_media'] = json.loads(profile_data['social_media'])
+        except Exception:
+            profile_data['social_media'] = None
+    profile_data['timezone'] = normalize_timezone(profile_data.get('timezone'))
+    return TenantPublicProfile(**profile_data)
 
 
 async def upsert_public_profile(
@@ -64,7 +81,7 @@ async def upsert_public_profile(
                         tenant_id, slug, is_active,
                         display_name, description, logo_url, banner_url,
                         phone_number, email, address,
-                        city, neighborhood, latitude, longitude,
+                        city, neighborhood, latitude, longitude, timezone,
                         business_hours, social_media,
                         seo_title, seo_description,
                         accepts_online_orders, min_order_amount, online_order_max_amount, estimated_preparation_time,
@@ -75,7 +92,7 @@ async def upsert_public_profile(
                         minimum_consumption_enabled, minimum_consumption_amount, minimum_consumption_restrictive,
                         updated_at
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, CURRENT_TIMESTAMP)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, CURRENT_TIMESTAMP)
                     ON CONFLICT (tenant_id)
                     DO UPDATE SET
                         slug = EXCLUDED.slug,
@@ -91,6 +108,7 @@ async def upsert_public_profile(
                         neighborhood = EXCLUDED.neighborhood,
                         latitude = EXCLUDED.latitude,
                         longitude = EXCLUDED.longitude,
+                        timezone = EXCLUDED.timezone,
                         business_hours = EXCLUDED.business_hours,
                         social_media = EXCLUDED.social_media,
                         seo_title = EXCLUDED.seo_title,
@@ -127,6 +145,7 @@ async def upsert_public_profile(
                     profile_data.neighborhood,
                     profile_data.latitude,
                     profile_data.longitude,
+                    profile_data.timezone,
                     json.dumps(profile_data.business_hours) if profile_data.business_hours is not None else None,
                     json.dumps(profile_data.social_media) if profile_data.social_media is not None else None,
                     profile_data.seo_title,
@@ -145,7 +164,7 @@ async def upsert_public_profile(
                     profile_data.minimum_consumption_restrictive
                 )
 
-                profile = TenantPublicProfile(**dict(result))
+                profile = _profile_from_row(result)
 
                 logger.info(f"Upserted public profile for tenant {tenant_id}")
 
@@ -219,14 +238,14 @@ async def update_public_profile(
                         description, logo_url, banner_url,
                         phone_number, email, address,
                         country, city, city_slug, neighborhood,
-                        business_hours, social_media,
+                        business_hours, social_media, timezone,
                         accepts_online_orders, min_order_amount, online_order_max_amount, estimated_preparation_time,
                         is_manually_open,
                         comandas_enabled, kds_enabled,
                         auto_select_generic_enabled,
                         expediter_enabled,
                         minimum_consumption_enabled, minimum_consumption_amount, minimum_consumption_restrictive
-                    ) VALUES ($1, $2, $3, FALSE, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27)
+                    ) VALUES ($1, $2, $3, FALSE, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28)
                     RETURNING *
                 """
                 result = await conn.fetchrow(
@@ -246,6 +265,7 @@ async def update_public_profile(
                     data_dict.get('neighborhood'),
                     json.dumps(data_dict['business_hours']) if data_dict.get('business_hours') is not None else None,
                     json.dumps(data_dict['social_media']) if data_dict.get('social_media') is not None else None,
+                    data_dict.get('timezone', DEFAULT_TENANT_TIMEZONE),
                     # Default True so new tenants are immediately able to
                     # receive online orders — the platform's core value
                     # prop (warocol.com#626). Operators can still toggle
@@ -265,19 +285,7 @@ async def update_public_profile(
                     data_dict.get('minimum_consumption_restrictive', False),
                 )
 
-                profile_data_dict = dict(result)
-                if isinstance(profile_data_dict.get('business_hours'), str):
-                    try:
-                        profile_data_dict['business_hours'] = json.loads(profile_data_dict['business_hours'])
-                    except Exception:
-                        profile_data_dict['business_hours'] = None
-                if isinstance(profile_data_dict.get('social_media'), str):
-                    try:
-                        profile_data_dict['social_media'] = json.loads(profile_data_dict['social_media'])
-                    except Exception:
-                        profile_data_dict['social_media'] = None
-
-                profile = TenantPublicProfile(**profile_data_dict)
+                profile = _profile_from_row(result)
                 logger.info(f"Created new public profile for tenant {tenant_id} via PATCH upsert")
                 return TenantPublicProfileResponse(success=True, data=profile)
 
@@ -335,6 +343,9 @@ async def update_public_profile(
                                "Pick a city from /public/cities.",
                     )
 
+            if 'timezone' in data_dict:
+                data_dict['timezone'] = validate_timezone(data_dict['timezone'])
+
             _jsonb_fields = {'business_hours', 'social_media'}
             for field, value in data_dict.items():
                 update_fields.append(f"{field} = ${param_counter}")
@@ -362,19 +373,7 @@ async def update_public_profile(
 
             result = await conn.fetchrow(query, *params)
 
-            profile_data_dict = dict(result)
-            if isinstance(profile_data_dict.get('business_hours'), str):
-                try:
-                    profile_data_dict['business_hours'] = json.loads(profile_data_dict['business_hours'])
-                except Exception:
-                    profile_data_dict['business_hours'] = None
-            if isinstance(profile_data_dict.get('social_media'), str):
-                try:
-                    profile_data_dict['social_media'] = json.loads(profile_data_dict['social_media'])
-                except Exception:
-                    profile_data_dict['social_media'] = None
-
-            profile = TenantPublicProfile(**profile_data_dict)
+            profile = _profile_from_row(result)
 
             logger.info(f"Updated public profile for tenant {tenant_id}")
 
@@ -498,27 +497,12 @@ async def get_own_public_profile(request: Request) -> Optional[TenantPublicProfi
             if not result:
                 return None
 
-            profile_data = dict(result)
-
-            # asyncpg returns JSONB columns as strings — parse them
-            if isinstance(profile_data.get('business_hours'), str):
-                try:
-                    profile_data['business_hours'] = json.loads(profile_data['business_hours'])
-                except Exception:
-                    profile_data['business_hours'] = None
-
-            if isinstance(profile_data.get('social_media'), str):
-                try:
-                    profile_data['social_media'] = json.loads(profile_data['social_media'])
-                except Exception:
-                    profile_data['social_media'] = None
-
-            profile_data['is_currently_open'] = public_restaurant_service.is_currently_open(
-                profile_data.get('business_hours'),
-                profile_data.get('is_manually_open', True),
+            profile = _profile_from_row(result)
+            profile.is_currently_open = public_restaurant_service.is_currently_open(
+                profile.business_hours,
+                profile.is_manually_open,
+                profile.timezone,
             )
-
-            profile = TenantPublicProfile(**profile_data)
 
             return TenantPublicProfileResponse(
                 success=True,

--- a/app/services/tenants_service.py
+++ b/app/services/tenants_service.py
@@ -6,6 +6,7 @@ from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, AuthorizationError, ValidationError
 from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
+from app.core.timezones import DEFAULT_TENANT_TIMEZONE
 from app.models.auth import Tenant, UserTenantsResponse
 from app.models.tenant import (
     TenantMembersResponse, TenantMemberDetail, TenantMemberProfile,
@@ -413,9 +414,9 @@ async def create_tenant(request: Request, body: TenantCreate) -> TenantCreateRes
                     """INSERT INTO tenant_public_profiles
                            (tenant_id, display_name, slug,
                             is_active, is_manually_open, welcome_email_sent, tables_enabled,
-                            comandas_enabled, kds_enabled)
-                       VALUES ($1, $2, $3, true, false, false, false, false, false)""",
-                    tenant_id, body.name, slug
+                            comandas_enabled, kds_enabled, timezone)
+                       VALUES ($1, $2, $3, true, false, false, false, false, false, $4)""",
+                    tenant_id, body.name, slug, DEFAULT_TENANT_TIMEZONE
                 )
 
                 # 3. Add creator as superuser

--- a/migrations/095_tenant_timezone.sql
+++ b/migrations/095_tenant_timezone.sql
@@ -1,0 +1,22 @@
+-- 095_tenant_timezone.sql
+-- api-warolabs#530 - tenant operational timezone contract.
+--
+-- Defaults preserve existing Colombia behavior while allowing future tenants
+-- to declare an IANA timezone for operational dates and business hours.
+
+ALTER TABLE tenant_public_profiles
+    ADD COLUMN IF NOT EXISTS timezone TEXT NOT NULL DEFAULT 'America/Bogota';
+
+UPDATE tenant_public_profiles
+SET timezone = 'America/Bogota'
+WHERE timezone IS NULL OR btrim(timezone) = '';
+
+ALTER TABLE tenant_public_profiles
+    DROP CONSTRAINT IF EXISTS tenant_public_profiles_timezone_non_blank;
+
+ALTER TABLE tenant_public_profiles
+    ADD CONSTRAINT tenant_public_profiles_timezone_non_blank
+    CHECK (btrim(timezone) <> '');
+
+COMMENT ON COLUMN tenant_public_profiles.timezone IS
+    'IANA timezone for tenant operational dates, business hours, and report boundaries. Defaults to America/Bogota.';

--- a/sql/20260626_tenant_timezone.sql
+++ b/sql/20260626_tenant_timezone.sql
@@ -1,0 +1,16 @@
+ALTER TABLE tenant_public_profiles
+    ADD COLUMN IF NOT EXISTS timezone TEXT NOT NULL DEFAULT 'America/Bogota';
+
+UPDATE tenant_public_profiles
+SET timezone = 'America/Bogota'
+WHERE timezone IS NULL OR btrim(timezone) = '';
+
+ALTER TABLE tenant_public_profiles
+    DROP CONSTRAINT IF EXISTS tenant_public_profiles_timezone_non_blank;
+
+ALTER TABLE tenant_public_profiles
+    ADD CONSTRAINT tenant_public_profiles_timezone_non_blank
+    CHECK (btrim(timezone) <> '');
+
+COMMENT ON COLUMN tenant_public_profiles.timezone IS
+    'IANA timezone for tenant operational dates, business hours, and report boundaries. Defaults to America/Bogota.';

--- a/tests/test_pos_permissions.py
+++ b/tests/test_pos_permissions.py
@@ -161,6 +161,7 @@ def test_cashier_role_passes_pos_restaurant_context_under_enforce():
                  "fiscal_data": {"nit": "900000000"},
                  "tax_config": {"iva_applicable": False},
                  "invoicing_ready": False,
+                 "timezone": "America/Bogota",
              }),
          ):
         client = TestClient(app)
@@ -168,3 +169,4 @@ def test_cashier_role_passes_pos_restaurant_context_under_enforce():
 
     assert response.status_code == 200
     assert response.json()["data"]["display_name"] == "Demo"
+    assert response.json()["data"]["timezone"] == "America/Bogota"

--- a/tests/test_tenant_timezones.py
+++ b/tests/test_tenant_timezones.py
@@ -1,0 +1,126 @@
+from contextlib import asynccontextmanager
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from app.core.timezones import (
+    DEFAULT_TENANT_TIMEZONE,
+    local_day_utc_range,
+    normalize_timezone,
+    tenant_today,
+)
+from app.models.tenant_public_profile import TenantPublicProfileUpdate
+from app.services import pos_context_service, tenant_config_service
+
+
+def test_normalize_timezone_falls_back_for_missing_or_invalid_values():
+    assert normalize_timezone(None) == DEFAULT_TENANT_TIMEZONE
+    assert normalize_timezone("") == DEFAULT_TENANT_TIMEZONE
+    assert normalize_timezone("Not/AZone") == DEFAULT_TENANT_TIMEZONE
+    assert normalize_timezone("America/Mexico_City") == "America/Mexico_City"
+
+
+def test_tenant_today_and_local_day_range_use_tenant_timezone():
+    now = datetime(2026, 1, 2, 4, 30, tzinfo=timezone.utc)
+
+    assert tenant_today("America/Bogota", now=now) == date(2026, 1, 1)
+    assert tenant_today("America/Mexico_City", now=now) == date(2026, 1, 1)
+
+    start_utc, end_utc = local_day_utc_range(date(2026, 1, 1), "America/Bogota")
+    assert start_utc.isoformat() == "2026-01-01T05:00:00+00:00"
+    assert end_utc.isoformat() == "2026-01-02T05:00:00+00:00"
+
+
+def test_public_profile_write_model_rejects_invalid_timezone():
+    with pytest.raises(PydanticValidationError):
+        TenantPublicProfileUpdate(timezone="Not/AZone")
+
+    model = TenantPublicProfileUpdate(timezone="America/Mexico_City")
+    assert model.timezone == "America/Mexico_City"
+
+
+def test_profile_from_row_normalizes_legacy_invalid_timezone():
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    profile = tenant_config_service._profile_from_row({
+        "id": uuid4(),
+        "tenant_id": uuid4(),
+        "slug": "demo",
+        "display_name": "Demo",
+        "is_active": True,
+        "timezone": "Legacy/Bad",
+        "created_at": now,
+        "updated_at": now,
+    })
+
+    assert profile.timezone == DEFAULT_TENANT_TIMEZONE
+
+
+def _pos_context_row(timezone_name):
+    return {
+        "display_name": "Demo",
+        "timezone": timezone_name,
+        "kds_enabled": None,
+        "comandas_enabled": None,
+        "expediter_enabled": None,
+        "tables_enabled": None,
+        "table_qr_module_enabled": None,
+        "accepts_online_orders": None,
+        "auto_select_generic_enabled": None,
+        "open_sale_enabled": None,
+        "minimum_consumption_enabled": None,
+        "minimum_consumption_amount": None,
+        "minimum_consumption_restrictive": None,
+        "waiter_attribution_enabled": None,
+        "tables_label_singular": None,
+        "tables_label_plural": None,
+        "tip_enabled": None,
+        "tip_taxable_default": None,
+        "tip_default_percentages": None,
+        "tip_preselect_index": None,
+        "logo_url": None,
+        "allow_promo_line_opt_out": None,
+        "promo_conflict_strategy": None,
+        "promo_type_block_map": None,
+        "nit": None,
+        "business_name": None,
+        "type_organization_id": None,
+        "tax_regime_id": None,
+        "tax_level_id": None,
+        "fiscal_address": None,
+        "city": None,
+        "city_id": None,
+        "fiscal_phone": None,
+        "fiscal_email": None,
+        "receipt_document_label": None,
+        "receipt_tip_label": None,
+        "show_logo_on_receipts": None,
+        "inc_applicable": None,
+        "inc_rate": None,
+        "inc_included_in_price": None,
+        "iva_applicable": None,
+        "iva_rate": None,
+        "iva_included_in_price": None,
+        "liquor_tax_applicable": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_pos_context_exposes_normalized_timezone():
+    tenant_id = UUID("93b3e582-34fa-44a6-8d0f-bf82a3608727")
+
+    @asynccontextmanager
+    async def _ctx(*_, **__):
+        conn = MagicMock()
+        conn.fetchrow = AsyncMock(return_value=_pos_context_row("Bad/Legacy"))
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+
+    with patch("app.services.pos_context_service.get_db_connection", side_effect=_ctx), \
+         patch("app.services.pos_context_service.get_readiness", new=AsyncMock(return_value={"ready": False})), \
+         patch("app.services.pos_context_service.fetch_open_sale_product", new=AsyncMock(return_value=None)):
+        payload = await pos_context_service.get_restaurant_context(tenant_id)
+
+    assert payload["timezone"] == DEFAULT_TENANT_TIMEZONE


### PR DESCRIPTION
## Summary
- add tenant_public_profiles timezone migration/default and shared operational timezone helpers
- validate timezone writes while normalizing legacy invalid reads to America/Bogota
- expose normalized timezone through tenant profile/public/POS context payloads

## Tests
- pytest tests/test_tenant_timezones.py tests/test_mi_negocio_permissions.py tests/test_pos_permissions.py

Closes #530