### PR TITLE
Define subscription plan quotas

### DIFF
--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -17,12 +17,41 @@ from uuid import UUID
 from fastapi import HTTPException
 
 from app.config import settings
+from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
 
 logger = logging.getLogger(__name__)
 
 ELECTRONIC_INVOICE_PLAN_SLUG = "facturacion-electronica"
 ELECTRONIC_INVOICE_PERIOD_LIMIT = 200
 ELECTRONIC_INVOICE_LIMIT_FEATURE = "electronic_invoice_limit"
+QUOTAS_FEATURE = "quotas"
+QUOTA_KEYS = (
+    "admin_users",
+    "active_sessions_per_admin_user",
+    "active_kitchens",
+    "active_tables_including_bar",
+    "active_qr_tables",
+    "completed_online_orders_per_month",
+    "electronic_invoices_per_period",
+)
+BASE_OPERATIONAL_QUOTAS = {
+    "admin_users": 6,
+    "active_sessions_per_admin_user": 1,
+    "active_kitchens": 2,
+    "active_tables_including_bar": 20,
+    "active_qr_tables": 20,
+    "completed_online_orders_per_month": 300,
+}
+PLAN_QUOTA_DEFAULTS = {
+    "pro": {
+        **BASE_OPERATIONAL_QUOTAS,
+        "electronic_invoices_per_period": 0,
+    },
+    ELECTRONIC_INVOICE_PLAN_SLUG: {
+        **BASE_OPERATIONAL_QUOTAS,
+        "electronic_invoices_per_period": ELECTRONIC_INVOICE_PERIOD_LIMIT,
+    },
+}
 
 
 async def check_scan_quota(tenant_id: UUID, conn) -> None:
@@ -284,6 +313,8 @@ async def list_tenant_billing_events(
 # ── Serialization helpers ─────────────────────────────────────────────────────
 
 def _serialize_plan(row) -> Dict[str, Any]:
+    features = _jsonb_to_dict(row["features"])
+    quotas = _normalize_plan_quotas(row["slug"], features)
     return {
         "id": str(row["id"]),
         "name": row["name"],
@@ -293,7 +324,8 @@ def _serialize_plan(row) -> Dict[str, Any]:
         "price_annual": str(row["price_annual"]),
         "scan_limit": row["scan_limit"],
         "is_active": row["is_active"],
-        "features": (json.loads(row["features"]) if isinstance(row["features"], str) else dict(row["features"])) if row["features"] else {},
+        "features": features,
+        "quotas": quotas,
         "created_at": row["created_at"].isoformat(),
         "updated_at": row["updated_at"].isoformat(),
     }
@@ -307,11 +339,43 @@ def _jsonb_to_dict(value: Any) -> Dict[str, Any]:
     return dict(value)
 
 
+def _coerce_quota_value(value: Any, default: int) -> int:
+    try:
+        return max(int(value), 0)
+    except (TypeError, ValueError):
+        return default
+
+
+def _normalize_plan_quotas(plan_slug: str, features: Any) -> Dict[str, int]:
+    plan_features = _jsonb_to_dict(features)
+    defaults = PLAN_QUOTA_DEFAULTS.get(plan_slug, {})
+    configured = plan_features.get(QUOTAS_FEATURE)
+    if not isinstance(configured, dict):
+        configured = {}
+
+    quotas: Dict[str, int] = {}
+    for key in QUOTA_KEYS:
+        default = defaults.get(key, 0)
+        quotas[key] = _coerce_quota_value(configured.get(key), default)
+
+    if plan_slug == ELECTRONIC_INVOICE_PLAN_SLUG and not configured.get("electronic_invoices_per_period"):
+        quotas["electronic_invoices_per_period"] = _electronic_invoice_limit_for_plan(
+            plan_slug,
+            plan_features,
+        )
+
+    return quotas
+
+
 def _electronic_invoice_limit_for_plan(plan_slug: str, features: Any) -> int:
     if plan_slug != ELECTRONIC_INVOICE_PLAN_SLUG:
         return 0
 
     plan_features = _jsonb_to_dict(features)
+    configured_quotas = plan_features.get(QUOTAS_FEATURE)
+    if isinstance(configured_quotas, dict) and "electronic_invoices_per_period" in configured_quotas:
+        return _coerce_quota_value(configured_quotas.get("electronic_invoices_per_period"), 0)
+
     configured_limit = plan_features.get(ELECTRONIC_INVOICE_LIMIT_FEATURE)
     if configured_limit is None:
         return ELECTRONIC_INVOICE_PERIOD_LIMIT
@@ -596,6 +660,7 @@ async def get_tenant_subscription(conn, tenant_id: UUID) -> Dict[str, Any]:
             sp.name AS plan_name,
             sp.slug AS plan_slug,
             sp.scan_limit,
+            sp.features AS plan_features,
             ts.billing_cycle,
             ts.status,
             ts.current_period_start,
@@ -625,6 +690,7 @@ async def get_tenant_subscription(conn, tenant_id: UUID) -> Dict[str, Any]:
         "plan_name": row["plan_name"],
         "plan_slug": row["plan_slug"],
         "scan_limit": row["scan_limit"],
+        "quotas": _normalize_plan_quotas(row["plan_slug"], row["plan_features"]),
         "billing_cycle": row["billing_cycle"],
         "status": row["status"],
         "current_period_start": row["current_period_start"].isoformat(),
@@ -690,6 +756,64 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
               AND COALESCE(emitted_at, created_at) < $3
         """, tenant_id, period_start, period_end) or 0)
 
+    quotas = _normalize_plan_quotas(row["plan_slug"], row["plan_features"])
+    quota_counts = await conn.fetchrow("""
+        SELECT
+            (
+                SELECT COUNT(DISTINCT tm.id)
+                FROM tenant_members tm
+                WHERE tm.tenant_id = $1
+                  AND tm.is_active
+                  AND tm.role = ANY($4::text[])
+            ) AS admin_users,
+            (
+                SELECT COALESCE(MAX(active_session_count), 0)
+                FROM (
+                    SELECT COUNT(DISTINCT s.id) AS active_session_count
+                    FROM tenant_members tm
+                    JOIN sessions s
+                      ON s.tenant_id = tm.tenant_id
+                     AND s.user_id = tm.user_id
+                    WHERE tm.tenant_id = $1
+                      AND tm.is_active
+                      AND tm.role = ANY($4::text[])
+                      AND s.is_active
+                      AND s.expires_at > now()
+                    GROUP BY tm.user_id
+                ) per_admin
+            ) AS active_sessions_per_admin_user,
+            (
+                SELECT COUNT(DISTINCT ks.id)
+                FROM kitchen_stations ks
+                WHERE ks.tenant_id = $1
+                  AND ks.is_active
+            ) AS active_kitchens,
+            (
+                SELECT COUNT(DISTINCT t.id)
+                FROM tables t
+                WHERE t.tenant_id = $1
+                  AND t.is_active
+                  AND t.deleted_at IS NULL
+            ) AS active_tables_including_bar,
+            (
+                SELECT COUNT(DISTINCT t.id)
+                FROM tables t
+                WHERE t.tenant_id = $1
+                  AND t.is_active
+                  AND t.deleted_at IS NULL
+                  AND t.qr_enabled
+            ) AS active_qr_tables,
+            (
+                SELECT COUNT(DISTINCT o.id)
+                FROM orders o
+                WHERE o.tenant_id = $1
+                  AND o.online_cart_id IS NOT NULL
+                  AND o.status = 'completed'
+                  AND o.order_date >= $2
+                  AND o.order_date < $3
+            ) AS completed_online_orders_per_month
+    """, tenant_id, period_start, period_end, list(LEGACY_INTERNAL_TEAM_ROLES))
+
     def metric(used: int, limit: int) -> Dict[str, Any]:
         return {
             "used": used,
@@ -704,6 +828,33 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
         "period_end": period_end_iso,
         "scan_usage": metric(scans_used, scans_limit),
         "electronic_invoice_usage": metric(invoice_used, invoice_limit),
+        "quota_usage": {
+            "admin_users": metric(int(quota_counts["admin_users"] or 0), quotas["admin_users"]),
+            "active_sessions_per_admin_user": metric(
+                int(quota_counts["active_sessions_per_admin_user"] or 0),
+                quotas["active_sessions_per_admin_user"],
+            ),
+            "active_kitchens": metric(
+                int(quota_counts["active_kitchens"] or 0),
+                quotas["active_kitchens"],
+            ),
+            "active_tables_including_bar": metric(
+                int(quota_counts["active_tables_including_bar"] or 0),
+                quotas["active_tables_including_bar"],
+            ),
+            "active_qr_tables": metric(
+                int(quota_counts["active_qr_tables"] or 0),
+                quotas["active_qr_tables"],
+            ),
+            "completed_online_orders_per_month": metric(
+                int(quota_counts["completed_online_orders_per_month"] or 0),
+                quotas["completed_online_orders_per_month"],
+            ),
+            "electronic_invoices_per_period": metric(
+                invoice_used,
+                quotas["electronic_invoices_per_period"],
+            ),
+        },
     }
 
 

--- a/sql/20260701_subscription_plan_quotas.sql
+++ b/sql/20260701_subscription_plan_quotas.sql
@@ -1,0 +1,115 @@
+-- api-warolabs#573: structured plan quota metadata.
+-- Non-destructive: this updates global plan metadata only. It does not modify
+-- tenants, memberships, sessions, kitchens, tables, carts, orders, or invoices.
+
+UPDATE subscription_plans
+SET features = jsonb_set(
+        COALESCE(features, '{}'::jsonb),
+        '{quotas}',
+        '{
+          "admin_users": 6,
+          "active_sessions_per_admin_user": 1,
+          "active_kitchens": 2,
+          "active_tables_including_bar": 20,
+          "active_qr_tables": 20,
+          "completed_online_orders_per_month": 300,
+          "electronic_invoices_per_period": 0
+        }'::jsonb,
+        true
+    ),
+    updated_at = now()
+WHERE slug = 'pro';
+
+UPDATE subscription_plans
+SET features = jsonb_set(
+        COALESCE(features, '{}'::jsonb),
+        '{quotas}',
+        '{
+          "admin_users": 6,
+          "active_sessions_per_admin_user": 1,
+          "active_kitchens": 2,
+          "active_tables_including_bar": 20,
+          "active_qr_tables": 20,
+          "completed_online_orders_per_month": 300,
+          "electronic_invoices_per_period": 200
+        }'::jsonb,
+        true
+    ),
+    updated_at = now()
+WHERE slug = 'facturacion-electronica';
+
+-- Manual PR validation: current tenant usage against proposed limits.
+-- Run read-only in production/staging and include the over-quota summary in
+-- the PR. Customer/buyer memberships are intentionally excluded.
+/*
+WITH quota_plans AS (
+  SELECT id, slug, features->'quotas' AS quotas
+  FROM subscription_plans
+  WHERE slug IN ('pro', 'facturacion-electronica')
+), active_subs AS (
+  SELECT DISTINCT ON (ts.tenant_id)
+    ts.tenant_id,
+    t.slug AS tenant_slug,
+    qp.slug AS plan_slug,
+    ts.current_period_start,
+    ts.current_period_end,
+    qp.quotas
+  FROM tenant_subscriptions ts
+  JOIN tenants t ON t.id = ts.tenant_id
+  JOIN quota_plans qp ON qp.id = ts.plan_id
+  WHERE ts.status = 'active'
+  ORDER BY ts.tenant_id, ts.current_period_end DESC
+), usage AS (
+  SELECT
+    s.tenant_id,
+    COUNT(DISTINCT tm.id) FILTER (
+      WHERE tm.is_active
+        AND tm.role = ANY(ARRAY['superuser','admin','employee','member','promotor']::text[])
+    ) AS admin_users,
+    COALESCE(MAX(sess.active_sessions), 0) AS active_sessions_per_admin_user,
+    COUNT(DISTINCT ks.id) FILTER (WHERE ks.is_active) AS active_kitchens,
+    COUNT(DISTINCT tb.id) FILTER (WHERE tb.is_active AND tb.deleted_at IS NULL) AS active_tables_including_bar,
+    COUNT(DISTINCT tb.id) FILTER (WHERE tb.is_active AND tb.deleted_at IS NULL AND tb.qr_enabled) AS active_qr_tables,
+    COUNT(DISTINCT o.id) FILTER (
+      WHERE o.online_cart_id IS NOT NULL
+        AND o.status = 'completed'
+        AND o.order_date >= s.current_period_start
+        AND o.order_date < s.current_period_end
+    ) AS completed_online_orders_per_month,
+    COUNT(DISTINCT ei.id) FILTER (
+      WHERE ei.status = 'accepted'
+        AND ei.document_type = 'invoice'
+        AND COALESCE(ei.emitted_at, ei.created_at) >= s.current_period_start
+        AND COALESCE(ei.emitted_at, ei.created_at) < s.current_period_end
+    ) AS electronic_invoices_per_period
+  FROM active_subs s
+  LEFT JOIN tenant_members tm ON tm.tenant_id = s.tenant_id
+  LEFT JOIN LATERAL (
+    SELECT COUNT(DISTINCT se.id) AS active_sessions
+    FROM sessions se
+    WHERE se.tenant_id = s.tenant_id
+      AND se.user_id = tm.user_id
+      AND se.is_active
+      AND se.expires_at > now()
+  ) sess ON tm.is_active AND tm.role = ANY(ARRAY['superuser','admin','employee','member','promotor']::text[])
+  LEFT JOIN kitchen_stations ks ON ks.tenant_id = s.tenant_id
+  LEFT JOIN tables tb ON tb.tenant_id = s.tenant_id
+  LEFT JOIN orders o ON o.tenant_id = s.tenant_id
+  LEFT JOIN electronic_invoices ei ON ei.tenant_id = s.tenant_id
+  GROUP BY s.tenant_id
+)
+SELECT
+  s.tenant_slug,
+  s.plan_slug,
+  u.*,
+  (u.admin_users > COALESCE((s.quotas->>'admin_users')::int, 0)) AS over_admin_users,
+  (u.active_sessions_per_admin_user > COALESCE((s.quotas->>'active_sessions_per_admin_user')::int, 0)) AS over_active_sessions_per_admin_user,
+  (u.active_kitchens > COALESCE((s.quotas->>'active_kitchens')::int, 0)) AS over_active_kitchens,
+  (u.active_tables_including_bar > COALESCE((s.quotas->>'active_tables_including_bar')::int, 0)) AS over_active_tables,
+  (u.active_qr_tables > COALESCE((s.quotas->>'active_qr_tables')::int, 0)) AS over_active_qr_tables,
+  (u.completed_online_orders_per_month > COALESCE((s.quotas->>'completed_online_orders_per_month')::int, 0)) AS over_online_orders,
+  (u.electronic_invoices_per_period > COALESCE((s.quotas->>'electronic_invoices_per_period')::int, 0)) AS over_electronic_invoices
+FROM active_subs s
+JOIN usage u ON u.tenant_id = s.tenant_id
+ORDER BY s.tenant_slug;
+*/

--- a/tests/test_billing_plan_quotas.py
+++ b/tests/test_billing_plan_quotas.py
@@ -1,0 +1,125 @@
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
+from app.services import billing_service
+
+
+def _plan_row(slug: str, features: dict):
+    now = datetime.now(timezone.utc)
+    return {
+        "id": uuid4(),
+        "name": slug,
+        "slug": slug,
+        "description": None,
+        "price_monthly": 0,
+        "price_annual": 0,
+        "scan_limit": 500,
+        "is_active": True,
+        "features": features,
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+def test_serialize_plan_exposes_pro_quota_defaults():
+    plan = billing_service._serialize_plan(_plan_row("pro", {"support": True}))
+
+    assert plan["features"] == {"support": True}
+    assert plan["quotas"]["admin_users"] == 6
+    assert plan["quotas"]["active_sessions_per_admin_user"] == 1
+    assert plan["quotas"]["active_kitchens"] == 2
+    assert plan["quotas"]["active_tables_including_bar"] == 20
+    assert plan["quotas"]["active_qr_tables"] == 20
+    assert plan["quotas"]["completed_online_orders_per_month"] == 300
+    assert plan["quotas"]["electronic_invoices_per_period"] == 0
+
+
+def test_serialize_plan_keeps_facturacion_legacy_invoice_limit():
+    plan = billing_service._serialize_plan(
+        _plan_row(
+            "facturacion-electronica",
+            {"electronic_invoice_limit": 200},
+        )
+    )
+
+    assert plan["quotas"]["electronic_invoices_per_period"] == 200
+
+
+def test_serialize_plan_prefers_structured_quota_values():
+    plan = billing_service._serialize_plan(
+        _plan_row(
+            "facturacion-electronica",
+            {
+                "electronic_invoice_limit": 200,
+                "quotas": {
+                    "admin_users": 8,
+                    "electronic_invoices_per_period": 300,
+                },
+            },
+        )
+    )
+
+    assert plan["quotas"]["admin_users"] == 8
+    assert plan["quotas"]["active_kitchens"] == 2
+    assert plan["quotas"]["electronic_invoices_per_period"] == 300
+
+
+@pytest.mark.asyncio
+async def test_remaining_usage_exposes_quota_usage_and_internal_roles_only():
+    tenant_id = uuid4()
+    period_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    period_end = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {
+                "current_period_start": period_start,
+                "current_period_end": period_end,
+                "plan_slug": "facturacion-electronica",
+                "plan_features": {
+                    "quotas": {
+                        "admin_users": 6,
+                        "active_sessions_per_admin_user": 1,
+                        "active_kitchens": 2,
+                        "active_tables_including_bar": 20,
+                        "active_qr_tables": 20,
+                        "completed_online_orders_per_month": 300,
+                        "electronic_invoices_per_period": 200,
+                    }
+                },
+                "plan_scan_limit": 500,
+                "scans_used": 25,
+                "scans_limit": 500,
+            },
+            {
+                "admin_users": 4,
+                "active_sessions_per_admin_user": 1,
+                "active_kitchens": 2,
+                "active_tables_including_bar": 7,
+                "active_qr_tables": 6,
+                "completed_online_orders_per_month": 28,
+            },
+        ]
+    )
+    conn.fetchval = AsyncMock(return_value=12)
+
+    usage = await billing_service.get_remaining_billing_usage(conn, tenant_id)
+
+    assert usage["quota_usage"]["admin_users"] == {
+        "used": 4,
+        "limit": 6,
+        "remaining": 2,
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+    }
+    assert usage["quota_usage"]["completed_online_orders_per_month"]["used"] == 28
+    assert usage["quota_usage"]["electronic_invoices_per_period"]["used"] == 12
+    assert usage["quota_usage"]["electronic_invoices_per_period"]["limit"] == 200
+
+    quota_query_args = conn.fetchrow.await_args_list[1].args
+    assert quota_query_args[4] == list(LEGACY_INTERNAL_TEAM_ROLES)
+    assert "customer" not in quota_query_args[4]


### PR DESCRIPTION
## Summary
- add structured plan quota defaults and expose normalized quotas in billing plan/subscription payloads
- extend remaining usage with quota_usage counts for admin users, sessions, kitchens, tables, QR tables, online orders, and electronic invoices
- add non-destructive SQL seed plus commented manual audit query for current over-quota tenants

## Tests
- pytest tests/test_billing_subscription_access.py tests/test_billing_plan_quotas.py
- Build not run per request

## Manual validation for PR
- GET /billing/plans and confirm pro/FE expose expected quotas
- GET /billing/remaining-usage for Pro and Facturacion Electronica tenants
- Run sql/20260701_subscription_plan_quotas.sql audit query and report over-quota tenants without modifying data

Closes #573