### PR TITLE
Gate sensitive API endpoints by module

### DIFF
--- a/app/routers/legal.py
+++ b/app/routers/legal.py
@@ -2,10 +2,11 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 
 from app.core.middleware import require_valid_session
+from app.core.permissions import Module, require_module
 from app.core.security import get_client_ip
 from app.database import get_db_connection
 from app.services import legal_service
@@ -24,6 +25,8 @@ def _require_session_tenant_id(session) -> UUID:
     return session.tenant_id
 
 
+# Global-auth exception: tenants must be able to read/accept current terms
+# before other module-gated flows are available.
 @router.get("/terms/current")
 async def get_current_terms(request: Request):
     session = require_valid_session(request)
@@ -39,7 +42,7 @@ async def get_terms_status(request: Request):
         return await legal_service.get_terms_status(conn, session.tenant_id)
 
 
-@router.get("/terms/audit")
+@router.get("/terms/audit", dependencies=[Depends(require_module(Module.MI_NEGOCIO))])
 async def list_terms_acceptance_audit(
     request: Request,
     document_version_id: Optional[UUID] = None,
@@ -64,7 +67,7 @@ async def list_terms_acceptance_audit(
         )
 
 
-@router.get("/terms/audit/{acceptance_id}")
+@router.get("/terms/audit/{acceptance_id}", dependencies=[Depends(require_module(Module.MI_NEGOCIO))])
 async def get_terms_acceptance_audit(acceptance_id: UUID, request: Request):
     session = require_valid_session(request)
     tenant_id = _require_session_tenant_id(session)

--- a/app/routers/notifications.py
+++ b/app/routers/notifications.py
@@ -4,11 +4,12 @@ Authenticated endpoints for restaurant operators to manage notifications.
 """
 import asyncio
 import asyncpg
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from uuid import UUID
 from app.config import settings
 from app.core.middleware import require_valid_session
+from app.core.permissions import Module, require_module
 from app.services import notifications_service
 
 router = APIRouter(prefix="/notifications", tags=["notifications"])
@@ -50,7 +51,7 @@ async def _remove_listener_if_empty(channel: str) -> None:
             _channel_locks.pop(channel, None)
 
 
-@router.get("/stream")
+@router.get("/stream", dependencies=[Depends(require_module(Module.POS))])
 async def notification_stream(request: Request):
     """
     SSE endpoint — keeps connection open and pushes new order notifications in real time.
@@ -99,7 +100,7 @@ async def notification_stream(request: Request):
     )
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(require_module(Module.POS))])
 async def get_notifications(request: Request):
     """
     List last 50 unread notifications for the authenticated tenant.
@@ -109,7 +110,7 @@ async def get_notifications(request: Request):
     return await notifications_service.get_unread_notifications(request)
 
 
-@router.patch("/{notification_id}/read")
+@router.patch("/{notification_id}/read", dependencies=[Depends(require_module(Module.POS))])
 async def mark_read(request: Request, notification_id: UUID):
     """
     Mark a single notification as read.
@@ -121,7 +122,7 @@ async def mark_read(request: Request, notification_id: UUID):
     return await notifications_service.mark_notification_read(request, notification_id)
 
 
-@router.post("/read-all")
+@router.post("/read-all", dependencies=[Depends(require_module(Module.POS))])
 async def mark_all_read(request: Request):
     """
     Mark all unread notifications as read for the authenticated tenant.

--- a/tests/test_legal_permissions.py
+++ b/tests/test_legal_permissions.py
@@ -1,0 +1,111 @@
+"""Permission smoke tests for legal terms endpoints."""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.core.permissions import Module
+from app.routers.legal import router as legal_router
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_session(role):
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": role,
+    })
+
+
+def _enforce_db_ctx():
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+    return _ctx
+
+
+def _legal_db_ctx():
+    @asynccontextmanager
+    async def _ctx(**_kwargs):
+        yield MagicMock()
+    return _ctx
+
+
+def test_owner_role_passes_legal_audit_under_enforce():
+    """Owner reaches legal audit because MI_NEGOCIO is owner-only."""
+    session = _build_session(role="owner")
+    app = FastAPI()
+    app.include_router(legal_router)
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.legal.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.routers.legal.get_db_connection", side_effect=_legal_db_ctx()), \
+         patch(
+             "app.routers.legal.legal_service.list_acceptance_audit_records",
+             new=AsyncMock(return_value={"success": True, "data": {"records": []}}),
+         ):
+        client = TestClient(app)
+        response = client.get("/legal/terms/audit")
+
+    assert response.status_code == 200
+
+
+def test_cashier_role_denied_legal_audit_under_enforce():
+    """Cashier hits 403 on legal audit because it exposes tenant compliance history."""
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(legal_router)
+
+    cashier_modules = frozenset({Module.POS, Module.VENTAS})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ):
+        client = TestClient(app)
+        response = client.get("/legal/terms/audit")
+
+    assert response.status_code == 403
+    assert "mi_negocio" in response.json()["detail"].lower()
+
+
+def test_cashier_role_can_still_read_terms_status_under_enforce():
+    """Terms status remains a global-auth exception so acceptance is never blocked."""
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(legal_router)
+
+    with patch("app.routers.legal.require_valid_session", return_value=session), \
+         patch("app.routers.legal.get_db_connection", side_effect=_legal_db_ctx()), \
+         patch(
+             "app.routers.legal.legal_service.get_terms_status",
+             new=AsyncMock(return_value={"success": True, "data": {"accepted": False}}),
+         ):
+        client = TestClient(app)
+        response = client.get("/legal/terms/status")
+
+    assert response.status_code == 200
+

--- a/tests/test_notifications_permissions.py
+++ b/tests/test_notifications_permissions.py
@@ -1,0 +1,108 @@
+"""Permission smoke tests for notifications endpoints."""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.core.permissions import Module
+from app.routers.notifications import router as notifications_router
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def _build_session(role):
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": role,
+    })
+
+
+def _enforce_db_ctx():
+    @asynccontextmanager
+    async def _ctx():
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+    return _ctx
+
+
+def test_owner_role_passes_notifications_under_enforce():
+    """Owner reaches GET /notifications under enforce."""
+    session = _build_session(role="owner")
+    app = FastAPI()
+    app.include_router(notifications_router)
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.routers.notifications.notifications_service.get_unread_notifications",
+             new=AsyncMock(return_value={"success": True, "data": []}),
+         ):
+        client = TestClient(app)
+        response = client.get("/notifications")
+
+    assert response.status_code == 200
+
+
+def test_kitchen_role_denied_notifications_under_enforce():
+    """Kitchen role hits 403 on POS-scoped notifications."""
+    session = _build_session(role="kitchen")
+    app = FastAPI()
+    app.include_router(notifications_router)
+
+    kitchen_modules = frozenset({Module.DESPACHO})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=kitchen_modules),
+         ):
+        client = TestClient(app)
+        response = client.get("/notifications/stream")
+
+    assert response.status_code == 403
+    assert "pos" in response.json()["detail"].lower()
+
+
+def test_cashier_role_passes_mark_all_notifications_under_enforce():
+    """Cashier keeps POS notification controls under enforce."""
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(notifications_router)
+
+    cashier_modules = frozenset({Module.POS, Module.VENTAS})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ), \
+         patch(
+             "app.routers.notifications.notifications_service.mark_all_notifications_read",
+             new=AsyncMock(return_value={"success": True, "data": {"marked_read": 0}}),
+         ):
+        client = TestClient(app)
+        response = client.post("/notifications/read-all")
+
+    assert response.status_code == 200
+


### PR DESCRIPTION
## Summary
- Gate notifications endpoints with POS module access.
- Gate legal terms audit endpoints with MI_NEGOCIO while leaving terms read/status/accept globally authenticated.
- Add focused permission smoke tests for allowed/denied behavior under enforce.

## Tests
- pytest tests/test_notifications_permissions.py tests/test_legal_permissions.py
- pytest tests/test_pos_permissions.py tests/test_mi_negocio_permissions.py

Closes uno0uno/warocol.com#1522