### PR TITLE
Fix online checkout and table QR confirmation flow

### DIFF
--- a/app/services/online_cart_service.py
+++ b/app/services/online_cart_service.py
@@ -628,12 +628,52 @@ async def checkout_cart(
                 if not cart:
                     raise HTTPException(status_code=404, detail="Carrito no encontrado")
 
+                if cart['status'] == 'checked_out':
+                    existing_order = await conn.fetchrow(
+                        """
+                        SELECT
+                            o.id,
+                            o.order_number,
+                            o.total_amount,
+                            o.tip_amount,
+                            o.tip_source,
+                            oc.order_type,
+                            oc.pickup_pin,
+                            tpp.estimated_preparation_time
+                        FROM orders o
+                        JOIN online_carts oc ON oc.id = o.online_cart_id
+                        LEFT JOIN tenant_public_profiles tpp ON tpp.tenant_id = o.tenant_id
+                        WHERE o.online_cart_id = $1
+                          AND o.tenant_id = $2
+                        ORDER BY o.created_at DESC
+                        LIMIT 1
+                        """,
+                        cart_id,
+                        cart['tenant_id'],
+                    )
+                    if existing_order:
+                        total_amount = float(existing_order['total_amount'] or 0)
+                        tip_amount_existing = float(existing_order['tip_amount'] or 0)
+                        return {
+                            "success": True,
+                            "data": {
+                                "order_id": str(existing_order['id']),
+                                "order_number": int(existing_order['order_number']),
+                                "total_amount": total_amount,
+                                "tip_amount": tip_amount_existing,
+                                "tip_source": existing_order['tip_source'] or 'none',
+                                "charged_amount": total_amount + tip_amount_existing,
+                                "order_type": existing_order['order_type'],
+                                "pickup_pin": existing_order['pickup_pin'],
+                                "estimated_preparation_time": existing_order['estimated_preparation_time'],
+                            },
+                        }
+
+                    raise HTTPException(status_code=409, detail="Este carrito ya fue procesado, pero no se encontró el pedido asociado.")
+
                 # 2. Validate state
                 if not cart['is_verified']:
                     raise HTTPException(status_code=400, detail="El carrito no ha sido verificado. Completa el proceso de verificación por OTP.")
-
-                if cart['status'] == 'checked_out':
-                    raise HTTPException(status_code=409, detail="Este carrito ya fue procesado. El pedido ya existe.")
 
                 if cart['status'] != 'active':
                     raise HTTPException(status_code=400, detail=f"El carrito no está activo (estado: {cart['status']})")
@@ -650,7 +690,7 @@ async def checkout_cart(
                 # 4. Validate online ordering gate, open status and minimum order amount from tenant profile
                 # warocol.com#637 — also read tip_enabled here to gate the optional tip fields
                 tenant_profile_query = """
-                    SELECT min_order_amount, estimated_preparation_time, is_manually_open, business_hours,
+                    SELECT min_order_amount, estimated_preparation_time, is_manually_open, business_hours, timezone,
                            accepts_online_orders, tip_enabled
                     FROM tenant_public_profiles
                     WHERE tenant_id = $1
@@ -671,7 +711,7 @@ async def checkout_cart(
                     bh = profile['business_hours']
                     if isinstance(bh, str):
                         bh = _json.loads(bh)
-                    if not is_currently_open(bh, profile['is_manually_open']):
+                    if not is_currently_open(bh, profile['is_manually_open'], profile['timezone']):
                         raise HTTPException(
                             status_code=409,
                             detail="El restaurante está cerrado en este momento. No se pueden procesar pedidos."
@@ -932,7 +972,7 @@ async def checkout_cart(
                     delivery_instructions=cart.get('delivery_instructions'),
                     pickup_pin=cart.get('pickup_pin'),
                     order_id=str(order_id),
-                    tenant_id=str(tenant_id),
+                    tenant_id=str(cart['tenant_id']),
                 )
             except Exception as email_err:
                 logger.error(f"Failed to send order confirmation email for order #{order_number}: {email_err}")

--- a/app/services/public_table_qr_service.py
+++ b/app/services/public_table_qr_service.py
@@ -35,6 +35,7 @@ _CONTEXT_SQL = """
         tpp.display_name,
         tpp.table_qr_module_enabled,
         tpp.is_active AS profile_active,
+        tpp.timezone,
         tpp.business_hours,
         tpp.is_manually_open
     FROM tables t
@@ -85,7 +86,11 @@ async def resolve_table_qr_context(token: str) -> Optional[Dict[str, Any]]:
         return None
 
     business_hours = _parse_business_hours(row["business_hours"])
-    is_open = is_currently_open(business_hours, bool(row["is_manually_open"]))
+    is_open = is_currently_open(
+        business_hours,
+        bool(row["is_manually_open"]),
+        row["timezone"],
+    )
     if not _is_context_active(row, is_open):
         return None
 
@@ -158,7 +163,7 @@ async def _find_matching_pending_request(
           AND payment_method IS NOT DISTINCT FROM $4
           AND payment_method_id IS NOT DISTINCT FROM $5
           AND customer_notes IS NOT DISTINCT FROM $6
-          AND created_at >= now() - ($7::text || ' minutes')::interval
+          AND created_at >= now() - ($7::int * interval '1 minute')
         ORDER BY created_at DESC
         LIMIT 1
         """,

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from fastapi import HTTPException
 
 from app.core.exceptions import APIError
 from app.services import billing_service, invitation_service, online_cart_service, stations_service, tables_service
@@ -433,6 +434,7 @@ async def test_checkout_online_order_quota_block_happens_before_cart_lock_and_or
                 "estimated_preparation_time": 20,
                 "is_manually_open": True,
                 "business_hours": {},
+                "timezone": "America/Bogota",
                 "accepts_online_orders": True,
                 "tip_enabled": False,
             }
@@ -463,3 +465,102 @@ async def test_checkout_online_order_quota_block_happens_before_cart_lock_and_or
     seen_queries = [call.args[0] for call in conn.fetchrow.await_args_list]
     assert not any("UPDATE online_carts SET status = 'checked_out'" in query for query in seen_queries)
     assert not any("INSERT INTO orders" in query for query in seen_queries)
+
+
+def test_checkout_open_status_uses_tenant_timezone():
+    import inspect
+
+    source = inspect.getsource(online_cart_service.checkout_cart)
+    assert "business_hours, timezone" in source
+    assert "is_currently_open(bh, profile['is_manually_open'], profile['timezone'])" in source
+
+
+@pytest.mark.asyncio
+async def test_checkout_checked_out_cart_returns_existing_order_payload():
+    tenant_id = uuid4()
+    cart_id = uuid4()
+    customer_id = uuid4()
+    order_id = uuid4()
+    conn = MagicMock()
+    conn.transaction.return_value = _tx()
+
+    async def fetchrow(query, *args):
+        if "FROM online_carts" in query and "WHERE id = $1" in query:
+            return {
+                "id": cart_id,
+                "tenant_id": tenant_id,
+                "customer_id": customer_id,
+                "order_type": "delivery",
+                "delivery_address_id": uuid4(),
+                "pickup_pin": None,
+                "is_verified": True,
+                "status": "checked_out",
+                "total_amount": Decimal("50000"),
+                "verified_email": "cliente@example.com",
+                "scheduled_time": None,
+                "delivery_instructions": None,
+            }
+        if "FROM orders o" in query and "o.online_cart_id = $1" in query:
+            return {
+                "id": order_id,
+                "order_number": 12345,
+                "total_amount": Decimal("50000"),
+                "tip_amount": Decimal("3000"),
+                "tip_source": "preset",
+                "order_type": "delivery",
+                "pickup_pin": None,
+                "estimated_preparation_time": 35,
+            }
+        return None
+
+    conn.fetchrow = AsyncMock(side_effect=fetchrow)
+
+    with (
+        patch("app.services.online_cart_service.get_db_connection", side_effect=_db_context(conn)),
+        patch("app.services.online_cart_service.get_cart_items", new=AsyncMock()) as get_cart_items,
+        patch("app.services.online_cart_service.check_completed_online_order_quota", new=AsyncMock()) as quota_check,
+    ):
+        result = await online_cart_service.checkout_cart(cart_id)
+
+    assert result["success"] is True
+    assert result["data"]["order_id"] == str(order_id)
+    assert result["data"]["order_number"] == 12345
+    assert result["data"]["charged_amount"] == 53000.0
+    get_cart_items.assert_not_awaited()
+    quota_check.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_checkout_checked_out_cart_without_order_stays_conflict():
+    tenant_id = uuid4()
+    cart_id = uuid4()
+    conn = MagicMock()
+    conn.transaction.return_value = _tx()
+
+    async def fetchrow(query, *args):
+        if "FROM online_carts" in query and "WHERE id = $1" in query:
+            return {
+                "id": cart_id,
+                "tenant_id": tenant_id,
+                "customer_id": uuid4(),
+                "order_type": "delivery",
+                "delivery_address_id": uuid4(),
+                "pickup_pin": None,
+                "is_verified": True,
+                "status": "checked_out",
+                "total_amount": Decimal("50000"),
+                "verified_email": "cliente@example.com",
+                "scheduled_time": None,
+                "delivery_instructions": None,
+            }
+        if "FROM orders o" in query and "o.online_cart_id = $1" in query:
+            return None
+        return None
+
+    conn.fetchrow = AsyncMock(side_effect=fetchrow)
+
+    with patch("app.services.online_cart_service.get_db_connection", side_effect=_db_context(conn)):
+        with pytest.raises(HTTPException) as exc:
+            await online_cart_service.checkout_cart(cart_id)
+
+    assert exc.value.status_code == 409

--- a/tests/test_table_qr_tokens.py
+++ b/tests/test_table_qr_tokens.py
@@ -37,6 +37,7 @@ async def test_resolve_table_qr_token_active():
         "display_name": "Café Demo",
         "table_qr_module_enabled": True,
         "profile_active": True,
+        "timezone": "America/Bogota",
     }
     conn = MagicMock()
     conn.fetchrow = AsyncMock(return_value=row)
@@ -45,12 +46,13 @@ async def test_resolve_table_qr_token_active():
     row["is_manually_open"] = True
 
     with patch("app.services.public_table_qr_service.get_db_connection") as mock_get_conn, \
-         patch("app.services.public_table_qr_service.is_currently_open", return_value=True):
+         patch("app.services.public_table_qr_service.is_currently_open", return_value=True) as is_open:
         mock_get_conn.return_value.__aenter__ = AsyncMock(return_value=conn)
         mock_get_conn.return_value.__aexit__ = AsyncMock(return_value=False)
         result = await public_table_qr_service.resolve_table_qr_token("tok-abc")
         assert result["tenant_slug"] == "cafe-demo"
         assert result["table_name"] == "Mesa 1"
+        is_open.assert_called_once_with(None, True, "America/Bogota")
 
 
 @pytest.mark.asyncio
@@ -63,6 +65,7 @@ async def test_resolve_table_qr_token_disabled_module_returns_none():
         "display_name": "Café Demo",
         "table_qr_module_enabled": False,
         "profile_active": True,
+        "timezone": "America/Bogota",
     }
     conn = MagicMock()
     conn.fetchrow = AsyncMock(return_value=row)
@@ -75,6 +78,14 @@ async def test_resolve_table_qr_token_disabled_module_returns_none():
         mock_get_conn.return_value.__aenter__ = AsyncMock(return_value=conn)
         mock_get_conn.return_value.__aexit__ = AsyncMock(return_value=False)
         assert await public_table_qr_service.resolve_table_qr_token("tok-abc") is None
+
+
+def test_table_qr_duplicate_window_uses_integer_interval():
+    import inspect
+
+    source = inspect.getsource(public_table_qr_service._find_matching_pending_request)
+    assert "$7::int * interval '1 minute'" in source
+    assert "$7::text" not in source
 
 
 def test_public_resolve_endpoint_404_when_inactive():


### PR DESCRIPTION
## Summary
- use tenant timezone when validating online checkout and table QR opening hours
- return existing order payload for already checked-out carts
- fix table QR duplicate window interval binding
- fix tenant id used by post-checkout confirmation email

## Validation
- venv/bin/python -m pytest tests/test_quota_enforcement.py tests/test_table_qr_tokens.py -q