### PR TITLE
Add operational observability runbook

### DIFF
--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -9,6 +9,57 @@ from app.config import settings
 
 logger = logging.getLogger(__name__)
 
+
+def _short_log_value(value: Any) -> str:
+    if value is None:
+        return "unknown"
+    text = str(value).strip()
+    if not text:
+        return "unknown"
+    return text.replace(" ", "_")[:64]
+
+
+def classify_request_severity(status_code: int, path: str) -> str:
+    if status_code == 401:
+        return "auth_expected"
+    if 500 <= status_code:
+        return "server_error"
+    if 400 <= status_code:
+        return "client_error"
+    if path == "/notifications/stream":
+        return "sse_stream"
+    return "ok"
+
+
+def format_request_log(
+    *,
+    method: str,
+    path: str,
+    status_code: int,
+    duration_ms: float,
+    tenant: Any,
+    user_id: Any,
+) -> str:
+    severity = classify_request_severity(status_code, path)
+    return (
+        "request "
+        f"method={method} "
+        f"path={path} "
+        f"status_code={status_code} "
+        f"duration_ms={duration_ms:.2f} "
+        f"severity={severity} "
+        f"tenant={_short_log_value(tenant)} "
+        f"user={_short_log_value(user_id)}"
+    )
+
+
+def _request_log_context(request: Request) -> tuple[Any, Any]:
+    tenant_name = getattr(getattr(request.state, 'tenant_context', None), 'tenant_name', 'unknown')
+    session_context = getattr(request.state, 'session_context', None)
+    user_id = getattr(session_context, 'user_id', 'anonymous') if session_context else 'anonymous'
+    return tenant_name, user_id
+
+
 class SessionContext:
     """Session context object.
 
@@ -599,22 +650,37 @@ async def request_logging_middleware(request: Request, call_next):
     method = request.method
     path = request.url.path
     
-    # Get tenant and user info if available
-    tenant_name = getattr(getattr(request.state, 'tenant_context', None), 'tenant_name', 'unknown')
-    session_context = getattr(request.state, 'session_context', None)
-    user_id = getattr(session_context, 'user_id', 'anonymous') if session_context else 'anonymous'
-    
-    # Process request
-    response = await call_next(request)
-    
-    # Calculate duration
-    duration = round((time.time() - start_time) * 1000, 2)  # milliseconds
-    
-    # Log endpoint call
-    # Simple endpoint logging with timestamp
-    from datetime import datetime
-    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    query = f"?{request.url.query}" if request.url.query else ""
-    logger.info(f"{timestamp} | {method} {path}{query}")
-    
+    try:
+        response = await call_next(request)
+    except Exception:
+        duration = round((time.time() - start_time) * 1000, 2)
+        tenant_name, user_id = _request_log_context(request)
+        logger.error(
+            format_request_log(
+                method=method,
+                path=path,
+                status_code=500,
+                duration_ms=duration,
+                tenant=tenant_name,
+                user_id=user_id,
+            )
+        )
+        raise
+
+    duration = round((time.time() - start_time) * 1000, 2)
+    tenant_name, user_id = _request_log_context(request)
+    message = format_request_log(
+        method=method,
+        path=path,
+        status_code=response.status_code,
+        duration_ms=duration,
+        tenant=tenant_name,
+        user_id=user_id,
+    )
+    severity = classify_request_severity(response.status_code, path)
+    if severity == "server_error":
+        logger.error(message)
+    else:
+        logger.info(message)
+
     return response

--- a/docs/operational-observability-runbook.md
+++ b/docs/operational-observability-runbook.md
@@ -1,0 +1,218 @@
+# Operational observability runbook
+
+Issue: api-warolabs#567
+
+Use this runbook when a customer reports slowness, failed buttons, missing
+updates, or "the system was down". The goal is to separate expected auth/SSE
+noise from real backend, database, host, or proxy failures.
+
+## 1. Define the window
+
+Convert the report to UTC before querying logs. Keep both values in the incident
+note.
+
+```text
+Customer report: 2026-06-27 09:00-11:00 America/Bogota
+UTC window:      2026-06-27 14:00-16:00 UTC
+Tenant/user:     <tenant or user if known>
+Symptoms:        <button, route, module, exact message>
+```
+
+## 2. API request logs
+
+New API request logs use a parseable shape:
+
+```text
+request method=GET path=/orders status_code=200 duration_ms=12.34 severity=ok tenant=Demo user=<id>
+```
+
+Severity buckets:
+
+| Severity | Meaning |
+|---|---|
+| `ok` | 2xx/3xx request |
+| `auth_expected` | 401 caused by missing/expired/invalid session |
+| `client_error` | non-auth 4xx |
+| `server_error` | 5xx or unexpected middleware failure |
+| `sse_stream` | successful notification stream request |
+
+Expected auth volume is not the same as downtime. Investigate 5xx,
+`server_error`, schema errors, and sustained high latency first.
+
+## 3. `waro_logs` SQL checks
+
+Daily volume:
+
+```sql
+SELECT
+  date_trunc('day', created_at) AS day_utc,
+  count(*) AS total_logs,
+  count(*) FILTER (WHERE level ILIKE 'error') AS raw_errors,
+  count(*) FILTER (
+    WHERE level ILIKE 'error'
+      AND message NOT ILIKE '%No session found%'
+      AND message NOT ILIKE '%Valid session required%'
+      AND message NOT ILIKE '%Session validation failed%'
+  ) AS errors_excluding_auth
+FROM waro_logs
+WHERE created_at >= TIMESTAMPTZ '2026-06-27 00:00:00+00'
+  AND created_at <  TIMESTAMPTZ '2026-06-28 00:00:00+00'
+GROUP BY 1
+ORDER BY 1;
+```
+
+Hourly spike view:
+
+```sql
+SELECT
+  date_trunc('hour', created_at) AS hour_utc,
+  count(*) AS total,
+  count(*) FILTER (WHERE message ILIKE '%severity=server_error%') AS server_errors,
+  count(*) FILTER (WHERE message ILIKE '%severity=auth_expected%') AS expected_auth,
+  count(*) FILTER (WHERE message ILIKE '%notifications/stream%') AS sse_stream,
+  count(*) FILTER (
+    WHERE message ILIKE '%column % does not exist%'
+       OR message ILIKE '%relation % does not exist%'
+       OR message ILIKE '%duplicate key value violates unique constraint%'
+  ) AS db_signatures
+FROM waro_logs
+WHERE created_at >= TIMESTAMPTZ '2026-06-27 14:00:00+00'
+  AND created_at <  TIMESTAMPTZ '2026-06-27 16:00:00+00'
+GROUP BY 1
+ORDER BY 1;
+```
+
+Slow endpoints from parseable request logs:
+
+```sql
+SELECT
+  regexp_replace(message, '.* path=([^ ]+) .*', '\1') AS path,
+  count(*) AS hits,
+  max((regexp_replace(message, '.* duration_ms=([0-9.]+) .*', '\1'))::numeric) AS max_ms,
+  percentile_cont(0.95) WITHIN GROUP (
+    ORDER BY (regexp_replace(message, '.* duration_ms=([0-9.]+) .*', '\1'))::numeric
+  ) AS p95_ms
+FROM waro_logs
+WHERE created_at >= TIMESTAMPTZ '2026-06-27 14:00:00+00'
+  AND created_at <  TIMESTAMPTZ '2026-06-27 16:00:00+00'
+  AND message LIKE 'request %duration_ms=%'
+GROUP BY 1
+ORDER BY p95_ms DESC
+LIMIT 20;
+```
+
+## 4. Docker API logs
+
+Do not assume a fixed container name. Discover the compose service/container,
+then read recent logs.
+
+```bash
+cd /home/saifer/api_warocol.com
+docker compose ps
+docker compose logs --since "2026-06-27T14:00:00Z" --until "2026-06-27T16:00:00Z" web
+```
+
+If compose metadata is unavailable:
+
+```bash
+docker ps --format '{{.Names}}\t{{.Image}}\t{{.Status}}' | grep -E 'api|warocol'
+docker logs --since "2026-06-27T14:00:00Z" --until "2026-06-27T16:00:00Z" <container>
+```
+
+## 5. Postgres health
+
+Cache hit and deadlocks:
+
+```sql
+SELECT
+  round(100 * sum(blks_hit)::numeric / nullif(sum(blks_hit + blks_read), 0), 2) AS hit_pct,
+  sum(deadlocks) AS deadlocks
+FROM pg_stat_database
+WHERE datname = current_database();
+```
+
+Waiting locks:
+
+```sql
+SELECT pid, wait_event_type, wait_event, state, now() - query_start AS age, query
+FROM pg_stat_activity
+WHERE wait_event_type IS NOT NULL
+ORDER BY age DESC
+LIMIT 20;
+```
+
+Long active queries:
+
+```sql
+SELECT pid, state, now() - query_start AS age, left(query, 300) AS query
+FROM pg_stat_activity
+WHERE state <> 'idle'
+ORDER BY age DESC
+LIMIT 20;
+```
+
+## 6. Host metrics with sysstat
+
+Check CPU/load and disk around the UTC window.
+
+```bash
+sar -u -f /var/log/sysstat/sa27
+sar -q -f /var/log/sysstat/sa27
+sar -d -f /var/log/sysstat/sa27
+```
+
+Healthy examples from #562 were high CPU idle, low load, no waiting Postgres
+locks, no deadlocks, and cache hit around 99%.
+
+## 7. Nginx access/error logs
+
+Support checks must not depend on an interactive sudo prompt. First test
+non-interactive access:
+
+```bash
+sudo -n tail -n 20 /var/log/nginx/access.log
+sudo -n tail -n 20 /var/log/nginx/error.log
+```
+
+If either command fails with a password/permission error, record it in the
+incident and request one of these operational fixes:
+
+```text
+- add the deploy/support user to a read-only log group for /var/log/nginx/*.log
+- add a sudoers rule for passwordless read-only tail/grep on nginx logs
+- ship Nginx access/error logs into the same central log store as waro_logs
+```
+
+Useful Nginx checks once readable:
+
+```bash
+sudo -n grep ' 5[0-9][0-9] ' /var/log/nginx/access.log | tail -n 50
+sudo -n grep ' 499 ' /var/log/nginx/access.log | tail -n 50
+sudo -n tail -n 100 /var/log/nginx/error.log
+```
+
+## 8. Decision guide
+
+| Evidence | Interpretation | Next action |
+|---|---|---|
+| High `auth_expected`, low 5xx | Sessions expired/missing; not platform downtime | Check session UX/auth batch behavior |
+| `sse_stream` or socket disconnects only | Normal browser reconnect/close unless paired with 5xx | Check notification lifecycle only if duplicated |
+| 5xx or `server_error` spike | Backend failure | Inspect endpoint logs and stack traces |
+| `column does not exist` / `relation does not exist` | Schema mismatch | Verify migrations/dbdoc |
+| High latency, host healthy, DB healthy | Application endpoint bottleneck | Rank slow endpoints by p95 |
+| Host CPU/load/disk saturated | Infrastructure bottleneck | Escalate capacity/host investigation |
+
+## 9. Incident note template
+
+```text
+Window:
+Tenant/user:
+Symptoms:
+API request buckets:
+Slow endpoints:
+DB health:
+Docker evidence:
+Nginx evidence:
+Conclusion:
+Follow-up issue/PR:
+```

--- a/tests/test_request_observability.py
+++ b/tests/test_request_observability.py
@@ -1,0 +1,34 @@
+"""Request observability helpers for high-demand incident review (#567)."""
+
+from app.core.middleware import classify_request_severity, format_request_log
+
+
+def test_classify_request_severity_separates_auth_and_errors():
+    assert classify_request_severity(200, "/orders") == "ok"
+    assert classify_request_severity(401, "/orders") == "auth_expected"
+    assert classify_request_severity(404, "/orders/missing") == "client_error"
+    assert classify_request_severity(500, "/orders") == "server_error"
+
+
+def test_classify_request_severity_marks_notification_stream():
+    assert classify_request_severity(200, "/notifications/stream") == "sse_stream"
+
+
+def test_format_request_log_is_parseable_and_sanitized():
+    line = format_request_log(
+        method="GET",
+        path="/orders",
+        status_code=200,
+        duration_ms=12.345,
+        tenant="Demo Tenant",
+        user_id="user with spaces",
+    )
+
+    assert line.startswith("request ")
+    assert "method=GET" in line
+    assert "path=/orders" in line
+    assert "status_code=200" in line
+    assert "duration_ms=12.35" in line
+    assert "severity=ok" in line
+    assert "tenant=Demo_Tenant" in line
+    assert "user=user_with_spaces" in line


### PR DESCRIPTION
## Summary
- Add parseable request logs with status, duration, severity, tenant, and user fields
- Add severity buckets for expected auth, SSE stream, client errors, and server errors
- Document the operational incident runbook for waro_logs, Docker, Postgres, sysstat, and Nginx checks

## Tests
- pytest tests/test_request_observability.py tests/test_notifications_terms_reminder.py tests/test_session_token.py
- Build skipped per request: sin build

Closes #567