### PR TITLE
Enforce one active admin session

### DIFF
--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -12,6 +12,28 @@ from app.models.auth import User, Session, Tenant, SessionResponse, SwitchTenant
 
 logger = logging.getLogger(__name__)
 
+
+async def replace_active_admin_sessions(conn, user_id, keep_session_id=None) -> int:
+    result = await conn.execute(
+        """
+        UPDATE sessions
+        SET is_active = false,
+            ended_at = NOW(),
+            end_reason = 'replaced_by_new_login'
+        WHERE user_id = $1
+          AND is_active = true
+          AND expires_at > NOW()
+          AND ($2::uuid IS NULL OR id <> $2::uuid)
+        """,
+        user_id,
+        keep_session_id,
+    )
+    count = int(result.split()[-1]) if result else 0
+    if count:
+        logger.info("Ended %s previous active admin sessions for user %s", count, user_id)
+    return count
+
+
 async def get_session_data(request: Request, response: Response) -> SessionResponse:
     """
     Port exact session validation logic from warolabs.com/server/api/auth/session.get.js
@@ -251,6 +273,7 @@ async def switch_tenant(request: Request, response: Response, tenant_slug: str) 
                 current_user_agent or user_agent,  # Use current or fallback to previous
                 login_method
             )
+            await replace_active_admin_sessions(conn, user_id, new_session_id)
             
             # Clear stale cookie variants before issuing the new session (tenant switch).
             cookie_site = target_site or tenant_site

--- a/app/services/invitation_service.py
+++ b/app/services/invitation_service.py
@@ -10,6 +10,7 @@ from app.core.middleware import require_valid_tenant, require_valid_session
 from app.core.exceptions import APIError, AuthenticationError, ValidationError, AuthorizationError
 from app.core.email_utils import normalize_email
 from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
+from app.services.auth_service import replace_active_admin_sessions
 from app.services.billing_service import check_plan_quota_growth
 from app.models.invitation import (
     SendInvitationRequest,
@@ -304,15 +305,6 @@ async def accept_invitation(request: Request, response: Response, token: str) ->
                 )
                 logger.info(f"🔄 Activated existing team member role to: {invitation['role']}")
 
-            # Mark invitation as accepted after membership succeeds, so quota
-            # blocks do not consume a still-actionable invitation.
-            await conn.execute(
-                """UPDATE tenant_invitations
-                   SET status = 'accepted', accepted_at = NOW()
-                   WHERE id = $1""",
-                invitation['id']
-            )
-
             # Create session (same as magic link flow)
             session_id = secrets.token_hex(16)
             expires_at = datetime.utcnow() + timedelta(days=7)
@@ -336,7 +328,17 @@ async def accept_invitation(request: Request, response: Response, token: str) ->
                 client_ip,
                 user_agent
             )
+            await replace_active_admin_sessions(conn, invitation['user_id'], session_id)
             logger.info(f"🎫 Session created: {session_id}")
+
+            # Mark invitation as accepted after membership and session creation succeed, so
+            # quota/session blocks do not consume a still-actionable invitation.
+            await conn.execute(
+                """UPDATE tenant_invitations
+                   SET status = 'accepted', accepted_at = NOW()
+                   WHERE id = $1""",
+                invitation['id']
+            )
 
             # Set session cookie
             await set_session_cookie(response, session_id, tenant_context.site)

--- a/app/services/magic_link_service.py
+++ b/app/services/magic_link_service.py
@@ -12,6 +12,7 @@ from app.core.exceptions import AuthenticationError, ValidationError
 from app.core.email_utils import normalize_email
 from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
 from app.models.auth import User, Tenant, MagicLinkResponse, VerifyCodeResponse, VerifyTokenResponse
+from app.services.auth_service import replace_active_admin_sessions
 
 logger = logging.getLogger(__name__)
 
@@ -218,30 +219,6 @@ async def verify_code(request: Request, response: Response, email: str, code: st
             )
             logger.info("✅ Verification code marked as used")
 
-            # Limit active sessions to 5 per user (end oldest sessions if limit exceeded)
-            MAX_SESSIONS_PER_USER = 5
-            active_sessions_query = """
-                SELECT id, created_at
-                FROM sessions
-                WHERE user_id = $1 AND is_active = true
-                ORDER BY created_at DESC
-            """
-            active_sessions = await conn.fetch(active_sessions_query, token_data['user_id'])
-
-            if len(active_sessions) >= MAX_SESSIONS_PER_USER:
-                # End the oldest sessions to keep only (MAX_SESSIONS_PER_USER - 1) active
-                sessions_to_keep = MAX_SESSIONS_PER_USER - 1
-                sessions_to_end = active_sessions[sessions_to_keep:]
-
-                for session in sessions_to_end:
-                    await conn.execute(
-                        'UPDATE sessions SET is_active = false, ended_at = NOW(), end_reason = $1 WHERE id = $2',
-                        'session_limit_exceeded', session['id']
-                    )
-                logger.info(f"🧹 Ended {len(sessions_to_end)} old sessions for user: {token_data['user_id']} (limit: {MAX_SESSIONS_PER_USER})")
-            else:
-                logger.info(f"✅ User has {len(active_sessions)} active sessions (limit: {MAX_SESSIONS_PER_USER})")
-
             # Create session with user's tenant from token
             session_id = secrets.token_hex(16)
             expires_at = datetime.utcnow() + timedelta(days=7)  # 7 days (1 week)
@@ -264,6 +241,7 @@ async def verify_code(request: Request, response: Response, email: str, code: st
                 session_id, token_data['user_id'], user_tenant_id,
                 expires_at, client_ip, user_agent
             )
+            await replace_active_admin_sessions(conn, token_data['user_id'], session_id)
             logger.info(f"🎫 Session created: {session_id} for tenant: {user_tenant_id}")
             
             # Get tenant info for response
@@ -359,30 +337,6 @@ async def verify_token(request: Request, response: Response, email: str, token: 
             )
             logger.info("✅ Token marked as used")
 
-            # Limit active sessions to 5 per user (end oldest sessions if limit exceeded)
-            MAX_SESSIONS_PER_USER = 5
-            active_sessions_query = """
-                SELECT id, created_at
-                FROM sessions
-                WHERE user_id = $1 AND is_active = true
-                ORDER BY created_at DESC
-            """
-            active_sessions = await conn.fetch(active_sessions_query, token_data['user_id'])
-
-            if len(active_sessions) >= MAX_SESSIONS_PER_USER:
-                # End the oldest sessions to keep only (MAX_SESSIONS_PER_USER - 1) active
-                sessions_to_keep = MAX_SESSIONS_PER_USER - 1
-                sessions_to_end = active_sessions[sessions_to_keep:]
-
-                for session in sessions_to_end:
-                    await conn.execute(
-                        'UPDATE sessions SET is_active = false, ended_at = NOW(), end_reason = $1 WHERE id = $2',
-                        'session_limit_exceeded', session['id']
-                    )
-                logger.info(f"🧹 Ended {len(sessions_to_end)} old sessions for user: {token_data['user_id']} (limit: {MAX_SESSIONS_PER_USER})")
-            else:
-                logger.info(f"✅ User has {len(active_sessions)} active sessions (limit: {MAX_SESSIONS_PER_USER})")
-
             # Create session with user's tenant from token
             session_id = secrets.token_hex(16)
             expires_at = datetime.utcnow() + timedelta(days=7)  # 7 days (1 week)
@@ -405,6 +359,7 @@ async def verify_token(request: Request, response: Response, email: str, token: 
                 session_id, token_data['user_id'], user_tenant_id,
                 expires_at, client_ip, user_agent
             )
+            await replace_active_admin_sessions(conn, token_data['user_id'], session_id)
             logger.info(f"🎫 Session created: {session_id} for tenant: {user_tenant_id}")
             
             # Get tenant info for notification

--- a/tests/test_customer_internal_access.py
+++ b/tests/test_customer_internal_access.py
@@ -90,6 +90,52 @@ async def test_verify_token_denies_customer_only_membership_before_session_creat
 
 
 @pytest.mark.asyncio
+async def test_verify_token_replaces_previous_active_admin_sessions():
+    """A successful admin magic-link login leaves only the newly created DB session active."""
+    from app.services.magic_link_service import verify_token
+
+    tenant_id = uuid4()
+    user_id = uuid4()
+    session_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    response = MagicMock()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {
+                "tenant_id": tenant_id,
+                "user_id": user_id,
+                "email": "admin@example.com",
+                "name": "Admin User",
+                "user_created_at": datetime(2024, 1, 1, tzinfo=timezone.utc),
+                "user_role": "admin",
+            },
+            {"name": "Tenant"},
+        ]
+    )
+    conn.fetch = AsyncMock(return_value=[])
+    conn.execute = AsyncMock(return_value="UPDATE 1")
+
+    @asynccontextmanager
+    async def db_ctx():
+        yield conn
+
+    with patch("app.services.magic_link_service.get_db_connection", side_effect=db_ctx), \
+         patch("app.services.magic_link_service.require_valid_tenant", return_value=_tenant_context(tenant_id)), \
+         patch("app.services.magic_link_service.secrets.token_hex", return_value=session_id), \
+         patch("app.services.magic_link_service.set_session_cookie", new=AsyncMock()), \
+         patch("app.services.discord_service.discord_session_service", None):
+        result = await verify_token(_request(), response, "admin@example.com", "token")
+
+    assert result.success is True
+    replacement_calls = [
+        call.args for call in conn.execute.await_args_list
+        if "replaced_by_new_login" in call.args[0]
+    ]
+    assert len(replacement_calls) == 1
+    assert replacement_calls[0][1:] == (user_id, session_id)
+
+
+@pytest.mark.asyncio
 async def test_auth_session_reports_internal_access_for_promotor():
     """Promotor is a valid internal role and gets an explicit allow flag."""
     from app.services.auth_service import get_session_data
@@ -170,3 +216,27 @@ async def test_session_resolver_invalidates_customer_internal_session():
     assert result is None
     conn.execute.assert_awaited_once()
     assert conn.execute.await_args.args[1] == session_token
+
+
+@pytest.mark.asyncio
+async def test_session_resolver_replaced_session_returns_invalid_without_overwriting_reason():
+    """A replaced token follows the normal invalid-session path and keeps its audit reason."""
+    from app.core.security import get_session_from_request
+
+    session_token = str(uuid4())
+    expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+    db_ctx, conn = _build_db_mock(fetchrow_side_effect=[
+        {
+            "id": session_token,
+            "expires_at": expires_at,
+            "is_active": False,
+            "ended_at": datetime.now(timezone.utc),
+        },
+    ])
+
+    with patch("app.database.get_db_connection", side_effect=db_ctx), \
+         patch("app.core.security.get_session_token", new=AsyncMock(return_value=session_token)):
+        result = await get_session_from_request(_request())
+
+    assert result is None
+    conn.execute.assert_not_awaited()

--- a/tests/test_invitation_team_membership.py
+++ b/tests/test_invitation_team_membership.py
@@ -142,6 +142,7 @@ async def test_accept_invitation_inserts_team_membership_without_updating_legacy
     assert len(tenant_member_writes) == 1
     assert "INSERT INTO tenant_members" in tenant_member_writes[0]
     assert "UPDATE tenant_members" not in tenant_member_writes[0]
+    assert any("replaced_by_new_login" in sql for sql in executed_sql)
 
 
 @pytest.mark.asyncio
@@ -182,6 +183,8 @@ async def test_accept_invitation_reactivates_existing_team_membership_by_id():
     assert len(tenant_member_writes) == 1
     assert "WHERE id = $2" in tenant_member_writes[0][0]
     assert tenant_member_writes[0][1:] == ("admin", member_id)
+    executed_sql = [call.args[0] for call in conn.execute.await_args_list]
+    assert any("replaced_by_new_login" in sql for sql in executed_sql)
 
 
 @pytest.mark.asyncio

--- a/tests/test_switch_tenant_membership.py
+++ b/tests/test_switch_tenant_membership.py
@@ -105,7 +105,7 @@ async def test_active_member_can_switch_tenant():
         },
     ]
 
-    db_ctx, _ = _build_db_mock(fetchrow_side_effect=fetchrow_responses)
+    db_ctx, conn = _build_db_mock(fetchrow_side_effect=fetchrow_responses)
 
     with patch("app.services.auth_service.get_db_connection", side_effect=db_ctx), \
          patch("app.services.auth_service.get_session_token", new=AsyncMock(return_value="tok")), \
@@ -116,6 +116,9 @@ async def test_active_member_can_switch_tenant():
 
     assert result.tenant.slug == "target-tenant"
     assert result.tenant.id == target_tenant_id
+    executed_sql = [call.args[0] for call in conn.execute.await_args_list]
+    assert any("end_reason = $1" in sql for sql in executed_sql)
+    assert any("replaced_by_new_login" in sql for sql in executed_sql)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- replace the old five-session magic-link cap with one active admin session per user
- reuse the replacement helper for magic-link login, tenant switch, and invitation acceptance
- keep replaced-token validation on the normal invalid-session path

## Tests
- pytest tests/test_session_token.py tests/test_switch_tenant_membership.py tests/test_invitation_team_membership.py tests/test_customer_internal_access.py

Closes #576