### PR TITLE
Add POS products catalog endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, ai_agents, customer_portal, leads, waros, billing, legal, payments_webhook, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
+from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, pos_products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, ai_agents, customer_portal, leads, waros, billing, legal, payments_webhook, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
 from app.config import settings
 from app.core.logging import setup_logging
 from app.core.exceptions import api_exception_handler, general_exception_handler, APIError
@@ -170,6 +170,7 @@ app.include_router(modifiers.router, prefix="/menu/modifier-groups", tags=["modi
 app.include_router(customers.router, prefix="/customers", tags=["customers"])
 app.include_router(pos_cart.router)
 app.include_router(pos_context.router)  # POS-scoped aggregator (BFF for /pos/restaurant-context)
+app.include_router(pos_products.router)  # POS-scoped product catalog read endpoint
 app.include_router(operaciones_context.router)  # OPERACIONES-scoped aggregator + 5 toggle PATCH endpoints
 app.include_router(operaciones_shifts.router)  # OPERACIONES shift templates CRUD (#682)
 app.include_router(operaciones_operation_events.router)  # Bitácora POS events list (#782)

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -15,6 +15,7 @@ from app.routers import (
     customers,
     pos_cart,
     pos_context,
+    pos_products,
     operaciones_context,
     orders,
     inventory,

--- a/app/routers/pos_products.py
+++ b/app/routers/pos_products.py
@@ -1,0 +1,78 @@
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query, Request, Response
+
+from app.core.permissions import Module, require_module
+from app.models.product import ProductsListResponse
+from app.services.products_service import get_products_list
+
+
+router = APIRouter(prefix="/pos/products", tags=["pos"])
+
+
+@router.get("", response_model=ProductsListResponse, dependencies=[Depends(require_module(Module.POS))])
+async def get_pos_products_endpoint(
+    request: Request,
+    response: Response,
+    page: int = Query(default=1, ge=1, description="Page number"),
+    limit: int = Query(default=50, ge=1, le=250, description="Items per page"),
+    search: Optional[str] = Query(default=None, description="Search term (see search_field)"),
+    search_field: Optional[str] = Query(
+        default=None,
+        description="Search in a single field: name, description, or kitchen_name. Omit to search name OR description.",
+    ),
+    category_id: Optional[UUID] = Query(default=None, description="Filter by category ID"),
+    is_available: Optional[bool] = Query(default=None, description="Filter by availability"),
+    is_combo: Optional[bool] = Query(default=None, description="Filter combos only"),
+    is_resale: Optional[bool] = Query(default=None, description="Filter resale products only"),
+    station_id: Optional[UUID] = Query(
+        default=None,
+        description="Filter by kitchen station (product.station_id OR category default station)",
+    ),
+    is_available_online: Optional[bool] = Query(default=None, description="Filter by online menu availability"),
+    is_available_table_qr: Optional[bool] = Query(default=None, description="Filter by table QR menu availability"),
+    has_recipe: Optional[bool] = Query(
+        default=None,
+        description="Filter products with/without recipe (ingredients, recipe bases, or base type)",
+    ),
+    margin_negative: Optional[bool] = Query(
+        default=None,
+        description="When true, only products where calculated cost exceeds price",
+    ),
+    sort: Optional[str] = Query(
+        default=None,
+        description=(
+            "Sort order: created_at_desc (default), created_at_asc, name_asc, name_desc, "
+            "price_asc, price_desc, margin_asc, margin_desc"
+        ),
+    ),
+    include_ingredients: bool = Query(default=False, description="Include recipe ingredients in response"),
+    include_modifiers: bool = Query(default=False, description="Include modifier groups in response (for POS)"),
+    include_all_types: bool = Query(
+        default=False,
+        description="Include menu and resale products (Productos list Todos filter)",
+    ),
+):
+    """POS-scoped product catalog read endpoint."""
+    return await get_products_list(
+        request,
+        response,
+        page,
+        limit,
+        search,
+        search_field,
+        category_id,
+        is_available,
+        is_combo,
+        is_resale,
+        station_id,
+        is_available_online,
+        is_available_table_qr,
+        has_recipe,
+        margin_negative,
+        sort,
+        include_ingredients,
+        include_modifiers,
+        include_all_types,
+    )

--- a/tests/test_pos_permissions.py
+++ b/tests/test_pos_permissions.py
@@ -22,6 +22,7 @@ from app.core.permissions import Module
 from app.routers.tables import router as tables_router
 from app.routers.comandas import router as comandas_router
 from app.routers.pos_context import router as pos_context_router
+from app.routers.pos_products import router as pos_products_router
 
 
 # ─── Fixtures ─────────────────────────────────────────────────────────
@@ -170,3 +171,58 @@ def test_cashier_role_passes_pos_restaurant_context_under_enforce():
     assert response.status_code == 200
     assert response.json()["data"]["display_name"] == "Demo"
     assert response.json()["data"]["timezone"] == "America/Bogota"
+
+
+def test_cashier_role_passes_pos_products_under_enforce_without_menu():
+    """Cashier reaches GET /pos/products with POS access but no MENU module."""
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(pos_products_router)
+
+    cashier_modules = frozenset({Module.POS})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ), \
+         patch(
+             "app.routers.pos_products.get_products_list",
+             new=AsyncMock(return_value={"success": True, "data": [], "total": 0}),
+         ) as get_products:
+        client = TestClient(app)
+        response = client.get("/pos/products?is_available=true&limit=250&include_modifiers=true")
+
+    assert response.status_code == 200
+    get_products.assert_awaited_once()
+    assert get_products.await_args.args[7] is True
+    assert get_products.await_args.args[17] is True
+
+
+def test_kitchen_role_denied_pos_products_under_enforce():
+    """Kitchen role hits 403 on POS catalog endpoint because it lacks POS."""
+    session = _build_session(role="kitchen")
+    app = FastAPI()
+    app.include_router(pos_products_router)
+
+    kitchen_modules = frozenset({Module.DESPACHO})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=kitchen_modules),
+         ), \
+         patch(
+             "app.routers.pos_products.get_products_list",
+             new=AsyncMock(return_value={"success": True, "data": [], "total": 0}),
+         ) as get_products:
+        client = TestClient(app)
+        response = client.get("/pos/products")
+
+    assert response.status_code == 403
+    assert "pos" in response.json()["detail"].lower()
+    get_products.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Add GET /pos/products protected by Module.POS.
- Reuse products_service.get_products_list for the existing product/modifier catalog behavior.
- Add POS permission regressions for cashier without MENU and kitchen denial.

## Tests
- pytest tests/test_pos_permissions.py tests/test_menu_permissions.py -q

Closes uno0uno/warocol.com#1538