### PR TITLE
Add tenant quota overrides

### DIFF
--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -69,6 +69,20 @@ ENFORCEABLE_QUOTA_RESOURCES = {
 }
 
 
+@dataclass(frozen=True)
+class EffectiveQuota:
+    resource: str
+    plan_limit: int
+    limit: Optional[int]
+    override_id: Optional[UUID] = None
+    override_disabled: bool = False
+    override_reason: Optional[str] = None
+
+    @property
+    def has_override(self) -> bool:
+        return self.override_id is not None
+
+
 async def check_scan_quota(tenant_id: UUID, conn) -> None:
     """
     Atomic scan quota check and increment.
@@ -152,9 +166,18 @@ async def check_plan_quota_growth(conn, tenant_id: UUID, resource: str) -> None:
 
     plan = await conn.fetchrow(
         """
-        SELECT sp.slug AS plan_slug, sp.features AS plan_features
+        SELECT
+            sp.slug AS plan_slug,
+            sp.features AS plan_features,
+            tq.id AS override_id,
+            tq.limit_override,
+            COALESCE(tq.disabled, false) AS override_disabled,
+            tq.reason AS override_reason
         FROM tenant_subscriptions ts
         JOIN subscription_plans sp ON sp.id = ts.plan_id
+        LEFT JOIN tenant_quota_overrides tq
+          ON tq.tenant_id = ts.tenant_id
+         AND tq.resource = $2
         WHERE ts.tenant_id = $1
           AND ts.status IN ('active', 'past_due')
           AND ts.current_period_end > now()
@@ -162,16 +185,27 @@ async def check_plan_quota_growth(conn, tenant_id: UUID, resource: str) -> None:
         LIMIT 1
         """,
         tenant_id,
+        resource,
     )
     if not plan:
         return
 
     quotas = _normalize_plan_quotas(plan["plan_slug"], plan["plan_features"])
-    limit = int(quotas.get(resource, 0))
-    used = await _count_quota_resource_usage(conn, tenant_id, resource)
-    if used < limit:
+    quota = _effective_quota_from_row(resource, quotas.get(resource, 0), plan)
+    if quota.limit is None:
         return
 
+    used = await _count_quota_resource_usage(conn, tenant_id, resource)
+    if used < quota.limit:
+        return
+
+    _log_quota_block(
+        tenant_id=tenant_id,
+        resource=resource,
+        used=used,
+        quota=quota,
+        plan_slug=plan["plan_slug"],
+    )
     raise APIError(
         "Límite del plan alcanzado",
         status_code=429,
@@ -180,8 +214,10 @@ async def check_plan_quota_growth(conn, tenant_id: UUID, resource: str) -> None:
             "error": "quota_exceeded",
             "resource": resource,
             "used": used,
-            "limit": limit,
+            "limit": quota.limit,
+            "plan_limit": quota.plan_limit,
             "plan_slug": plan["plan_slug"],
+            "override": _quota_override_payload(quota),
             "upgrade_url": QUOTA_UPGRADE_URL,
             "message": QUOTA_CONTACT_MESSAGE,
         },
@@ -201,9 +237,16 @@ async def check_completed_online_order_quota(conn, tenant_id: UUID) -> None:
             sp.slug AS plan_slug,
             sp.features AS plan_features,
             ts.current_period_start,
-            ts.current_period_end
+            ts.current_period_end,
+            tq.id AS override_id,
+            tq.limit_override,
+            COALESCE(tq.disabled, false) AS override_disabled,
+            tq.reason AS override_reason
         FROM tenant_subscriptions ts
         JOIN subscription_plans sp ON sp.id = ts.plan_id
+        LEFT JOIN tenant_quota_overrides tq
+          ON tq.tenant_id = ts.tenant_id
+         AND tq.resource = $2
         WHERE ts.tenant_id = $1
           AND ts.status IN ('active', 'past_due')
           AND ts.current_period_end > now()
@@ -211,13 +254,18 @@ async def check_completed_online_order_quota(conn, tenant_id: UUID) -> None:
         LIMIT 1
         """,
         tenant_id,
+        ONLINE_ORDER_QUOTA_RESOURCE,
     )
     if not plan:
         return
 
     quotas = _normalize_plan_quotas(plan["plan_slug"], plan["plan_features"])
-    limit = int(quotas.get(ONLINE_ORDER_QUOTA_RESOURCE, 0))
-    if limit <= 0:
+    quota = _effective_quota_from_row(
+        ONLINE_ORDER_QUOTA_RESOURCE,
+        quotas.get(ONLINE_ORDER_QUOTA_RESOURCE, 0),
+        plan,
+    )
+    if quota.limit is None or quota.limit <= 0:
         return
 
     period_start = plan["current_period_start"]
@@ -241,14 +289,21 @@ async def check_completed_online_order_quota(conn, tenant_id: UUID) -> None:
         tenant_id=tenant_id,
         plan_slug=plan["plan_slug"],
         used=used,
-        limit=limit,
+        limit=quota.limit,
         period_start=period_start,
         period_end=period_end,
     )
 
-    if used < limit:
+    if used < quota.limit:
         return
 
+    _log_quota_block(
+        tenant_id=tenant_id,
+        resource=ONLINE_ORDER_QUOTA_RESOURCE,
+        used=used,
+        quota=quota,
+        plan_slug=plan["plan_slug"],
+    )
     raise APIError(
         "Límite mensual de pedidos en línea alcanzado",
         status_code=429,
@@ -257,8 +312,10 @@ async def check_completed_online_order_quota(conn, tenant_id: UUID) -> None:
             "error": "online_order_quota_exceeded",
             "resource": ONLINE_ORDER_QUOTA_RESOURCE,
             "used": used,
-            "limit": limit,
+            "limit": quota.limit,
+            "plan_limit": quota.plan_limit,
             "plan_slug": plan["plan_slug"],
+            "override": _quota_override_payload(quota),
             "period_start": period_start.isoformat(),
             "period_end": period_end.isoformat(),
             "upgrade_url": QUOTA_UPGRADE_URL,
@@ -298,6 +355,113 @@ def _log_online_order_quota_usage(
             period_start.isoformat(),
             period_end.isoformat(),
         )
+
+
+def _row_value(row: Any, key: str, default: Any = None) -> Any:
+    try:
+        return row[key]
+    except (KeyError, IndexError, TypeError):
+        return default
+
+
+def _effective_quota_from_row(resource: str, plan_limit: Any, row: Any) -> EffectiveQuota:
+    plan_limit_int = _coerce_quota_value(plan_limit, 0)
+    override_id = _row_value(row, "override_id")
+    if not override_id:
+        return EffectiveQuota(resource=resource, plan_limit=plan_limit_int, limit=plan_limit_int)
+
+    disabled = bool(_row_value(row, "override_disabled", False))
+    limit_override = _row_value(row, "limit_override")
+    effective_limit = None if disabled else _coerce_quota_value(limit_override, plan_limit_int)
+    return EffectiveQuota(
+        resource=resource,
+        plan_limit=plan_limit_int,
+        limit=effective_limit,
+        override_id=override_id,
+        override_disabled=disabled,
+        override_reason=_row_value(row, "override_reason"),
+    )
+
+
+def _quota_override_payload(quota: EffectiveQuota) -> Optional[Dict[str, Any]]:
+    if not quota.has_override:
+        return None
+    return {
+        "id": str(quota.override_id),
+        "disabled": quota.override_disabled,
+        "reason": quota.override_reason,
+    }
+
+
+def _log_quota_block(
+    *,
+    tenant_id: UUID,
+    resource: str,
+    used: int,
+    quota: EffectiveQuota,
+    plan_slug: str,
+) -> None:
+    logger.warning(
+        "quota_blocked tenant=%s resource=%s used=%d limit=%s plan_limit=%d plan=%s override=%s override_id=%s",
+        tenant_id,
+        resource,
+        used,
+        quota.limit,
+        quota.plan_limit,
+        plan_slug,
+        quota.has_override,
+        quota.override_id,
+    )
+
+
+async def _fetch_tenant_quota_overrides(conn, tenant_id: UUID) -> Dict[str, EffectiveQuota]:
+    rows = await conn.fetch(
+        """
+        SELECT id, resource, limit_override, disabled, reason
+        FROM tenant_quota_overrides
+        WHERE tenant_id = $1
+          AND resource = ANY($2::text[])
+        """,
+        tenant_id,
+        list(QUOTA_KEYS),
+    )
+    return {
+        row["resource"]: EffectiveQuota(
+            resource=row["resource"],
+            plan_limit=0,
+            limit=None if row["disabled"] else _coerce_quota_value(row["limit_override"], 0),
+            override_id=row["id"],
+            override_disabled=bool(row["disabled"]),
+            override_reason=row["reason"],
+        )
+        for row in rows
+    }
+
+
+def _apply_effective_quotas(
+    plan_quotas: Dict[str, int],
+    overrides: Dict[str, EffectiveQuota],
+) -> Dict[str, EffectiveQuota]:
+    effective: Dict[str, EffectiveQuota] = {}
+    for resource in QUOTA_KEYS:
+        plan_limit = _coerce_quota_value(plan_quotas.get(resource), 0)
+        override = overrides.get(resource)
+        if override:
+            effective[resource] = EffectiveQuota(
+                resource=resource,
+                plan_limit=plan_limit,
+                limit=None if override.override_disabled else override.limit,
+                override_id=override.override_id,
+                override_disabled=override.override_disabled,
+                override_reason=override.override_reason,
+            )
+        else:
+            effective[resource] = EffectiveQuota(
+                resource=resource,
+                plan_limit=plan_limit,
+                limit=plan_limit,
+            )
+    return effective
 
 
 async def _count_quota_resource_usage(conn, tenant_id: UUID, resource: str) -> int:
@@ -983,7 +1147,11 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
               AND COALESCE(emitted_at, created_at) < $3
         """, tenant_id, period_start, period_end) or 0)
 
-    quotas = _normalize_plan_quotas(row["plan_slug"], row["plan_features"])
+    plan_quotas = _normalize_plan_quotas(row["plan_slug"], row["plan_features"])
+    effective_quotas = _apply_effective_quotas(
+        plan_quotas,
+        await _fetch_tenant_quota_overrides(conn, tenant_id),
+    )
     quota_counts = await conn.fetchrow("""
         SELECT
             (
@@ -1041,45 +1209,64 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
             ) AS completed_online_orders_per_month
     """, tenant_id, period_start, period_end, list(LEGACY_INTERNAL_TEAM_ROLES))
 
-    def metric(used: int, limit: int) -> Dict[str, Any]:
-        return {
+    def metric(used: int, quota: EffectiveQuota) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
             "used": used,
-            "limit": limit,
-            "remaining": max(limit - used, 0),
+            "limit": quota.limit,
+            "remaining": None if quota.limit is None else max(quota.limit - used, 0),
             "period_start": period_start_iso,
             "period_end": period_end_iso,
         }
+        if quota.has_override:
+            data["plan_limit"] = quota.plan_limit
+            data["override"] = _quota_override_payload(quota)
+        return data
 
     return {
         "period_start": period_start_iso,
         "period_end": period_end_iso,
-        "scan_usage": metric(scans_used, scans_limit),
-        "electronic_invoice_usage": metric(invoice_used, invoice_limit),
+        "scan_usage": {
+            "used": scans_used,
+            "limit": scans_limit,
+            "remaining": max(scans_limit - scans_used, 0),
+            "period_start": period_start_iso,
+            "period_end": period_end_iso,
+        },
+        "electronic_invoice_usage": {
+            "used": invoice_used,
+            "limit": invoice_limit,
+            "remaining": max(invoice_limit - invoice_used, 0),
+            "period_start": period_start_iso,
+            "period_end": period_end_iso,
+        },
         "quota_usage": {
-            "admin_users": metric(int(quota_counts["admin_users"] or 0), quotas["admin_users"]),
+            "admin_users": metric(
+                int(quota_counts["admin_users"] or 0),
+                effective_quotas["admin_users"],
+            ),
             "active_sessions_per_admin_user": metric(
                 int(quota_counts["active_sessions_per_admin_user"] or 0),
-                quotas["active_sessions_per_admin_user"],
+                effective_quotas["active_sessions_per_admin_user"],
             ),
             "active_kitchens": metric(
                 int(quota_counts["active_kitchens"] or 0),
-                quotas["active_kitchens"],
+                effective_quotas["active_kitchens"],
             ),
             "active_tables_including_bar": metric(
                 int(quota_counts["active_tables_including_bar"] or 0),
-                quotas["active_tables_including_bar"],
+                effective_quotas["active_tables_including_bar"],
             ),
             "active_qr_tables": metric(
                 int(quota_counts["active_qr_tables"] or 0),
-                quotas["active_qr_tables"],
+                effective_quotas["active_qr_tables"],
             ),
             "completed_online_orders_per_month": metric(
                 int(quota_counts["completed_online_orders_per_month"] or 0),
-                quotas["completed_online_orders_per_month"],
+                effective_quotas["completed_online_orders_per_month"],
             ),
             "electronic_invoices_per_period": metric(
                 invoice_used,
-                quotas["electronic_invoices_per_period"],
+                effective_quotas["electronic_invoices_per_period"],
             ),
         },
     }

--- a/docs/tenant-quota-overrides-runbook.md
+++ b/docs/tenant-quota-overrides-runbook.md
@@ -1,0 +1,197 @@
+# Tenant Quota Overrides Runbook
+
+Tenant quota overrides are commercial exceptions for plan quotas. They never
+delete, deactivate, or mutate tenant resources. They only change the effective
+limit used by quota checks and quota usage reporting.
+
+## When To Use
+
+- A paid tenant is already above a new plan limit during rollout.
+- A commercial agreement grants a higher limit for one resource.
+- Support needs to temporarily disable one quota while a contract is resolved.
+
+Do not change `subscription_plans.features` for one tenant. Global plan quota
+metadata must stay plan-wide.
+
+## Resources
+
+Valid `resource` values are:
+
+- `admin_users`
+- `active_sessions_per_admin_user`
+- `active_kitchens`
+- `active_tables_including_bar`
+- `active_qr_tables`
+- `completed_online_orders_per_month`
+- `electronic_invoices_per_period`
+
+## Grant Or Update A Limit Override
+
+Run this in the target environment after replacing the tenant slug, resource,
+limit, actor, and reason.
+
+```sql
+WITH target AS (
+  SELECT id AS tenant_id
+  FROM tenants
+  WHERE slug = 'tenant-slug'
+), previous AS (
+  SELECT tq.*
+  FROM tenant_quota_overrides tq
+  JOIN target t ON t.tenant_id = tq.tenant_id
+  WHERE tq.resource = 'active_kitchens'
+), upserted AS (
+  INSERT INTO tenant_quota_overrides (
+    tenant_id, resource, limit_override, disabled, reason, created_by, updated_by
+  )
+  SELECT
+    tenant_id,
+    'active_kitchens',
+    4,
+    false,
+    'Commercial exception approved by ops',
+    NULL,
+    NULL
+  FROM target
+  ON CONFLICT (tenant_id, resource) DO UPDATE SET
+    limit_override = EXCLUDED.limit_override,
+    disabled = false,
+    reason = EXCLUDED.reason,
+    updated_by = EXCLUDED.updated_by,
+    updated_at = now()
+  RETURNING *
+)
+INSERT INTO tenant_quota_override_audit (
+  tenant_id, resource, action,
+  previous_limit_override, new_limit_override,
+  previous_disabled, new_disabled,
+  reason, actor_user_id
+)
+SELECT
+  u.tenant_id,
+  u.resource,
+  CASE WHEN p.id IS NULL THEN 'grant' ELSE 'update' END,
+  p.limit_override,
+  u.limit_override,
+  p.disabled,
+  u.disabled,
+  u.reason,
+  u.updated_by
+FROM upserted u
+LEFT JOIN previous p ON p.tenant_id = u.tenant_id AND p.resource = u.resource;
+```
+
+## Disable A Quota For One Tenant
+
+Use `disabled = true` instead of storing `-1`. Application quota coercion treats
+negative numbers as `0`, so unlimited overrides must use the boolean flag.
+
+```sql
+WITH target AS (
+  SELECT id AS tenant_id
+  FROM tenants
+  WHERE slug = 'tenant-slug'
+), previous AS (
+  SELECT tq.*
+  FROM tenant_quota_overrides tq
+  JOIN target t ON t.tenant_id = tq.tenant_id
+  WHERE tq.resource = 'completed_online_orders_per_month'
+), upserted AS (
+  INSERT INTO tenant_quota_overrides (
+    tenant_id, resource, limit_override, disabled, reason, created_by, updated_by
+  )
+  SELECT
+    tenant_id,
+    'completed_online_orders_per_month',
+    NULL,
+    true,
+    'Temporary unlimited online orders during rollout',
+    NULL,
+    NULL
+  FROM target
+  ON CONFLICT (tenant_id, resource) DO UPDATE SET
+    limit_override = NULL,
+    disabled = true,
+    reason = EXCLUDED.reason,
+    updated_by = EXCLUDED.updated_by,
+    updated_at = now()
+  RETURNING *
+)
+INSERT INTO tenant_quota_override_audit (
+  tenant_id, resource, action,
+  previous_limit_override, new_limit_override,
+  previous_disabled, new_disabled,
+  reason, actor_user_id
+)
+SELECT
+  u.tenant_id,
+  u.resource,
+  CASE WHEN p.id IS NULL THEN 'grant' ELSE 'update' END,
+  p.limit_override,
+  u.limit_override,
+  p.disabled,
+  u.disabled,
+  u.reason,
+  u.updated_by
+FROM upserted u
+LEFT JOIN previous p ON p.tenant_id = u.tenant_id AND p.resource = u.resource;
+```
+
+## Remove An Override
+
+Removing the row returns the tenant to the plan quota. Run the rollout report
+first if the tenant may still be above the plan limit.
+
+```sql
+WITH target AS (
+  SELECT id AS tenant_id
+  FROM tenants
+  WHERE slug = 'tenant-slug'
+), removed AS (
+  DELETE FROM tenant_quota_overrides tq
+  USING target t
+  WHERE tq.tenant_id = t.tenant_id
+    AND tq.resource = 'active_kitchens'
+  RETURNING tq.*
+)
+INSERT INTO tenant_quota_override_audit (
+  tenant_id, resource, action,
+  previous_limit_override, new_limit_override,
+  previous_disabled, new_disabled,
+  reason, actor_user_id
+)
+SELECT
+  tenant_id,
+  resource,
+  'remove',
+  limit_override,
+  NULL,
+  disabled,
+  NULL,
+  'Override removed; tenant returns to plan limit',
+  NULL
+FROM removed;
+```
+
+## Rollout Report
+
+Run the read-only report in `sql/20260701_subscription_plan_quotas.sql` before
+enabling or tightening enforcement. The report returns one row per
+tenant/resource with:
+
+- `used`
+- `plan_limit`
+- `effective_limit`
+- `override_state`
+- `over_plan_limit`
+- `over_effective_limit`
+
+Tenants with `over_plan_limit = true` and `over_effective_limit = false` are
+protected by an override. Tenants with `over_effective_limit = true` will be
+blocked from further growth for that resource.
+
+## Observability
+
+Quota blocks are logged by `billing_service` with tenant, resource, usage,
+effective limit, plan limit, plan slug, and override id when present. Use those
+logs for support triage before changing a tenant override.

--- a/sql/20260701_subscription_plan_quotas.sql
+++ b/sql/20260701_subscription_plan_quotas.sql
@@ -38,9 +38,11 @@ SET features = jsonb_set(
     updated_at = now()
 WHERE slug = 'facturacion-electronica';
 
--- Manual PR validation: current tenant usage against proposed limits.
+-- Manual PR validation: current tenant usage against effective limits.
 -- Run read-only in production/staging and include the over-quota summary in
--- the PR. Customer/buyer memberships are intentionally excluded.
+-- the PR. Customer/buyer memberships are intentionally excluded. Tenant
+-- overrides from api-warolabs#578 win over plan quotas and can disable a
+-- selected resource limit.
 /*
 WITH quota_plans AS (
   SELECT id, slug, features->'quotas' AS quotas
@@ -97,19 +99,51 @@ WITH quota_plans AS (
   LEFT JOIN orders o ON o.tenant_id = s.tenant_id
   LEFT JOIN electronic_invoices ei ON ei.tenant_id = s.tenant_id
   GROUP BY s.tenant_id
+), resource_usage AS (
+  SELECT
+    s.tenant_id,
+    s.tenant_slug,
+    s.plan_slug,
+    resource.resource,
+    resource.used,
+    COALESCE((s.quotas->>resource.resource)::int, 0) AS plan_limit
+  FROM active_subs s
+  JOIN usage u ON u.tenant_id = s.tenant_id
+  CROSS JOIN LATERAL (
+    VALUES
+      ('admin_users', u.admin_users),
+      ('active_sessions_per_admin_user', u.active_sessions_per_admin_user),
+      ('active_kitchens', u.active_kitchens),
+      ('active_tables_including_bar', u.active_tables_including_bar),
+      ('active_qr_tables', u.active_qr_tables),
+      ('completed_online_orders_per_month', u.completed_online_orders_per_month),
+      ('electronic_invoices_per_period', u.electronic_invoices_per_period)
+  ) AS resource(resource, used)
 )
 SELECT
-  s.tenant_slug,
-  s.plan_slug,
-  u.*,
-  (u.admin_users > COALESCE((s.quotas->>'admin_users')::int, 0)) AS over_admin_users,
-  (u.active_sessions_per_admin_user > COALESCE((s.quotas->>'active_sessions_per_admin_user')::int, 0)) AS over_active_sessions_per_admin_user,
-  (u.active_kitchens > COALESCE((s.quotas->>'active_kitchens')::int, 0)) AS over_active_kitchens,
-  (u.active_tables_including_bar > COALESCE((s.quotas->>'active_tables_including_bar')::int, 0)) AS over_active_tables,
-  (u.active_qr_tables > COALESCE((s.quotas->>'active_qr_tables')::int, 0)) AS over_active_qr_tables,
-  (u.completed_online_orders_per_month > COALESCE((s.quotas->>'completed_online_orders_per_month')::int, 0)) AS over_online_orders,
-  (u.electronic_invoices_per_period > COALESCE((s.quotas->>'electronic_invoices_per_period')::int, 0)) AS over_electronic_invoices
-FROM active_subs s
-JOIN usage u ON u.tenant_id = s.tenant_id
-ORDER BY s.tenant_slug;
+  ru.tenant_slug,
+  ru.plan_slug,
+  ru.resource,
+  ru.used,
+  ru.plan_limit,
+  CASE
+    WHEN tq.disabled THEN NULL
+    ELSE COALESCE(tq.limit_override, ru.plan_limit)
+  END AS effective_limit,
+  CASE
+    WHEN tq.id IS NULL THEN 'plan'
+    WHEN tq.disabled THEN 'override_disabled_unlimited'
+    ELSE 'override_limit'
+  END AS override_state,
+  tq.reason AS override_reason,
+  (ru.used > ru.plan_limit) AS over_plan_limit,
+  CASE
+    WHEN tq.disabled THEN false
+    ELSE ru.used > COALESCE(tq.limit_override, ru.plan_limit)
+  END AS over_effective_limit
+FROM resource_usage ru
+LEFT JOIN tenant_quota_overrides tq
+  ON tq.tenant_id = ru.tenant_id
+ AND tq.resource = ru.resource
+ORDER BY ru.tenant_slug, ru.resource;
 */

--- a/sql/20260702_tenant_quota_overrides.sql
+++ b/sql/20260702_tenant_quota_overrides.sql
@@ -1,0 +1,65 @@
+-- api-warolabs#578: tenant-level quota overrides.
+-- Non-destructive: these tables only store commercial exceptions and audit
+-- history. They do not modify tenant resources or global plan quota metadata.
+
+CREATE TABLE IF NOT EXISTS tenant_quota_overrides (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    resource TEXT NOT NULL,
+    limit_override INTEGER,
+    disabled BOOLEAN NOT NULL DEFAULT false,
+    reason TEXT,
+    created_by UUID,
+    updated_by UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT tenant_quota_overrides_resource_check
+        CHECK (resource = ANY (ARRAY[
+            'admin_users'::text,
+            'active_sessions_per_admin_user'::text,
+            'active_kitchens'::text,
+            'active_tables_including_bar'::text,
+            'active_qr_tables'::text,
+            'completed_online_orders_per_month'::text,
+            'electronic_invoices_per_period'::text
+        ])),
+    CONSTRAINT tenant_quota_overrides_limit_check
+        CHECK (
+            (disabled = true AND limit_override IS NULL)
+            OR (disabled = false AND limit_override IS NOT NULL AND limit_override >= 0)
+        )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_tenant_quota_overrides_tenant_resource
+    ON tenant_quota_overrides (tenant_id, resource);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_quota_overrides_tenant
+    ON tenant_quota_overrides (tenant_id);
+
+COMMENT ON TABLE tenant_quota_overrides IS
+    'Tenant-specific effective quota overrides. disabled=true means unlimited for that resource.';
+
+CREATE TABLE IF NOT EXISTS tenant_quota_override_audit (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    resource TEXT NOT NULL,
+    action TEXT NOT NULL,
+    previous_limit_override INTEGER,
+    new_limit_override INTEGER,
+    previous_disabled BOOLEAN,
+    new_disabled BOOLEAN,
+    reason TEXT,
+    actor_user_id UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT tenant_quota_override_audit_action_check
+        CHECK (action = ANY (ARRAY['grant'::text, 'update'::text, 'remove'::text]))
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_quota_override_audit_tenant_created
+    ON tenant_quota_override_audit (tenant_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_quota_override_audit_tenant_resource
+    ON tenant_quota_override_audit (tenant_id, resource, created_at DESC);
+
+COMMENT ON TABLE tenant_quota_override_audit IS
+    'Append-only audit trail for tenant quota override grant/update/remove operations.';

--- a/tests/test_billing_plan_quotas.py
+++ b/tests/test_billing_plan_quotas.py
@@ -106,6 +106,7 @@ async def test_remaining_usage_exposes_quota_usage_and_internal_roles_only():
         ]
     )
     conn.fetchval = AsyncMock(return_value=12)
+    conn.fetch = AsyncMock(return_value=[])
 
     usage = await billing_service.get_remaining_billing_usage(conn, tenant_id)
 
@@ -123,3 +124,106 @@ async def test_remaining_usage_exposes_quota_usage_and_internal_roles_only():
     quota_query_args = conn.fetchrow.await_args_list[1].args
     assert quota_query_args[4] == list(LEGACY_INTERNAL_TEAM_ROLES)
     assert "customer" not in quota_query_args[4]
+
+
+@pytest.mark.asyncio
+async def test_remaining_usage_exposes_effective_quota_override_state():
+    tenant_id = uuid4()
+    override_id = uuid4()
+    period_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    period_end = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {
+                "current_period_start": period_start,
+                "current_period_end": period_end,
+                "plan_slug": "pro",
+                "plan_features": {"quotas": {"active_kitchens": 2}},
+                "plan_scan_limit": 500,
+                "scans_used": 0,
+                "scans_limit": 500,
+            },
+            {
+                "admin_users": 4,
+                "active_sessions_per_admin_user": 1,
+                "active_kitchens": 3,
+                "active_tables_including_bar": 7,
+                "active_qr_tables": 6,
+                "completed_online_orders_per_month": 28,
+            },
+        ]
+    )
+    conn.fetchval = AsyncMock(return_value=0)
+    conn.fetch = AsyncMock(return_value=[{
+        "id": override_id,
+        "resource": "active_kitchens",
+        "limit_override": 4,
+        "disabled": False,
+        "reason": "Commercial exception",
+    }])
+
+    usage = await billing_service.get_remaining_billing_usage(conn, tenant_id)
+
+    assert usage["quota_usage"]["active_kitchens"] == {
+        "used": 3,
+        "limit": 4,
+        "remaining": 1,
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+        "plan_limit": 2,
+        "override": {
+            "id": str(override_id),
+            "disabled": False,
+            "reason": "Commercial exception",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_remaining_usage_exposes_disabled_override_as_unlimited():
+    tenant_id = uuid4()
+    override_id = uuid4()
+    period_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    period_end = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {
+                "current_period_start": period_start,
+                "current_period_end": period_end,
+                "plan_slug": "pro",
+                "plan_features": {"quotas": {"completed_online_orders_per_month": 300}},
+                "plan_scan_limit": 500,
+                "scans_used": 0,
+                "scans_limit": 500,
+            },
+            {
+                "admin_users": 4,
+                "active_sessions_per_admin_user": 1,
+                "active_kitchens": 2,
+                "active_tables_including_bar": 7,
+                "active_qr_tables": 6,
+                "completed_online_orders_per_month": 301,
+            },
+        ]
+    )
+    conn.fetchval = AsyncMock(return_value=0)
+    conn.fetch = AsyncMock(return_value=[{
+        "id": override_id,
+        "resource": "completed_online_orders_per_month",
+        "limit_override": None,
+        "disabled": True,
+        "reason": "Pilot",
+    }])
+
+    usage = await billing_service.get_remaining_billing_usage(conn, tenant_id)
+
+    assert usage["quota_usage"]["completed_online_orders_per_month"]["limit"] is None
+    assert usage["quota_usage"]["completed_online_orders_per_month"]["remaining"] is None
+    assert usage["quota_usage"]["completed_online_orders_per_month"]["plan_limit"] == 300
+    assert usage["quota_usage"]["completed_online_orders_per_month"]["override"] == {
+        "id": str(override_id),
+        "disabled": True,
+        "reason": "Pilot",
+    }

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -71,8 +71,76 @@ async def test_check_plan_quota_growth_blocks_at_limit_with_stable_payload():
     assert exc.value.details["resource"] == "active_kitchens"
     assert exc.value.details["used"] == 2
     assert exc.value.details["limit"] == 2
+    assert exc.value.details["plan_limit"] == 2
+    assert exc.value.details["override"] is None
     assert exc.value.details["plan_slug"] == "pro"
     assert exc.value.details["upgrade_url"] == "/billing/planes"
+
+
+@pytest.mark.asyncio
+async def test_check_plan_quota_growth_uses_tenant_override_precedence():
+    tenant_id = uuid4()
+    override_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "plan_slug": "pro",
+        "plan_features": {"quotas": {"active_kitchens": 2}},
+        "override_id": override_id,
+        "limit_override": 3,
+        "override_disabled": False,
+        "override_reason": "Commercial exception",
+    })
+    conn.fetchval = AsyncMock(return_value=2)
+
+    await billing_service.check_plan_quota_growth(conn, tenant_id, "active_kitchens")
+
+    conn.fetchval.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_check_plan_quota_growth_blocks_at_override_limit_with_metadata():
+    tenant_id = uuid4()
+    override_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "plan_slug": "pro",
+        "plan_features": {"quotas": {"active_kitchens": 2}},
+        "override_id": override_id,
+        "limit_override": 3,
+        "override_disabled": False,
+        "override_reason": "Commercial exception",
+    })
+    conn.fetchval = AsyncMock(return_value=3)
+
+    with pytest.raises(APIError) as exc:
+        await billing_service.check_plan_quota_growth(conn, tenant_id, "active_kitchens")
+
+    assert exc.value.details["limit"] == 3
+    assert exc.value.details["plan_limit"] == 2
+    assert exc.value.details["override"] == {
+        "id": str(override_id),
+        "disabled": False,
+        "reason": "Commercial exception",
+    }
+
+
+@pytest.mark.asyncio
+async def test_check_plan_quota_growth_disabled_override_is_unlimited():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "plan_slug": "pro",
+        "plan_features": {"quotas": {"active_kitchens": 2}},
+        "override_id": uuid4(),
+        "limit_override": None,
+        "override_disabled": True,
+        "override_reason": "Unlimited pilot",
+    })
+    conn.fetchval = AsyncMock()
+
+    await billing_service.check_plan_quota_growth(conn, tenant_id, "active_kitchens")
+
+    conn.fetchval.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -285,11 +353,36 @@ async def test_completed_online_order_quota_blocks_at_limit_with_stable_payload(
     assert exc.value.details["resource"] == "completed_online_orders_per_month"
     assert exc.value.details["used"] == 300
     assert exc.value.details["limit"] == 300
+    assert exc.value.details["plan_limit"] == 300
+    assert exc.value.details["override"] is None
     assert exc.value.details["plan_slug"] == "pro"
     assert exc.value.details["period_start"] == period_start.isoformat()
     assert exc.value.details["period_end"] == period_end.isoformat()
     assert exc.value.details["tenant_message"]
     assert exc.value.details["customer_message"]
+
+
+@pytest.mark.asyncio
+async def test_completed_online_order_disabled_override_skips_count():
+    tenant_id = uuid4()
+    period_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    period_end = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "plan_slug": "pro",
+        "plan_features": {"quotas": {"completed_online_orders_per_month": 300}},
+        "current_period_start": period_start,
+        "current_period_end": period_end,
+        "override_id": uuid4(),
+        "limit_override": None,
+        "override_disabled": True,
+        "override_reason": "Launch exception",
+    })
+    conn.fetchval = AsyncMock()
+
+    await billing_service.check_completed_online_order_quota(conn, tenant_id)
+
+    conn.fetchval.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add tenant quota override storage and audit SQL
- apply effective override limits to quota enforcement and remaining usage
- update rollout report, docs, and focused quota tests

## Tests
- pytest tests/test_quota_enforcement.py tests/test_billing_plan_quotas.py
- python3 -m compileall app/services/billing_service.py

Closes #578