### PR TITLE
Use tenant timezone for order GL dates

### DIFF
--- a/app/core/timezones.py
+++ b/app/core/timezones.py
@@ -36,6 +36,15 @@ def get_zoneinfo(value: str | None) -> ZoneInfo:
     return ZoneInfo(normalize_timezone(value))
 
 
+def local_date_for_tenant(value: datetime | date, timezone_name: str | None) -> date:
+    """Return a tenant-local date while preserving legacy naive date handling."""
+    if isinstance(value, datetime):
+        if value.tzinfo is not None:
+            return value.astimezone(get_zoneinfo(timezone_name)).date()
+        return value.date()
+    return value
+
+
 async def resolve_tenant_timezone(conn, tenant_id) -> str:
     """Resolve a tenant's operational timezone from profile config."""
     result = conn.fetchval(

--- a/app/services/direct_purchase_service.py
+++ b/app/services/direct_purchase_service.py
@@ -7,9 +7,7 @@ from typing import Optional, List, Dict, Any
 from uuid import UUID
 from datetime import datetime
 from decimal import Decimal, InvalidOperation, localcontext
-from zoneinfo import ZoneInfo
 
-_BOG = ZoneInfo("America/Bogota")
 _DIRECT_PURCHASE_DECIMAL_SCALE = Decimal("0.000000000000001")
 _DIRECT_PURCHASE_DECIMAL_PRECISION = 42
 _DECIMAL_ZERO = Decimal("0")
@@ -128,7 +126,7 @@ from fastapi import Request, Response, HTTPException, UploadFile
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError
-from app.core.timezones import resolve_tenant_timezone
+from app.core.timezones import local_date_for_tenant, resolve_tenant_timezone
 from app.services.purchase_tracking_service import (
     create_status_history_entry,
     upload_purchase_attachments
@@ -188,6 +186,7 @@ async def _post_purchase_gl_entry(
     purchase_date,            # datetime or date
     description: str,
     payment_method_id: Optional[UUID],
+    timezone_name: str,
 ) -> None:
     """
     Post GL entry for a received purchase:
@@ -207,12 +206,7 @@ async def _post_purchase_gl_entry(
         logger.info(f"[GL] Purchase {purchase_id}: zero amount — skip GL post")
         return
 
-    if hasattr(purchase_date, 'tzinfo') and purchase_date.tzinfo is not None:
-        entry_date = purchase_date.astimezone(_BOG).date()
-    elif hasattr(purchase_date, 'date'):
-        entry_date = purchase_date.date()
-    else:
-        entry_date = purchase_date
+    entry_date = local_date_for_tenant(purchase_date, timezone_name)
     period_year = entry_date.year
     period_month = entry_date.month
 
@@ -432,6 +426,7 @@ async def create_direct_purchase(
             raise HTTPException(status_code=400, detail="At least one item is required")
 
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             async with conn.transaction():
                 # 1. Generate purchase number with WR-CD prefix
                 purchase_number = await get_next_direct_purchase_number(conn, tenant_id)
@@ -719,6 +714,7 @@ async def create_direct_purchase(
                             purchase_row['purchase_date'],
                             purchase_number,
                             UUID(payment_method_id) if payment_method_id else None,
+                            timezone_name,
                         )
                 except Exception as _gl_err:
                     logger.warning(

--- a/app/services/online_orders_service.py
+++ b/app/services/online_orders_service.py
@@ -6,12 +6,11 @@ import asyncio
 from decimal import Decimal
 from typing import Optional
 from uuid import UUID
-from zoneinfo import ZoneInfo
 from fastapi import Request
-_BOG = ZoneInfo("America/Bogota")
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError, NotFoundError, ValidationError
+from app.core.timezones import local_date_for_tenant, resolve_tenant_timezone
 from app.services.email_helpers import send_order_accepted_email
 from app.services.waros_service import evaluate_and_award
 from app.services.cierre_service import _get_tenant_tax_config, _post_order_gl_entry, _post_order_cogs_gl_entry
@@ -434,6 +433,7 @@ async def update_order_status(
         changed_by = session.user_id
 
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             # 1. Fetch current order (tenant-scoped, online orders only)
             row = await conn.fetchrow(
                 """
@@ -599,11 +599,12 @@ async def update_order_status(
                         order_id,
                     )
                     tax_config = await _get_tenant_tax_config(conn, tenant_id)
+                    gl_order_date = local_date_for_tenant(order_for_gl["order_date"], timezone_name)
                     await _post_order_gl_entry(
                         conn=conn,
                         tenant_id=tenant_id,
                         order_id=order_id,
-                        order_date=order_for_gl["order_date"].astimezone(_BOG).date(),
+                        order_date=gl_order_date,
                         total_amount=Decimal(str(order_for_gl["total_amount"])),
                         payment_method=order_for_gl["payment_method"] or "digital",
                         payment_method_id=order_for_gl["payment_method_id"],
@@ -622,7 +623,7 @@ async def update_order_status(
                         conn=conn,
                         tenant_id=tenant_id,
                         order_id=order_id,
-                        order_date=order_for_gl["order_date"].astimezone(_BOG).date(),
+                        order_date=gl_order_date,
                         order_number=int(order_for_gl["order_number"]),
                     )
                 except Exception as e:
@@ -721,11 +722,12 @@ async def update_order_status(
                         order_id,
                     )
                     tax_config = await _get_tenant_tax_config(conn, tenant_id)
+                    gl_order_date = local_date_for_tenant(order_for_gl["order_date"], timezone_name)
                     await _post_order_gl_entry(
                         conn=conn,
                         tenant_id=tenant_id,
                         order_id=order_id,
-                        order_date=order_for_gl["order_date"].astimezone(_BOG).date(),
+                        order_date=gl_order_date,
                         total_amount=Decimal(str(order_for_gl["total_amount"])),
                         payment_method=order_for_gl["payment_method"] or "digital",
                         payment_method_id=order_for_gl["payment_method_id"],
@@ -744,7 +746,7 @@ async def update_order_status(
                         conn=conn,
                         tenant_id=tenant_id,
                         order_id=order_id,
-                        order_date=order_for_gl["order_date"].astimezone(_BOG).date(),
+                        order_date=gl_order_date,
                         order_number=int(order_for_gl["order_number"]),
                     )
                 except Exception as e:

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -6,12 +6,11 @@ import asyncio
 from decimal import Decimal
 from typing import Any, Dict, Optional, List
 from uuid import UUID
-from zoneinfo import ZoneInfo
 from fastapi import Request
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError
-from app.core.timezones import resolve_tenant_timezone, tenant_today
+from app.core.timezones import local_date_for_tenant, resolve_tenant_timezone, tenant_today
 from app.services.aws_ses_service import ses_service
 from app.services.waros_service import evaluate_and_award
 from app.services.cierre_service import (
@@ -41,7 +40,6 @@ def parse_date(date_str: Optional[str]) -> Optional[date]:
         return None
 
 logger = logging.getLogger(__name__)
-_BOG = ZoneInfo("America/Bogota")
 _INVENTORY_QUANTITY_SCALE = Decimal("0.000001")
 
 
@@ -1122,12 +1120,7 @@ async def bulk_update_order_status(
                     )
                     tax_config = await _get_tenant_tax_config(conn, tenant_id)
                     for ord_row in completed_orders:
-                        order_date = ord_row["order_date"]
-                        gl_order_date = (
-                            order_date.astimezone(_BOG).date()
-                            if order_date.tzinfo
-                            else order_date.date()
-                        )
+                        gl_order_date = local_date_for_tenant(ord_row["order_date"], timezone_name)
                         await _post_order_gl_entry(
                             conn=conn,
                             tenant_id=tenant_id,
@@ -1183,6 +1176,7 @@ async def update_order_status(
         waros_award_customer_id = None
 
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             row = await conn.fetchrow(
                 """SELECT id, status, order_number, table_session_id, pos_cart_id,
                           payment_status, order_date, total_amount, customer_id
@@ -1343,12 +1337,7 @@ async def update_order_status(
                             if cid:
                                 waros_award_order_id = completed_order["id"]
                                 waros_award_customer_id = cid
-                            order_date = completed_order["order_date"]
-                            gl_order_date = (
-                                order_date.astimezone(_BOG).date()
-                                if order_date.tzinfo
-                                else order_date.date()
-                            )
+                            gl_order_date = local_date_for_tenant(completed_order["order_date"], timezone_name)
                             tax_config = await _get_tenant_tax_config(conn, tenant_id)
                             await _post_order_gl_entry(
                                 conn=conn,
@@ -3461,6 +3450,7 @@ async def create_manual_order(
                     raise APIError("payment_method_id no es un UUID válido", status_code=422)
 
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             async with conn.transaction():
                 # Guard: block creation if order_date falls in a closed monthly accounting period (#362)
                 await assert_order_not_in_closed_monthly_period(conn, tenant_id, order_datetime)
@@ -3715,11 +3705,7 @@ async def create_manual_order(
                         user_id,
                     )
 
-                gl_order_date = (
-                    order_datetime.astimezone(_BOG).date()
-                    if order_datetime.tzinfo
-                    else order_datetime.date()
-                )
+                gl_order_date = local_date_for_tenant(order_datetime, timezone_name)
                 gl_payment_method_id = payment_method_uuid
 
                 try:

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -13,6 +13,7 @@ _BOG = ZoneInfo("America/Bogota")
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError
+from app.core.timezones import local_date_for_tenant, resolve_tenant_timezone
 from app.services.waros_service import evaluate_and_award
 from app.services.orders_service import _get_order_waro_redemption_summary
 from app.services.email_helpers import send_pos_receipt_email
@@ -1276,6 +1277,7 @@ async def add_order_payment(
         award_customer_id = None
 
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             async with conn.transaction():
                 # 1. Lock cart row
                 cart_row = await conn.fetchrow(
@@ -1511,7 +1513,7 @@ async def add_order_payment(
                             conn=conn,
                             tenant_id=tenant_id,
                             order_id=order_id,
-                            order_date=order_meta["order_date"].astimezone(_BOG).date(),
+                            order_date=local_date_for_tenant(order_meta["order_date"], timezone_name),
                             total_amount=Decimal(str(order_meta["total_amount"])),
                             payment_method=payment_method,
                             payment_method_id=UUID(payment_method_id) if payment_method_id else None,
@@ -2412,6 +2414,7 @@ async def complete_pos_order(
 
                 # Tax config — fetched once, used for GL entry and receipt breakdown
                 tax_config = await _get_tenant_tax_config(conn, tenant_id)
+                timezone_name = await resolve_tenant_timezone(conn, tenant_id)
 
                 if order_status == 'completed' and (not split_mode or _split_is_complete):
                     # GL journal entry — failure never blocks order completion
@@ -2425,7 +2428,7 @@ async def complete_pos_order(
                             conn=conn,
                             tenant_id=tenant_id,
                             order_id=order_id,
-                            order_date=order_row['created_at'].astimezone(_BOG).date(),
+                            order_date=local_date_for_tenant(order_row['created_at'], timezone_name),
                             total_amount=Decimal(str(_discounted_total)),
                             payment_method=payment_method,
                             payment_method_id=payment_method_id,
@@ -2445,7 +2448,7 @@ async def complete_pos_order(
                             conn=conn,
                             tenant_id=tenant_id,
                             order_id=order_id,
-                            order_date=order_row['created_at'].astimezone(_BOG).date(),
+                            order_date=local_date_for_tenant(order_row['created_at'], timezone_name),
                             order_number=int(order_number),
                         )
                     except Exception as e:

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -10,12 +10,11 @@ from typing import Optional, List, Any, Dict
 from uuid import UUID
 from datetime import date
 from decimal import Decimal
-from zoneinfo import ZoneInfo
-_BOG = ZoneInfo("America/Bogota")
 from fastapi import Request
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError, NotFoundError
+from app.core.timezones import local_date_for_tenant, resolve_tenant_timezone
 from app.services.cierre_service import (
     _get_tenant_tax_config,
     _post_order_gl_entry,
@@ -1000,6 +999,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
             raise AuthenticationError("Tenant ID is required")
 
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             async with conn.transaction():
                 table_row = await conn.fetchrow(
                     "SELECT id, is_bar, name FROM tables WHERE id = $1 AND tenant_id = $2 AND is_active = true FOR UPDATE",
@@ -1508,7 +1508,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                                     conn=conn,
                                     tenant_id=tenant_id,
                                     order_id=ord_row["id"],
-                                    order_date=ord_row["order_date"].astimezone(_BOG).date(),
+                                    order_date=local_date_for_tenant(ord_row["order_date"], timezone_name),
                                     total_amount=Decimal(str(ord_row["total_amount"])),
                                     payment_method=ord_row["payment_method"] or payment_method or "digital",
                                     payment_method_id=ord_row["payment_method_id"],
@@ -1522,7 +1522,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                                     conn=conn,
                                     tenant_id=tenant_id,
                                     order_id=ord_row["id"],
-                                    order_date=ord_row["order_date"].astimezone(_BOG).date(),
+                                    order_date=local_date_for_tenant(ord_row["order_date"], timezone_name),
                                     order_number=int(ord_row["order_number"]),
                                 )
                     except Exception as _gl_exc:
@@ -1620,7 +1620,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                                         conn=conn,
                                         tenant_id=tenant_id,
                                         order_id=split_ord["id"],
-                                        order_date=split_ord["order_date"].astimezone(_BOG).date(),
+                                        order_date=local_date_for_tenant(split_ord["order_date"], timezone_name),
                                         total_amount=Decimal(str(split_ord["total_amount"])),
                                         payment_method=split_ord["payment_method"] or payment_method or "digital",
                                         payment_method_id=split_ord["payment_method_id"],
@@ -1632,7 +1632,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                                         conn=conn,
                                         tenant_id=tenant_id,
                                         order_id=split_ord["id"],
-                                        order_date=split_ord["order_date"].astimezone(_BOG).date(),
+                                        order_date=local_date_for_tenant(split_ord["order_date"], timezone_name),
                                         order_number=int(split_ord["order_number"]),
                                     )
                                 if first_tip_order and split_tip_amount > 0:
@@ -1947,6 +1947,7 @@ async def add_session_payment(
         user_id = session_context.user_id if hasattr(session_context, 'user_id') else None
 
         async with get_db_connection() as conn:
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             async with conn.transaction():
                 # Get open session
                 session_row = await conn.fetchrow(
@@ -2088,7 +2089,7 @@ async def add_session_payment(
                                 conn=conn,
                                 tenant_id=tenant_id,
                                 order_id=ord_row["id"],
-                                order_date=ord_row["order_date"].astimezone(_BOG).date(),
+                                order_date=local_date_for_tenant(ord_row["order_date"], timezone_name),
                                 total_amount=Decimal(str(ord_row["total_amount"])),
                                 payment_method=ord_row["payment_method"] or payment_method or "digital",
                                 payment_method_id=ord_row["payment_method_id"],
@@ -2100,7 +2101,7 @@ async def add_session_payment(
                                 conn=conn,
                                 tenant_id=tenant_id,
                                 order_id=ord_row["id"],
-                                order_date=ord_row["order_date"].astimezone(_BOG).date(),
+                                order_date=local_date_for_tenant(ord_row["order_date"], timezone_name),
                                 order_number=int(ord_row["order_number"]),
                             )
                     except Exception as _split_gl_exc:

--- a/tests/test_bulk_order_status_gl_cogs.py
+++ b/tests/test_bulk_order_status_gl_cogs.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
@@ -28,9 +28,10 @@ async def test_bulk_complete_posts_gl_cogs_only_for_new_completions():
     payment_method_id = uuid4()
     pending_order_id = uuid4()
     completed_order_id = uuid4()
-    order_date = datetime(2026, 6, 7, 10, 30)
+    order_date = datetime(2026, 6, 7, 0, 30, tzinfo=timezone.utc)
 
     conn = AsyncMock()
+    conn.fetchval = AsyncMock(return_value="Europe/Madrid")
     conn.fetchrow = AsyncMock(
         side_effect=[
             None,

--- a/tests/test_manual_order_gl_cogs.py
+++ b/tests/test_manual_order_gl_cogs.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -224,10 +224,12 @@ async def test_update_order_status_finalizes_pending_table_with_gl_cogs_without_
             "completed",
             "card",
             str(payment_method_id),
-        )
+    )
 
     assert result["success"] is True
-    conn.fetchval.assert_awaited_once()
+    assert conn.fetchval.await_count == 2
+    assert "tenant_public_profiles" in conn.fetchval.await_args_list[0].args[0]
+    assert "tenant_ingredient_movements" in conn.fetchval.await_args_list[1].args[0]
     deduct_stock.assert_not_awaited()
     post_gl.assert_awaited_once()
     post_cogs.assert_awaited_once_with(
@@ -319,7 +321,9 @@ async def test_update_order_status_deducts_stock_for_pending_table_without_consu
         )
 
     assert result["success"] is True
-    conn.fetchval.assert_awaited_once()
+    assert conn.fetchval.await_count == 2
+    assert "tenant_public_profiles" in conn.fetchval.await_args_list[0].args[0]
+    assert "tenant_ingredient_movements" in conn.fetchval.await_args_list[1].args[0]
     deduct_stock.assert_awaited_once_with(conn, order_id, tenant_id, user_id, 8523)
 
 
@@ -825,8 +829,9 @@ async def test_create_manual_order_captures_snapshots_and_posts_gl_cogs():
     order_item_id = uuid4()
     product_id = uuid4()
     payment_method_id = uuid4()
-    order_date = datetime(2026, 6, 7, 10, 30)
+    order_date = datetime(2026, 6, 7, 0, 30, tzinfo=timezone.utc)
     conn = _manual_order_conn(order_id, order_item_id, order_date)
+    conn.fetchval = AsyncMock(return_value="Europe/Madrid")
 
     capture_snapshot = AsyncMock()
     deduct_modifier_inventory = AsyncMock()
@@ -860,7 +865,7 @@ async def test_create_manual_order_captures_snapshots_and_posts_gl_cogs():
     ):
         result = await orders_service.create_manual_order(
             Request({"type": "http"}),
-            order_date="2026-06-07T10:30:00",
+            order_date="2026-06-07T00:30:00+00:00",
             payment_method="digital",
             payment_method_id=str(payment_method_id),
             items=[

--- a/tests/test_tenant_timezones.py
+++ b/tests/test_tenant_timezones.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError as PydanticValidationError
 
 from app.core.timezones import (
     DEFAULT_TENANT_TIMEZONE,
+    local_date_for_tenant,
     local_day_utc_range,
     normalize_timezone,
     resolve_tenant_timezone,
@@ -33,6 +34,16 @@ def test_tenant_today_and_local_day_range_use_tenant_timezone():
     start_utc, end_utc = local_day_utc_range(date(2026, 1, 1), "America/Bogota")
     assert start_utc.isoformat() == "2026-01-01T05:00:00+00:00"
     assert end_utc.isoformat() == "2026-01-02T05:00:00+00:00"
+
+
+def test_local_date_for_tenant_preserves_naive_and_converts_aware_datetimes():
+    aware = datetime(2026, 6, 7, 0, 30, tzinfo=timezone.utc)
+    naive = datetime(2026, 6, 7, 0, 30)
+
+    assert local_date_for_tenant(aware, "Europe/Madrid") == date(2026, 6, 7)
+    assert local_date_for_tenant(aware, "America/Bogota") == date(2026, 6, 6)
+    assert local_date_for_tenant(naive, "America/Bogota") == date(2026, 6, 7)
+    assert local_date_for_tenant(date(2026, 6, 7), "America/Bogota") == date(2026, 6, 7)
 
 
 def test_public_profile_write_model_rejects_invalid_timezone():


### PR DESCRIPTION
## Summary
- Add a shared tenant-local date helper for accounting date conversion
- Use tenant timezone for order, POS, online order, table, and direct purchase GL posting dates
- Cover aware boundary timestamps and naive datetime preservation in targeted tests

## Tests
- pytest tests/test_tenant_timezones.py tests/test_bulk_order_status_gl_cogs.py tests/test_manual_order_gl_cogs.py
- python3 -m py_compile app/core/timezones.py app/services/orders_service.py app/services/pos_cart_service.py app/services/online_orders_service.py app/services/tables_service.py app/services/direct_purchase_service.py
- git diff --check -- app/core/timezones.py app/services/orders_service.py app/services/pos_cart_service.py app/services/online_orders_service.py app/services/tables_service.py app/services/direct_purchase_service.py tests/test_tenant_timezones.py tests/test_bulk_order_status_gl_cogs.py tests/test_manual_order_gl_cogs.py

Closes #542