### PR TITLE
Block DIAN invoice for pure credit orders

### DIFF
--- a/app/services/facturacion_service.py
+++ b/app/services/facturacion_service.py
@@ -52,7 +52,19 @@ async def emit_invoice(
     # Verify order exists, belongs to tenant, and is completed
     async with get_db_connection(use_transaction=False) as conn:
         order = await conn.fetchrow(
-            "SELECT id, status FROM orders WHERE id = $1 AND tenant_id = $2",
+            """SELECT o.id,
+                      o.status,
+                      o.payment_method,
+                      o.payment_status,
+                      COALESCE((
+                          SELECT COUNT(*)
+                          FROM order_payments op
+                          WHERE op.order_id = o.id
+                            AND op.tenant_id = o.tenant_id
+                            AND op.voided_at IS NULL
+                      ), 0) AS active_payment_count
+               FROM orders o
+               WHERE o.id = $1 AND o.tenant_id = $2""",
             UUID(order_id), UUID(tenant_id),
         )
 
@@ -89,6 +101,18 @@ async def emit_invoice(
         if existing is not None:
             logger.info(f"Invoice already accepted for order {order_id}, short-circuiting emit")
             return existing
+
+    payment_method = (order['payment_method'] or '').lower()
+    payment_status = (order['payment_status'] or '').lower()
+    active_payment_count = int(order['active_payment_count'] or 0)
+    if payment_method == 'credit' and payment_status == 'credit' and active_payment_count == 0:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Las ventas con pago solo crédito no emiten factura electrónica desde este flujo. "
+                "Usa pago dividido si necesitas emitir la factura al momento de la venta."
+            ),
+        )
 
     if (
         latest

--- a/tests/test_emit_short_circuit.py
+++ b/tests/test_emit_short_circuit.py
@@ -54,8 +54,19 @@ def _patch_db(rows):
     )
 
 
-def _order_row(status: str = 'completed'):
-    return {'id': UUID(_ORDER_ID), 'status': status}
+def _order_row(
+    status: str = 'completed',
+    payment_method: str = 'cash',
+    payment_status: str = 'paid',
+    active_payment_count: int = 0,
+):
+    return {
+        'id': UUID(_ORDER_ID),
+        'status': status,
+        'payment_method': payment_method,
+        'payment_status': payment_status,
+        'active_payment_count': active_payment_count,
+    }
 
 
 def _latest_invoice_row(
@@ -189,3 +200,55 @@ async def test_accepted_short_circuits_to_existing_invoice():
 
     assert result == existing_payload
     fake_client.post.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_credit_only_order_does_not_reach_proxy():
+    """Pure credit orders are blocked before api-facturacion can return Matias 422."""
+    rows = [
+        _order_row(payment_method='credit', payment_status='credit', active_payment_count=0),
+        None,
+    ]
+
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock()
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=False)
+
+    with _patch_db(rows), patch(
+        'app.services.facturacion_service.httpx.AsyncClient',
+        return_value=fake_client,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await facturacion_service.emit_invoice(_ORDER_ID, _TENANT_ID, 'pos')
+
+    assert exc_info.value.status_code == 422
+    assert 'solo crédito' in exc_info.value.detail
+    fake_client.post.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_split_credit_order_falls_through_to_proxy():
+    """Credit as part of split tender remains invoice-eligible."""
+    rows = [
+        _order_row(payment_method='credit', payment_status='paid', active_payment_count=1),
+        None,
+    ]
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.is_success = True
+    fake_resp.json = MagicMock(return_value={'status': 'accepted'})
+    fake_resp.text = '{"status":"accepted"}'
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=fake_resp)
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=False)
+
+    with _patch_db(rows), patch(
+        'app.services.facturacion_service.httpx.AsyncClient',
+        return_value=fake_client,
+    ):
+        await facturacion_service.emit_invoice(_ORDER_ID, _TENANT_ID, 'pos')
+
+    fake_client.post.assert_awaited_once()


### PR DESCRIPTION
## Summary
- block pure credit orders before delegating to api-facturacion
- keep accepted invoice short-circuit intact
- allow split credit orders through

## Tests
- pytest tests/test_emit_short_circuit.py