### PR TITLE
Include delivery orders in customer analytics

### DIFF
--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -1585,7 +1585,7 @@ async def get_customers_list(
     offset: int = 0
 ) -> dict:
     """
-    List tenant customers with POS order metrics for the filtered period.
+    List tenant customers with sales order metrics for the filtered period.
     Includes profiles linked via tenant_members even when they have zero orders
     (warocol.com#1099). Payment/status filters require a matching order.
     """
@@ -1600,7 +1600,7 @@ async def get_customers_list(
             timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             order_conditions = [
                 "o.tenant_id = $1",
-                "(o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')",
+                ANALYTICS_SALES_FILTER_ALIAS_O,
                 "o.customer_id IS NOT NULL",
             ]
             params: list = [tenant_id]
@@ -1740,9 +1740,9 @@ async def get_customer_detail(
     per_page: int = 20
 ) -> dict:
     """
-    Get a single customer's aggregate stats plus their paginated POS order history.
+    Get a single customer's aggregate stats plus their paginated sales order history.
     Returns 404 if the customer is not linked to the tenant.
-    Profiles without POS orders return zeroed stats and empty order history.
+    Profiles without sales orders return zeroed stats and empty order history.
     """
     try:
         session_context = require_valid_session(request)
@@ -1754,8 +1754,29 @@ async def get_customer_detail(
         async with get_db_connection() as conn:
             timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             # --- Customer aggregate stats ---
+            parsed_date_from = parse_date(date_from)
+            parsed_date_to = parse_date(date_to)
+
+            aggregate_conditions = [
+                "o.tenant_id = $1",
+                ANALYTICS_SALES_FILTER_ALIAS_O,
+                "o.customer_id = $2",
+            ]
+            aggregate_params = [tenant_id, customer_id, timezone_name]
+            aggregate_param_count = 3
+            aggregate_param_count = _append_local_date_bounds(
+                aggregate_conditions,
+                aggregate_params,
+                aggregate_param_count,
+                "o.order_date",
+                parsed_date_from,
+                parsed_date_to,
+                timezone_name,
+            )
+            aggregate_where_clause = " AND ".join(aggregate_conditions)
+
             customer_row = await conn.fetchrow(
-                """
+                f"""
                 SELECT
                     o.customer_id,
                     COALESCE(p.name, 'Sin identificar') AS name,
@@ -1767,14 +1788,10 @@ async def get_customer_detail(
                     MAX(DATE(o.order_date AT TIME ZONE $3)) AS last_purchase
                 FROM orders o
                 LEFT JOIN profile p ON o.customer_id = p.id
-                WHERE o.tenant_id = $1
-                  AND (o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')
-                  AND o.customer_id = $2
+                WHERE {aggregate_where_clause}
                 GROUP BY o.customer_id, p.name, p.phone_number, p.email
                 """,
-                tenant_id,
-                customer_id,
-                timezone_name,
+                *aggregate_params,
             )
 
             if not customer_row:
@@ -1811,14 +1828,12 @@ async def get_customer_detail(
             # --- Paginated order history ---
             where_conditions = [
                 "o.tenant_id = $1",
-                "(o.pos_cart_id IS NOT NULL OR o.table_session_id IS NOT NULL OR o.extra_attributes->>'source' = 'manual')",
+                ANALYTICS_SALES_FILTER_ALIAS_O,
                 "o.customer_id = $2",
             ]
             params = [tenant_id, customer_id]
             param_count = 2
 
-            parsed_date_from = parse_date(date_from)
-            parsed_date_to = parse_date(date_to)
             param_count = _append_local_date_bounds(
                 where_conditions,
                 params,

--- a/tests/test_customer_detail.py
+++ b/tests/test_customer_detail.py
@@ -1,5 +1,5 @@
 """Tests for GET /orders/customers/{customer_id} — profile without POS orders (#377)."""
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
@@ -114,3 +114,40 @@ async def test_get_customer_detail_with_orders_unchanged():
     assert result['customer']['total_spent'] == 50000.0
     assert result['customer']['first_purchase'] == '2026-01-10'
     assert result['customer']['last_purchase'] == '2026-05-01'
+    aggregate_query = _SeqConnCtx.latest_conn.fetchrow.await_args_list[0].args[0]
+    history_query = _SeqConnCtx.latest_conn.fetch.await_args_list[0].args[0]
+    assert "o.online_cart_id IS NOT NULL" in aggregate_query
+    assert "o.online_cart_id IS NOT NULL" in history_query
+
+
+@pytest.mark.asyncio
+async def test_get_customer_detail_aggregate_uses_tenant_local_date_filters():
+    """Customer header stats should use the same tenant-local range as history."""
+    order_agg = {
+        'customer_id': _CUSTOMER_ID,
+        'name': 'Filtered Customer',
+        'phone': '3009876543',
+        'email': 'buyer@example.com',
+        'total_orders': 1,
+        'total_spent': 25000.0,
+        'first_purchase': date(2026, 6, 29),
+        'last_purchase': date(2026, 6, 29),
+    }
+
+    with _patch_session(), _patch_conn([order_agg, None], [[], []]):
+        result = await orders_service.get_customer_detail(
+            Request({'type': 'http'}),
+            customer_id=_CUSTOMER_ID,
+            date_from='2026-06-29',
+            date_to='2026-06-29',
+        )
+
+    aggregate_call = _SeqConnCtx.latest_conn.fetchrow.await_args_list[0]
+    aggregate_query = aggregate_call.args[0]
+    aggregate_args = aggregate_call.args[1:]
+    assert "o.order_date >= ($4::timestamp AT TIME ZONE $5)" in aggregate_query
+    assert "o.order_date < (($6::timestamp + interval '1 day') AT TIME ZONE $7)" in aggregate_query
+    assert aggregate_args[3] == date(2026, 6, 29)
+    assert aggregate_args[5] == date(2026, 6, 29)
+    assert result['customer']['first_purchase'] == '2026-06-29'
+    assert result['customer']['last_purchase'] == '2026-06-29'

--- a/tests/test_customers_list.py
+++ b/tests/test_customers_list.py
@@ -85,5 +85,6 @@ async def test_customers_list_includes_zero_order_customer():
   assert "tenant_customers tc" in query
   assert "tc.profile_id" in query
   assert "tc.is_active = true" in query
+  assert "o.online_cart_id IS NOT NULL" in query
   assert "tenant_members" not in query
   assert "role = 'customer'" not in query


### PR DESCRIPTION
## Summary\n- Include online/delivery orders in customer analytics list and detail aggregations\n- Apply tenant-local date bounds to customer detail header stats\n- Cover customer analytics filters with tests\n\n## Tests\n- pytest tests/test_customer_detail.py tests/test_customers_list.py\n- python3 -m py_compile app/services/orders_service.py\n- git diff --check