### PR TITLE
Enforce backend plan quotas

### DIFF
--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -17,6 +17,7 @@ from uuid import UUID
 from fastapi import HTTPException
 
 from app.config import settings
+from app.core.exceptions import APIError
 from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
 
 logger = logging.getLogger(__name__)
@@ -51,6 +52,15 @@ PLAN_QUOTA_DEFAULTS = {
         **BASE_OPERATIONAL_QUOTAS,
         "electronic_invoices_per_period": ELECTRONIC_INVOICE_PERIOD_LIMIT,
     },
+}
+
+QUOTA_UPGRADE_URL = "/billing/planes"
+QUOTA_CONTACT_MESSAGE = "Actualiza tu plan o contacta a soporte para ampliar este límite."
+ENFORCEABLE_QUOTA_RESOURCES = {
+    "admin_users",
+    "active_kitchens",
+    "active_tables_including_bar",
+    "active_qr_tables",
 }
 
 
@@ -123,6 +133,106 @@ async def check_scan_quota(tenant_id: UUID, conn) -> None:
 
     # Log monthly usage
     await _upsert_monthly_log(tenant_id, conn)
+
+
+async def check_plan_quota_growth(conn, tenant_id: UUID, resource: str) -> None:
+    """
+    Block active resource growth once the tenant reaches the plan quota.
+
+    This is intentionally non-destructive: it never modifies existing rows and
+    should be called only before create/reactivate/enable transitions.
+    """
+    if resource not in ENFORCEABLE_QUOTA_RESOURCES:
+        raise ValueError(f"Unsupported quota resource: {resource}")
+
+    plan = await conn.fetchrow(
+        """
+        SELECT sp.slug AS plan_slug, sp.features AS plan_features
+        FROM tenant_subscriptions ts
+        JOIN subscription_plans sp ON sp.id = ts.plan_id
+        WHERE ts.tenant_id = $1
+          AND ts.status IN ('active', 'past_due')
+          AND ts.current_period_end > now()
+        ORDER BY ts.current_period_end DESC
+        LIMIT 1
+        """,
+        tenant_id,
+    )
+    if not plan:
+        return
+
+    quotas = _normalize_plan_quotas(plan["plan_slug"], plan["plan_features"])
+    limit = int(quotas.get(resource, 0))
+    used = await _count_quota_resource_usage(conn, tenant_id, resource)
+    if used < limit:
+        return
+
+    raise APIError(
+        "Límite del plan alcanzado",
+        status_code=429,
+        details={
+            "code": "quota_exceeded",
+            "error": "quota_exceeded",
+            "resource": resource,
+            "used": used,
+            "limit": limit,
+            "plan_slug": plan["plan_slug"],
+            "upgrade_url": QUOTA_UPGRADE_URL,
+            "message": QUOTA_CONTACT_MESSAGE,
+        },
+    )
+
+
+async def _count_quota_resource_usage(conn, tenant_id: UUID, resource: str) -> int:
+    if resource == "admin_users":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(DISTINCT tm.id)
+            FROM tenant_members tm
+            WHERE tm.tenant_id = $1
+              AND tm.is_active
+              AND tm.role = ANY($2::text[])
+            """,
+            tenant_id,
+            list(LEGACY_INTERNAL_TEAM_ROLES),
+        )
+    elif resource == "active_kitchens":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(DISTINCT ks.id)
+            FROM kitchen_stations ks
+            WHERE ks.tenant_id = $1
+              AND ks.is_active
+            """,
+            tenant_id,
+        )
+    elif resource == "active_tables_including_bar":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(DISTINCT t.id)
+            FROM tables t
+            WHERE t.tenant_id = $1
+              AND t.is_active
+              AND t.deleted_at IS NULL
+            """,
+            tenant_id,
+        )
+    elif resource == "active_qr_tables":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(DISTINCT t.id)
+            FROM tables t
+            WHERE t.tenant_id = $1
+              AND t.is_active
+              AND t.deleted_at IS NULL
+              AND t.qr_enabled
+            """,
+            tenant_id,
+        )
+    else:
+        raise ValueError(f"Unsupported quota resource: {resource}")
+
+    return int(value or 0)
 
 
 async def _create_period_usage(tenant_id: UUID, conn) -> None:

--- a/app/services/invitation_service.py
+++ b/app/services/invitation_service.py
@@ -7,9 +7,10 @@ from fastapi import Request, Response
 from app.database import get_db_connection
 from app.core.security import set_session_cookie, get_client_ip, get_current_user_id
 from app.core.middleware import require_valid_tenant, require_valid_session
-from app.core.exceptions import AuthenticationError, ValidationError, AuthorizationError
+from app.core.exceptions import APIError, AuthenticationError, ValidationError, AuthorizationError
 from app.core.email_utils import normalize_email
 from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
+from app.services.billing_service import check_plan_quota_growth
 from app.models.invitation import (
     SendInvitationRequest,
     SendInvitationResponse,
@@ -262,14 +263,6 @@ async def accept_invitation(request: Request, response: Response, token: str) ->
 
             logger.info(f"✅ Valid invitation found for user: {invitation['user_id']}")
 
-            # Mark invitation as accepted
-            await conn.execute(
-                """UPDATE tenant_invitations
-                   SET status = 'accepted', accepted_at = NOW()
-                   WHERE id = $1""",
-                invitation['id']
-            )
-
             # Add or reactivate an internal team membership without touching customer state.
             team_member = await conn.fetchrow(
                 """
@@ -286,6 +279,7 @@ async def accept_invitation(request: Request, response: Response, token: str) ->
             )
 
             if not team_member:
+                await check_plan_quota_growth(conn, invitation['tenant_id'], "admin_users")
                 await conn.execute(
                     """INSERT INTO tenant_members (id, user_id, tenant_id, role)
                        VALUES (gen_random_uuid(), $1, $2, $3)""",
@@ -295,6 +289,8 @@ async def accept_invitation(request: Request, response: Response, token: str) ->
                 )
                 logger.info(f"👥 User added to tenant_members with role: {invitation['role']}")
             else:
+                if not team_member["is_active"]:
+                    await check_plan_quota_growth(conn, invitation['tenant_id'], "admin_users")
                 await conn.execute(
                     """
                     UPDATE tenant_members
@@ -307,6 +303,15 @@ async def accept_invitation(request: Request, response: Response, token: str) ->
                     team_member['id'],
                 )
                 logger.info(f"🔄 Activated existing team member role to: {invitation['role']}")
+
+            # Mark invitation as accepted after membership succeeds, so quota
+            # blocks do not consume a still-actionable invitation.
+            await conn.execute(
+                """UPDATE tenant_invitations
+                   SET status = 'accepted', accepted_at = NOW()
+                   WHERE id = $1""",
+                invitation['id']
+            )
 
             # Create session (same as magic link flow)
             session_id = secrets.token_hex(16)
@@ -367,7 +372,7 @@ async def accept_invitation(request: Request, response: Response, token: str) ->
                 )
             )
 
-    except AuthenticationError:
+    except (APIError, AuthenticationError):
         raise
     except Exception as e:
         logger.error(f"❌ Accept invitation error: {e}", exc_info=True)

--- a/app/services/stations_service.py
+++ b/app/services/stations_service.py
@@ -11,6 +11,7 @@ from fastapi import Request, HTTPException
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError
+from app.services.billing_service import check_plan_quota_growth
 import logging
 
 logger = logging.getLogger(__name__)
@@ -68,6 +69,7 @@ async def create_station(request: Request, body) -> dict:
 
     try:
         async with get_db_connection() as conn:
+            await check_plan_quota_growth(conn, tenant_id, "active_kitchens")
             row = await conn.fetchrow(
                 """
                 INSERT INTO kitchen_stations (
@@ -227,6 +229,17 @@ async def toggle_station(request: Request, station_id: UUID, is_active: bool) ->
         raise AuthenticationError("Tenant ID is required")
 
     async with get_db_connection() as conn:
+        if is_active:
+            existing = await conn.fetchrow(
+                "SELECT id, is_active FROM kitchen_stations WHERE id = $1 AND tenant_id = $2",
+                station_id,
+                tenant_id,
+            )
+            if not existing:
+                raise HTTPException(status_code=404, detail="Station not found")
+            if not existing["is_active"]:
+                await check_plan_quota_growth(conn, tenant_id, "active_kitchens")
+
         if not is_active:
             active_count = await conn.fetchval(
                 """

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -40,6 +40,7 @@ from app.services.tip_tax_service import (
 from app.services.orders_service import _compute_tax_breakdown
 from app.services.ingredient_purchase_units_service import resolve_recipe_quantity_to_base_unit
 from app.services.comandas_service import fire_comandas
+from app.services.billing_service import check_plan_quota_growth
 from app.services.operation_events_service import DOMAIN_POS, record_operation_event
 from app.services.open_priced_service import (
     fetch_product_pricing_map,
@@ -477,6 +478,7 @@ async def create_table(
                 except ValueError as exc:
                     raise APIError(str(exc), status_code=400) from exc
 
+                await check_plan_quota_growth(conn, tenant_id, "active_tables_including_bar")
                 row = await conn.fetchrow(
                     """
                     INSERT INTO tables (tenant_id, name, capacity, code)
@@ -709,6 +711,7 @@ async def activate_table(request: Request, table_id: UUID) -> dict:
             if existing["is_active"]:
                 return {"success": True, "message": "Table already active"}
 
+            await check_plan_quota_growth(conn, tenant_id, "active_tables_including_bar")
             await conn.execute(
                 "UPDATE tables SET is_active = true WHERE id = $1 AND tenant_id = $2",
                 table_id,
@@ -4314,6 +4317,8 @@ async def set_table_qr_enabled(request: Request, table_id: UUID, enabled: bool) 
                 table = await _get_table_for_qr_management(conn, tenant_id, table_id)
                 token = table["qr_public_token"]
                 if enabled:
+                    if not table["qr_enabled"]:
+                        await check_plan_quota_growth(conn, tenant_id, "active_qr_tables")
                     if not token:
                         token = await _generate_unique_qr_token(conn)
                     row = await conn.fetchrow(
@@ -4361,7 +4366,9 @@ async def regenerate_table_qr_token(request: Request, table_id: UUID) -> dict:
         async with get_db_connection() as conn:
             async with conn.transaction():
                 await _require_table_qr_module(conn, tenant_id)
-                await _get_table_for_qr_management(conn, tenant_id, table_id)
+                table = await _get_table_for_qr_management(conn, tenant_id, table_id)
+                if not table["qr_enabled"]:
+                    await check_plan_quota_growth(conn, tenant_id, "active_qr_tables")
                 token = await _generate_unique_qr_token(conn)
                 row = await conn.fetchrow(
                     """

--- a/tests/test_invitation_team_membership.py
+++ b/tests/test_invitation_team_membership.py
@@ -124,6 +124,7 @@ async def test_accept_invitation_inserts_team_membership_without_updating_legacy
         patch("app.services.invitation_service.require_valid_tenant", return_value=_tenant_context(tenant_id)),
         patch("app.services.invitation_service.get_db_connection", side_effect=_db_context(conn)),
         patch("app.services.invitation_service.set_session_cookie", new=AsyncMock()),
+        patch("app.services.invitation_service.check_plan_quota_growth", new=AsyncMock()),
     ):
         response = await invitation_service.accept_invitation(_request(), MagicMock(), "token")
 
@@ -170,6 +171,7 @@ async def test_accept_invitation_reactivates_existing_team_membership_by_id():
         patch("app.services.invitation_service.require_valid_tenant", return_value=_tenant_context(tenant_id)),
         patch("app.services.invitation_service.get_db_connection", side_effect=_db_context(conn)),
         patch("app.services.invitation_service.set_session_cookie", new=AsyncMock()),
+        patch("app.services.invitation_service.check_plan_quota_growth", new=AsyncMock()),
     ):
         await invitation_service.accept_invitation(_request(), MagicMock(), "token")
 

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -1,0 +1,237 @@
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.exceptions import APIError
+from app.services import billing_service, invitation_service, stations_service, tables_service
+
+
+def _db_context(conn):
+    @asynccontextmanager
+    async def _ctx():
+        yield conn
+
+    return _ctx
+
+
+def _tx():
+    tx = MagicMock()
+    tx.__aenter__ = AsyncMock(return_value=None)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    return tx
+
+
+def _session(tenant_id=None):
+    return SimpleNamespace(user_id=uuid4(), tenant_id=tenant_id or uuid4())
+
+
+def _request():
+    request = MagicMock()
+    request.headers = {"user-agent": "pytest"}
+    return request
+
+
+@pytest.mark.asyncio
+async def test_check_plan_quota_growth_allows_below_limit_and_excludes_customers():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "plan_slug": "pro",
+        "plan_features": {"quotas": {"admin_users": 2}},
+    })
+    conn.fetchval = AsyncMock(return_value=1)
+
+    await billing_service.check_plan_quota_growth(conn, tenant_id, "admin_users")
+
+    count_args = conn.fetchval.await_args.args
+    assert "role = ANY" in count_args[0]
+    assert "customer" not in count_args[2]
+
+
+@pytest.mark.asyncio
+async def test_check_plan_quota_growth_blocks_at_limit_with_stable_payload():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "plan_slug": "pro",
+        "plan_features": {"quotas": {"active_kitchens": 2}},
+    })
+    conn.fetchval = AsyncMock(return_value=2)
+
+    with pytest.raises(APIError) as exc:
+        await billing_service.check_plan_quota_growth(conn, tenant_id, "active_kitchens")
+
+    assert exc.value.status_code == 429
+    assert exc.value.details["code"] == "quota_exceeded"
+    assert exc.value.details["resource"] == "active_kitchens"
+    assert exc.value.details["used"] == 2
+    assert exc.value.details["limit"] == 2
+    assert exc.value.details["plan_slug"] == "pro"
+    assert exc.value.details["upgrade_url"] == "/billing/planes"
+
+
+@pytest.mark.asyncio
+async def test_check_plan_quota_growth_without_active_subscription_is_noop():
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+    conn.fetchval = AsyncMock()
+
+    await billing_service.check_plan_quota_growth(conn, uuid4(), "active_tables_including_bar")
+
+    conn.fetchval.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_table_quota_count_includes_bar_by_not_filtering_is_bar():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "plan_slug": "pro",
+        "plan_features": {"quotas": {"active_tables_including_bar": 20}},
+    })
+    conn.fetchval = AsyncMock(return_value=19)
+
+    await billing_service.check_plan_quota_growth(conn, tenant_id, "active_tables_including_bar")
+
+    query = conn.fetchval.await_args.args[0]
+    assert "deleted_at IS NULL" in query
+    assert "is_bar" not in query
+
+
+@pytest.mark.asyncio
+async def test_accept_invitation_quota_block_does_not_accept_or_create_member():
+    tenant_id = uuid4()
+    profile_id = uuid4()
+    invitation_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        {
+            "id": invitation_id,
+            "tenant_id": tenant_id,
+            "user_id": profile_id,
+            "email": "new-admin@example.com",
+            "name": "New Admin",
+            "role": "admin",
+        },
+        None,
+    ])
+    conn.execute = AsyncMock()
+    quota_error = APIError("Límite del plan alcanzado", status_code=429)
+
+    with (
+        patch("app.services.invitation_service.require_valid_tenant", return_value=SimpleNamespace(site="tenant.example.com")),
+        patch("app.services.invitation_service.get_db_connection", side_effect=_db_context(conn)),
+        patch("app.services.invitation_service.check_plan_quota_growth", new=AsyncMock(side_effect=quota_error)),
+    ):
+        with pytest.raises(APIError):
+            await invitation_service.accept_invitation(_request(), MagicMock(), "token")
+
+    conn.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_station_create_checks_quota_before_insert():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock()
+    quota_error = APIError("Límite del plan alcanzado", status_code=429)
+    body = SimpleNamespace(
+        name="Parrilla",
+        kitchen_name="Cocina",
+        color="#ff0000",
+        alert_threshold_1_min=5,
+        alert_threshold_2_min=10,
+        display_order=1,
+    )
+
+    with (
+        patch("app.services.stations_service.require_valid_session", return_value=_session(tenant_id)),
+        patch("app.services.stations_service.get_db_connection", side_effect=_db_context(conn)),
+        patch("app.services.stations_service.check_plan_quota_growth", new=AsyncMock(side_effect=quota_error)),
+    ):
+        with pytest.raises(APIError):
+            await stations_service.create_station(_request(), body)
+
+    conn.fetchrow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_station_deactivation_does_not_check_growth_quota():
+    tenant_id = uuid4()
+    station_id = uuid4()
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=0)
+    conn.fetchrow = AsyncMock(return_value={"id": station_id, "is_active": False})
+
+    with (
+        patch("app.services.stations_service.require_valid_session", return_value=_session(tenant_id)),
+        patch("app.services.stations_service.get_db_connection", side_effect=_db_context(conn)),
+        patch("app.services.stations_service.check_plan_quota_growth", new=AsyncMock()) as quota_check,
+    ):
+        await stations_service.toggle_station(_request(), station_id, False)
+
+    quota_check.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_table_create_checks_quota_before_insert():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.transaction.return_value = _tx()
+    conn.fetchrow = AsyncMock()
+    quota_error = APIError("Límite del plan alcanzado", status_code=429)
+
+    with (
+        patch("app.services.tables_service.require_valid_session", return_value=_session(tenant_id)),
+        patch("app.services.tables_service.get_db_connection", side_effect=_db_context(conn)),
+        patch("app.services.tables_service._resolve_table_code", new=AsyncMock(return_value="M1")),
+        patch("app.services.tables_service.check_plan_quota_growth", new=AsyncMock(side_effect=quota_error)),
+    ):
+        with pytest.raises(APIError):
+            await tables_service.create_table(_request(), "Mesa 1", 4)
+
+    conn.fetchrow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_table_qr_disable_does_not_check_growth_quota():
+    tenant_id = uuid4()
+    table_id = uuid4()
+    conn = MagicMock()
+    conn.transaction.return_value = _tx()
+    row = {
+        "id": table_id,
+        "name": "Mesa 2",
+        "capacity": 4,
+        "status": "free",
+        "is_active": True,
+        "is_bar": False,
+        "qr_enabled": False,
+        "qr_public_token": "tok",
+        "created_at": MagicMock(isoformat=lambda: "2026-01-01T00:00:00"),
+    }
+    conn.fetchval = AsyncMock(return_value=True)
+    conn.fetchrow = AsyncMock(side_effect=[
+        {
+            "id": table_id,
+            "name": "Mesa 2",
+            "is_bar": False,
+            "is_active": True,
+            "deleted_at": None,
+            "qr_enabled": True,
+            "qr_public_token": "tok",
+        },
+        row,
+    ])
+
+    with (
+        patch("app.services.tables_service.require_valid_session", return_value=_session(tenant_id)),
+        patch("app.services.tables_service.get_db_connection", side_effect=_db_context(conn)),
+        patch("app.services.tables_service.check_plan_quota_growth", new=AsyncMock()) as quota_check,
+    ):
+        await tables_service.set_table_qr_enabled(_request(), table_id, False)
+
+    quota_check.assert_not_awaited()

--- a/tests/test_table_qr_tokens.py
+++ b/tests/test_table_qr_tokens.py
@@ -161,7 +161,8 @@ async def test_set_table_qr_enabled_generates_token():
 
     with patch("app.services.tables_service.require_valid_session", return_value=session), \
          patch("app.services.tables_service.get_db_connection") as mock_conn, \
-         patch("app.services.tables_service._generate_unique_qr_token", new_callable=AsyncMock, return_value=token):
+         patch("app.services.tables_service._generate_unique_qr_token", new_callable=AsyncMock, return_value=token), \
+         patch("app.services.tables_service.check_plan_quota_growth", new_callable=AsyncMock):
         mock_conn.return_value.__aenter__ = AsyncMock(return_value=conn)
         mock_conn.return_value.__aexit__ = AsyncMock(return_value=False)
 


### PR DESCRIPTION
## Summary
- add shared backend quota growth checks for plan-limited resources
- block admin member, kitchen, table, and QR active-growth paths at quota
- preserve non-destructive behavior for deactivation/disable/no-op paths

## Tests
- pytest tests/test_billing_plan_quotas.py tests/test_invitation_team_membership.py tests/test_table_qr_tokens.py tests/test_quota_enforcement.py
- python3 -m py_compile app/services/billing_service.py app/services/invitation_service.py app/services/stations_service.py app/services/tables_service.py tests/test_quota_enforcement.py

Closes #574