### PR TITLE
Restrict cashier default RBAC to POS

### DIFF
--- a/app/core/permissions.py
+++ b/app/core/permissions.py
@@ -74,9 +74,9 @@ class Module(str, Enum):
 _ALL_MODULES: FrozenSet[Module] = frozenset(Module)
 
 
-# Permissive defaults that mirror today's effective access. Tightening happens
-# per-tenant via overrides + by flipping `tenants.permissions_enforcement_mode`
-# from 'disabled' to 'shadow'/'enforce' once a tenant has reviewed the matrix.
+# Default access floor for each role. Tenants can expand or reduce access with
+# `tenant_role_module_overrides`; `permissions_enforcement_mode` controls when
+# missing modules are observed or enforced.
 DEFAULT_ROLE_MODULES: Dict[Role, FrozenSet[Module]] = {
     Role.OWNER: _ALL_MODULES,
     Role.ADMIN: frozenset({
@@ -107,8 +107,6 @@ DEFAULT_ROLE_MODULES: Dict[Role, FrozenSet[Module]] = {
     }),
     Role.CASHIER: frozenset({
         Module.POS,
-        Module.VENTAS,
-        Module.MENU,  # Read access for POS catalog (products + categories)
     }),
     Role.KITCHEN: frozenset({
         Module.DESPACHO,

--- a/tests/test_me_access.py
+++ b/tests/test_me_access.py
@@ -2,7 +2,7 @@
 
 Sub-task E2.17 of Epic 2 (#200). Validates that:
 1. Owner role under enforce reaches the handler and gets ALL modules.
-2. Cashier role returns only ["pos", "ventas"] (sorted).
+2. Cashier role returns only ["pos"].
 3. Session with role=None short-circuits to empty modules without crashing.
 4. Tenant with enforcement_mode='disabled' is reported correctly.
 5. Tenant with enforcement_mode='enforce' is reported correctly.
@@ -89,13 +89,14 @@ def test_owner_returns_all_modules():
     assert body["features"]["kali_enabled"] is True
 
 
-def test_cashier_returns_pos_ventas_only():
-    """Cashier sees only [pos, ventas] per DEFAULT_ROLE_MODULES."""
-    session = _build_session(role="cashier")
+@pytest.mark.parametrize("role", ["cashier", "employee"])
+def test_cashier_and_legacy_employee_return_pos_only(role):
+    """Cashier and legacy employee see only [pos] per DEFAULT_ROLE_MODULES."""
+    session = _build_session(role=role)
     app = FastAPI()
     app.include_router(me_router, prefix="/me")
 
-    cashier_modules = frozenset({Module.POS, Module.VENTAS})
+    cashier_modules = frozenset({Module.POS})
 
     with patch("app.core.middleware.get_session_context", return_value=session), \
          patch("app.routers.me.require_valid_session", return_value=session), \
@@ -113,8 +114,8 @@ def test_cashier_returns_pos_ventas_only():
 
     assert response.status_code == 200
     body = response.json()
-    assert body["role"] == "cashier"
-    assert body["modules"] == ["pos", "ventas"]
+    assert body["role"] == role
+    assert body["modules"] == ["pos"]
     assert body["features"]["kali_enabled"] is False
 
 

--- a/tests/test_menu_permissions.py
+++ b/tests/test_menu_permissions.py
@@ -1,8 +1,8 @@
 """End-to-end smoke tests for MENU group endpoints under require_module(MENU).
 
 Sub-task E2.6 of Epic 2 (#190). Validates that:
-1. Cashier role under enforce reaches a MENU handler — proves the matrix
-   update (added Module.MENU to CASHIER defaults) unblocks POS catalog reads.
+1. Cashier role under enforce gets 403 on MENU because POS catalog reads now
+   go through /pos/products instead of admin Menu endpoints.
 2. Kitchen role under enforce gets 403 on a MENU endpoint — kitchen lacks
    MENU (only has DESPACHO), so the gate denies as expected.
 
@@ -59,8 +59,8 @@ def _enforce_db_ctx():
 # ─── Tests ────────────────────────────────────────────────────────────
 
 
-def test_cashier_role_passes_menu_endpoint_under_enforce():
-    """Cashier reaches GET /menu/products under enforce — POS catalog unblocked."""
+def test_cashier_role_denied_menu_endpoint_under_enforce():
+    """Cashier hits 403 on MENU — cashier defaults are POS-only."""
     session = _build_session(role="cashier")
     app = FastAPI()
     app.include_router(products_router, prefix="/menu/products")
@@ -71,12 +71,13 @@ def test_cashier_role_passes_menu_endpoint_under_enforce():
          patch(
              "app.routers.products.get_products_list",
              new=AsyncMock(return_value={"data": [], "total": 0}),
-         ):
+         ) as get_products:
         client = TestClient(app)
         response = client.get("/menu/products")
 
-    # Handler reached → matrix update grants CASHIER access to MENU.
-    assert response.status_code == 200
+    assert response.status_code == 403
+    assert "menu" in response.json()["detail"].lower()
+    get_products.assert_not_awaited()
 
 
 def test_kitchen_role_denied_menu_endpoint_under_enforce():

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -56,10 +56,8 @@ class TestDefaultRoleModules:
     def test_kitchen_only_has_despacho(self):
         assert DEFAULT_ROLE_MODULES[Role.KITCHEN] == frozenset({Module.DESPACHO})
 
-    def test_cashier_has_pos_ventas_and_menu(self):
-        assert DEFAULT_ROLE_MODULES[Role.CASHIER] == frozenset({
-            Module.POS, Module.VENTAS, Module.MENU,
-        })
+    def test_cashier_only_has_pos(self):
+        assert DEFAULT_ROLE_MODULES[Role.CASHIER] == frozenset({Module.POS})
 
     def test_admin_does_not_get_equipo(self):
         # EQUIPO (membership/role changes) is owner-only by default

--- a/tests/test_permissions_resolver.py
+++ b/tests/test_permissions_resolver.py
@@ -79,12 +79,12 @@ class TestDefaultsAndOverrides:
     @pytest.mark.asyncio
     async def test_grant_adds_module_not_in_defaults(self):
         tenant = uuid4()
-        # cashier defaults exclude ABASTECIMIENTO — grant it
-        rows = [{"module": Module.ABASTECIMIENTO.value, "granted": True}]
+        # Cashier defaults are POS-only; owners can explicitly grant admin modules.
+        rows = [{"module": Module.VENTAS.value, "granted": True}]
         patcher, _conn = _patch_pool(rows=rows)
         with patcher:
             result = await get_role_modules(tenant, Role.CASHIER)
-        assert Module.ABASTECIMIENTO in result
+        assert Module.VENTAS in result
         assert DEFAULT_ROLE_MODULES[Role.CASHIER].issubset(result)
 
     @pytest.mark.asyncio
@@ -96,7 +96,7 @@ class TestDefaultsAndOverrides:
         with patcher:
             result = await get_role_modules(tenant, Role.CASHIER)
         assert Module.POS not in result
-        assert Module.VENTAS in result  # other defaults preserved
+        assert result == frozenset()
 
     @pytest.mark.asyncio
     async def test_unknown_module_in_db_is_ignored(self):

--- a/tests/test_pos_permissions.py
+++ b/tests/test_pos_permissions.py
@@ -143,7 +143,7 @@ def test_cashier_role_passes_pos_restaurant_context_under_enforce():
     app = FastAPI()
     app.include_router(pos_context_router)
 
-    cashier_modules = frozenset({Module.POS, Module.VENTAS})
+    cashier_modules = frozenset({Module.POS})
 
     with patch("app.core.middleware.get_session_context", return_value=session), \
          patch("app.routers.pos_context.require_valid_session", return_value=session), \

--- a/tests/test_ventas_permissions.py
+++ b/tests/test_ventas_permissions.py
@@ -2,7 +2,7 @@
 
 Sub-task E2.4 of Epic 2 (#189). Validates that:
 1. Owner role under enforce reaches the handler.
-2. Kitchen role under enforce gets 403 (kitchen lacks VENTAS in default
+2. Cashier/kitchen roles under enforce get 403 (they lack VENTAS in default
    matrix — same matrix gap surfaced by E2.3 / POS).
 
 No KDS-passthrough test needed: VENTAS routers (customers, online_orders,
@@ -104,3 +104,25 @@ def test_kitchen_role_denied_ventas_endpoint_under_enforce():
 
     assert response.status_code == 403
     assert "ventas" in response.json()["detail"].lower()
+
+
+def test_cashier_role_denied_ventas_endpoint_under_enforce():
+    """Cashier role hits 403 on VENTAS — cashier defaults are POS-only."""
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(orders_router)
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.routers.orders.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.routers.orders.orders_service.get_orders_dashboard",
+             new=AsyncMock(return_value={"data": []}),
+         ) as dashboard:
+        client = TestClient(app)
+        response = client.get("/orders/dashboard")
+
+    assert response.status_code == 403
+    assert "ventas" in response.json()["detail"].lower()
+    dashboard.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Restrict cashier default modules to POS only
- Update /me/access, Menu, Ventas, POS, and resolver tests for POS-only cashier defaults
- Preserve tenant override behavior for explicitly granting Menu/Ventas

## Tests
- pytest tests/test_permissions.py tests/test_permissions_resolver.py tests/test_me_access.py tests/test_menu_permissions.py tests/test_pos_permissions.py tests/test_ventas_permissions.py -q

Closes uno0uno/warocol.com#1537