### PR TITLE
POS mesa: comandar solo items recién agregados

### DIFF
--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -3664,6 +3664,7 @@ async def _add_tab_items_core(
         order_total = float(order_row["total_amount"])
         logger.info(f"[add_tab_items] created new order {order_id}")
 
+    created_order_item_ids: List[UUID] = []
     for item in items:
         modifier_unit_total = sum(_modifier_unit_total(m) for m in (item.get("modifiers") or []))
         subtotal = item["quantity"] * (item["unit_price"] + modifier_unit_total)
@@ -3685,6 +3686,7 @@ async def _add_tab_items_core(
             item_notes,
         )
         order_item_id = order_item_row["id"]
+        created_order_item_ids.append(order_item_id)
 
         for mod in item.get("modifiers") or []:
             modifier_qty = mod.get("quantity", 1)
@@ -3826,6 +3828,7 @@ async def _add_tab_items_core(
         "total_amount": order_total,
         "session_id": session_id,
         "items_count": len(items),
+        "created_order_item_ids": created_order_item_ids,
         "promo_savings": float(promo_eval.get("promo_savings") or 0),
         "promo_breakdown": promo_eval.get("promo_breakdown") or [],
         "promo_lines": promo_eval.get("lines") or [],
@@ -3861,12 +3864,17 @@ async def add_tab_items(
         promo_savings = tab_result.get("promo_savings", 0)
         promo_breakdown = tab_result.get("promo_breakdown") or []
         promo_lines = tab_result.get("promo_lines") or []
+        created_order_item_ids = tab_result.get("created_order_item_ids") or []
 
         # Auto-fire comandas if enabled (#753 — return comandas for POS print)
         fired_comandas: List[dict] = []
         fired_items_count = 0
         try:
-            fire_result = await fire_table_items(request, table_id)
+            fire_result = await fire_table_items(
+                request,
+                table_id,
+                item_ids=created_order_item_ids,
+            )
             if fire_result and isinstance(fire_result.get("data"), dict):
                 fired_comandas = fire_result["data"].get("comandas") or []
                 fired_items_count = int(fire_result["data"].get("fired_items_count") or 0)

--- a/tests/test_fire_table_item_ids.py
+++ b/tests/test_fire_table_item_ids.py
@@ -57,3 +57,84 @@ async def test_fire_table_items_passes_item_ids_to_fire_comandas():
 
     assert result["success"] is True
     assert captured_item_ids == [[item_a, item_b]]
+
+
+@pytest.mark.asyncio
+async def test_add_tab_items_auto_fires_only_created_order_item_ids():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    order_id = uuid4()
+    old_new_item_id = uuid4()
+    created_item_id = uuid4()
+
+    mock_conn = AsyncMock()
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    captured_item_ids = []
+
+    async def capture_fire(_request, _table_id, item_ids=None):
+        captured_item_ids.append(item_ids)
+        return {
+            "success": True,
+            "data": {
+                "comandas": [{
+                    "items": [{"order_item_id": str(created_item_id)}],
+                }],
+                "fired_items_count": 1,
+            },
+        }
+
+    mock_request = MagicMock()
+    with patch("app.services.tables_service.require_valid_session") as mock_sess, \
+         patch("app.services.tables_service.get_db_connection", return_value=mock_cm), \
+         patch(
+             "app.services.tables_service._add_tab_items_core",
+             new=AsyncMock(return_value={
+                 "order_id": order_id,
+                 "order_number": 77,
+                 "total_amount": 25000.0,
+                 "created_order_item_ids": [created_item_id],
+                 "promo_savings": 0,
+                 "promo_breakdown": [],
+                 "promo_lines": [],
+             }),
+         ), patch(
+             "app.services.tables_service.fire_table_items",
+             side_effect=capture_fire,
+         ):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+
+        result = await tables_service.add_tab_items(
+            mock_request,
+            table_id,
+            [{
+                "product_id": uuid4(),
+                "quantity": 1,
+                "unit_price": 25000.0,
+                "modifiers": [{
+                    "id": str(uuid4()),
+                    "name": "Tocineta",
+                    "price": 4000.0,
+                    "quantity": 1,
+                }],
+                "notes": "sin cebolla",
+            }],
+        )
+
+    assert result["success"] is True
+    assert result["data"]["fired_items_count"] == 1
+    assert captured_item_ids == [[created_item_id]]
+    assert old_new_item_id not in captured_item_ids[0]

--- a/tests/test_tables_tab_operation_events.py
+++ b/tests/test_tables_tab_operation_events.py
@@ -35,6 +35,7 @@ async def test_add_tab_items_core_records_tab_item_added_per_line():
         None,
         {"id": order_id, "order_number": 42, "total_amount": 15.0},
         {"id": order_item_id},
+        {"total_amount": 15.0},
     ])
     mock_conn.fetch = AsyncMock(return_value=[])
     mock_conn.execute = AsyncMock()
@@ -68,6 +69,7 @@ async def test_add_tab_items_core_records_tab_item_added_per_line():
         )
 
     assert result["session_id"] == session_id
+    assert result["created_order_item_ids"] == [order_item_id]
     assert len(recorded) == 1
     assert recorded[0]["action"] == "tab_item_added"
     assert recorded[0]["tab_ctx"]["channel"] == "mesa"
@@ -180,6 +182,7 @@ async def test_add_then_remove_shares_table_session_id():
         None,
         {"id": order_id, "order_number": 1, "total_amount": 5.0},
         {"id": order_item_id},
+        {"total_amount": 5.0},
     ])
     mock_conn_add.fetch = AsyncMock(return_value=[])
     mock_conn_add.execute = AsyncMock()
@@ -190,6 +193,11 @@ async def test_add_then_remove_shares_table_session_id():
     ), patch(
         "app.services.tables_service._prefetch_product_names",
         new=AsyncMock(return_value={str(product_id): "Agua"}),
+    ), patch(
+        "app.services.tables_service.fetch_product_pricing_map",
+        new=AsyncMock(return_value={
+            str(product_id): {"price": Decimal("5.00"), "open_priced": False},
+        }),
     ), patch(
         "app.services.tables_service._capture_order_item_ingredients",
         new=AsyncMock(),
@@ -513,6 +521,7 @@ async def test_fired_qty_decrease_with_reason_records_event():
         "order_id": order_id,
         "total_amount": 30.0,
         "order_number": 7,
+        "product_name": "Agua",
         "table_name": "Barra",
         "is_bar": True,
         "table_session_id": session_id,


### PR DESCRIPTION
## Resumen
- `_add_tab_items_core` devuelve los `order_item_id` creados por la acción de agregar al tab.
- `/tab/add` dispara comandas pasando esos IDs, evitando arrastrar items viejos en estado `new`.
- Se mantienen las defensas existentes de `fire_comandas` por `fulfillment_status='new'`.

## Validación
- `./venv/bin/python -m pytest tests/test_tables_tab_operation_events.py tests/test_fire_table_item_ids.py tests/test_comanda_item_notes.py -q`
- Sin build, por solicitud.

Closes #552
