### PR TITLE
Pass tenant timezone to agent API

### DIFF
--- a/app/routers/ai_agents.py
+++ b/app/routers/ai_agents.py
@@ -12,6 +12,7 @@ from app.config import settings
 from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
 from app.core.middleware import require_valid_session
 from app.core.permissions import Module, require_module
+from app.core.timezones import DEFAULT_TENANT_TIMEZONE, resolve_tenant_timezone
 from app.database import get_db_connection
 from app.services.kali_access_service import is_kali_enabled
 
@@ -70,6 +71,7 @@ def _sign_internal_request(
     profile_id: str,
     member_id: Optional[str],
     scopes: str,
+    timezone: str,
     body: bytes,
 ) -> str:
     body_digest = hashlib.sha256(body).hexdigest()
@@ -82,6 +84,7 @@ def _sign_internal_request(
             profile_id,
             member_id or "",
             scopes,
+            timezone,
             body_digest,
         ]
     )
@@ -114,6 +117,11 @@ async def _resolve_member_id(profile_id: str, tenant_id: str) -> Optional[str]:
     return str(member_id) if member_id else None
 
 
+async def _resolve_agent_timezone(tenant_id: str) -> str:
+    async with get_db_connection() as conn:
+        return await resolve_tenant_timezone(conn, tenant_id)
+
+
 def _build_internal_headers(
     path: str,
     request_id: str,
@@ -121,6 +129,7 @@ def _build_internal_headers(
     profile_id: str,
     member_id: Optional[str],
     scopes: str,
+    timezone: str,
     body: bytes,
 ) -> Dict[str, str]:
     headers = {
@@ -130,6 +139,7 @@ def _build_internal_headers(
         "x-waro-profile-id": profile_id,
         "x-waro-request-id": request_id,
         "x-waro-scopes": scopes,
+        "x-waro-timezone": timezone or DEFAULT_TENANT_TIMEZONE,
     }
     if member_id:
         headers["x-waro-member-id"] = member_id
@@ -141,6 +151,7 @@ def _build_internal_headers(
         profile_id=profile_id,
         member_id=member_id,
         scopes=scopes,
+        timezone=headers["x-waro-timezone"],
         body=body,
     )
     return headers
@@ -182,6 +193,7 @@ async def _proxy_agent_stream(
     tenant_id = str(session.tenant_id)
     profile_id = str(session.user_id)
     member_id = await _resolve_member_id(profile_id, tenant_id)
+    tenant_timezone = await _resolve_agent_timezone(tenant_id)
     scope_header = ",".join(scopes)
     base_url = _agent_api_base_url()
     upstream_url = f"{base_url}{upstream_path}"
@@ -192,6 +204,7 @@ async def _proxy_agent_stream(
         profile_id=profile_id,
         member_id=member_id,
         scopes=scope_header,
+        timezone=tenant_timezone,
         body=body,
     )
 

--- a/tests/test_ai_agents_proxy.py
+++ b/tests/test_ai_agents_proxy.py
@@ -112,6 +112,7 @@ def test_sign_internal_request_matches_agent_api_contract():
             profile_id="profile-1",
             member_id=None,
             scopes="orders:read,financial:read",
+            timezone="America/Mexico_City",
             body=BODY,
         )
 
@@ -123,6 +124,7 @@ def test_sign_internal_request_matches_agent_api_contract():
         "profile-1",
         "",
         "orders:read,financial:read",
+        "America/Mexico_City",
         hashlib.sha256(BODY).hexdigest(),
     ])
     expected = hmac.new(b"secret", canonical.encode("utf-8"), hashlib.sha256).hexdigest()
@@ -141,6 +143,7 @@ def test_sales_proxy_streams_frames_and_preserves_request_id():
          patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
          patch("app.routers.ai_agents.is_kali_enabled", AsyncMock(return_value=True)), \
          patch("app.routers.ai_agents._resolve_member_id", AsyncMock(return_value=str(MEMBER_ID))), \
+         patch("app.routers.ai_agents._resolve_agent_timezone", AsyncMock(return_value="America/Mexico_City")), \
          patch.object(ai_agents.settings, "agent_api_url", "http://agent-api:8100"), \
          patch.object(ai_agents.settings, "agent_internal_signature_secret", "secret"), \
          patch("app.routers.ai_agents.httpx.AsyncClient", FakeAsyncClient):
@@ -165,8 +168,9 @@ def test_sales_proxy_streams_frames_and_preserves_request_id():
     assert sent["headers"]["x-waro-profile-id"] == str(PROFILE_ID)
     assert sent["headers"]["x-waro-member-id"] == str(MEMBER_ID)
     assert sent["headers"]["x-waro-request-id"] == "req-preserved"
+    assert sent["headers"]["x-waro-timezone"] == "America/Mexico_City"
     assert sent["headers"]["x-waro-scopes"] == (
-        "orders:read,financial:read,analytics:read,menu:read,customers:read"
+        "orders:read,financial:read,analytics:read,menu:read,customers:read,dataset_scope"
     )
     assert sent["headers"]["x-waro-internal-signature"]
     assert FakeAsyncClient.instances[0].closed is True
@@ -183,6 +187,7 @@ def test_food_cost_proxy_uses_analytics_menu_financial_scopes():
          patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
          patch("app.routers.ai_agents.is_kali_enabled", AsyncMock(return_value=True)), \
          patch("app.routers.ai_agents._resolve_member_id", AsyncMock(return_value=None)), \
+         patch("app.routers.ai_agents._resolve_agent_timezone", AsyncMock(return_value="America/Bogota")), \
          patch.object(ai_agents.settings, "agent_api_url", "http://agent-api:8100"), \
          patch.object(ai_agents.settings, "agent_internal_signature_secret", "secret"), \
          patch("app.routers.ai_agents.httpx.AsyncClient", FakeAsyncClient):
@@ -252,6 +257,7 @@ def test_missing_agent_config_rejects_before_upstream_call():
          patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
          patch("app.routers.ai_agents.is_kali_enabled", AsyncMock(return_value=True)), \
          patch("app.routers.ai_agents._resolve_member_id", AsyncMock(return_value=None)), \
+         patch("app.routers.ai_agents._resolve_agent_timezone", AsyncMock(return_value="America/Bogota")), \
          patch.object(ai_agents.settings, "agent_api_url", None), \
          patch.object(ai_agents.settings, "agent_internal_signature_secret", "secret"), \
          patch("app.routers.ai_agents.httpx.AsyncClient", FakeAsyncClient):
@@ -286,10 +292,12 @@ def test_build_headers_generates_request_id_signature_and_content_headers():
             profile_id=str(PROFILE_ID),
             member_id=None,
             scopes="analytics:read,menu:read,financial:read",
+            timezone="America/Bogota",
             body=BODY,
         )
 
     assert headers["Content-Type"] == "application/json"
     assert headers["Accept"] == "text/event-stream"
     assert headers["x-waro-request-id"] == "req-generated"
+    assert headers["x-waro-timezone"] == "America/Bogota"
     assert headers["x-waro-internal-signature"]


### PR DESCRIPTION
## Summary\n- resolve tenant timezone in the AI proxy\n- send x-waro-timezone through the signed internal agent-api request\n- update proxy tests for the signed timezone contract\n\n## Tests\n- pytest tests/test_ai_agents_proxy.py\n\nCloses #534