### PR TITLE
Record promotion deletes in operation events

### DIFF
--- a/app/models/tenant_promotion.py
+++ b/app/models/tenant_promotion.py
@@ -111,6 +111,10 @@ class PromotionUpdate(BaseModel):
     overlap_acknowledged: bool = False
 
 
+class PromotionDeleteRequest(BaseModel):
+    reason: str = Field(..., min_length=1, max_length=500)
+
+
 class PromotionResponse(BaseModel):
     id: UUID
     tenant_id: UUID

--- a/app/routers/promotions.py
+++ b/app/routers/promotions.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, Query, Request
 
 from app.core.permissions import Module, require_module
-from app.models.tenant_promotion import PromotionCreate, PromotionUpdate
+from app.models.tenant_promotion import PromotionCreate, PromotionDeleteRequest, PromotionUpdate
 from app.services import promotions_service
 
 router = APIRouter(prefix="/api/promotions", tags=["promotions"])
@@ -134,5 +134,13 @@ async def update_promotion_endpoint(
     dependencies=[Depends(require_module(Module.MI_NEGOCIO))],
     summary="Delete promotion",
 )
-async def delete_promotion_endpoint(request: Request, promotion_id: UUID):
-    return await promotions_service.delete_promotion(request, promotion_id)
+async def delete_promotion_endpoint(
+    request: Request,
+    promotion_id: UUID,
+    body: PromotionDeleteRequest,
+):
+    return await promotions_service.delete_promotion(
+        request,
+        promotion_id,
+        reason=body.reason,
+    )

--- a/app/services/operation_events_service.py
+++ b/app/services/operation_events_service.py
@@ -26,6 +26,7 @@ ACTIONS: FrozenSet[str] = frozenset({
     "cart_cleared",
     "payment_voided",
     "comanda_line_cancelled",
+    "promotion_deleted",
 })
 
 

--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -21,6 +21,7 @@ from app.models.tenant_promotion import (
     PromotionUpdate,
     ScopeType,
 )
+from app.services.operation_events_service import DOMAIN_POS, record_operation_event
 
 logger = logging.getLogger(__name__)
 
@@ -1105,19 +1106,40 @@ async def update_promotion(
     )
 
 
-async def delete_promotion(request: Request, promotion_id: UUID) -> dict:
+async def delete_promotion(request: Request, promotion_id: UUID, *, reason: str) -> dict:
     session = require_valid_session(request)
     tenant_id = session.tenant_id
     if not tenant_id:
         raise AuthenticationError("Tenant ID is required")
+    normalized_reason = reason.strip()
+    if not normalized_reason:
+        raise HTTPException(status_code=400, detail="reason is required")
 
     async with get_db_connection() as conn:
-        await _get_owned_promotion(conn, promotion_id, tenant_id)
-        await conn.execute(
-            "DELETE FROM tenant_promotions WHERE id = $1 AND tenant_id = $2",
-            promotion_id,
-            tenant_id,
-        )
+        async with conn.transaction():
+            row = await _get_owned_promotion(conn, promotion_id, tenant_id)
+            await record_operation_event(
+                conn,
+                tenant_id,
+                domain=DOMAIN_POS,
+                channel="mostrador",
+                action="promotion_deleted",
+                actor_user_id=session.user_id,
+                payload={
+                    "promotion_id": promotion_id,
+                    "promotion_name": row["name"],
+                    "promo_type": row["promo_type"],
+                    "scope_type": row["scope_type"],
+                    "priority": row["priority"],
+                    "is_active": row["is_active"],
+                },
+                reason=normalized_reason,
+            )
+            await conn.execute(
+                "DELETE FROM tenant_promotions WHERE id = $1 AND tenant_id = $2",
+                promotion_id,
+                tenant_id,
+            )
 
     return {"success": True, "message": "Promotion deleted successfully"}
 

--- a/sql/20260521_create_tenant_operation_events.sql
+++ b/sql/20260521_create_tenant_operation_events.sql
@@ -25,11 +25,14 @@ CREATE TABLE IF NOT EXISTS tenant_operation_events (
             'tab_item_added'::text,
             'tab_item_removed'::text,
             'tab_item_qty_changed'::text,
+            'tab_item_edited'::text,
+            'tab_item_edit_blocked'::text,
             'tab_cleared'::text,
             'cart_line_removed'::text,
             'cart_cleared'::text,
             'payment_voided'::text,
-            'comanda_line_cancelled'::text
+            'comanda_line_cancelled'::text,
+            'promotion_deleted'::text
         ]))
 );
 

--- a/sql/20260627_add_promotion_deleted_operation_event.sql
+++ b/sql/20260627_add_promotion_deleted_operation_event.sql
@@ -1,0 +1,19 @@
+-- Allow promotion deletes to appear in Bitácora de operaciones.
+ALTER TABLE tenant_operation_events
+    DROP CONSTRAINT IF EXISTS tenant_operation_events_action_check;
+
+ALTER TABLE tenant_operation_events
+    ADD CONSTRAINT tenant_operation_events_action_check
+    CHECK (action = ANY (ARRAY[
+        'tab_item_added'::text,
+        'tab_item_removed'::text,
+        'tab_item_qty_changed'::text,
+        'tab_item_edited'::text,
+        'tab_item_edit_blocked'::text,
+        'tab_cleared'::text,
+        'cart_line_removed'::text,
+        'cart_cleared'::text,
+        'payment_voided'::text,
+        'comanda_line_cancelled'::text,
+        'promotion_deleted'::text
+    ]));

--- a/tests/test_operation_events.py
+++ b/tests/test_operation_events.py
@@ -108,6 +108,29 @@ async def test_record_operation_event_inserts_on_valid_input():
     assert args[4] == "cart_line_removed"
 
 
+@pytest.mark.asyncio
+async def test_record_operation_event_accepts_promotion_deleted():
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    tenant_id = uuid4()
+
+    await operation_events_service.record_operation_event(
+        conn,
+        tenant_id,
+        domain="pos",
+        channel="mostrador",
+        action="promotion_deleted",
+        actor_user_id=uuid4(),
+        payload={"promotion_name": "Happy hour"},
+        reason="Campaña finalizada",
+    )
+
+    conn.execute.assert_called_once()
+    args = conn.execute.call_args[0]
+    assert args[1] == tenant_id
+    assert args[4] == "promotion_deleted"
+
+
 def test_supervisor_passes_list_operation_events_under_enforce():
     session = _build_session(role="supervisor")
     app = FastAPI()

--- a/tests/test_promotions_crud.py
+++ b/tests/test_promotions_crud.py
@@ -138,6 +138,30 @@ def test_owner_passes_list_promotions_under_enforce():
     assert response.status_code == 200
 
 
+def test_owner_delete_promotion_sends_reason_under_enforce():
+    promo_id = uuid4()
+    session = _build_session(role="owner")
+    app = FastAPI()
+    app.include_router(promotions_router)
+    delete_mock = AsyncMock(return_value={"success": True})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.services.promotions_service.delete_promotion", new=delete_mock):
+        client = TestClient(app)
+        response = client.request(
+            "DELETE",
+            f"/api/promotions/{promo_id}",
+            json={"reason": "Campaña finalizada"},
+        )
+
+    assert response.status_code == 200
+    delete_mock.assert_awaited_once()
+    assert delete_mock.await_args.args[1] == promo_id
+    assert delete_mock.await_args.kwargs["reason"] == "Campaña finalizada"
+
+
 def test_cashier_passes_active_promotions_under_enforce():
     session = _build_session(role="cashier")
     app = FastAPI()


### PR DESCRIPTION
## Summary\n- allow promotion_deleted operation events\n- record deleted promotion context/reason from the delete endpoint\n- cover operation event and promotion delete behavior with tests\n\n## Tests\n- ./venv/bin/python -m pytest tests/test_operation_events.py tests/test_promotions_crud.py