### PR TITLE
Handle tenant timezone schema mismatch

### DIFF
--- a/app/core/timezones.py
+++ b/app/core/timezones.py
@@ -5,10 +5,15 @@ boundaries. Fiscal/legal Colombia time should use a separate named helper.
 """
 from datetime import date, datetime, time, timedelta, timezone
 from inspect import isawaitable
+import logging
 from typing import Optional, Tuple, Union
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+import asyncpg
+
+
 DEFAULT_TENANT_TIMEZONE = "America/Bogota"
+logger = logging.getLogger(__name__)
 
 
 def validate_timezone(value: Optional[str]) -> str:
@@ -48,11 +53,18 @@ def local_date_for_tenant(value: Union[datetime, date], timezone_name: Optional[
 
 async def resolve_tenant_timezone(conn, tenant_id) -> str:
     """Resolve a tenant's operational timezone from profile config."""
-    result = conn.fetchval(
-        "SELECT timezone FROM tenant_public_profiles WHERE tenant_id = $1",
-        tenant_id,
-    )
-    value = await result if isawaitable(result) else result
+    try:
+        result = conn.fetchval(
+            "SELECT timezone FROM tenant_public_profiles WHERE tenant_id = $1",
+            tenant_id,
+        )
+        value = await result if isawaitable(result) else result
+    except asyncpg.UndefinedColumnError:
+        logger.warning(
+            "tenant_public_profiles.timezone missing; using default timezone. "
+            "Apply sql/20260626_tenant_timezone.sql."
+        )
+        return DEFAULT_TENANT_TIMEZONE
     return normalize_timezone(value)
 
 

--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -8,8 +8,11 @@ gated under Module.POS so cashiers reach it without needing MI_NEGOCIO
 
 Single query joins four tables; everything POS needs in one round-trip.
 """
+import logging
 from typing import Any, Dict, Optional
 from uuid import UUID
+
+import asyncpg
 
 from app.database import get_db_connection
 from app.core.timezones import normalize_timezone
@@ -19,6 +22,8 @@ from app.services.promotions_service import (
     DEFAULT_PROMO_CONFLICT_STRATEGY,
     normalize_promo_type_block_map,
 )
+
+logger = logging.getLogger(__name__)
 
 
 _CONTEXT_QUERY = """
@@ -74,6 +79,11 @@ LEFT JOIN tenant_tax_config       ttc ON ttc.tenant_id = t.id
 WHERE t.id = $1
 """
 
+_CONTEXT_QUERY_WITHOUT_TIMEZONE = _CONTEXT_QUERY.replace(
+    "    tpp.timezone,\n",
+    "    NULL AS timezone,\n",
+)
+
 
 _MEMBERS_QUERY = """
 SELECT tm.id, p.name, tm.role
@@ -100,7 +110,14 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
     Module.EQUIPO access (which gates /api/tenants/members).
     """
     async with get_db_connection(use_transaction=False) as conn:
-        row = await conn.fetchrow(_CONTEXT_QUERY, tenant_id)
+        try:
+            row = await conn.fetchrow(_CONTEXT_QUERY, tenant_id)
+        except asyncpg.UndefinedColumnError:
+            logger.warning(
+                "tenant_public_profiles.timezone missing in POS context query; "
+                "using default timezone. Apply sql/20260626_tenant_timezone.sql."
+            )
+            row = await conn.fetchrow(_CONTEXT_QUERY_WITHOUT_TIMEZONE, tenant_id)
         if row is None:
             return None
         members_rows = await conn.fetch(_MEMBERS_QUERY, tenant_id)

--- a/dbdoc/README.md
+++ b/dbdoc/README.md
@@ -139,7 +139,7 @@
 | [public.recurring_expense_instances](public.recurring_expense_instances.md) | 14 | Individual payment instances for recurring expenses | BASE TABLE |
 | [public.salary_payment_change_history](public.salary_payment_change_history.md) | 12 | Audit log for tracking all changes to salary payments | BASE TABLE |
 | [public.salary_config_change_history](public.salary_config_change_history.md) | 12 | Audit log for tracking changes to employee salary configuration | BASE TABLE |
-| [public.tenant_public_profiles](public.tenant_public_profiles.md) | 41 | Perfiles públicos de restaurantes para mostrar menú y información | BASE TABLE |
+| [public.tenant_public_profiles](public.tenant_public_profiles.md) | 42 | Perfiles públicos de restaurantes para mostrar menú y información | BASE TABLE |
 | [public.promoter_codes](public.promoter_codes.md) | 8 |  | BASE TABLE |
 | [public.commission_configs](public.commission_configs.md) | 8 |  | BASE TABLE |
 | [public.order_commissions](public.order_commissions.md) | 20 |  | BASE TABLE |

--- a/dbdoc/public.tenant_public_profiles.md
+++ b/dbdoc/public.tenant_public_profiles.md
@@ -49,6 +49,7 @@ Perfiles públicos de restaurantes para mostrar menú y información
 | tip_preselect_index | integer |  | true |  |  | Index into tip_default_percentages to pre-select at checkout. NULL means nothing is pre-selected (recommended — Ley 1935/2018 voluntariness). |
 | table_qr_module_enabled | boolean | false | false |  |  | Table QR ordering module (warocol.com#710). When true, tenant can enable per-table static QR links for diner self-order with staff confirmation. Default false preserves current behaviour. |
 | tip_taxable_default | boolean | false | false |  |  | warocol.com#740 — default: include standard consumption tax on tips at checkout |
+| timezone | text | 'America/Bogota'::text | false |  |  | IANA timezone for tenant operational dates, business hours, and report boundaries. Defaults to America/Bogota. |
 
 ## Constraints
 
@@ -58,6 +59,7 @@ Perfiles públicos de restaurantes para mostrar menú y información
 | tenant_public_profiles_pkey | PRIMARY KEY | PRIMARY KEY (id) |
 | tenant_public_profiles_tenant_id_key | UNIQUE | UNIQUE (tenant_id) |
 | tenant_public_profiles_slug_key | UNIQUE | UNIQUE (slug) |
+| tenant_public_profiles_timezone_non_blank | CHECK | CHECK (btrim(timezone) <> '') |
 
 ## Indexes
 

--- a/dbdoc/schema.json
+++ b/dbdoc/schema.json
@@ -20410,6 +20410,13 @@
           "nullable": false,
           "default": "false",
           "comment": "warocol.com#740 — default: include standard consumption tax on tips at checkout"
+        },
+        {
+          "name": "timezone",
+          "type": "text",
+          "nullable": false,
+          "default": "'America/Bogota'::text",
+          "comment": "IANA timezone for tenant operational dates, business hours, and report boundaries. Defaults to America/Bogota."
         }
       ],
       "indexes": [
@@ -20512,6 +20519,16 @@
           "referenced_table": "",
           "columns": [
             "slug"
+          ]
+        },
+        {
+          "name": "tenant_public_profiles_timezone_non_blank",
+          "type": "CHECK",
+          "def": "CHECK (btrim(timezone) <> '')",
+          "table": "public.tenant_public_profiles",
+          "referenced_table": "",
+          "columns": [
+            "timezone"
           ]
         }
       ]

--- a/tests/test_tenant_timezones.py
+++ b/tests/test_tenant_timezones.py
@@ -3,6 +3,7 @@ from datetime import date, datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
+import asyncpg
 import pytest
 from pydantic import ValidationError as PydanticValidationError
 
@@ -87,6 +88,18 @@ async def test_resolve_tenant_timezone_falls_back_for_missing_or_legacy_value():
     assert await resolve_tenant_timezone(conn, uuid4()) == DEFAULT_TENANT_TIMEZONE
 
 
+@pytest.mark.asyncio
+async def test_resolve_tenant_timezone_falls_back_when_column_is_missing():
+    conn = AsyncMock()
+    conn.fetchval = AsyncMock(
+        side_effect=asyncpg.UndefinedColumnError(
+            'column "timezone" does not exist'
+        )
+    )
+
+    assert await resolve_tenant_timezone(conn, uuid4()) == DEFAULT_TENANT_TIMEZONE
+
+
 def _pos_context_row(timezone_name):
     return {
         "display_name": "Demo",
@@ -144,6 +157,32 @@ async def test_pos_context_exposes_normalized_timezone():
     async def _ctx(*_, **__):
         conn = MagicMock()
         conn.fetchrow = AsyncMock(return_value=_pos_context_row("Bad/Legacy"))
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+
+    with patch("app.services.pos_context_service.get_db_connection", side_effect=_ctx), \
+         patch("app.services.pos_context_service.get_readiness", new=AsyncMock(return_value={"ready": False})), \
+         patch("app.services.pos_context_service.fetch_open_sale_product", new=AsyncMock(return_value=None)):
+        payload = await pos_context_service.get_restaurant_context(tenant_id)
+
+    assert payload["timezone"] == DEFAULT_TENANT_TIMEZONE
+
+
+@pytest.mark.asyncio
+async def test_pos_context_falls_back_when_timezone_column_is_missing():
+    tenant_id = UUID("93b3e582-34fa-44a6-8d0f-bf82a3608727")
+
+    @asynccontextmanager
+    async def _ctx(*_, **__):
+        conn = MagicMock()
+        conn.fetchrow = AsyncMock(
+            side_effect=[
+                asyncpg.UndefinedColumnError(
+                    'column tpp.timezone does not exist'
+                ),
+                _pos_context_row(None),
+            ]
+        )
         conn.fetch = AsyncMock(return_value=[])
         yield conn
 


### PR DESCRIPTION
## Summary
- fall back to the default tenant timezone when production is missing tenant_public_profiles.timezone
- retry POS restaurant context without the timezone column during migration drift
- sync tenant_public_profiles dbdoc/schema metadata for timezone

## Tests
- pytest tests/test_tenant_timezones.py
- python3 -m json.tool dbdoc/schema.json >/dev/null

Build not run per request.

Closes #565