### PR TITLE
POS: imprimir comanda sin cocina asociada

### DIFF
--- a/app/services/comandas_service.py
+++ b/app/services/comandas_service.py
@@ -23,6 +23,8 @@ from fastapi import Request
 
 logger = logging.getLogger(__name__)
 
+FALLBACK_STATION_NAME = "Sin cocina asignada"
+
 
 def _parse_item_row(ir: Any, *, is_promo_free: bool = False) -> Dict[str, Any]:
     """Convert an asyncpg comanda_items row to a serializable dict.
@@ -109,6 +111,47 @@ def _comanda_kitchen_lines_for_order_item(item: Dict[str, Any]) -> List[Dict[str
         promotion_name=item.get("promotion_name") or "",
         base_notes=base_notes,
     )
+
+
+async def _build_comanda_print_items_for_order_item(
+    conn,
+    item: Dict[str, Any],
+) -> List[Dict[str, Any]]:
+    """Build printable comanda item rows from one order_item without requiring a persisted comanda."""
+    order_item_id = item["id"]
+    mod_rows = await conn.fetch(
+        """
+        SELECT modifier_name, price_at_purchase, quantity
+        FROM order_item_modifiers
+        WHERE order_item_id = $1
+        ORDER BY created_at
+        """,
+        order_item_id,
+    )
+    modifiers_snapshot = [
+        {
+            "name": m["modifier_name"],
+            "price": float(m["price_at_purchase"]),
+            "quantity": int(m["quantity"]),
+        }
+        for m in mod_rows
+    ] if mod_rows else None
+
+    rows: List[Dict[str, Any]] = []
+    for kitchen_line in _comanda_kitchen_lines_for_order_item(item):
+        rows.append({
+            "id": None,
+            "order_item_id": order_item_id,
+            "kitchen_name": item["kitchen_name"],
+            "quantity": kitchen_line["quantity"],
+            "notes": kitchen_line["notes"],
+            "modifiers_snapshot": modifiers_snapshot,
+            "status": "pending",
+            "ready_at": None,
+            "created_at": None,
+            "is_promo_free": kitchen_line["is_promo_free"],
+        })
+    return rows
 
 
 _UNFIRED_ORDER_ITEMS_SELECT = """
@@ -293,23 +336,18 @@ async def _fire_with_conn(
     # ─── Step 2: Resolve effective station per item ──────────────────────────
     # get_effective_station() uses the shared conn to run inside our transaction
     items_by_station: Dict[UUID, List[Any]] = {}
+    unrouted_items: List[Any] = []
     skipped = 0
 
     for row in rows:
         station_id = await get_effective_station(row['product_id'], tenant_id, conn)
         if station_id is None:
             skipped += 1
+            unrouted_items.append(row)
             continue
         if station_id not in items_by_station:
             items_by_station[station_id] = []
         items_by_station[station_id].append(row)
-
-    if not items_by_station:
-        logger.info(
-            f"fire_comandas: all {len(rows)} items have no station routing "
-            f"for order {order_id} (skipped={skipped})"
-        )
-        return []
 
     # ─── Step 3: Create one comanda per station ──────────────────────────────
     created_comandas: List[Dict[str, Any]] = []
@@ -350,27 +388,15 @@ async def _fire_with_conn(
             order_item_id = item['id']
             item_ids_in_group.append(order_item_id)
 
-            mod_rows = await conn.fetch(
-                """
-                SELECT modifier_name, price_at_purchase, quantity
-                FROM order_item_modifiers
-                WHERE order_item_id = $1
-                ORDER BY created_at
-                """,
-                order_item_id,
+            printable_items = await _build_comanda_print_items_for_order_item(
+                conn, dict(item)
             )
-            modifiers_snapshot = [
-                {
-                    "name": m['modifier_name'],
-                    "price": float(m['price_at_purchase']),
-                    "quantity": int(m['quantity']),
-                }
-                for m in mod_rows
-            ] if mod_rows else None
+            modifiers_snapshot = (
+                printable_items[0]["modifiers_snapshot"] if printable_items else None
+            )
             modifiers_json = json.dumps(modifiers_snapshot) if modifiers_snapshot else None
 
-            kitchen_lines = _comanda_kitchen_lines_for_order_item(dict(item))
-            for kitchen_line in kitchen_lines:
+            for printable_item in printable_items:
                 ci_row = await conn.fetchrow(
                     """
                     INSERT INTO comanda_items (
@@ -384,12 +410,12 @@ async def _fire_with_conn(
                     comanda_id,
                     order_item_id,
                     item['kitchen_name'],
-                    kitchen_line['quantity'],
+                    printable_item['quantity'],
                     modifiers_json,
-                    kitchen_line['notes'],
+                    printable_item['notes'],
                 )
                 inserted_items.append(
-                    _parse_item_row(ci_row, is_promo_free=kitchen_line['is_promo_free'])
+                    _parse_item_row(ci_row, is_promo_free=printable_item['is_promo_free'])
                 )
 
         # 3d. Mark fired items as 'sent'
@@ -416,6 +442,54 @@ async def _fire_with_conn(
         logger.info(
             f"fire_comandas: comanda #{comanda_number} created "
             f"(station={station_id}, items={len(inserted_items)}, order={order_id})"
+        )
+
+    if unrouted_items:
+        comanda_number = await conn.fetchval(
+            "SELECT order_number FROM orders WHERE id = $1",
+            order_id,
+        )
+        comanda_index = await conn.fetchval(
+            "SELECT COUNT(*) + 1 FROM comandas WHERE order_id = $1",
+            order_id,
+        )
+        fallback_items: List[Dict[str, Any]] = []
+        fallback_item_ids: List[UUID] = []
+        for item in unrouted_items:
+            fallback_item_ids.append(item["id"])
+            fallback_items.extend(
+                await _build_comanda_print_items_for_order_item(conn, dict(item))
+            )
+
+        if fallback_item_ids:
+            await conn.execute(
+                """
+                UPDATE order_items
+                SET fulfillment_status = 'sent', sent_at = now()
+                WHERE id = ANY($1::uuid[])
+                """,
+                fallback_item_ids,
+            )
+
+        created_comandas.append({
+            "id": None,
+            "comanda_number": comanda_number,
+            "comanda_index": comanda_index,
+            "station_id": None,
+            "station_name": FALLBACK_STATION_NAME,
+            "status": "pending",
+            "source_type": source_type,
+            "table_display_name": table_display_name,
+            "notes": None,
+            "fired_at": datetime.now(timezone.utc),
+            "ready_at": None,
+            "created_at": None,
+            "items": fallback_items,
+            "print_fallback": True,
+        })
+        logger.info(
+            f"fire_comandas: printable fallback created "
+            f"(items={len(fallback_items)}, order={order_id}, skipped={skipped})"
         )
 
     fired_count = sum(len(c['items']) for c in created_comandas)

--- a/tests/test_comanda_item_notes.py
+++ b/tests/test_comanda_item_notes.py
@@ -98,3 +98,186 @@ async def test_fire_comandas_copies_order_item_notes_to_comanda_items():
     insert_calls = [c for c in fetchrow_calls if "INSERT INTO comanda_items" in " ".join(c[0].split())]
     assert len(insert_calls) == 1
     assert insert_calls[0][1][5] == "Sin cebolla"
+
+
+@pytest.mark.asyncio
+async def test_fire_comandas_returns_printable_fallback_for_item_without_station():
+    tenant_id = uuid4()
+    order_id = uuid4()
+    order_item_id = uuid4()
+    product_id = uuid4()
+
+    mock_conn = AsyncMock()
+
+    order_rows = [
+        {
+            "id": order_item_id,
+            "quantity": 1,
+            "product_id": product_id,
+            "notes": "prueba de paoas en nota",
+            "kitchen_name": "Santa inquisicion",
+        },
+    ]
+
+    async def fetch_side_effect(query, *args):
+        if "order_item_modifiers" in query:
+            return [
+                {
+                    "modifier_name": "Extra salsa",
+                    "price_at_purchase": 2500,
+                    "quantity": 2,
+                },
+            ]
+        return order_rows
+
+    mock_conn.fetch = AsyncMock(side_effect=fetch_side_effect)
+    mock_conn.fetchrow = AsyncMock()
+    mock_conn.fetchval = AsyncMock(
+        side_effect=lambda q, *a: 42 if "order_number" in q else 1
+    )
+    mock_conn.execute = AsyncMock()
+
+    with patch(
+        "app.services.comandas_service.get_effective_station",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        result = await _fire_with_conn(
+            mock_conn,
+            order_id,
+            tenant_id,
+            "table",
+            "Mesa 1",
+            None,
+        )
+
+    assert len(result) == 1
+    fallback = result[0]
+    assert fallback["station_id"] is None
+    assert fallback["station_name"] == "Sin cocina asignada"
+    assert fallback["print_fallback"] is True
+    assert fallback["comanda_number"] == 42
+
+    item = fallback["items"][0]
+    assert item["order_item_id"] == order_item_id
+    assert item["kitchen_name"] == "Santa inquisicion"
+    assert item["quantity"] == 1.0
+    assert item["notes"] == "prueba de paoas en nota"
+    assert item["modifiers_snapshot"] == [
+        {"name": "Extra salsa", "price": 2500.0, "quantity": 2}
+    ]
+
+    mock_conn.fetchrow.assert_not_awaited()
+    update_sql = " ".join(mock_conn.execute.await_args.args[0].split())
+    assert "UPDATE order_items SET fulfillment_status = 'sent'" in update_sql
+    assert mock_conn.execute.await_args.args[1] == [order_item_id]
+
+
+@pytest.mark.asyncio
+async def test_fire_comandas_keeps_station_group_and_adds_unrouted_fallback():
+    tenant_id = uuid4()
+    order_id = uuid4()
+    routed_item_id = uuid4()
+    unrouted_item_id = uuid4()
+    routed_product_id = uuid4()
+    unrouted_product_id = uuid4()
+    station_id = uuid4()
+    comanda_id = uuid4()
+
+    mock_conn = AsyncMock()
+
+    order_rows = [
+        {
+            "id": routed_item_id,
+            "quantity": 1,
+            "product_id": routed_product_id,
+            "notes": None,
+            "kitchen_name": "Hamburguesa",
+        },
+        {
+            "id": unrouted_item_id,
+            "quantity": 1,
+            "product_id": unrouted_product_id,
+            "notes": "sin papa",
+            "kitchen_name": "Santa inquisicion",
+        },
+    ]
+
+    async def fetch_side_effect(query, *args):
+        if "order_item_modifiers" in query:
+            return []
+        return order_rows
+
+    mock_conn.fetch = AsyncMock(side_effect=fetch_side_effect)
+
+    async def fetchrow_side_effect(query, *args):
+        q = " ".join(query.split())
+        if "INSERT INTO comandas" in q:
+            return {
+                "id": comanda_id,
+                "comanda_number": 42,
+                "comanda_index": 1,
+                "station_id": station_id,
+                "status": "pending",
+                "source_type": "table",
+                "table_display_name": "Mesa 1",
+                "notes": None,
+                "fired_at": None,
+                "ready_at": None,
+                "created_at": None,
+            }
+        if "INSERT INTO comanda_items" in q:
+            return {
+                "id": uuid4(),
+                "order_item_id": routed_item_id,
+                "kitchen_name": "Hamburguesa",
+                "quantity": args[3],
+                "notes": args[5] if len(args) > 5 else None,
+                "modifiers_snapshot": args[4] if len(args) > 4 else None,
+                "status": "pending",
+                "ready_at": None,
+                "created_at": None,
+            }
+        return None
+
+    mock_conn.fetchrow = AsyncMock(side_effect=fetchrow_side_effect)
+
+    def fetchval_side_effect(query, *args):
+        if "order_number" in query:
+            return 42
+        if "SELECT name FROM kitchen_stations" in query:
+            return "Parrilla"
+        return 2
+
+    mock_conn.fetchval = AsyncMock(side_effect=fetchval_side_effect)
+    mock_conn.execute = AsyncMock()
+
+    async def station_side_effect(product_id, *_args):
+        if product_id == routed_product_id:
+            return station_id
+        return None
+
+    with patch(
+        "app.services.comandas_service.get_effective_station",
+        new_callable=AsyncMock,
+        side_effect=station_side_effect,
+    ):
+        result = await _fire_with_conn(
+            mock_conn,
+            order_id,
+            tenant_id,
+            "table",
+            "Mesa 1",
+            None,
+        )
+
+    assert len(result) == 2
+    routed, fallback = result
+    assert routed["station_id"] == station_id
+    assert routed["station_name"] == "Parrilla"
+    assert routed["items"][0]["order_item_id"] == routed_item_id
+
+    assert fallback["station_id"] is None
+    assert fallback["station_name"] == "Sin cocina asignada"
+    assert fallback["items"][0]["order_item_id"] == unrouted_item_id
+    assert fallback["items"][0]["notes"] == "sin papa"


### PR DESCRIPTION
## Resumen
- Devuelve una comanda imprimible de fallback cuando un item no tiene cocina efectiva asociada.
- Conserva nota, modificadores, cantidad y order_item_id para que el frontend pueda imprimir la comanda.
- Mantiene las comandas por cocina cuando hay items mixtos y agrega el fallback solo para los items sin ruta.

## Validacion
- ./venv/bin/python -m pytest tests/test_comanda_item_notes.py tests/test_comanda_bogo_fire.py tests/test_tables_tab_modifier_inventory.py -q
- Sin build, por solicitud.

Closes #550