### PR TITLE
Expose public online order quota availability

### DIFF
--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -83,6 +83,15 @@ class EffectiveQuota:
         return self.override_id is not None
 
 
+@dataclass(frozen=True)
+class OnlineOrderQuotaState:
+    plan_slug: str
+    quota: EffectiveQuota
+    period_start: datetime
+    period_end: datetime
+    used: int
+
+
 async def check_scan_quota(tenant_id: UUID, conn) -> None:
     """
     Atomic scan quota check and increment.
@@ -224,12 +233,12 @@ async def check_plan_quota_growth(conn, tenant_id: UUID, resource: str) -> None:
     )
 
 
-async def check_completed_online_order_quota(conn, tenant_id: UUID) -> None:
+async def _get_completed_online_order_quota_state(conn, tenant_id: UUID) -> Optional[OnlineOrderQuotaState]:
     """
-    Block final public checkout once the tenant reaches its online-order quota.
+    Read current online-order quota state.
 
-    Unlike active-resource quotas, this is period-based: the usage window comes
-    from the current subscription period and counts only completed online orders.
+    Returns None when no finite active quota applies, matching checkout's
+    fail-open behavior for tenants without an active paid period.
     """
     plan = await conn.fetchrow(
         """
@@ -257,7 +266,7 @@ async def check_completed_online_order_quota(conn, tenant_id: UUID) -> None:
         ONLINE_ORDER_QUOTA_RESOURCE,
     )
     if not plan:
-        return
+        return None
 
     quotas = _normalize_plan_quotas(plan["plan_slug"], plan["plan_features"])
     quota = _effective_quota_from_row(
@@ -266,7 +275,7 @@ async def check_completed_online_order_quota(conn, tenant_id: UUID) -> None:
         plan,
     )
     if quota.limit is None or quota.limit <= 0:
-        return
+        return None
 
     period_start = plan["current_period_start"]
     period_end = plan["current_period_end"]
@@ -285,24 +294,66 @@ async def check_completed_online_order_quota(conn, tenant_id: UUID) -> None:
         period_end,
     ) or 0)
 
-    _log_online_order_quota_usage(
-        tenant_id=tenant_id,
+    return OnlineOrderQuotaState(
         plan_slug=plan["plan_slug"],
-        used=used,
-        limit=quota.limit,
+        quota=quota,
         period_start=period_start,
         period_end=period_end,
+        used=used,
     )
 
-    if used < quota.limit:
+
+async def get_public_online_order_quota_availability(conn, tenant_id: UUID) -> Dict[str, Any]:
+    """
+    Public-safe availability for online-order quota.
+
+    This intentionally returns only a boolean, reason, and customer copy. It
+    does not expose usage, plan, period, or override metadata.
+    """
+    state = await _get_completed_online_order_quota_state(conn, tenant_id)
+    if state is None or state.used < state.quota.limit:
+        return {
+            "available": True,
+            "reason": None,
+            "message": None,
+        }
+
+    return {
+        "available": False,
+        "reason": "online_order_quota_exceeded",
+        "message": ONLINE_ORDER_QUOTA_CUSTOMER_MESSAGE,
+    }
+
+
+async def check_completed_online_order_quota(conn, tenant_id: UUID) -> None:
+    """
+    Block final public checkout once the tenant reaches its online-order quota.
+
+    Unlike active-resource quotas, this is period-based: the usage window comes
+    from the current subscription period and counts only completed online orders.
+    """
+    state = await _get_completed_online_order_quota_state(conn, tenant_id)
+    if state is None:
+        return
+
+    _log_online_order_quota_usage(
+        tenant_id=tenant_id,
+        plan_slug=state.plan_slug,
+        used=state.used,
+        limit=state.quota.limit,
+        period_start=state.period_start,
+        period_end=state.period_end,
+    )
+
+    if state.used < state.quota.limit:
         return
 
     _log_quota_block(
         tenant_id=tenant_id,
         resource=ONLINE_ORDER_QUOTA_RESOURCE,
-        used=used,
-        quota=quota,
-        plan_slug=plan["plan_slug"],
+        used=state.used,
+        quota=state.quota,
+        plan_slug=state.plan_slug,
     )
     raise APIError(
         "Límite mensual de pedidos en línea alcanzado",
@@ -311,13 +362,13 @@ async def check_completed_online_order_quota(conn, tenant_id: UUID) -> None:
             "code": "online_order_quota_exceeded",
             "error": "online_order_quota_exceeded",
             "resource": ONLINE_ORDER_QUOTA_RESOURCE,
-            "used": used,
-            "limit": quota.limit,
-            "plan_limit": quota.plan_limit,
-            "plan_slug": plan["plan_slug"],
-            "override": _quota_override_payload(quota),
-            "period_start": period_start.isoformat(),
-            "period_end": period_end.isoformat(),
+            "used": state.used,
+            "limit": state.quota.limit,
+            "plan_limit": state.quota.plan_limit,
+            "plan_slug": state.plan_slug,
+            "override": _quota_override_payload(state.quota),
+            "period_start": state.period_start.isoformat(),
+            "period_end": state.period_end.isoformat(),
             "upgrade_url": QUOTA_UPGRADE_URL,
             "tenant_message": QUOTA_CONTACT_MESSAGE,
             "customer_message": ONLINE_ORDER_QUOTA_CUSTOMER_MESSAGE,

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -163,7 +163,13 @@ async def check_scan_quota(tenant_id: UUID, conn) -> None:
     await _upsert_monthly_log(tenant_id, conn)
 
 
-async def check_plan_quota_growth(conn, tenant_id: UUID, resource: str) -> None:
+async def check_plan_quota_growth(
+    conn,
+    tenant_id: UUID,
+    resource: str,
+    *,
+    exclude_pending_invitation_id: Optional[UUID] = None,
+) -> None:
     """
     Block active resource growth once the tenant reaches the plan quota.
 
@@ -204,7 +210,12 @@ async def check_plan_quota_growth(conn, tenant_id: UUID, resource: str) -> None:
     if quota.limit is None:
         return
 
-    used = await _count_quota_resource_usage(conn, tenant_id, resource)
+    used = await _count_quota_resource_usage(
+        conn,
+        tenant_id,
+        resource,
+        exclude_pending_invitation_id=exclude_pending_invitation_id,
+    )
     if used < quota.limit:
         return
 
@@ -515,18 +526,37 @@ def _apply_effective_quotas(
     return effective
 
 
-async def _count_quota_resource_usage(conn, tenant_id: UUID, resource: str) -> int:
+async def _count_quota_resource_usage(
+    conn,
+    tenant_id: UUID,
+    resource: str,
+    *,
+    exclude_pending_invitation_id: Optional[UUID] = None,
+) -> int:
     if resource == "admin_users":
         value = await conn.fetchval(
             """
-            SELECT COUNT(DISTINCT tm.id)
-            FROM tenant_members tm
-            WHERE tm.tenant_id = $1
-              AND tm.is_active
-              AND tm.role = ANY($2::text[])
+            SELECT
+                (
+                    SELECT COUNT(DISTINCT tm.id)
+                    FROM tenant_members tm
+                    WHERE tm.tenant_id = $1
+                      AND tm.is_active
+                      AND tm.role = ANY($2::text[])
+                )
+                +
+                (
+                    SELECT COUNT(DISTINCT ti.id)
+                    FROM tenant_invitations ti
+                    WHERE ti.tenant_id = $1
+                      AND ti.status = 'pending'
+                      AND ti.role = ANY($2::text[])
+                      AND NOT ($3::uuid IS NOT NULL AND ti.id = $3)
+                )
             """,
             tenant_id,
             list(LEGACY_INTERNAL_TEAM_ROLES),
+            exclude_pending_invitation_id,
         )
     elif resource == "active_kitchens":
         value = await conn.fetchval(
@@ -1206,11 +1236,22 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
     quota_counts = await conn.fetchrow("""
         SELECT
             (
-                SELECT COUNT(DISTINCT tm.id)
-                FROM tenant_members tm
-                WHERE tm.tenant_id = $1
-                  AND tm.is_active
-                  AND tm.role = ANY($4::text[])
+                SELECT
+                    (
+                        SELECT COUNT(DISTINCT tm.id)
+                        FROM tenant_members tm
+                        WHERE tm.tenant_id = $1
+                          AND tm.is_active
+                          AND tm.role = ANY($4::text[])
+                    )
+                    +
+                    (
+                        SELECT COUNT(DISTINCT ti.id)
+                        FROM tenant_invitations ti
+                        WHERE ti.tenant_id = $1
+                          AND ti.status = 'pending'
+                          AND ti.role = ANY($4::text[])
+                    )
             ) AS admin_users,
             (
                 SELECT COALESCE(MAX(active_session_count), 0)

--- a/app/services/invitation_service.py
+++ b/app/services/invitation_service.py
@@ -83,6 +83,8 @@ async def send_invitation(request: Request, payload: SendInvitationRequest) -> S
             if user_role not in ('admin', 'superuser'):
                 raise AuthorizationError("Only admin or superuser can send invitations")
 
+            quota_checked = False
+
             # Check if email already exists in profile
             existing_user = await conn.fetchrow(
                 "SELECT id, email FROM profile WHERE lower(trim(email)) = $1",
@@ -109,6 +111,9 @@ async def send_invitation(request: Request, payload: SendInvitationRequest) -> S
                 user_id = existing_user['id']
                 logger.info(f"✅ Existing user found: {user_id}")
             else:
+                await check_plan_quota_growth(conn, session_tenant_id, "admin_users")
+                quota_checked = True
+
                 # Create new profile
                 create_profile_query = """
                     INSERT INTO profile (
@@ -139,6 +144,9 @@ async def send_invitation(request: Request, payload: SendInvitationRequest) -> S
                     existing_invitation
                 )
                 logger.info(f"🔄 Cancelled old pending invitation: {existing_invitation}")
+
+            if not quota_checked:
+                await check_plan_quota_growth(conn, session_tenant_id, "admin_users")
 
             # Generate secure token
             token = secrets.token_hex(32)
@@ -280,7 +288,12 @@ async def accept_invitation(request: Request, response: Response, token: str) ->
             )
 
             if not team_member:
-                await check_plan_quota_growth(conn, invitation['tenant_id'], "admin_users")
+                await check_plan_quota_growth(
+                    conn,
+                    invitation['tenant_id'],
+                    "admin_users",
+                    exclude_pending_invitation_id=invitation['id'],
+                )
                 await conn.execute(
                     """INSERT INTO tenant_members (id, user_id, tenant_id, role)
                        VALUES (gen_random_uuid(), $1, $2, $3)""",
@@ -291,7 +304,12 @@ async def accept_invitation(request: Request, response: Response, token: str) ->
                 logger.info(f"👥 User added to tenant_members with role: {invitation['role']}")
             else:
                 if not team_member["is_active"]:
-                    await check_plan_quota_growth(conn, invitation['tenant_id'], "admin_users")
+                    await check_plan_quota_growth(
+                        conn,
+                        invitation['tenant_id'],
+                        "admin_users",
+                        exclude_pending_invitation_id=invitation['id'],
+                    )
                 await conn.execute(
                     """
                     UPDATE tenant_members

--- a/app/services/public_restaurant_service.py
+++ b/app/services/public_restaurant_service.py
@@ -6,6 +6,10 @@ from typing import Optional, Dict, Any, List
 from uuid import UUID
 from datetime import datetime, time
 from fastapi import HTTPException
+from app.services.billing_service import (
+    ONLINE_ORDER_QUOTA_CUSTOMER_MESSAGE,
+    get_public_online_order_quota_availability,
+)
 from app.core.timezones import get_zoneinfo, normalize_timezone
 from app.database import get_db_connection
 import json
@@ -91,6 +95,7 @@ async def get_profile_by_slug(slug: str) -> Optional[Dict[str, Any]]:
                 profile.get('is_manually_open', True),
                 profile.get('timezone'),
             )
+            profile.update(await _public_online_order_availability(conn, profile))
 
             return profile
 
@@ -242,12 +247,36 @@ async def get_profile_by_tenant_id(tenant_id: UUID) -> Optional[Dict[str, Any]]:
                 profile.get('is_manually_open', True),
                 profile.get('timezone'),
             )
+            profile.update(await _public_online_order_availability(conn, profile))
 
             return profile
 
     except Exception as e:
         logger.error(f"Error getting profile by tenant_id '{tenant_id}': {e}")
         raise HTTPException(status_code=500, detail="Error fetching restaurant profile")
+
+
+async def _public_online_order_availability(conn, profile: Dict[str, Any]) -> Dict[str, Any]:
+    if not profile.get('accepts_online_orders'):
+        return {
+            "online_orders_available": False,
+            "online_orders_unavailable_reason": "online_orders_disabled",
+            "online_orders_unavailable_message": "Este restaurante no recibe pedidos en línea actualmente.",
+        }
+
+    quota = await get_public_online_order_quota_availability(conn, profile['tenant_id'])
+    if not quota["available"]:
+        return {
+            "online_orders_available": False,
+            "online_orders_unavailable_reason": quota["reason"],
+            "online_orders_unavailable_message": quota["message"] or ONLINE_ORDER_QUOTA_CUSTOMER_MESSAGE,
+        }
+
+    return {
+        "online_orders_available": True,
+        "online_orders_unavailable_reason": None,
+        "online_orders_unavailable_message": None,
+    }
 
 
 async def get_menu_by_tenant_id(

--- a/app/services/public_restaurant_service.py
+++ b/app/services/public_restaurant_service.py
@@ -675,6 +675,7 @@ async def list_restaurants(
                     tpp.city, tpp.city_slug, tpp.country, tpp.neighborhood,
                     tpp.timezone,
                     tpp.is_manually_open, tpp.business_hours,
+                    tpp.accepts_online_orders,
                     tpp.created_at, tpp.updated_at
                 FROM tenant_public_profiles tpp
                 JOIN tenant_subscriptions ts ON ts.tenant_id = tpp.tenant_id
@@ -712,7 +713,7 @@ async def list_restaurants(
 
                 timezone_name = normalize_timezone(row["timezone"])
 
-                restaurants.append({
+                restaurant = {
                     "id": str(row["id"]),
                     "tenant_id": str(row["tenant_id"]),
                     "slug": row["slug"],
@@ -729,6 +730,7 @@ async def list_restaurants(
                     "city_slug": row["city_slug"],
                     "neighborhood": row["neighborhood"],
                     "timezone": timezone_name,
+                    "accepts_online_orders": bool(row["accepts_online_orders"]),
                     "is_currently_open": is_currently_open(
                         business_hours,
                         row["is_manually_open"],
@@ -736,7 +738,9 @@ async def list_restaurants(
                     ),
                     "created_at": row["created_at"].isoformat() if row["created_at"] else None,
                     "updated_at": row["updated_at"].isoformat() if row["updated_at"] else None
-                })
+                }
+                restaurant.update(await _public_online_order_availability(conn, restaurant))
+                restaurants.append(restaurant)
 
             return restaurants
 

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -9,7 +9,7 @@ import pytest
 from fastapi import HTTPException
 
 from app.core.exceptions import APIError
-from app.services import billing_service, invitation_service, online_cart_service, stations_service, tables_service
+from app.services import billing_service, invitation_service, online_cart_service, public_restaurant_service, stations_service, tables_service
 
 
 def _db_context(conn):
@@ -395,6 +395,96 @@ async def test_completed_online_order_quota_without_active_subscription_is_noop(
     await billing_service.check_completed_online_order_quota(conn, uuid4())
 
     conn.fetchval.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_public_online_order_quota_availability_hides_internal_payload_when_exhausted():
+    tenant_id = uuid4()
+    period_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    period_end = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "plan_slug": "pro",
+        "plan_features": {"quotas": {"completed_online_orders_per_month": 300}},
+        "current_period_start": period_start,
+        "current_period_end": period_end,
+    })
+    conn.fetchval = AsyncMock(return_value=300)
+
+    result = await billing_service.get_public_online_order_quota_availability(conn, tenant_id)
+
+    assert result == {
+        "available": False,
+        "reason": "online_order_quota_exceeded",
+        "message": billing_service.ONLINE_ORDER_QUOTA_CUSTOMER_MESSAGE,
+    }
+    assert "used" not in result
+    assert "limit" not in result
+    assert "plan_slug" not in result
+    assert "override" not in result
+
+
+@pytest.mark.asyncio
+async def test_public_profile_exposes_safe_online_order_unavailable_signal_for_quota():
+    tenant_id = uuid4()
+    period_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    period_end = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        {
+            "id": uuid4(),
+            "tenant_id": tenant_id,
+            "slug": "restaurante",
+            "is_active": True,
+            "display_name": "Restaurante",
+            "description": None,
+            "logo_url": None,
+            "banner_url": None,
+            "phone_number": None,
+            "email": None,
+            "address": None,
+            "city": None,
+            "neighborhood": None,
+            "latitude": None,
+            "longitude": None,
+            "timezone": "America/Bogota",
+            "business_hours": {},
+            "social_media": {},
+            "seo_title": None,
+            "seo_description": None,
+            "accepts_online_orders": True,
+            "min_order_amount": Decimal("0"),
+            "estimated_preparation_time": 20,
+            "is_manually_open": True,
+            "tip_enabled": False,
+            "tip_default_percentages": None,
+            "tip_preselect_index": None,
+            "created_at": None,
+            "updated_at": None,
+        },
+        {
+            "plan_slug": "pro",
+            "plan_features": {"quotas": {"completed_online_orders_per_month": 300}},
+            "current_period_start": period_start,
+            "current_period_end": period_end,
+        },
+    ])
+    conn.fetchval = AsyncMock(return_value=300)
+
+    with (
+        patch("app.services.public_restaurant_service.get_db_connection", side_effect=_db_context(conn)),
+        patch("app.services.public_restaurant_service.is_currently_open", return_value=True),
+    ):
+        profile = await public_restaurant_service.get_profile_by_slug("restaurante")
+
+    assert profile["is_currently_open"] is True
+    assert profile["online_orders_available"] is False
+    assert profile["online_orders_unavailable_reason"] == "online_order_quota_exceeded"
+    assert profile["online_orders_unavailable_message"] == billing_service.ONLINE_ORDER_QUOTA_CUSTOMER_MESSAGE
+    assert "used" not in profile
+    assert "limit" not in profile
+    assert "plan_slug" not in profile
+    assert "override" not in profile
 
 
 @pytest.mark.asyncio

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -51,7 +51,52 @@ async def test_check_plan_quota_growth_allows_below_limit_and_excludes_customers
 
     count_args = conn.fetchval.await_args.args
     assert "role = ANY" in count_args[0]
+    assert "tenant_invitations" in count_args[0]
     assert "customer" not in count_args[2]
+
+
+@pytest.mark.asyncio
+async def test_admin_users_quota_counts_pending_invitations():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "plan_slug": "pro",
+        "plan_features": {"quotas": {"admin_users": 6}},
+    })
+    conn.fetchval = AsyncMock(return_value=6)
+
+    with pytest.raises(APIError) as exc:
+        await billing_service.check_plan_quota_growth(conn, tenant_id, "admin_users")
+
+    assert exc.value.status_code == 429
+    assert exc.value.details["resource"] == "admin_users"
+    assert exc.value.details["used"] == 6
+    count_args = conn.fetchval.await_args.args
+    assert "tenant_invitations" in count_args[0]
+    assert count_args[3] is None
+
+
+@pytest.mark.asyncio
+async def test_accept_invitation_excludes_current_pending_invitation_from_reserved_quota():
+    tenant_id = uuid4()
+    invitation_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "plan_slug": "pro",
+        "plan_features": {"quotas": {"admin_users": 6}},
+    })
+    conn.fetchval = AsyncMock(return_value=5)
+
+    await billing_service.check_plan_quota_growth(
+        conn,
+        tenant_id,
+        "admin_users",
+        exclude_pending_invitation_id=invitation_id,
+    )
+
+    count_args = conn.fetchval.await_args.args
+    assert "ti.id = $3" in count_args[0]
+    assert count_args[3] == invitation_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a public-safe online order quota availability helper
- include online order availability fields on public restaurant profiles
- cover exhausted quota profile responses without leaking usage or plan metadata

## Tests
- pytest tests/test_quota_enforcement.py

Refs uno0uno/warocol.com#1512