### PR TITLE
Make sensitive actions idempotent

### DIFF
--- a/app/services/expenses_service.py
+++ b/app/services/expenses_service.py
@@ -78,6 +78,29 @@ def _raise_duplicate_expense_error(exc: asyncpg.UniqueViolationError) -> None:
     raise exc
 
 
+def _format_recurring_instance_response(instance_row) -> Dict[str, Any]:
+    return {
+        'success': True,
+        'data': {
+            'id': str(instance_row['id']),
+            'tenantId': str(instance_row['tenant_id']),
+            'expenseId': str(instance_row['expense_id']),
+            'periodMonth': instance_row['period_month'],
+            'scheduledDate': instance_row['scheduled_date'].isoformat(),
+            'amount': float(instance_row['amount']),
+            'status': instance_row['status'],
+            'paymentDate': instance_row['payment_date'].isoformat() if instance_row['payment_date'] else None,
+            'paymentMethod': instance_row['payment_method'],
+            'paymentReference': instance_row['payment_reference'],
+            'notes': instance_row['notes'],
+            'createdBy': str(instance_row['created_by']) if instance_row['created_by'] else None,
+            'createdAt': instance_row['created_at'].isoformat(),
+            'updatedAt': instance_row['updated_at'].isoformat(),
+            'attachments': []
+        }
+    }
+
+
 async def get_next_expense_number(conn, tenant_id: UUID) -> str:
     """Generate the next WR-GTO-YYYY-NNNN number for a tenant."""
     current_year = datetime.now().year
@@ -2348,7 +2371,8 @@ async def create_recurring_instance_json(
             # Use expense amount if not provided
             instance_amount = instance_data.amount if instance_data.amount is not None else float(expense['amount'])
 
-            # Insert instance
+            # Insert instance. Retrying the same recurring period returns the
+            # existing row instead of surfacing a duplicate-key failure.
             instance_id = await conn.fetchval("""
                 INSERT INTO recurring_expense_instances (
                     tenant_id,
@@ -2363,6 +2387,8 @@ async def create_recurring_instance_json(
                     notes,
                     created_by
                 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+                ON CONFLICT (expense_id, period_month)
+                DO UPDATE SET period_month = EXCLUDED.period_month
                 RETURNING id
             """,
                 tenant_id,
@@ -2383,26 +2409,7 @@ async def create_recurring_instance_json(
                 SELECT * FROM recurring_expense_instances WHERE id = $1
             """, instance_id)
 
-            return {
-                'success': True,
-                'data': {
-                    'id': str(instance_row['id']),
-                    'tenantId': str(instance_row['tenant_id']),
-                    'expenseId': str(instance_row['expense_id']),
-                    'periodMonth': instance_row['period_month'],
-                    'scheduledDate': instance_row['scheduled_date'].isoformat(),
-                    'amount': float(instance_row['amount']),
-                    'status': instance_row['status'],
-                    'paymentDate': instance_row['payment_date'].isoformat() if instance_row['payment_date'] else None,
-                    'paymentMethod': instance_row['payment_method'],
-                    'paymentReference': instance_row['payment_reference'],
-                    'notes': instance_row['notes'],
-                    'createdBy': str(instance_row['created_by']) if instance_row['created_by'] else None,
-                    'createdAt': instance_row['created_at'].isoformat(),
-                    'updatedAt': instance_row['updated_at'].isoformat(),
-                    'attachments': []
-                }
-            }
+            return _format_recurring_instance_response(instance_row)
 
     except AuthenticationError:
         raise

--- a/app/services/public_table_qr_service.py
+++ b/app/services/public_table_qr_service.py
@@ -46,6 +46,7 @@ _CONTEXT_SQL = """
 _SUBMIT_LIMIT_PER_TOKEN = 10
 _SUBMIT_LIMIT_PER_IP = 30
 _SUBMIT_WINDOW_SECONDS = 300
+_DUPLICATE_PENDING_WINDOW_MINUTES = 3
 _submit_rate_buckets: Dict[str, List[float]] = defaultdict(list)
 
 
@@ -127,6 +128,48 @@ def _check_submit_rate_limit(*, token: str, client_ip: Optional[str]) -> None:
                 detail="Demasiadas solicitudes. Intenta de nuevo en unos minutos.",
             )
         bucket.append(now)
+
+
+async def _lock_table_qr_submit(conn, tenant_id: UUID, table_id: UUID) -> None:
+    await conn.execute(
+        "SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))",
+        str(tenant_id),
+        str(table_id),
+    )
+
+
+async def _find_matching_pending_request(
+    conn,
+    tenant_id: UUID,
+    table_id: UUID,
+    items_json: str,
+    payment_method: Optional[str],
+    payment_method_id: Optional[UUID],
+    customer_notes: Optional[str],
+) -> Optional[dict]:
+    return await conn.fetchrow(
+        """
+        SELECT id, created_at
+        FROM table_qr_requests
+        WHERE tenant_id = $1
+          AND table_id = $2
+          AND status = 'pending'
+          AND items = $3::jsonb
+          AND payment_method IS NOT DISTINCT FROM $4
+          AND payment_method_id IS NOT DISTINCT FROM $5
+          AND customer_notes IS NOT DISTINCT FROM $6
+          AND created_at >= now() - ($7::text || ' minutes')::interval
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+        tenant_id,
+        table_id,
+        items_json,
+        payment_method,
+        payment_method_id,
+        customer_notes,
+        _DUPLICATE_PENDING_WINDOW_MINUTES,
+    )
 
 
 async def get_menu_for_token(
@@ -463,39 +506,53 @@ async def submit_table_qr_request(
         async with conn.transaction():
             item_snapshots, total_amount = await _build_item_snapshots(conn, tenant_id, items)
             await _validate_payment_selection(conn, tenant_id, payment_method, payment_method_id)
+            items_json = json.dumps(item_snapshots, sort_keys=True)
 
-            row = await conn.fetchrow(
-                """
-                INSERT INTO table_qr_requests (
-                    tenant_id, table_id, status, items,
-                    payment_method, payment_method_id, customer_notes
-                )
-                VALUES ($1, $2, 'pending', $3::jsonb, $4, $5, $6)
-                RETURNING id, created_at
-                """,
+            await _lock_table_qr_submit(conn, tenant_id, table_id)
+            existing = await _find_matching_pending_request(
+                conn,
                 tenant_id,
                 table_id,
-                json.dumps(item_snapshots),
+                items_json,
                 payment_method,
                 payment_method_id,
                 customer_notes,
             )
-
-            request_id = row["id"]
-            payload = {
-                "type": "table_qr_request",
-                "request_id": str(request_id),
-                "table_id": str(table_id),
-                "table_name": ctx["table_name"],
-                "item_count": len(item_snapshots),
-                "total_amount": float(total_amount),
-            }
-            try:
-                await notifications_service.create_table_qr_notification(
-                    conn, tenant_id, request_id, payload
+            if existing:
+                request_id = existing["id"]
+            else:
+                row = await conn.fetchrow(
+                    """
+                    INSERT INTO table_qr_requests (
+                        tenant_id, table_id, status, items,
+                        payment_method, payment_method_id, customer_notes
+                    )
+                    VALUES ($1, $2, 'pending', $3::jsonb, $4, $5, $6)
+                    RETURNING id, created_at
+                    """,
+                    tenant_id,
+                    table_id,
+                    items_json,
+                    payment_method,
+                    payment_method_id,
+                    customer_notes,
                 )
-            except Exception as err:
-                logger.warning("Table QR notification failed for %s: %s", request_id, err)
+
+                request_id = row["id"]
+                payload = {
+                    "type": "table_qr_request",
+                    "request_id": str(request_id),
+                    "table_id": str(table_id),
+                    "table_name": ctx["table_name"],
+                    "item_count": len(item_snapshots),
+                    "total_amount": float(total_amount),
+                }
+                try:
+                    await notifications_service.create_table_qr_notification(
+                        conn, tenant_id, request_id, payload
+                    )
+                except Exception as err:
+                    logger.warning("Table QR notification failed for %s: %s", request_id, err)
 
     return {
         "request_id": str(request_id),

--- a/tests/test_expenses_idempotency.py
+++ b/tests/test_expenses_idempotency.py
@@ -1,0 +1,82 @@
+"""Idempotency tests for expense retry paths (api-warolabs#566)."""
+from contextlib import asynccontextmanager
+from datetime import date, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.middleware import SessionContext
+from app.models.expense import RecurringExpenseInstanceCreate
+from app.services.expenses_service import create_recurring_instance_json
+
+
+def _session(tenant_id, user_id):
+    return SessionContext({
+        "user_id": user_id,
+        "tenant_id": tenant_id,
+        "email": "test@warocol.com",
+        "name": "Test",
+        "expires_at": None,
+        "is_active": True,
+    })
+
+
+@pytest.mark.asyncio
+async def test_create_recurring_instance_retry_returns_existing_period():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    expense_id = uuid4()
+    instance_id = uuid4()
+    now = datetime(2026, 7, 1, 12, 0, 0)
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=instance_id)
+    conn.fetchrow = AsyncMock(side_effect=[
+        {"id": expense_id, "is_recurring": True, "amount": 50000},
+        {
+            "id": instance_id,
+            "tenant_id": tenant_id,
+            "expense_id": expense_id,
+            "period_month": "2026-07",
+            "scheduled_date": date(2026, 7, 5),
+            "amount": 50000,
+            "status": "pending",
+            "payment_date": None,
+            "payment_method": None,
+            "payment_reference": None,
+            "notes": None,
+            "created_by": user_id,
+            "created_at": now,
+            "updated_at": now,
+        },
+    ])
+
+    @asynccontextmanager
+    async def _db_ctx():
+        yield conn
+
+    body = RecurringExpenseInstanceCreate(
+        periodMonth="2026-07",
+        scheduledDate=date(2026, 7, 5),
+        status="pending",
+    )
+
+    with patch(
+        "app.services.expenses_service.require_valid_session",
+        return_value=_session(tenant_id, user_id),
+    ), patch(
+        "app.services.expenses_service.get_db_connection",
+        side_effect=_db_ctx,
+    ):
+        result = await create_recurring_instance_json(
+            MagicMock(),
+            MagicMock(),
+            expense_id,
+            body,
+        )
+
+    insert_sql = conn.fetchval.await_args.args[0]
+    assert "ON CONFLICT (expense_id, period_month)" in insert_sql
+    assert result["success"] is True
+    assert result["data"]["id"] == str(instance_id)
+    assert result["data"]["periodMonth"] == "2026-07"

--- a/tests/test_table_qr_public.py
+++ b/tests/test_table_qr_public.py
@@ -1,4 +1,5 @@
 """Tests for public Table QR menu and submit (api-warolabs#267)."""
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -90,6 +91,63 @@ async def test_submit_requires_open_restaurant():
                 customer_notes=None,
             )
         assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_submit_duplicate_pending_request_returns_existing_id():
+    ctx = _active_ctx()
+    request_id = uuid4()
+    snapshots = [{
+        "product_id": str(uuid4()),
+        "quantity": 1,
+        "unit_price": 10000.0,
+        "modifiers": [],
+        "notes": None,
+        "line_total": 10000.0,
+    }]
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"id": request_id, "created_at": None})
+    conn.transaction = MagicMock()
+
+    @asynccontextmanager
+    async def _txn():
+        yield
+
+    conn.transaction.return_value = _txn()
+
+    with patch(
+        "app.services.public_table_qr_service.resolve_table_qr_context",
+        new_callable=AsyncMock,
+        return_value=ctx,
+    ), patch(
+        "app.services.public_table_qr_service.get_db_connection",
+    ) as mock_conn, patch(
+        "app.services.public_table_qr_service._build_item_snapshots",
+        new=AsyncMock(return_value=(snapshots, 10000)),
+    ), patch(
+        "app.services.public_table_qr_service._validate_payment_selection",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.public_table_qr_service.notifications_service.create_table_qr_notification",
+        new=AsyncMock(),
+    ) as notify:
+        mock_conn.return_value.__aenter__ = AsyncMock(return_value=conn)
+        mock_conn.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await public_table_qr_service.submit_table_qr_request(
+            MagicMock(client=MagicMock(host="127.0.0.1")),
+            "tok",
+            items=[{"product_id": snapshots[0]["product_id"], "quantity": 1, "modifiers": []}],
+            payment_method="cash",
+            payment_method_id=None,
+            customer_notes=None,
+        )
+
+    assert result["request_id"] == str(request_id)
+    assert result["status"] == "pending"
+    assert conn.fetchrow.await_count == 1
+    notify.assert_not_awaited()
 
 
 def test_menu_endpoint_success():


### PR DESCRIPTION
## Summary
- Return existing recurring expense instance on duplicate period retry
- Reuse matching pending Table QR request within a short window instead of inserting a duplicate
- Add targeted idempotency coverage for recurring expenses and Table QR submit

## Tests
- pytest tests/test_table_qr_public.py tests/test_product_duplicate_name.py tests/test_ingredients.py tests/test_expenses_idempotency.py
- pytest tests/test_table_qr_requests.py
- Build skipped per request: sin build

Closes #566