### PR TITLE
Enforce monthly online order quota

### DIFF
--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -56,6 +56,11 @@ PLAN_QUOTA_DEFAULTS = {
 
 QUOTA_UPGRADE_URL = "/billing/planes"
 QUOTA_CONTACT_MESSAGE = "Actualiza tu plan o contacta a soporte para ampliar este límite."
+ONLINE_ORDER_QUOTA_CUSTOMER_MESSAGE = (
+    "El restaurante no puede recibir más pedidos en línea por este periodo. "
+    "Intenta contactarlo directamente."
+)
+ONLINE_ORDER_QUOTA_RESOURCE = "completed_online_orders_per_month"
 ENFORCEABLE_QUOTA_RESOURCES = {
     "admin_users",
     "active_kitchens",
@@ -181,6 +186,118 @@ async def check_plan_quota_growth(conn, tenant_id: UUID, resource: str) -> None:
             "message": QUOTA_CONTACT_MESSAGE,
         },
     )
+
+
+async def check_completed_online_order_quota(conn, tenant_id: UUID) -> None:
+    """
+    Block final public checkout once the tenant reaches its online-order quota.
+
+    Unlike active-resource quotas, this is period-based: the usage window comes
+    from the current subscription period and counts only completed online orders.
+    """
+    plan = await conn.fetchrow(
+        """
+        SELECT
+            sp.slug AS plan_slug,
+            sp.features AS plan_features,
+            ts.current_period_start,
+            ts.current_period_end
+        FROM tenant_subscriptions ts
+        JOIN subscription_plans sp ON sp.id = ts.plan_id
+        WHERE ts.tenant_id = $1
+          AND ts.status IN ('active', 'past_due')
+          AND ts.current_period_end > now()
+        ORDER BY ts.current_period_end DESC
+        LIMIT 1
+        """,
+        tenant_id,
+    )
+    if not plan:
+        return
+
+    quotas = _normalize_plan_quotas(plan["plan_slug"], plan["plan_features"])
+    limit = int(quotas.get(ONLINE_ORDER_QUOTA_RESOURCE, 0))
+    if limit <= 0:
+        return
+
+    period_start = plan["current_period_start"]
+    period_end = plan["current_period_end"]
+    used = int(await conn.fetchval(
+        """
+        SELECT COUNT(DISTINCT o.id)
+        FROM orders o
+        WHERE o.tenant_id = $1
+          AND o.online_cart_id IS NOT NULL
+          AND o.status = 'completed'
+          AND o.order_date >= $2
+          AND o.order_date < $3
+        """,
+        tenant_id,
+        period_start,
+        period_end,
+    ) or 0)
+
+    _log_online_order_quota_usage(
+        tenant_id=tenant_id,
+        plan_slug=plan["plan_slug"],
+        used=used,
+        limit=limit,
+        period_start=period_start,
+        period_end=period_end,
+    )
+
+    if used < limit:
+        return
+
+    raise APIError(
+        "Límite mensual de pedidos en línea alcanzado",
+        status_code=429,
+        details={
+            "code": "online_order_quota_exceeded",
+            "error": "online_order_quota_exceeded",
+            "resource": ONLINE_ORDER_QUOTA_RESOURCE,
+            "used": used,
+            "limit": limit,
+            "plan_slug": plan["plan_slug"],
+            "period_start": period_start.isoformat(),
+            "period_end": period_end.isoformat(),
+            "upgrade_url": QUOTA_UPGRADE_URL,
+            "tenant_message": QUOTA_CONTACT_MESSAGE,
+            "customer_message": ONLINE_ORDER_QUOTA_CUSTOMER_MESSAGE,
+        },
+    )
+
+
+def _log_online_order_quota_usage(
+    *,
+    tenant_id: UUID,
+    plan_slug: str,
+    used: int,
+    limit: int,
+    period_start: datetime,
+    period_end: datetime,
+) -> None:
+    usage_ratio = used / limit if limit else 0
+    if usage_ratio >= 1:
+        logger.warning(
+            "online_order_quota_threshold tenant=%s plan=%s used=%d limit=%d threshold=100 period_start=%s period_end=%s",
+            tenant_id,
+            plan_slug,
+            used,
+            limit,
+            period_start.isoformat(),
+            period_end.isoformat(),
+        )
+    elif usage_ratio >= 0.8:
+        logger.info(
+            "online_order_quota_threshold tenant=%s plan=%s used=%d limit=%d threshold=80 period_start=%s period_end=%s",
+            tenant_id,
+            plan_slug,
+            used,
+            limit,
+            period_start.isoformat(),
+            period_end.isoformat(),
+        )
 
 
 async def _count_quota_resource_usage(conn, tenant_id: UUID, resource: str) -> int:

--- a/app/services/online_cart_service.py
+++ b/app/services/online_cart_service.py
@@ -7,6 +7,7 @@ from uuid import UUID, uuid4
 from fastapi import HTTPException
 from app.database import get_db_connection
 from app.core.exceptions import APIError
+from app.services.billing_service import check_completed_online_order_quota
 from app.services.email_helpers import send_order_confirmation_email
 import logging
 import datetime as _dt
@@ -772,6 +773,8 @@ async def checkout_cart(
                         detail=f"Los siguientes productos ya no están disponibles para domicilios: {names}. Por favor actualiza tu carrito."
                     )
 
+                await check_completed_online_order_quota(conn, cart['tenant_id'])
+
                 # 7. Atomically lock cart — prevents double checkout
                 locked = await conn.fetchrow(
                     "UPDATE online_carts SET status = 'checked_out', completed_at = now(), updated_at = now() WHERE id = $1 AND status = 'active' RETURNING id",
@@ -937,6 +940,8 @@ async def checkout_cart(
         return order_result
 
     except HTTPException:
+        raise
+    except APIError:
         raise
     except Exception as e:
         logger.error(f"Error during checkout for cart {cart_id}: {str(e)}")

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -1,4 +1,6 @@
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -6,7 +8,7 @@ from uuid import uuid4
 import pytest
 
 from app.core.exceptions import APIError
-from app.services import billing_service, invitation_service, stations_service, tables_service
+from app.services import billing_service, invitation_service, online_cart_service, stations_service, tables_service
 
 
 def _db_context(conn):
@@ -235,3 +237,136 @@ async def test_table_qr_disable_does_not_check_growth_quota():
         await tables_service.set_table_qr_enabled(_request(), table_id, False)
 
     quota_check.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_completed_online_order_quota_allows_below_limit_and_counts_completed_online_orders():
+    tenant_id = uuid4()
+    period_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    period_end = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "plan_slug": "pro",
+        "plan_features": {"quotas": {"completed_online_orders_per_month": 300}},
+        "current_period_start": period_start,
+        "current_period_end": period_end,
+    })
+    conn.fetchval = AsyncMock(return_value=299)
+
+    await billing_service.check_completed_online_order_quota(conn, tenant_id)
+
+    count_args = conn.fetchval.await_args.args
+    assert "o.online_cart_id IS NOT NULL" in count_args[0]
+    assert "o.status = 'completed'" in count_args[0]
+    assert "o.order_date >= $2" in count_args[0]
+    assert "o.order_date < $3" in count_args[0]
+    assert count_args[1:] == (tenant_id, period_start, period_end)
+
+
+@pytest.mark.asyncio
+async def test_completed_online_order_quota_blocks_at_limit_with_stable_payload():
+    tenant_id = uuid4()
+    period_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    period_end = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "plan_slug": "pro",
+        "plan_features": {"quotas": {"completed_online_orders_per_month": 300}},
+        "current_period_start": period_start,
+        "current_period_end": period_end,
+    })
+    conn.fetchval = AsyncMock(return_value=300)
+
+    with pytest.raises(APIError) as exc:
+        await billing_service.check_completed_online_order_quota(conn, tenant_id)
+
+    assert exc.value.status_code == 429
+    assert exc.value.details["code"] == "online_order_quota_exceeded"
+    assert exc.value.details["resource"] == "completed_online_orders_per_month"
+    assert exc.value.details["used"] == 300
+    assert exc.value.details["limit"] == 300
+    assert exc.value.details["plan_slug"] == "pro"
+    assert exc.value.details["period_start"] == period_start.isoformat()
+    assert exc.value.details["period_end"] == period_end.isoformat()
+    assert exc.value.details["tenant_message"]
+    assert exc.value.details["customer_message"]
+
+
+@pytest.mark.asyncio
+async def test_completed_online_order_quota_without_active_subscription_is_noop():
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+    conn.fetchval = AsyncMock()
+
+    await billing_service.check_completed_online_order_quota(conn, uuid4())
+
+    conn.fetchval.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_checkout_online_order_quota_block_happens_before_cart_lock_and_order_insert():
+    tenant_id = uuid4()
+    cart_id = uuid4()
+    customer_id = uuid4()
+    product_id = uuid4()
+    conn = MagicMock()
+    conn.transaction.return_value = _tx()
+    conn.fetch = AsyncMock(return_value=[])
+    quota_error = APIError(
+        "Límite mensual de pedidos en línea alcanzado",
+        status_code=429,
+        details={"code": "online_order_quota_exceeded"},
+    )
+
+    async def fetchrow(query, *args):
+        if "FROM online_carts" in query:
+            return {
+                "id": cart_id,
+                "tenant_id": tenant_id,
+                "customer_id": customer_id,
+                "order_type": "pickup",
+                "delivery_address_id": None,
+                "pickup_pin": "1234",
+                "is_verified": True,
+                "status": "active",
+                "total_amount": Decimal("50000"),
+                "verified_email": "cliente@example.com",
+                "scheduled_time": None,
+                "delivery_instructions": None,
+            }
+        if "FROM tenant_public_profiles" in query:
+            return {
+                "min_order_amount": Decimal("0"),
+                "estimated_preparation_time": 20,
+                "is_manually_open": True,
+                "business_hours": {},
+                "accepts_online_orders": True,
+                "tip_enabled": False,
+            }
+        if "UPDATE online_carts" in query or "INSERT INTO orders" in query:
+            raise AssertionError("checkout side effect happened before quota block")
+        return None
+
+    conn.fetchrow = AsyncMock(side_effect=fetchrow)
+
+    with (
+        patch("app.services.online_cart_service.get_db_connection", side_effect=_db_context(conn)),
+        patch("app.services.online_cart_service.get_cart_items", new=AsyncMock(return_value=[{
+            "product_id": str(product_id),
+            "quantity": 1,
+            "unit_price": Decimal("50000"),
+            "subtotal": Decimal("50000"),
+            "notes": None,
+            "modifiers": [],
+        }])),
+        patch("app.services.public_restaurant_service.is_currently_open", return_value=True),
+        patch("app.services.online_cart_service.check_completed_online_order_quota", new=AsyncMock(side_effect=quota_error)),
+    ):
+        with pytest.raises(APIError) as exc:
+            await online_cart_service.checkout_cart(cart_id)
+
+    assert exc.value.status_code == 429
+    assert exc.value.details["code"] == "online_order_quota_exceeded"
+    seen_queries = [call.args[0] for call in conn.fetchrow.await_args_list]
+    assert not any("UPDATE online_carts SET status = 'checked_out'" in query for query in seen_queries)
+    assert not any("INSERT INTO orders" in query for query in seen_queries)


### PR DESCRIPTION
## Summary
- add a billing helper that checks completed online order quota in the active subscription period
- block public checkout before cart lock/order creation when the quota is reached
- add targeted quota and checkout pre-side-effect tests

## Tests
- pytest tests/test_quota_enforcement.py tests/test_online_order_status.py
- pytest tests/test_billing_plan_quotas.py

Build not run per request.

Closes #575