### PR TITLE
Use tenant timezone for promotion schedules

### DIFF
--- a/app/routers/promotions.py
+++ b/app/routers/promotions.py
@@ -56,7 +56,8 @@ async def create_promotion_endpoint(request: Request, body: PromotionCreate):
     dependencies=[Depends(require_module(Module.POS))],
     summary="List promotions with active status for POS",
     description=(
-        "Read-only endpoint for POS. Evaluates schedules in America/Bogota. "
+        "Read-only endpoint for POS. Evaluates schedules in the tenant operational timezone "
+        "with America/Bogota fallback. "
         f"{_CONFLICT_DOC}"
     ),
 )
@@ -64,17 +65,18 @@ async def list_active_promotions_endpoint(
     request: Request,
     at: Optional[datetime] = Query(
         None,
-        description="Evaluation timestamp (ISO). Defaults to now in America/Bogota.",
+        description=(
+            "Evaluation timestamp (ISO). Defaults to now in the tenant operational timezone."
+        ),
     ),
     only_current: bool = Query(
         False,
         description="When true, return only promotions active at `at`.",
     ),
 ):
-    evaluation_at = at or promotions_service.default_at_bogota()
     return await promotions_service.list_active_promotions(
         request,
-        evaluation_at,
+        at,
         only_current=only_current,
     )
 

--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -4,13 +4,17 @@ import logging
 from datetime import datetime, time
 from typing import Any, Dict, List, Optional, Sequence, Set
 from uuid import UUID
-from zoneinfo import ZoneInfo
 
 import asyncpg
 from fastapi import HTTPException, Request
 
 from app.core.exceptions import AuthenticationError
 from app.core.middleware import require_valid_session
+from app.core.timezones import (
+    DEFAULT_TENANT_TIMEZONE,
+    get_zoneinfo,
+    resolve_tenant_timezone,
+)
 from app.database import get_db_connection
 from app.models.tenant_promotion import (
     PromotionCreate,
@@ -19,8 +23,6 @@ from app.models.tenant_promotion import (
 )
 
 logger = logging.getLogger(__name__)
-
-BOGOTA = ZoneInfo("America/Bogota")
 
 VALID_PROMO_TYPES = frozenset({"percent_off", "fixed_off", "bogo"})
 DEFAULT_PROMO_CONFLICT_STRATEGY = "priority"
@@ -89,9 +91,19 @@ def validate_promo_type_block_map(
     return normalized or dict(DEFAULT_PROMO_TYPE_BLOCK_MAP)
 
 
-def day_bit_for_datetime(at: datetime) -> int:
-    """Monday=1<<0 … Sunday=1<<6 in America/Bogota."""
-    local = at.astimezone(BOGOTA)
+def _evaluation_datetime(at: datetime, timezone_name: str | None) -> datetime:
+    zone = get_zoneinfo(timezone_name)
+    if at.tzinfo is None:
+        return at.replace(tzinfo=zone)
+    return at.astimezone(zone)
+
+
+def day_bit_for_datetime(
+    at: datetime,
+    timezone_name: str | None = DEFAULT_TENANT_TIMEZONE,
+) -> int:
+    """Monday=1<<0 … Sunday=1<<6 in the tenant operational timezone."""
+    local = _evaluation_datetime(at, timezone_name)
     return 1 << local.weekday()
 
 
@@ -102,10 +114,11 @@ def time_in_schedule_window(
     start_time: time,
     end_time: time,
     crosses_midnight: bool,
+    timezone_name: str | None = DEFAULT_TENANT_TIMEZONE,
 ) -> bool:
-    local = at.astimezone(BOGOTA)
+    local = _evaluation_datetime(at, timezone_name)
     current = local.time()
-    today_bit = day_bit_for_datetime(local)
+    today_bit = day_bit_for_datetime(local, timezone_name)
     if crosses_midnight:
         if (days_of_week & today_bit) and current >= start_time:
             return True
@@ -125,8 +138,9 @@ def is_active_at(
     starts_at: Optional[datetime],
     ends_at: Optional[datetime],
     schedules: Sequence[Dict[str, Any]],
+    timezone_name: str | None = DEFAULT_TENANT_TIMEZONE,
 ) -> bool:
-    """Return whether a promotion rule is active at `at` (evaluated in Bogotá)."""
+    """Return whether a promotion rule is active at `at` in tenant local time."""
     if not is_active:
         return False
     if starts_at is not None and at < starts_at:
@@ -142,6 +156,7 @@ def is_active_at(
             start_time=row["start_time"],
             end_time=row["end_time"],
             crosses_midnight=bool(row["crosses_midnight"]),
+            timezone_name=timezone_name,
         ):
             return True
     return False
@@ -491,6 +506,7 @@ def _serialize_promotion(
     scope: Dict[str, Any],
     *,
     at: Optional[datetime] = None,
+    timezone_name: str | None = DEFAULT_TENANT_TIMEZONE,
 ) -> Dict[str, Any]:
     schedule_dicts = [_row_to_schedule(r) for r in schedules]
     category_ids = scope["category_ids"]
@@ -534,6 +550,7 @@ def _serialize_promotion(
             starts_at=promo_row["starts_at"],
             ends_at=promo_row["ends_at"],
             schedules=schedule_dicts,
+            timezone_name=timezone_name,
         )
     return payload
 
@@ -697,6 +714,7 @@ async def list_promotions(
     *,
     include_inactive: bool = False,
     at: Optional[datetime] = None,
+    timezone_name: str | None = None,
 ) -> dict:
     session = require_valid_session(request)
     tenant_id = session.tenant_id
@@ -712,6 +730,9 @@ async def list_promotions(
     query += " ORDER BY priority DESC, name"
 
     async with get_db_connection(use_transaction=False) as conn:
+        evaluation_timezone = timezone_name or DEFAULT_TENANT_TIMEZONE
+        if timezone_name is None and at is not None:
+            evaluation_timezone = await resolve_tenant_timezone(conn, tenant_id)
         rows = await conn.fetch(query, tenant_id)
         scope_by_id = await _load_scope_summaries_batch(conn, [row["id"] for row in rows])
         data = []
@@ -723,6 +744,7 @@ async def list_promotions(
                     schedules,
                     scope_by_id.get(row["id"], _empty_scope_summary()),
                     at=at,
+                    timezone_name=evaluation_timezone,
                 )
             )
 
@@ -741,13 +763,24 @@ async def get_promotion(
         raise AuthenticationError("Tenant ID is required")
 
     async with get_db_connection(use_transaction=False) as conn:
+        timezone_name = (
+            await resolve_tenant_timezone(conn, tenant_id)
+            if at is not None
+            else DEFAULT_TENANT_TIMEZONE
+        )
         row = await _get_owned_promotion(conn, promotion_id, tenant_id)
         schedules = await _load_schedules(conn, promotion_id)
         scope = await _load_scope_summary(conn, promotion_id)
 
     return {
         "success": True,
-        "data": _serialize_promotion(row, schedules, scope, at=at),
+        "data": _serialize_promotion(
+            row,
+            schedules,
+            scope,
+            at=at,
+            timezone_name=timezone_name,
+        ),
     }
 
 
@@ -1091,15 +1124,24 @@ async def delete_promotion(request: Request, promotion_id: UUID) -> dict:
 
 async def list_active_promotions(
     request: Request,
-    at: datetime,
+    at: Optional[datetime] = None,
     *,
     only_current: bool = False,
 ) -> dict:
     """List tenant promotions with is_currently_active for POS (read-only)."""
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    async with get_db_connection(use_transaction=False) as conn:
+        timezone_name = await resolve_tenant_timezone(conn, tenant_id)
+    evaluation_at = at or default_at_tenant(timezone_name)
     result = await list_promotions(
         request,
         include_inactive=False,
-        at=at,
+        at=evaluation_at,
+        timezone_name=timezone_name,
     )
     if only_current:
         result["data"] = [
@@ -1109,8 +1151,8 @@ async def list_active_promotions(
     return result
 
 
-def default_at_bogota() -> datetime:
-    return datetime.now(tz=BOGOTA)
+def default_at_tenant(timezone_name: str | None = DEFAULT_TENANT_TIMEZONE) -> datetime:
+    return datetime.now(tz=get_zoneinfo(timezone_name))
 
 
 def _promo_matches_line(
@@ -1589,8 +1631,11 @@ async def load_promotions_for_evaluation(
     conn: asyncpg.Connection,
     tenant_id: UUID,
     at: datetime,
+    *,
+    timezone_name: str | None = None,
 ) -> List[Dict[str, Any]]:
     """Load tenant promotions that are active at `at`, with scope for POS evaluation."""
+    evaluation_timezone = timezone_name or await resolve_tenant_timezone(conn, tenant_id)
     rows = await conn.fetch(
         """
         SELECT * FROM tenant_promotions
@@ -1609,6 +1654,7 @@ async def load_promotions_for_evaluation(
             starts_at=row["starts_at"],
             ends_at=row["ends_at"],
             schedules=schedule_dicts,
+            timezone_name=evaluation_timezone,
         ):
             continue
         category_ids, product_ids = await _load_scope_ids(conn, row["id"])
@@ -1638,8 +1684,14 @@ async def evaluate_checkout_promotions(
     preserve_persisted_promos: bool = False,
 ) -> Dict[str, Any]:
     """DB-backed promo evaluation plus optional manual discount stacking."""
-    evaluation_at = at or default_at_bogota()
-    promotions = await load_promotions_for_evaluation(conn, tenant_id, evaluation_at)
+    timezone_name = await resolve_tenant_timezone(conn, tenant_id)
+    evaluation_at = at or default_at_tenant(timezone_name)
+    promotions = await load_promotions_for_evaluation(
+        conn,
+        tenant_id,
+        evaluation_at,
+        timezone_name=timezone_name,
+    )
     profile_row = await conn.fetchrow(
         """
         SELECT promo_type_block_map

--- a/tests/test_promotions_crud.py
+++ b/tests/test_promotions_crud.py
@@ -34,7 +34,7 @@ def _clear_caches():
     permissions._role_modules_cache.clear()
 
 
-def _build_session(role: str):
+def _build_session(role: str = "owner"):
     return SessionContext({
         "user_id": uuid4(),
         "tenant_id": uuid4(),
@@ -269,6 +269,49 @@ def test_serialize_promotion_includes_scope_summary_fields():
     assert payload["product_ids"] == [str(pid)]
     assert payload["category_count"] == 0
     assert payload["category_names_preview"] == []
+
+
+def test_serialize_promotion_active_status_uses_tenant_timezone():
+    promo_id = uuid4()
+    tenant_id = uuid4()
+    schedule_id = uuid4()
+    scope = _empty_scope_summary()
+    promo_row = {
+        "id": promo_id,
+        "tenant_id": tenant_id,
+        "name": "Happy hour",
+        "promo_type": "percent_off",
+        "value_json": {"percent": 10},
+        "scope_type": "all_products",
+        "priority": 0,
+        "is_active": True,
+        "stackable": False,
+        "starts_at": None,
+        "ends_at": None,
+        "created_at": datetime(2026, 5, 29, tzinfo=timezone.utc),
+        "updated_at": datetime(2026, 5, 29, tzinfo=timezone.utc),
+    }
+    schedules = [{
+        "id": schedule_id,
+        "days_of_week": 1 + 2 + 4 + 8 + 16,
+        "start_time": datetime.strptime("17:00", "%H:%M").time(),
+        "end_time": datetime.strptime("20:00", "%H:%M").time(),
+        "crosses_midnight": False,
+        "sort_order": 0,
+    }]
+    at = datetime.fromisoformat("2026-05-30T01:30:00+00:00")
+
+    bogota_payload = _serialize_promotion(promo_row, schedules, scope, at=at)
+    la_payload = _serialize_promotion(
+        promo_row,
+        schedules,
+        scope,
+        at=at,
+        timezone_name="America/Los_Angeles",
+    )
+
+    assert bogota_payload["is_currently_active"] is False
+    assert la_payload["is_currently_active"] is True
 
 
 def test_cashier_denied_create_promotion_under_enforce():

--- a/tests/test_promotions_schedule.py
+++ b/tests/test_promotions_schedule.py
@@ -1,10 +1,10 @@
 """Schedule matching for tenant promotions (warocol.com#980)."""
 from datetime import datetime, time
-from zoneinfo import ZoneInfo
 
+from app.core.timezones import DEFAULT_TENANT_TIMEZONE, get_zoneinfo
 from app.services.promotions_service import (
-    BOGOTA,
     day_bit_for_datetime,
+    default_at_tenant,
     is_active_at,
     time_in_schedule_window,
 )
@@ -56,6 +56,38 @@ def test_overnight_schedule_active_after_midnight():
     )
 
 
+def test_schedule_uses_tenant_timezone_for_same_instant():
+    # Same instant: 20:30 in Bogota but 18:30 in Los Angeles.
+    at = _at("2026-05-30T01:30:00+00:00")
+    assert not time_in_schedule_window(
+        at,
+        days_of_week=WEEKDAYS,
+        start_time=time(17, 0),
+        end_time=time(20, 0),
+        crosses_midnight=False,
+    )
+    assert time_in_schedule_window(
+        at,
+        days_of_week=WEEKDAYS,
+        start_time=time(17, 0),
+        end_time=time(20, 0),
+        crosses_midnight=False,
+        timezone_name="America/Los_Angeles",
+    )
+
+
+def test_overnight_schedule_uses_tenant_timezone_after_midnight():
+    at = _at("2026-05-30T08:30:00+00:00")  # Saturday 01:30 in Los Angeles
+    assert time_in_schedule_window(
+        at,
+        days_of_week=1 << 4,  # Friday
+        start_time=time(22, 0),
+        end_time=time(6, 0),
+        crosses_midnight=True,
+        timezone_name="America/Los_Angeles",
+    )
+
+
 def test_is_active_at_no_schedules_always_on_when_enabled():
     at = _at("2026-05-29T12:00:00-05:00")
     assert is_active_at(
@@ -99,9 +131,10 @@ def test_is_active_at_with_schedule_row():
     )
 
 
-def test_bogota_offset_is_minus_five():
-    at = datetime.now(tz=BOGOTA)
-    assert str(at.tzinfo) == "America/Bogota"
+def test_default_timezone_falls_back_to_bogota():
+    at = default_at_tenant(None)
+    assert str(at.tzinfo) == DEFAULT_TENANT_TIMEZONE
+    assert str(get_zoneinfo("not-a-timezone")) == DEFAULT_TENANT_TIMEZONE
 
 
 def test_is_active_at_multiple_ranges_same_day():


### PR DESCRIPTION
## Summary
- Evaluate promotion schedules and active status in tenant operational timezone
- Keep America/Bogota as legacy fallback via shared timezone helpers
- Add non-Bogota and overnight schedule coverage

## Tests
- pytest tests/test_promotions_schedule.py tests/test_promotions_crud.py tests/test_promo_cart_evaluation.py

Closes #541