### PR TITLE
Use tenant timezone for report date filters

### DIFF
--- a/app/core/timezones.py
+++ b/app/core/timezones.py
@@ -4,6 +4,7 @@ Operational tenant time controls local business dates, schedules, and report
 boundaries. Fiscal/legal Colombia time should use a separate named helper.
 """
 from datetime import date, datetime, time, timedelta, timezone
+from inspect import isawaitable
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 DEFAULT_TENANT_TIMEZONE = "America/Bogota"
@@ -33,6 +34,16 @@ def normalize_timezone(value: str | None) -> str:
 def get_zoneinfo(value: str | None) -> ZoneInfo:
     """Return ZoneInfo for a tenant timezone, using the safe default if needed."""
     return ZoneInfo(normalize_timezone(value))
+
+
+async def resolve_tenant_timezone(conn, tenant_id) -> str:
+    """Resolve a tenant's operational timezone from profile config."""
+    result = conn.fetchval(
+        "SELECT timezone FROM tenant_public_profiles WHERE tenant_id = $1",
+        tenant_id,
+    )
+    value = await result if isawaitable(result) else result
+    return normalize_timezone(value)
 
 
 def tenant_today(value: str | None, now: datetime | None = None) -> date:

--- a/app/routers/operaciones_operation_events.py
+++ b/app/routers/operaciones_operation_events.py
@@ -17,8 +17,8 @@ router = APIRouter(prefix="/operaciones", tags=["Operaciones Bitácora"])
 async def list_operation_events_endpoint(
     request: Request,
     domain: str = Query("pos", description="Event domain (MVP: pos)"),
-    date_from: Optional[str] = Query(None, description="ISO date YYYY-MM-DD (inclusive, Bogotá)"),
-    date_to: Optional[str] = Query(None, description="ISO date YYYY-MM-DD (inclusive, Bogotá)"),
+    date_from: Optional[str] = Query(None, description="ISO date YYYY-MM-DD (inclusive, tenant local day)"),
+    date_to: Optional[str] = Query(None, description="ISO date YYYY-MM-DD (inclusive, tenant local day)"),
     channel: Optional[str] = Query(None, description="mesa | barra | mostrador"),
     action: Optional[str] = Query(None, description="Action filter (see epic catalog)"),
     actor_user_id: Optional[UUID] = Query(None),

--- a/app/services/analytics_service.py
+++ b/app/services/analytics_service.py
@@ -9,6 +9,7 @@ from app.database import get_db_connection
 from app.services import cost_resolution_service
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError
+from app.core.timezones import normalize_timezone, resolve_tenant_timezone, tenant_today
 from datetime import datetime, date, timedelta
 from statistics import mean as st_mean, quantiles
 import logging
@@ -65,12 +66,13 @@ async def _get_menu_analysis_for_tenant(
     parsed_date_from = parse_date(date_from)
     parsed_date_to = parse_date(date_to)
 
-    if not parsed_date_from or not parsed_date_to:
-        today = datetime.now().date()
-        parsed_date_to = today
-        parsed_date_from = today.replace(month=1, day=1)
-
     async with get_db_connection() as conn:
+        timezone_name = await resolve_tenant_timezone(conn, tenant_id)
+        if not parsed_date_from or not parsed_date_to:
+            today = tenant_today(timezone_name)
+            parsed_date_to = today
+            parsed_date_from = today.replace(month=1, day=1)
+
         # Real/perceived costs from product table (#744/#745); BCG uses operativo when set (#747).
         query = f"""
             WITH {_PRODUCT_COSTS_CTE},
@@ -98,8 +100,8 @@ async def _get_menu_analysis_for_tenant(
                     AND (
                         o.id IS NULL OR (
                             o.status = 'completed'
-                            AND DATE(o.order_date AT TIME ZONE 'America/Bogota') >= $2
-                            AND DATE(o.order_date AT TIME ZONE 'America/Bogota') <= $3
+                            AND DATE(o.order_date AT TIME ZONE $4) >= $2
+                            AND DATE(o.order_date AT TIME ZONE $4) <= $3
                         )
                     )
                 GROUP BY p.id, p.name, pc.price, pc.estimated_cost, pc.costo_percibido,
@@ -142,7 +144,7 @@ async def _get_menu_analysis_for_tenant(
             FROM product_sales ps
             CROSS JOIN sales_stats ss
             ORDER BY ps.total_revenue DESC
-            LIMIT $4
+            LIMIT $5
         """
 
         rows = await conn.fetch(
@@ -150,6 +152,7 @@ async def _get_menu_analysis_for_tenant(
             tenant_id,
             parsed_date_from,
             parsed_date_to,
+            timezone_name,
             limit
         )
 
@@ -257,28 +260,29 @@ async def _get_food_cost_for_tenant(
     parsed_date_from = parse_date(date_from)
     parsed_date_to = parse_date(date_to)
 
-    if not parsed_date_from or not parsed_date_to:
-        today = datetime.now().date()
-        parsed_date_to = today
-        parsed_date_from = today.replace(month=1, day=1)
-
-    # Determine comparison window based on compare_to mode.
-    # Default (None or "previous_period") mirrors the same duration immediately before date_from.
-    if compare_to == "previous_year":
-        prev_date_from = parsed_date_from - timedelta(days=365)
-        prev_date_to = parsed_date_to - timedelta(days=365)
-    elif compare_to == "custom":
-        cf = parse_date(compare_from)
-        ct = parse_date(compare_date_to)
-        prev_date_from = cf if cf else parsed_date_from - timedelta(days=(parsed_date_to - parsed_date_from).days + 1)
-        prev_date_to = ct if ct else parsed_date_from - timedelta(days=1)
-    else:
-        # "previous_period" (default) — same duration immediately before
-        days_diff = (parsed_date_to - parsed_date_from).days + 1
-        prev_date_to = parsed_date_from - timedelta(days=1)
-        prev_date_from = prev_date_to - timedelta(days=days_diff - 1)
-
     async with get_db_connection() as conn:
+        timezone_name = await resolve_tenant_timezone(conn, tenant_id)
+        if not parsed_date_from or not parsed_date_to:
+            today = tenant_today(timezone_name)
+            parsed_date_to = today
+            parsed_date_from = today.replace(month=1, day=1)
+
+        # Determine comparison window based on compare_to mode.
+        # Default (None or "previous_period") mirrors the same duration immediately before date_from.
+        if compare_to == "previous_year":
+            prev_date_from = parsed_date_from - timedelta(days=365)
+            prev_date_to = parsed_date_to - timedelta(days=365)
+        elif compare_to == "custom":
+            cf = parse_date(compare_from)
+            ct = parse_date(compare_date_to)
+            prev_date_from = cf if cf else parsed_date_from - timedelta(days=(parsed_date_to - parsed_date_from).days + 1)
+            prev_date_to = ct if ct else parsed_date_from - timedelta(days=1)
+        else:
+            # "previous_period" (default) — same duration immediately before
+            days_diff = (parsed_date_to - parsed_date_from).days + 1
+            prev_date_to = parsed_date_from - timedelta(days=1)
+            prev_date_from = prev_date_to - timedelta(days=days_diff - 1)
+
         query = f"""
             WITH {_PRODUCT_COSTS_CTE},
             period_costs AS (
@@ -287,8 +291,8 @@ async def _get_food_cost_for_tenant(
                     SUM(oi.quantity * pc.estimated_cost) as total_cost,
                     SUM(oi.quantity * pc.effective_cost) as total_cost_operativo,
                     CASE
-                        WHEN DATE(o.order_date AT TIME ZONE 'America/Bogota') >= $2
-                            AND DATE(o.order_date AT TIME ZONE 'America/Bogota') <= $3
+                        WHEN DATE(o.order_date AT TIME ZONE $6) >= $2
+                            AND DATE(o.order_date AT TIME ZONE $6) <= $3
                         THEN 'current'
                         ELSE 'previous'
                     END as period
@@ -298,11 +302,11 @@ async def _get_food_cost_for_tenant(
                 WHERE o.tenant_id = $1
                     AND o.status = 'completed'
                     AND (
-                        (DATE(o.order_date AT TIME ZONE 'America/Bogota') >= $2
-                            AND DATE(o.order_date AT TIME ZONE 'America/Bogota') <= $3)
+                        (DATE(o.order_date AT TIME ZONE $6) >= $2
+                            AND DATE(o.order_date AT TIME ZONE $6) <= $3)
                         OR
-                        (DATE(o.order_date AT TIME ZONE 'America/Bogota') >= $4
-                            AND DATE(o.order_date AT TIME ZONE 'America/Bogota') <= $5)
+                        (DATE(o.order_date AT TIME ZONE $6) >= $4
+                            AND DATE(o.order_date AT TIME ZONE $6) <= $5)
                     )
                 GROUP BY period
             )
@@ -321,7 +325,8 @@ async def _get_food_cost_for_tenant(
             parsed_date_from,
             parsed_date_to,
             prev_date_from,
-            prev_date_to
+            prev_date_to,
+            timezone_name,
         )
 
         # Parse results — food_cost_pct = real (estimated_cost); operativo KPI optional (#747)
@@ -414,6 +419,7 @@ async def _get_alerts_for_tenant(
     alerts = []
 
     async with get_db_connection() as conn:
+        timezone_name = await resolve_tenant_timezone(conn, tenant_id)
         # 1. CRITICAL: Ingredients with zero stock but active consumption (POS-only detection)
         zero_stock_active_query = """
             WITH recent_consumption AS (
@@ -483,7 +489,7 @@ async def _get_alerts_for_tenant(
                     JOIN product p ON oi.product_id = p.id
                     WHERE o.tenant_id = $1
                         AND o.status = 'completed'
-                        AND DATE(o.order_date AT TIME ZONE 'America/Bogota') >= CURRENT_DATE - INTERVAL '7 days'
+                        AND DATE(o.order_date AT TIME ZONE $2) >= (NOW() AT TIME ZONE $2)::date - INTERVAL '7 days'
                     GROUP BY p.id, p.name
                     ORDER BY order_count DESC
                     LIMIT 3
@@ -515,7 +521,7 @@ async def _get_alerts_for_tenant(
                 ORDER BY order_count DESC
                 LIMIT 2
             """
-            blocked_rows = await conn.fetch(blocked_products_query, tenant_id)
+            blocked_rows = await conn.fetch(blocked_products_query, tenant_id, timezone_name)
 
             for row in blocked_rows:
                 title = f"🔴 Producto bloqueado: {row['product_name']}"
@@ -679,12 +685,12 @@ async def _get_alerts_for_tenant(
                 JOIN product p ON oi.product_id = p.id
                 WHERE o.tenant_id = $1
                     AND o.status = 'completed'
-                    AND DATE(o.order_date AT TIME ZONE 'America/Bogota') >= CURRENT_DATE - INTERVAL '7 days'
+                    AND DATE(o.order_date AT TIME ZONE $2) >= (NOW() AT TIME ZONE $2)::date - INTERVAL '7 days'
                 GROUP BY p.id, p.name
                 ORDER BY order_count DESC
                 LIMIT 1
             """
-            top_row = await conn.fetchrow(top_products_query, tenant_id)
+            top_row = await conn.fetchrow(top_products_query, tenant_id, timezone_name)
 
             if top_row:
                 alerts.append({
@@ -1402,7 +1408,8 @@ async def _get_cohort_for_tenant(
     if period not in ("weekly", "monthly"):
         raise APIError("period must be 'weekly' or 'monthly'", status_code=400)
 
-    today = datetime.now().date()
+    timezone = normalize_timezone(timezone)
+    today = tenant_today(timezone)
 
     parsed_date_from = parse_date(date_from)
     parsed_date_to = parse_date(date_to)
@@ -1424,7 +1431,7 @@ async def _get_cohort_for_tenant(
                 SELECT
                     customer_id,
                     DATE_TRUNC('{trunc_unit}',
-                        MIN(order_date) AT TIME ZONE '{timezone}') AS cohort_period
+                        MIN(order_date) AT TIME ZONE $5) AS cohort_period
                 FROM orders
                 WHERE customer_id IS NOT NULL
                   AND tenant_id = $1
@@ -1442,7 +1449,7 @@ async def _get_cohort_for_tenant(
                     fo.customer_id,
                     fo.cohort_period,
                     DATE_TRUNC('{trunc_unit}',
-                        o.order_date AT TIME ZONE '{timezone}') AS active_period
+                        o.order_date AT TIME ZONE $5) AS active_period
                 FROM orders o
                 JOIN first_orders fo ON fo.customer_id = o.customer_id
                 WHERE o.tenant_id = $1
@@ -1473,7 +1480,7 @@ async def _get_cohort_for_tenant(
                 SELECT
                     customer_id,
                     DATE_TRUNC('{trunc_unit}',
-                        MIN(order_date) AT TIME ZONE '{timezone}') AS cohort_period
+                        MIN(order_date) AT TIME ZONE $5) AS cohort_period
                 FROM orders
                 WHERE customer_id IS NOT NULL
                   AND tenant_id = $1
@@ -1491,7 +1498,7 @@ async def _get_cohort_for_tenant(
                     fo.customer_id,
                     fo.cohort_period,
                     DATE_TRUNC('{trunc_unit}',
-                        o.order_date AT TIME ZONE '{timezone}') AS active_period
+                        o.order_date AT TIME ZONE $5) AS active_period
                 FROM orders o
                 JOIN first_orders fo ON fo.customer_id = o.customer_id
                 WHERE o.tenant_id = $1
@@ -1526,6 +1533,7 @@ async def _get_cohort_for_tenant(
             parsed_date_from,
             parsed_date_to,
             periods,
+            timezone,
         )
 
     # Group rows by cohort_period and build the full retention matrix.
@@ -1591,7 +1599,8 @@ async def _get_rfm_for_tenant(
       Hibernating — low recency and low frequency
       Lost        — catch-all for remaining combinations
     """
-    today = datetime.now().date()
+    timezone = normalize_timezone(timezone)
+    today = tenant_today(timezone)
 
     parsed_date_from = parse_date(date_from)
     parsed_date_to = parse_date(date_to)
@@ -1616,12 +1625,12 @@ async def _get_rfm_for_tenant(
                 o.customer_id,
                 p.name                                                     AS customer_name,
                 COUNT(*)::int                                              AS order_count,
-                MAX(o.order_date AT TIME ZONE '{timezone}')                AS last_order_date,
+                MAX(o.order_date AT TIME ZONE $8)                          AS last_order_date,
                 SUM(o.total_amount)::bigint                                AS total_spent,
                 EXTRACT(
                     EPOCH FROM (
-                        NOW() AT TIME ZONE '{timezone}'
-                        - MAX(o.order_date AT TIME ZONE '{timezone}')
+                        NOW() AT TIME ZONE $8
+                        - MAX(o.order_date AT TIME ZONE $8)
                     )
                 ) / 86400.0                                                AS recency_days
             FROM orders o
@@ -1630,8 +1639,8 @@ async def _get_rfm_for_tenant(
               AND o.status      = 'completed'
               AND o.customer_id IS NOT NULL
               AND p.email NOT LIKE '%@customer.temp'
-              AND DATE(o.order_date AT TIME ZONE '{timezone}') >= $2
-              AND DATE(o.order_date AT TIME ZONE '{timezone}') <= $3
+              AND DATE(o.order_date AT TIME ZONE $8) >= $2
+              AND DATE(o.order_date AT TIME ZONE $8) <= $3
             GROUP BY o.customer_id, p.name
         ),
         scored AS (
@@ -1676,6 +1685,7 @@ async def _get_rfm_for_tenant(
             high_threshold,
             mid_threshold,
             low_threshold,
+            timezone,
         )
 
     customers = [
@@ -1863,15 +1873,16 @@ async def get_kitchen_metrics(
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
 
-        parsed_date_from = parse_date(date_from)
-        parsed_date_to = parse_date(date_to)
-
-        if not parsed_date_from or not parsed_date_to:
-            today = datetime.now().date()
-            parsed_date_to = today
-            parsed_date_from = today - timedelta(days=7)
-
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
+            parsed_date_from = parse_date(date_from)
+            parsed_date_to = parse_date(date_to)
+
+            if not parsed_date_from or not parsed_date_to:
+                today = tenant_today(timezone_name)
+                parsed_date_to = today
+                parsed_date_from = today - timedelta(days=7)
+
             # 1. Summary Metrics & Station Breakdown
             # Uses kitchen_stations left join to include stations even if they had no orders in period
             query_stations = """
@@ -1886,8 +1897,8 @@ async def get_kitchen_metrics(
                     FROM comandas c
                     JOIN kitchen_stations ks ON c.station_id = ks.id
                     WHERE c.tenant_id = $1
-                        AND DATE(c.fired_at AT TIME ZONE 'America/Bogota') >= $2
-                        AND DATE(c.fired_at AT TIME ZONE 'America/Bogota') <= $3
+                        AND DATE(c.fired_at AT TIME ZONE $4) >= $2
+                        AND DATE(c.fired_at AT TIME ZONE $4) <= $3
                         AND c.status IN ('ready', 'delivered')
                         AND c.ready_at IS NOT NULL
                     GROUP BY c.station_id, ks.alert_threshold_2_min
@@ -1905,7 +1916,7 @@ async def get_kitchen_metrics(
                 ORDER BY ks.display_order
             """
             
-            station_rows = await conn.fetch(query_stations, tenant_id, parsed_date_from, parsed_date_to)
+            station_rows = await conn.fetch(query_stations, tenant_id, parsed_date_from, parsed_date_to, timezone_name)
             
             station_metrics = []
             total_orders = 0
@@ -1932,16 +1943,16 @@ async def get_kitchen_metrics(
             # 2. Daily/Hourly Volume (Peak Hours)
             query_volume = """
                 SELECT 
-                    EXTRACT(HOUR FROM fired_at AT TIME ZONE 'America/Bogota')::int as hour,
+                    EXTRACT(HOUR FROM fired_at AT TIME ZONE $4)::int as hour,
                     COUNT(id) as count
                 FROM comandas
                 WHERE tenant_id = $1
-                    AND DATE(fired_at AT TIME ZONE 'America/Bogota') >= $2
-                    AND DATE(fired_at AT TIME ZONE 'America/Bogota') <= $3
+                    AND DATE(fired_at AT TIME ZONE $4) >= $2
+                    AND DATE(fired_at AT TIME ZONE $4) <= $3
                 GROUP BY hour
                 ORDER BY hour
             """
-            volume_rows = await conn.fetch(query_volume, tenant_id, parsed_date_from, parsed_date_to)
+            volume_rows = await conn.fetch(query_volume, tenant_id, parsed_date_from, parsed_date_to, timezone_name)
             volume_by_hour = {row['hour']: row['count'] for row in volume_rows}
             
             # Fill missing hours
@@ -1958,15 +1969,15 @@ async def get_kitchen_metrics(
                 FROM comanda_items ci
                 JOIN comandas c ON ci.comanda_id = c.id
                 WHERE c.tenant_id = $1
-                    AND DATE(c.fired_at AT TIME ZONE 'America/Bogota') >= $2
-                    AND DATE(c.fired_at AT TIME ZONE 'America/Bogota') <= $3
+                    AND DATE(c.fired_at AT TIME ZONE $4) >= $2
+                    AND DATE(c.fired_at AT TIME ZONE $4) <= $3
                     AND ci.status = 'ready'
                     AND ci.ready_at IS NOT NULL
                 GROUP BY ci.kitchen_name
                 ORDER BY avg_prep_min DESC
                 LIMIT 10
             """
-            product_rows = await conn.fetch(query_products, tenant_id, parsed_date_from, parsed_date_to)
+            product_rows = await conn.fetch(query_products, tenant_id, parsed_date_from, parsed_date_to, timezone_name)
             slowest_products = [{
                 "name": r['name'],
                 "total_qty": float(r['total_qty']),

--- a/app/services/direct_purchase_service.py
+++ b/app/services/direct_purchase_service.py
@@ -128,6 +128,7 @@ from fastapi import Request, Response, HTTPException, UploadFile
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError
+from app.core.timezones import resolve_tenant_timezone
 from app.services.purchase_tracking_service import (
     create_status_history_entry,
     upload_purchase_attachments
@@ -771,6 +772,7 @@ async def _get_direct_purchases_for_tenant(
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             # Build query with tenant isolation and is_direct_entry filter
             base_query = """
                 SELECT
@@ -832,25 +834,28 @@ async def _get_direct_purchases_for_tenant(
                 param_count += 1
 
             # Date filter
-            if date_filter:
+            if date_filter in {'today', 'yesterday', 'last_week', '15_days', '1_month', '3_months'}:
+                tz_param = param_count
+                params.append(timezone_name)
+                param_count += 1
                 if date_filter == 'today':
-                    base_query += f" AND DATE(tp.purchase_date AT TIME ZONE 'America/Bogota') = (NOW() AT TIME ZONE 'America/Bogota')::date"
-                    count_query += f" AND DATE(tp.purchase_date AT TIME ZONE 'America/Bogota') = (NOW() AT TIME ZONE 'America/Bogota')::date"
+                    base_query += f" AND DATE(tp.purchase_date AT TIME ZONE ${tz_param}) = (NOW() AT TIME ZONE ${tz_param})::date"
+                    count_query += f" AND DATE(tp.purchase_date AT TIME ZONE ${tz_param}) = (NOW() AT TIME ZONE ${tz_param})::date"
                 elif date_filter == 'yesterday':
-                    base_query += f" AND DATE(tp.purchase_date AT TIME ZONE 'America/Bogota') = (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '1 day'"
-                    count_query += f" AND DATE(tp.purchase_date AT TIME ZONE 'America/Bogota') = (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '1 day'"
+                    base_query += f" AND DATE(tp.purchase_date AT TIME ZONE ${tz_param}) = (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '1 day'"
+                    count_query += f" AND DATE(tp.purchase_date AT TIME ZONE ${tz_param}) = (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '1 day'"
                 elif date_filter == 'last_week':
-                    base_query += f" AND (tp.purchase_date AT TIME ZONE 'America/Bogota') >= (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '7 days'"
-                    count_query += f" AND (tp.purchase_date AT TIME ZONE 'America/Bogota') >= (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '7 days'"
+                    base_query += f" AND (tp.purchase_date AT TIME ZONE ${tz_param}) >= (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '7 days'"
+                    count_query += f" AND (tp.purchase_date AT TIME ZONE ${tz_param}) >= (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '7 days'"
                 elif date_filter == '15_days':
-                    base_query += f" AND (tp.purchase_date AT TIME ZONE 'America/Bogota') >= (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '15 days'"
-                    count_query += f" AND (tp.purchase_date AT TIME ZONE 'America/Bogota') >= (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '15 days'"
+                    base_query += f" AND (tp.purchase_date AT TIME ZONE ${tz_param}) >= (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '15 days'"
+                    count_query += f" AND (tp.purchase_date AT TIME ZONE ${tz_param}) >= (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '15 days'"
                 elif date_filter == '1_month':
-                    base_query += f" AND (tp.purchase_date AT TIME ZONE 'America/Bogota') >= (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '1 month'"
-                    count_query += f" AND (tp.purchase_date AT TIME ZONE 'America/Bogota') >= (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '1 month'"
+                    base_query += f" AND (tp.purchase_date AT TIME ZONE ${tz_param}) >= (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '1 month'"
+                    count_query += f" AND (tp.purchase_date AT TIME ZONE ${tz_param}) >= (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '1 month'"
                 elif date_filter == '3_months':
-                    base_query += f" AND (tp.purchase_date AT TIME ZONE 'America/Bogota') >= (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '3 months'"
-                    count_query += f" AND (tp.purchase_date AT TIME ZONE 'America/Bogota') >= (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '3 months'"
+                    base_query += f" AND (tp.purchase_date AT TIME ZONE ${tz_param}) >= (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '3 months'"
+                    count_query += f" AND (tp.purchase_date AT TIME ZONE ${tz_param}) >= (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '3 months'"
 
             # Add pagination
             offset = (page - 1) * limit

--- a/app/services/operation_events_service.py
+++ b/app/services/operation_events_service.py
@@ -10,6 +10,7 @@ from fastapi import Request
 
 from app.core.exceptions import AuthenticationError
 from app.core.middleware import require_valid_session
+from app.core.timezones import resolve_tenant_timezone
 from app.database import get_db_connection
 
 logger = logging.getLogger(__name__)
@@ -191,20 +192,31 @@ async def list_operation_events(
     parsed_date_from = _parse_date(date_from)
     parsed_date_to = _parse_date(date_to)
 
+    async with get_db_connection(use_transaction=False) as conn:
+        timezone_name = await resolve_tenant_timezone(conn, tenant_id)
+
     if parsed_date_from:
         param_count += 1
+        date_param = param_count
+        param_count += 1
+        tz_param = param_count
         where_conditions.append(
-            f"e.created_at >= (${param_count}::timestamp AT TIME ZONE 'America/Bogota')"
+            f"e.created_at >= (${date_param}::timestamp AT TIME ZONE ${tz_param})"
         )
         params.append(parsed_date_from)
+        params.append(timezone_name)
 
     if parsed_date_to:
         param_count += 1
+        date_param = param_count
+        param_count += 1
+        tz_param = param_count
         where_conditions.append(
-            f"e.created_at < ((${param_count}::timestamp + interval '1 day') "
-            f"AT TIME ZONE 'America/Bogota')"
+            f"e.created_at < ((${date_param}::timestamp + interval '1 day') "
+            f"AT TIME ZONE ${tz_param})"
         )
         params.append(parsed_date_to)
+        params.append(timezone_name)
 
     if channel:
         param_count += 1

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -11,6 +11,7 @@ from fastapi import Request
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError
+from app.core.timezones import resolve_tenant_timezone, tenant_today
 from app.services.aws_ses_service import ses_service
 from app.services.waros_service import evaluate_and_award
 from app.services.cierre_service import (
@@ -42,6 +43,36 @@ def parse_date(date_str: Optional[str]) -> Optional[date]:
 logger = logging.getLogger(__name__)
 _BOG = ZoneInfo("America/Bogota")
 _INVENTORY_QUANTITY_SCALE = Decimal("0.000001")
+
+
+def _append_local_date_bounds(
+    where_conditions: List[str],
+    params: List[Any],
+    param_count: int,
+    column: str,
+    parsed_date_from: Optional[date],
+    parsed_date_to: Optional[date],
+    timezone_name: str,
+) -> int:
+    if parsed_date_from:
+        param_count += 1
+        date_param = param_count
+        param_count += 1
+        tz_param = param_count
+        where_conditions.append(f"{column} >= (${date_param}::timestamp AT TIME ZONE ${tz_param})")
+        params.extend([parsed_date_from, timezone_name])
+
+    if parsed_date_to:
+        param_count += 1
+        date_param = param_count
+        param_count += 1
+        tz_param = param_count
+        where_conditions.append(
+            f"{column} < ((${date_param}::timestamp + interval '1 day') AT TIME ZONE ${tz_param})"
+        )
+        params.extend([parsed_date_to, timezone_name])
+
+    return param_count
 
 
 def _inventory_quantity(value: Any) -> float:
@@ -268,6 +299,7 @@ async def get_orders_list(
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             # Build WHERE clause
             where_conditions = [
                 "o.tenant_id = $1",
@@ -310,16 +342,15 @@ async def get_orders_list(
             # Date range filter
             parsed_date_from = parse_date(date_from)
             parsed_date_to = parse_date(date_to)
-
-            if parsed_date_from:
-                param_count += 1
-                where_conditions.append(f"o.order_date >= (${param_count}::timestamp AT TIME ZONE 'America/Bogota')")
-                params.append(parsed_date_from)
-
-            if parsed_date_to:
-                param_count += 1
-                where_conditions.append(f"o.order_date < ((${param_count}::timestamp + interval '1 day') AT TIME ZONE 'America/Bogota')")
-                params.append(parsed_date_to)
+            param_count = _append_local_date_bounds(
+                where_conditions,
+                params,
+                param_count,
+                "o.order_date",
+                parsed_date_from,
+                parsed_date_to,
+                timezone_name,
+            )
 
             # Delivery-only filter: composes with POS_LIKE_FILTER, uses partial index idx_orders_delivery_address_id
             if delivery_only:
@@ -492,6 +523,7 @@ async def get_tips_list(
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             where_conditions = [
                 "o.tenant_id = $1",
                 "o.tip_amount > 0",
@@ -525,16 +557,15 @@ async def get_tips_list(
 
             parsed_date_from = parse_date(date_from)
             parsed_date_to = parse_date(date_to)
-
-            if parsed_date_from:
-                param_count += 1
-                where_conditions.append(f"o.order_date >= (${param_count}::timestamp AT TIME ZONE 'America/Bogota')")
-                params.append(parsed_date_from)
-
-            if parsed_date_to:
-                param_count += 1
-                where_conditions.append(f"o.order_date < ((${param_count}::timestamp + interval '1 day') AT TIME ZONE 'America/Bogota')")
-                params.append(parsed_date_to)
+            param_count = _append_local_date_bounds(
+                where_conditions,
+                params,
+                param_count,
+                "o.order_date",
+                parsed_date_from,
+                parsed_date_to,
+                timezone_name,
+            )
 
             where_clause = " AND ".join(where_conditions)
 
@@ -916,19 +947,20 @@ async def bulk_update_order_status(
         ids = [_UUID(oid) for oid in order_ids]
 
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             # Guard: fail fast if any order falls in a closed monthly accounting period (#362)
             closed_check = await conn.fetchrow(
                 """
                 SELECT 1 FROM orders o
                 JOIN tenant_monthly_periods mp
                     ON mp.tenant_id = o.tenant_id
-                    AND EXTRACT(YEAR  FROM o.order_date AT TIME ZONE 'America/Bogota') = mp.year
-                    AND EXTRACT(MONTH FROM o.order_date AT TIME ZONE 'America/Bogota') = mp.month
+                    AND EXTRACT(YEAR  FROM o.order_date AT TIME ZONE $3) = mp.year
+                    AND EXTRACT(MONTH FROM o.order_date AT TIME ZONE $3) = mp.month
                     AND mp.status = 'closed'
                 WHERE o.id = ANY($1) AND o.tenant_id = $2
                 LIMIT 1
                 """,
-                ids, tenant_id,
+                ids, tenant_id, timezone_name,
             )
             if closed_check:
                 raise APIError(
@@ -1558,6 +1590,7 @@ async def get_customers_list(
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             order_conditions = [
                 "o.tenant_id = $1",
                 "(o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')",
@@ -1578,20 +1611,15 @@ async def get_customers_list(
 
             parsed_date_from = parse_date(date_from)
             parsed_date_to = parse_date(date_to)
-
-            if parsed_date_from:
-                param_count += 1
-                order_conditions.append(
-                    f"o.order_date >= (${param_count}::timestamp AT TIME ZONE 'America/Bogota')"
-                )
-                params.append(parsed_date_from)
-
-            if parsed_date_to:
-                param_count += 1
-                order_conditions.append(
-                    f"o.order_date < ((${param_count}::timestamp + interval '1 day') AT TIME ZONE 'America/Bogota')"
-                )
-                params.append(parsed_date_to)
+            param_count = _append_local_date_bounds(
+                order_conditions,
+                params,
+                param_count,
+                "o.order_date",
+                parsed_date_from,
+                parsed_date_to,
+                timezone_name,
+            )
 
             order_where = " AND ".join(order_conditions)
 
@@ -1713,6 +1741,7 @@ async def get_customer_detail(
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             # --- Customer aggregate stats ---
             customer_row = await conn.fetchrow(
                 """
@@ -1778,20 +1807,15 @@ async def get_customer_detail(
 
             parsed_date_from = parse_date(date_from)
             parsed_date_to = parse_date(date_to)
-
-            if parsed_date_from:
-                param_count += 1
-                where_conditions.append(
-                    f"o.order_date >= (${param_count}::timestamp AT TIME ZONE 'America/Bogota')"
-                )
-                params.append(parsed_date_from)
-
-            if parsed_date_to:
-                param_count += 1
-                where_conditions.append(
-                    f"o.order_date < ((${param_count}::timestamp + interval '1 day') AT TIME ZONE 'America/Bogota')"
-                )
-                params.append(parsed_date_to)
+            param_count = _append_local_date_bounds(
+                where_conditions,
+                params,
+                param_count,
+                "o.order_date",
+                parsed_date_from,
+                parsed_date_to,
+                timezone_name,
+            )
 
             where_clause = " AND ".join(where_conditions)
 
@@ -1953,6 +1977,7 @@ async def get_orders_metrics(
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             # Build WHERE clause
             where_conditions = ["tenant_id = $1", "(pos_cart_id IS NOT NULL OR table_session_id IS NOT NULL OR extra_attributes->>'source' = 'manual')"]
             params = [tenant_id]
@@ -1960,16 +1985,15 @@ async def get_orders_metrics(
 
             parsed_date_from = parse_date(date_from)
             parsed_date_to = parse_date(date_to)
-
-            if parsed_date_from:
-                param_count += 1
-                where_conditions.append(f"order_date >= (${param_count}::timestamp AT TIME ZONE 'America/Bogota')")
-                params.append(parsed_date_from)
-
-            if parsed_date_to:
-                param_count += 1
-                where_conditions.append(f"order_date < ((${param_count}::timestamp + interval '1 day') AT TIME ZONE 'America/Bogota')")
-                params.append(parsed_date_to)
+            param_count = _append_local_date_bounds(
+                where_conditions,
+                params,
+                param_count,
+                "order_date",
+                parsed_date_from,
+                parsed_date_to,
+                timezone_name,
+            )
 
             if payment_method:
                 param_count += 1
@@ -2015,14 +2039,15 @@ async def get_orders_metrics(
                              "(o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')"]
                 tax_params: List[Any] = [tenant_id]
                 tax_pc = 1
-                if parsed_date_from:
-                    tax_pc += 1
-                    tax_where.append(f"o.order_date >= (${tax_pc}::timestamp AT TIME ZONE 'America/Bogota')")
-                    tax_params.append(parsed_date_from)
-                if parsed_date_to:
-                    tax_pc += 1
-                    tax_where.append(f"o.order_date < ((${tax_pc}::timestamp + interval '1 day') AT TIME ZONE 'America/Bogota')")
-                    tax_params.append(parsed_date_to)
+                tax_pc = _append_local_date_bounds(
+                    tax_where,
+                    tax_params,
+                    tax_pc,
+                    "o.order_date",
+                    parsed_date_from,
+                    parsed_date_to,
+                    timezone_name,
+                )
                 if payment_method:
                     tax_pc += 1
                     tax_where.append(f"o.payment_method = ${tax_pc}")
@@ -2093,6 +2118,7 @@ async def get_orders_dashboard(
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             # Build optional filters for the main (all-time) metrics
             main_filters = []
             params = [tenant_id]
@@ -2113,6 +2139,10 @@ async def get_orders_dashboard(
             if main_filters:
                 main_filter_sql = " AND " + " AND ".join(main_filters)
 
+            param_count += 1
+            timezone_param = param_count
+            params.append(timezone_name)
+
             dashboard_query = f"""
                 SELECT
                     -- Main: all-time (with optional payment/status filters)
@@ -2125,24 +2155,24 @@ async def get_orders_dashboard(
                     -- Month-to-date (with optional payment/status filters)
                     COUNT(*) FILTER (
                         WHERE status = 'completed'
-                        AND DATE(order_date AT TIME ZONE 'America/Bogota') >= DATE_TRUNC('month', NOW() AT TIME ZONE 'America/Bogota')::date
+                        AND DATE(order_date AT TIME ZONE ${timezone_param}) >= DATE_TRUNC('month', NOW() AT TIME ZONE ${timezone_param})::date
                         {main_filter_sql}
                     ) as month_completed,
                     COALESCE(SUM(total_amount) FILTER (
                         WHERE status = 'completed'
-                        AND DATE(order_date AT TIME ZONE 'America/Bogota') >= DATE_TRUNC('month', NOW() AT TIME ZONE 'America/Bogota')::date
+                        AND DATE(order_date AT TIME ZONE ${timezone_param}) >= DATE_TRUNC('month', NOW() AT TIME ZONE ${timezone_param})::date
                         {main_filter_sql}
                     ), 0) as month_sales,
 
                     -- Year-to-date (with optional payment/status filters)
                     COUNT(*) FILTER (
                         WHERE status = 'completed'
-                        AND DATE(order_date AT TIME ZONE 'America/Bogota') >= DATE_TRUNC('year', NOW() AT TIME ZONE 'America/Bogota')::date
+                        AND DATE(order_date AT TIME ZONE ${timezone_param}) >= DATE_TRUNC('year', NOW() AT TIME ZONE ${timezone_param})::date
                         {main_filter_sql}
                     ) as year_completed,
                     COALESCE(SUM(total_amount) FILTER (
                         WHERE status = 'completed'
-                        AND DATE(order_date AT TIME ZONE 'America/Bogota') >= DATE_TRUNC('year', NOW() AT TIME ZONE 'America/Bogota')::date
+                        AND DATE(order_date AT TIME ZONE ${timezone_param}) >= DATE_TRUNC('year', NOW() AT TIME ZONE ${timezone_param})::date
                         {main_filter_sql}
                     ), 0) as year_sales
 
@@ -2242,15 +2272,17 @@ async def get_orders_dashboard(
                 )
                 month_tax_rows = await conn.fetch(
                     f"""{_tax_select} WHERE {_base_filter}
-                        AND DATE(o.order_date AT TIME ZONE 'America/Bogota') >= DATE_TRUNC('month', NOW() AT TIME ZONE 'America/Bogota')::date
+                        AND DATE(o.order_date AT TIME ZONE $2) >= DATE_TRUNC('month', NOW() AT TIME ZONE $2)::date
                         GROUP BY COALESCE(p.tax_category, 'standard')""",
-                    tenant_id
+                    tenant_id,
+                    timezone_name,
                 )
                 year_tax_rows = await conn.fetch(
                     f"""{_tax_select} WHERE {_base_filter}
-                        AND DATE(o.order_date AT TIME ZONE 'America/Bogota') >= DATE_TRUNC('year', NOW() AT TIME ZONE 'America/Bogota')::date
+                        AND DATE(o.order_date AT TIME ZONE $2) >= DATE_TRUNC('year', NOW() AT TIME ZONE $2)::date
                         GROUP BY COALESCE(p.tax_category, 'standard')""",
-                    tenant_id
+                    tenant_id,
+                    timezone_name,
                 )
                 _main_std, _main_liq, _tax_label = _compute_tax_breakdown(main_tax_rows, tax_config)
                 _month_std, _month_liq, _ = _compute_tax_breakdown(month_tax_rows, tax_config)
@@ -2332,6 +2364,7 @@ async def export_orders_to_email(
             raise APIError("No se encontró el correo del usuario", status_code=400)
 
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             # Build WHERE clause (same as get_orders_list but without pagination).
             # warocol.com#640 — tips-only mode swaps the orders-list base predicate
             # for tip_amount > 0 (all tips, regardless of channel).
@@ -2380,16 +2413,15 @@ async def export_orders_to_email(
             # Date range filter
             parsed_date_from = parse_date(date_from)
             parsed_date_to = parse_date(date_to)
-
-            if parsed_date_from:
-                param_count += 1
-                where_conditions.append(f"o.order_date >= (${param_count}::timestamp AT TIME ZONE 'America/Bogota')")
-                params.append(parsed_date_from)
-
-            if parsed_date_to:
-                param_count += 1
-                where_conditions.append(f"o.order_date < ((${param_count}::timestamp + interval '1 day') AT TIME ZONE 'America/Bogota')")
-                params.append(parsed_date_to)
+            param_count = _append_local_date_bounds(
+                where_conditions,
+                params,
+                param_count,
+                "o.order_date",
+                parsed_date_from,
+                parsed_date_to,
+                timezone_name,
+            )
 
             # warocol.com#640 — tips-only filters (ignored when tips_only is False)
             if tips_only and member_id:
@@ -3147,35 +3179,36 @@ async def get_sales_flow(
         # Parse dates and calculate periods
         from datetime import datetime, timedelta
 
-        parsed_date_from = parse_date(date_from)
-        parsed_date_to = parse_date(date_to)
-
-        # Default to year-to-date if no dates provided (same as metrics cards)
-        if not parsed_date_from or not parsed_date_to:
-            today = datetime.now().date()
-            parsed_date_to = today
-            # Start from January 1st of current year
-            parsed_date_from = today.replace(month=1, day=1)
-
-        # Calculate range duration
-        days_diff = (parsed_date_to - parsed_date_from).days + 1
-
-        # Determine comparison period and grouping
-        if days_diff <= 30:
-            # Compare with previous period
-            comparison_date_to = parsed_date_from - timedelta(days=1)
-            comparison_date_from = comparison_date_to - timedelta(days=days_diff - 1)
-            comparison_label = "Período Anterior"
-        else:
-            # Compare with same period last year
-            comparison_date_from = parsed_date_from.replace(year=parsed_date_from.year - 1)
-            comparison_date_to = parsed_date_to.replace(year=parsed_date_to.year - 1)
-            comparison_label = "Año Anterior"
-
-        # Determine grouping: hourly (≤3 days), daily (>3 days)
-        group_by = 'hour' if days_diff <= 3 else 'day'
-
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
+            parsed_date_from = parse_date(date_from)
+            parsed_date_to = parse_date(date_to)
+
+            # Default to year-to-date if no dates provided (same as metrics cards)
+            if not parsed_date_from or not parsed_date_to:
+                today = tenant_today(timezone_name)
+                parsed_date_to = today
+                # Start from January 1st of current year
+                parsed_date_from = today.replace(month=1, day=1)
+
+            # Calculate range duration
+            days_diff = (parsed_date_to - parsed_date_from).days + 1
+
+            # Determine comparison period and grouping
+            if days_diff <= 30:
+                # Compare with previous period
+                comparison_date_to = parsed_date_from - timedelta(days=1)
+                comparison_date_from = comparison_date_to - timedelta(days=days_diff - 1)
+                comparison_label = "Período Anterior"
+            else:
+                # Compare with same period last year
+                comparison_date_from = parsed_date_from.replace(year=parsed_date_from.year - 1)
+                comparison_date_to = parsed_date_to.replace(year=parsed_date_to.year - 1)
+                comparison_label = "Año Anterior"
+
+            # Determine grouping: hourly (≤3 days), daily (>3 days)
+            group_by = 'hour' if days_diff <= 3 else 'day'
+
             # Build WHERE conditions
             where_conditions = ["tenant_id = $1", "(pos_cart_id IS NOT NULL OR table_session_id IS NOT NULL OR extra_attributes->>'source' = 'manual')"]
             params = [tenant_id]
@@ -3208,8 +3241,10 @@ async def get_sales_flow(
                 comp_from_param_idx = param_count
                 param_count += 1
                 comp_to_param_idx = param_count
+                param_count += 1
+                timezone_param_idx = param_count
 
-                params.extend([parsed_date_from, parsed_date_to, comparison_date_from, comparison_date_to])
+                params.extend([parsed_date_from, parsed_date_to, comparison_date_from, comparison_date_to, timezone_name])
 
                 query = f"""
                     WITH hours AS (
@@ -3217,23 +3252,23 @@ async def get_sales_flow(
                     ),
                     current_period AS (
                         SELECT
-                            EXTRACT(HOUR FROM order_date AT TIME ZONE 'America/Bogota') AS hour,
+                            EXTRACT(HOUR FROM order_date AT TIME ZONE ${timezone_param_idx}) AS hour,
                             SUM(total_amount) AS sales
                         FROM orders
                         WHERE {where_clause}
-                          AND DATE(order_date AT TIME ZONE 'America/Bogota') >= ${date_from_param_idx}
-                          AND DATE(order_date AT TIME ZONE 'America/Bogota') <= ${date_to_param_idx}
-                        GROUP BY EXTRACT(HOUR FROM order_date AT TIME ZONE 'America/Bogota')
+                          AND DATE(order_date AT TIME ZONE ${timezone_param_idx}) >= ${date_from_param_idx}
+                          AND DATE(order_date AT TIME ZONE ${timezone_param_idx}) <= ${date_to_param_idx}
+                        GROUP BY EXTRACT(HOUR FROM order_date AT TIME ZONE ${timezone_param_idx})
                     ),
                     comparison_period AS (
                         SELECT
-                            EXTRACT(HOUR FROM order_date AT TIME ZONE 'America/Bogota') AS hour,
+                            EXTRACT(HOUR FROM order_date AT TIME ZONE ${timezone_param_idx}) AS hour,
                             SUM(total_amount) AS sales
                         FROM orders
                         WHERE {where_clause}
-                          AND DATE(order_date AT TIME ZONE 'America/Bogota') >= ${comp_from_param_idx}
-                          AND DATE(order_date AT TIME ZONE 'America/Bogota') <= ${comp_to_param_idx}
-                        GROUP BY EXTRACT(HOUR FROM order_date AT TIME ZONE 'America/Bogota')
+                          AND DATE(order_date AT TIME ZONE ${timezone_param_idx}) >= ${comp_from_param_idx}
+                          AND DATE(order_date AT TIME ZONE ${timezone_param_idx}) <= ${comp_to_param_idx}
+                        GROUP BY EXTRACT(HOUR FROM order_date AT TIME ZONE ${timezone_param_idx})
                     )
                     SELECT
                         h.hour,
@@ -3277,8 +3312,10 @@ async def get_sales_flow(
                 comp_from_param_idx = param_count
                 param_count += 1
                 comp_to_param_idx = param_count
+                param_count += 1
+                timezone_param_idx = param_count
 
-                params.extend([parsed_date_from, parsed_date_to, comparison_date_from, comparison_date_to])
+                params.extend([parsed_date_from, parsed_date_to, comparison_date_from, comparison_date_to, timezone_name])
 
                 # Use generate_series directly in the query (more efficient than recursive CTE)
                 query = f"""
@@ -3291,23 +3328,23 @@ async def get_sales_flow(
                     ),
                     current_period AS (
                         SELECT
-                            DATE(order_date AT TIME ZONE 'America/Bogota') AS day,
+                            DATE(order_date AT TIME ZONE ${timezone_param_idx}) AS day,
                             SUM(total_amount) AS sales
                         FROM orders
                         WHERE {where_clause}
-                          AND DATE(order_date AT TIME ZONE 'America/Bogota') >= ${date_from_param_idx}
-                          AND DATE(order_date AT TIME ZONE 'America/Bogota') <= ${date_to_param_idx}
-                        GROUP BY DATE(order_date AT TIME ZONE 'America/Bogota')
+                          AND DATE(order_date AT TIME ZONE ${timezone_param_idx}) >= ${date_from_param_idx}
+                          AND DATE(order_date AT TIME ZONE ${timezone_param_idx}) <= ${date_to_param_idx}
+                        GROUP BY DATE(order_date AT TIME ZONE ${timezone_param_idx})
                     ),
                     comparison_period AS (
                         SELECT
-                            DATE(order_date AT TIME ZONE 'America/Bogota') AS day,
+                            DATE(order_date AT TIME ZONE ${timezone_param_idx}) AS day,
                             SUM(total_amount) AS sales
                         FROM orders
                         WHERE {where_clause}
-                          AND DATE(order_date AT TIME ZONE 'America/Bogota') >= ${comp_from_param_idx}
-                          AND DATE(order_date AT TIME ZONE 'America/Bogota') <= ${comp_to_param_idx}
-                        GROUP BY DATE(order_date AT TIME ZONE 'America/Bogota')
+                          AND DATE(order_date AT TIME ZONE ${timezone_param_idx}) >= ${comp_from_param_idx}
+                          AND DATE(order_date AT TIME ZONE ${timezone_param_idx}) <= ${comp_to_param_idx}
+                        GROUP BY DATE(order_date AT TIME ZONE ${timezone_param_idx})
                     )
                     SELECT
                         ds.day,
@@ -3672,26 +3709,22 @@ async def get_products_sold(
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             where_conditions = ["o.tenant_id = $1", "o.status = 'completed'"]
             params: List = [tenant_id]
             param_count = 1
 
             parsed_date_from = parse_date(date_from)
             parsed_date_to = parse_date(date_to)
-
-            if parsed_date_from:
-                param_count += 1
-                where_conditions.append(
-                    f"o.order_date >= (${param_count}::timestamp AT TIME ZONE 'America/Bogota')"
-                )
-                params.append(parsed_date_from)
-
-            if parsed_date_to:
-                param_count += 1
-                where_conditions.append(
-                    f"o.order_date < ((${param_count}::timestamp + interval '1 day') AT TIME ZONE 'America/Bogota')"
-                )
-                params.append(parsed_date_to)
+            param_count = _append_local_date_bounds(
+                where_conditions,
+                params,
+                param_count,
+                "o.order_date",
+                parsed_date_from,
+                parsed_date_to,
+                timezone_name,
+            )
 
             if category_id:
                 param_count += 1

--- a/app/services/purchases_service.py
+++ b/app/services/purchases_service.py
@@ -7,6 +7,7 @@ from fastapi import Request, Response, HTTPException, UploadFile
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError
+from app.core.timezones import resolve_tenant_timezone
 from app.config import settings
 
 logger = logging.getLogger(__name__)
@@ -46,6 +47,7 @@ async def get_purchases_list(
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             # Build query with tenant isolation, supplier name, and payment history
             base_query = """
                 SELECT
@@ -178,26 +180,29 @@ async def get_purchases_list(
                     base_query += f" AND (tp.payment_due_date IS NULL OR tp.payment_due_date > NOW() + INTERVAL '7 days')"
                     count_query += f" AND (tp.payment_due_date IS NULL OR tp.payment_due_date > NOW() + INTERVAL '7 days')"
 
-            # Date filter (using Colombia timezone)
-            if date_filter:
+            # Date filter using tenant operational timezone.
+            if date_filter in {'today', 'yesterday', 'last_week', '15_days', '1_month', '3_months'}:
+                tz_param = param_count
+                params.append(timezone_name)
+                param_count += 1
                 if date_filter == 'today':
-                    base_query += f" AND DATE(tp.purchase_date AT TIME ZONE 'America/Bogota') = (NOW() AT TIME ZONE 'America/Bogota')::date"
-                    count_query += f" AND DATE(tp.purchase_date AT TIME ZONE 'America/Bogota') = (NOW() AT TIME ZONE 'America/Bogota')::date"
+                    base_query += f" AND DATE(tp.purchase_date AT TIME ZONE ${tz_param}) = (NOW() AT TIME ZONE ${tz_param})::date"
+                    count_query += f" AND DATE(tp.purchase_date AT TIME ZONE ${tz_param}) = (NOW() AT TIME ZONE ${tz_param})::date"
                 elif date_filter == 'yesterday':
-                    base_query += f" AND DATE(tp.purchase_date AT TIME ZONE 'America/Bogota') = (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '1 day'"
-                    count_query += f" AND DATE(tp.purchase_date AT TIME ZONE 'America/Bogota') = (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '1 day'"
+                    base_query += f" AND DATE(tp.purchase_date AT TIME ZONE ${tz_param}) = (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '1 day'"
+                    count_query += f" AND DATE(tp.purchase_date AT TIME ZONE ${tz_param}) = (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '1 day'"
                 elif date_filter == 'last_week':
-                    base_query += f" AND (tp.purchase_date AT TIME ZONE 'America/Bogota') >= (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '7 days'"
-                    count_query += f" AND (tp.purchase_date AT TIME ZONE 'America/Bogota') >= (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '7 days'"
+                    base_query += f" AND (tp.purchase_date AT TIME ZONE ${tz_param}) >= (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '7 days'"
+                    count_query += f" AND (tp.purchase_date AT TIME ZONE ${tz_param}) >= (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '7 days'"
                 elif date_filter == '15_days':
-                    base_query += f" AND (tp.purchase_date AT TIME ZONE 'America/Bogota') >= (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '15 days'"
-                    count_query += f" AND (tp.purchase_date AT TIME ZONE 'America/Bogota') >= (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '15 days'"
+                    base_query += f" AND (tp.purchase_date AT TIME ZONE ${tz_param}) >= (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '15 days'"
+                    count_query += f" AND (tp.purchase_date AT TIME ZONE ${tz_param}) >= (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '15 days'"
                 elif date_filter == '1_month':
-                    base_query += f" AND (tp.purchase_date AT TIME ZONE 'America/Bogota') >= (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '1 month'"
-                    count_query += f" AND (tp.purchase_date AT TIME ZONE 'America/Bogota') >= (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '1 month'"
+                    base_query += f" AND (tp.purchase_date AT TIME ZONE ${tz_param}) >= (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '1 month'"
+                    count_query += f" AND (tp.purchase_date AT TIME ZONE ${tz_param}) >= (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '1 month'"
                 elif date_filter == '3_months':
-                    base_query += f" AND (tp.purchase_date AT TIME ZONE 'America/Bogota') >= (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '3 months'"
-                    count_query += f" AND (tp.purchase_date AT TIME ZONE 'America/Bogota') >= (NOW() AT TIME ZONE 'America/Bogota')::date - INTERVAL '3 months'"
+                    base_query += f" AND (tp.purchase_date AT TIME ZONE ${tz_param}) >= (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '3 months'"
+                    count_query += f" AND (tp.purchase_date AT TIME ZONE ${tz_param}) >= (NOW() AT TIME ZONE ${tz_param})::date - INTERVAL '3 months'"
 
             # Add pagination
             offset = (page - 1) * limit

--- a/tests/test_analytics_dual_cost.py
+++ b/tests/test_analytics_dual_cost.py
@@ -38,6 +38,7 @@ async def test_menu_analysis_response_includes_dual_margin_fields():
     }
 
     mock_conn = AsyncMock()
+    mock_conn.fetchval = AsyncMock(return_value="America/Mexico_City")
     mock_conn.fetch = AsyncMock(return_value=[fake_row])
     mock_cm = MagicMock()
     mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
@@ -63,12 +64,15 @@ async def test_menu_analysis_response_includes_dual_margin_fields():
 async def test_menu_analysis_classification_uses_operativo_margin():
     """BCG query uses effective_cost; operativo product has higher margin % on price."""
     captured_query = []
+    captured_args = []
 
     async def capture_fetch(query, *args):
         captured_query.append(query)
+        captured_args.append(args)
         return []
 
     mock_conn = AsyncMock()
+    mock_conn.fetchval = AsyncMock(return_value="America/Mexico_City")
     mock_conn.fetch = capture_fetch
     mock_cm = MagicMock()
     mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
@@ -86,6 +90,9 @@ async def test_menu_analysis_classification_uses_operativo_margin():
     assert "cost_used_for_classification" in sql
     assert "profit_margin_operativo_pct" in sql
     assert "latest_ingredient_costs" not in sql
+    assert "AT TIME ZONE $4" in sql
+    assert "AT TIME ZONE 'America/Bogota'" not in sql
+    assert captured_args[0][3] == "America/Mexico_City"
 
 
 @pytest.mark.asyncio
@@ -108,6 +115,7 @@ async def test_food_cost_includes_operativo_pct():
     ]
 
     mock_conn = AsyncMock()
+    mock_conn.fetchval = AsyncMock(return_value="America/Mexico_City")
     mock_conn.fetch = AsyncMock(return_value=rows)
     mock_cm = MagicMock()
     mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)

--- a/tests/test_tenant_timezones.py
+++ b/tests/test_tenant_timezones.py
@@ -10,6 +10,7 @@ from app.core.timezones import (
     DEFAULT_TENANT_TIMEZONE,
     local_day_utc_range,
     normalize_timezone,
+    resolve_tenant_timezone,
     tenant_today,
 )
 from app.models.tenant_public_profile import TenantPublicProfileUpdate
@@ -56,6 +57,23 @@ def test_profile_from_row_normalizes_legacy_invalid_timezone():
     })
 
     assert profile.timezone == DEFAULT_TENANT_TIMEZONE
+
+
+@pytest.mark.asyncio
+async def test_resolve_tenant_timezone_normalizes_profile_value():
+    conn = AsyncMock()
+    conn.fetchval = AsyncMock(return_value="America/Mexico_City")
+
+    assert await resolve_tenant_timezone(conn, uuid4()) == "America/Mexico_City"
+
+
+@pytest.mark.asyncio
+async def test_resolve_tenant_timezone_falls_back_for_missing_or_legacy_value():
+    conn = AsyncMock()
+    conn.fetchval = AsyncMock(side_effect=[None, "Legacy/Bad"])
+
+    assert await resolve_tenant_timezone(conn, uuid4()) == DEFAULT_TENANT_TIMEZONE
+    assert await resolve_tenant_timezone(conn, uuid4()) == DEFAULT_TENANT_TIMEZONE
 
 
 def _pos_context_row(timezone_name):


### PR DESCRIPTION
## Summary
- resolve tenant operational timezone from tenant_public_profiles for report/date services
- bind timezone parameters in analytics, orders, purchase presets, and operation event filters
- use tenant_today for report defaults and cover resolver fallback behavior in tests

## Tests
- pytest tests/test_tenant_timezones.py
- pytest tests/test_analytics_dual_cost.py
- pytest tests/test_cierre_shift_filters.py
- pytest tests/test_operation_events.py
- pytest tests/test_customer_detail.py
- pytest tests/test_customers_list.py
- rg -n "AT TIME ZONE 'America/Bogota'|datetime\\.now\\(\\)\\.date\\(\\)" app/services/analytics_service.py app/services/orders_service.py app/services/purchases_service.py app/services/direct_purchase_service.py app/services/operation_events_service.py\n\n## Manual validation\n- GET /analytics/menu-analysis?date_from=2026-06-01&date_to=2026-06-30 under a Colombia tenant and a non-Colombia IANA timezone tenant should use each tenant local day boundary.\n\nCloses #531