### PR TITLE
Add table session comandas endpoint

### DIFF
--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -347,6 +347,15 @@ async def get_current_session(request: Request, table_id: UUID):
     return await tables_service.get_current_session(request, table_id)
 
 
+@router.get("/{table_id}/comandas", dependencies=[Depends(require_module(Module.POS))])
+async def get_table_session_comandas(request: Request, table_id: UUID):
+    """
+    Get persisted printable comandas for the table's currently open session.
+    Returns 404 if no open session exists.
+    """
+    return await tables_service.get_table_session_comandas(request, table_id)
+
+
 @router.post("/{table_id}/tab/add", dependencies=[Depends(require_module(Module.POS))])
 async def add_tab_items(request: Request, table_id: UUID, body: TabAddRequest):
     """

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -39,7 +39,7 @@ from app.services.tip_tax_service import (
 )
 from app.services.orders_service import _compute_tax_breakdown
 from app.services.ingredient_purchase_units_service import resolve_recipe_quantity_to_base_unit
-from app.services.comandas_service import fire_comandas
+from app.services.comandas_service import _parse_item_row, fire_comandas
 from app.services.billing_service import check_plan_quota_growth
 from app.services.operation_events_service import DOMAIN_POS, record_operation_event
 from app.services.open_priced_service import (
@@ -2654,6 +2654,155 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
     except Exception as e:
         logger.error(f"Error fetching current session for table {table_id}: {e}")
         raise APIError(f"Error fetching session: {e}", status_code=500)
+
+
+def _serialize_comanda_item(row: Any) -> Dict[str, Any]:
+    item = _parse_item_row(row)
+    return {
+        "id": str(item["id"]),
+        "order_item_id": str(item["order_item_id"]) if item.get("order_item_id") else None,
+        "kitchen_name": item["kitchen_name"],
+        "quantity": float(item["quantity"]),
+        "notes": item.get("notes"),
+        "modifiers_snapshot": item.get("modifiers_snapshot"),
+        "is_promo_free": bool(item.get("is_promo_free")),
+        "status": item["status"],
+        "ready_at": item["ready_at"].isoformat() if item.get("ready_at") else None,
+        "created_at": item["created_at"].isoformat() if item.get("created_at") else None,
+    }
+
+
+def _serialize_table_session_comanda(row: Any, items: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return {
+        "id": str(row["id"]),
+        "comanda_number": int(row["comanda_number"]),
+        "comanda_index": int(row["comanda_index"]),
+        "status": row["status"],
+        "source_type": row["source_type"],
+        "table_display_name": row["table_display_name"],
+        "notes": row.get("notes"),
+        "station_id": str(row["station_id"]) if row.get("station_id") else None,
+        "station_name": row.get("station_name"),
+        "station_kitchen_name": row.get("station_kitchen_name"),
+        "station_color": row.get("station_color"),
+        "fired_at": row["fired_at"].isoformat() if row.get("fired_at") else None,
+        "preparing_at": row["preparing_at"].isoformat() if row.get("preparing_at") else None,
+        "ready_at": row["ready_at"].isoformat() if row.get("ready_at") else None,
+        "delivered_at": row["delivered_at"].isoformat() if row.get("delivered_at") else None,
+        "created_at": row["created_at"].isoformat() if row.get("created_at") else None,
+        "items": items,
+    }
+
+
+async def get_table_session_comandas(request: Request, table_id: UUID) -> dict:
+    """
+    Get persisted printable comandas for the table's currently open session.
+    Includes delivered tickets for reprint and excludes cancelled rows by default.
+    """
+    try:
+        session_context = require_valid_session(request)
+        tenant_id = session_context.tenant_id
+        if not tenant_id:
+            raise AuthenticationError("Tenant ID is required")
+
+        async with get_db_connection(use_transaction=False) as conn:
+            table_row = await conn.fetchrow(
+                "SELECT id, name, status FROM tables WHERE id = $1 AND tenant_id = $2 AND is_active = true",
+                table_id,
+                tenant_id,
+            )
+            if not table_row:
+                raise NotFoundError("Table not found")
+
+            session_row = await conn.fetchrow(
+                """
+                SELECT id, opened_at
+                FROM table_sessions
+                WHERE table_id = $1
+                  AND tenant_id = $2
+                  AND closed_at IS NULL
+                """,
+                table_id,
+                tenant_id,
+            )
+            if not session_row:
+                raise NotFoundError("No open session for this table")
+
+            rows = await conn.fetch(
+                """
+                SELECT
+                    c.id,
+                    c.comanda_number,
+                    c.comanda_index,
+                    c.status,
+                    c.source_type,
+                    c.table_display_name,
+                    c.notes,
+                    c.fired_at,
+                    c.preparing_at,
+                    c.ready_at,
+                    c.delivered_at,
+                    c.created_at,
+                    ks.id AS station_id,
+                    ks.name AS station_name,
+                    ks.kitchen_name AS station_kitchen_name,
+                    ks.color AS station_color
+                FROM table_sessions ts
+                JOIN orders o ON o.table_session_id = ts.id
+                JOIN comandas c ON c.order_id = o.id
+                JOIN kitchen_stations ks ON ks.id = c.station_id
+                WHERE ts.id = $1
+                  AND ts.table_id = $2
+                  AND ts.tenant_id = $3
+                  AND ts.closed_at IS NULL
+                  AND o.tenant_id = $3
+                  AND c.tenant_id = $3
+                  AND c.status IN ('pending', 'preparing', 'ready', 'delivered')
+                  AND (o.status IS NULL OR o.status != 'cancelled')
+                ORDER BY c.fired_at ASC, c.comanda_number ASC, c.comanda_index ASC, c.id ASC
+                """,
+                session_row["id"],
+                table_id,
+                tenant_id,
+            )
+
+            comandas: List[Dict[str, Any]] = []
+            for row in rows:
+                item_rows = await conn.fetch(
+                    """
+                    SELECT id, order_item_id, kitchen_name, quantity, notes,
+                           modifiers_snapshot, status, ready_at, created_at
+                    FROM comanda_items
+                    WHERE comanda_id = $1
+                      AND status != 'cancelled'
+                    ORDER BY created_at ASC, id ASC
+                    """,
+                    row["id"],
+                )
+                items = [_serialize_comanda_item(ir) for ir in item_rows]
+                comandas.append(_serialize_table_session_comanda(row, items))
+
+        return {
+            "success": True,
+            "data": {
+                "table": {
+                    "id": str(table_id),
+                    "name": table_row["name"],
+                    "status": table_row["status"],
+                },
+                "session": {
+                    "id": str(session_row["id"]),
+                    "opened_at": session_row["opened_at"].isoformat() if session_row.get("opened_at") else None,
+                },
+                "comandas": comandas,
+            },
+        }
+
+    except (AuthenticationError, NotFoundError):
+        raise
+    except Exception as e:
+        logger.error(f"Error fetching table session comandas for table {table_id}: {e}")
+        raise APIError(f"Error fetching table comandas: {e}", status_code=500)
 
 
 async def _fetch_tab_operation_context(

--- a/tests/test_table_session_comandas.py
+++ b/tests/test_table_session_comandas.py
@@ -1,0 +1,164 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.exceptions import NotFoundError
+from app.services import tables_service
+
+
+class _DbContext:
+    def __init__(self, conn):
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_table_session_comandas_returns_delivered_nested_items():
+    tenant_id = uuid4()
+    table_id = uuid4()
+    session_id = uuid4()
+    comanda_id = uuid4()
+    station_id = uuid4()
+    item_id = uuid4()
+    order_item_id = uuid4()
+    now = datetime(2026, 7, 4, 12, 0, tzinfo=timezone.utc)
+
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        {"id": table_id, "name": "Mesa 1", "status": "open"},
+        {"id": session_id, "opened_at": now},
+    ])
+    conn.fetch = AsyncMock(side_effect=[
+        [{
+            "id": comanda_id,
+            "comanda_number": 25,
+            "comanda_index": 2,
+            "status": "delivered",
+            "source_type": "table",
+            "table_display_name": "Mesa 1",
+            "notes": None,
+            "fired_at": now,
+            "preparing_at": None,
+            "ready_at": now,
+            "delivered_at": now,
+            "created_at": now,
+            "station_id": station_id,
+            "station_name": "Cocina",
+            "station_kitchen_name": "Cocina caliente",
+            "station_color": "#123456",
+        }],
+        [{
+            "id": item_id,
+            "order_item_id": order_item_id,
+            "kitchen_name": "Hamburguesa",
+            "quantity": Decimal("2"),
+            "notes": "Sin cebolla",
+            "modifiers_snapshot": '[{"name": "Queso", "quantity": 1}]',
+            "status": "ready",
+            "ready_at": now,
+            "created_at": now,
+        }],
+    ])
+
+    with patch(
+        "app.services.tables_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id),
+    ), patch(
+        "app.services.tables_service.get_db_connection",
+        return_value=_DbContext(conn),
+    ):
+        result = await tables_service.get_table_session_comandas(object(), table_id)
+
+    assert result["success"] is True
+    assert result["data"]["table"]["id"] == str(table_id)
+    assert result["data"]["session"]["id"] == str(session_id)
+
+    comanda = result["data"]["comandas"][0]
+    assert comanda["id"] == str(comanda_id)
+    assert comanda["comanda_number"] == 25
+    assert comanda["comanda_index"] == 2
+    assert comanda["status"] == "delivered"
+    assert comanda["source_type"] == "table"
+    assert comanda["station_id"] == str(station_id)
+    assert comanda["station_name"] == "Cocina"
+    assert comanda["fired_at"] == now.isoformat()
+
+    item = comanda["items"][0]
+    assert item["id"] == str(item_id)
+    assert item["order_item_id"] == str(order_item_id)
+    assert item["kitchen_name"] == "Hamburguesa"
+    assert item["quantity"] == 2.0
+    assert item["notes"] == "Sin cebolla"
+    assert item["modifiers_snapshot"] == [{"name": "Queso", "quantity": 1}]
+    assert item["status"] == "ready"
+
+    comandas_query = conn.fetch.await_args_list[0].args[0]
+    assert "ts.table_id = $2" in comandas_query
+    assert "ts.tenant_id = $3" in comandas_query
+    assert "ts.closed_at IS NULL" in comandas_query
+    assert "o.tenant_id = $3" in comandas_query
+    assert "c.tenant_id = $3" in comandas_query
+    assert "'delivered'" in comandas_query
+    assert "'cancelled'" not in comandas_query.split("c.status IN", 1)[1].split(")", 1)[0]
+
+    items_query = conn.fetch.await_args_list[1].args[0]
+    assert "status != 'cancelled'" in items_query
+
+
+@pytest.mark.asyncio
+async def test_table_session_comandas_requires_open_session():
+    tenant_id = uuid4()
+    table_id = uuid4()
+
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        {"id": table_id, "name": "Mesa 1", "status": "open"},
+        None,
+    ])
+    conn.fetch = AsyncMock()
+
+    with patch(
+        "app.services.tables_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id),
+    ), patch(
+        "app.services.tables_service.get_db_connection",
+        return_value=_DbContext(conn),
+    ):
+        with pytest.raises(NotFoundError):
+            await tables_service.get_table_session_comandas(object(), table_id)
+
+    conn.fetch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_table_session_comandas_uses_tenant_scoped_table_lookup():
+    tenant_id = uuid4()
+    table_id = uuid4()
+
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock()
+
+    with patch(
+        "app.services.tables_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id),
+    ), patch(
+        "app.services.tables_service.get_db_connection",
+        return_value=_DbContext(conn),
+    ):
+        with pytest.raises(NotFoundError):
+            await tables_service.get_table_session_comandas(object(), table_id)
+
+    table_query = conn.fetchrow.await_args_list[0].args[0]
+    assert "tenant_id = $2" in table_query
+    assert conn.fetchrow.await_args_list[0].args[1:] == (table_id, tenant_id)
+    conn.fetch.assert_not_awaited()


### PR DESCRIPTION
## Summary
- add GET /api/tables/{table_id}/comandas for the open table session
- return persisted printable comandas, including delivered status, with nested non-cancelled items
- add focused tenant/session/status/item response tests

## Tests
- pytest tests/test_table_session_comandas.py
- pytest tests/test_tables_current_session_order.py tests/test_pos_permissions.py

## Manual validation
- curl -H "Authorization: Bearer $TOKEN" "$API_BASE/api/tables/$TABLE_ID/comandas"

Closes #594