### PR TITLE
Add manual table display ordering

### DIFF
--- a/app/routers/tables.py
+++ b/app/routers/tables.py
@@ -87,6 +87,10 @@ class TableQrToggleRequest(BaseModel):
     enabled: bool
 
 
+class ReorderTablesRequest(BaseModel):
+    table_ids: List[UUID] = Field(..., min_length=1)
+
+
 @router.get("", dependencies=[Depends(require_module(Module.POS))])
 async def list_tables(request: Request, include_inactive: bool = Query(False)):
     """
@@ -103,6 +107,15 @@ async def create_table(request: Request, body: CreateTableRequest):
     Create a new table for the tenant.
     """
     return await tables_service.create_table(request, body.name, body.capacity, body.code)
+
+
+@router.patch("/reorder", dependencies=[Depends(require_module(Module.POS))])
+async def reorder_tables(request: Request, body: ReorderTablesRequest):
+    """
+    Persist manual display order for regular tenant tables.
+    Barra is fixed/protected and cannot be included.
+    """
+    return await tables_service.reorder_tables(request, body.table_ids)
 
 
 @router.put("/{table_id}", dependencies=[Depends(require_module(Module.POS))])

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -327,6 +327,20 @@ async def _ensure_bar_table(conn, tenant_id) -> None:
         )
 
 
+async def _next_regular_table_display_order(conn, tenant_id) -> int:
+    value = await conn.fetchval(
+        """
+        SELECT COALESCE(MAX(display_order), 0) + 1
+        FROM tables
+        WHERE tenant_id = $1
+          AND deleted_at IS NULL
+          AND is_bar IS FALSE
+        """,
+        tenant_id,
+    )
+    return int(value or 1)
+
+
 async def list_tables(request: Request, include_inactive: bool = False) -> dict:
     """
     List tables for the tenant.
@@ -356,6 +370,7 @@ async def list_tables(request: Request, include_inactive: bool = False) -> dict:
                     t.is_bar,
                     t.qr_enabled,
                     t.qr_public_token,
+                    t.display_order,
                     t.created_at,
                     t.assigned_member_id,
                     p_assigned.name AS assigned_member_name,
@@ -436,7 +451,7 @@ async def list_tables(request: Request, include_inactive: bool = False) -> dict:
                 WHERE t.tenant_id = $1
                   AND t.deleted_at IS NULL
                   AND (t.is_active = true OR $2)
-                ORDER BY t.is_bar DESC, t.is_active DESC, t.name
+                ORDER BY t.is_bar DESC, t.is_active DESC, t.display_order NULLS LAST, t.name
                 """,
                 tenant_id,
                 include_inactive,
@@ -479,17 +494,19 @@ async def create_table(
                     raise APIError(str(exc), status_code=400) from exc
 
                 await check_plan_quota_growth(conn, tenant_id, "active_tables_including_bar")
+                display_order = await _next_regular_table_display_order(conn, tenant_id)
                 row = await conn.fetchrow(
                     """
-                    INSERT INTO tables (tenant_id, name, capacity, code)
-                    VALUES ($1, $2, $3, $4)
+                    INSERT INTO tables (tenant_id, name, capacity, code, display_order)
+                    VALUES ($1, $2, $3, $4, $5)
                     RETURNING id, name, code, capacity, status, is_active, is_bar,
-                              qr_enabled, qr_public_token, created_at
+                              qr_enabled, qr_public_token, display_order, created_at
                     """,
                     tenant_id,
                     name,
                     capacity,
                     resolved_code,
+                    display_order,
                 )
                 module_on = await conn.fetchval(
                     """
@@ -507,7 +524,7 @@ async def create_table(
                         SET qr_public_token = $1
                         WHERE id = $2 AND tenant_id = $3
                         RETURNING id, name, code, capacity, status, is_active, is_bar,
-                                  qr_enabled, qr_public_token, created_at
+                                  qr_enabled, qr_public_token, display_order, created_at
                         """,
                         token,
                         row["id"],
@@ -522,6 +539,90 @@ async def create_table(
     except Exception as e:
         logger.error(f"Error creating table: {e}")
         raise APIError(f"Error creating table: {e}", status_code=500)
+
+
+async def reorder_tables(request: Request, table_ids: List[UUID]) -> dict:
+    """
+    Persist manual display order for regular tables.
+    Submitted ids become the ordered set; omitted regular tables fall back by name.
+    """
+    try:
+        session_context = require_valid_session(request)
+        tenant_id = session_context.tenant_id
+        if not tenant_id:
+            raise AuthenticationError("Tenant ID is required")
+
+        if not table_ids:
+            raise APIError("table_ids is required", status_code=400)
+
+        unique_ids = list(dict.fromkeys(table_ids))
+        if len(unique_ids) != len(table_ids):
+            raise APIError("table_ids contains duplicates", status_code=400)
+
+        async with get_db_connection() as conn:
+            async with conn.transaction():
+                rows = await conn.fetch(
+                    """
+                    SELECT id, is_bar, deleted_at
+                    FROM tables
+                    WHERE tenant_id = $1
+                      AND id = ANY($2::uuid[])
+                    """,
+                    tenant_id,
+                    unique_ids,
+                )
+
+                rows_by_id = {row["id"]: row for row in rows}
+                missing_ids = [table_id for table_id in unique_ids if table_id not in rows_by_id]
+                if missing_ids:
+                    raise NotFoundError("One or more tables were not found")
+
+                for row in rows:
+                    if row["deleted_at"] is not None:
+                        raise NotFoundError("One or more tables were not found")
+                    if row["is_bar"]:
+                        raise APIError("La Barra no puede reordenarse", status_code=409)
+
+                await conn.execute(
+                    """
+                    UPDATE tables
+                    SET display_order = NULL
+                    WHERE tenant_id = $1
+                      AND deleted_at IS NULL
+                      AND is_bar IS FALSE
+                    """,
+                    tenant_id,
+                )
+                await conn.execute(
+                    """
+                    WITH ordered AS (
+                        SELECT id, ord::integer AS display_order
+                        FROM UNNEST($2::uuid[]) WITH ORDINALITY AS u(id, ord)
+                    )
+                    UPDATE tables t
+                    SET display_order = ordered.display_order
+                    FROM ordered
+                    WHERE t.tenant_id = $1
+                      AND t.id = ordered.id
+                      AND t.deleted_at IS NULL
+                      AND t.is_bar IS FALSE
+                    """,
+                    tenant_id,
+                    unique_ids,
+                )
+
+        return {
+            "success": True,
+            "data": {
+                "table_ids": [str(table_id) for table_id in unique_ids],
+            },
+        }
+
+    except (AuthenticationError, NotFoundError, APIError):
+        raise
+    except Exception as e:
+        logger.error(f"Error reordering tables: {e}")
+        raise APIError(f"Error reordering tables: {e}", status_code=500)
 
 
 async def update_table(
@@ -556,7 +657,7 @@ async def update_table(
                 row = await conn.fetchrow(
                     """
                     SELECT id, name, code, capacity, status, is_active, is_bar,
-                           qr_enabled, qr_public_token, created_at
+                           qr_enabled, qr_public_token, display_order, created_at
                     FROM tables WHERE id = $1 AND tenant_id = $2
                     """,
                     table_id,
@@ -620,7 +721,7 @@ async def update_table(
                 SET {", ".join(set_clauses)}
                 WHERE id = $1 AND tenant_id = $2
                 RETURNING id, name, code, capacity, status, is_active, is_bar,
-                          qr_enabled, qr_public_token, created_at
+                          qr_enabled, qr_public_token, display_order, created_at
                 """,
                 *params,
             )
@@ -4549,6 +4650,7 @@ def _format_table_row(row: dict) -> dict:
         "name": row["name"],
         "code": row.get("code"),
         "capacity": row["capacity"],
+        "display_order": row.get("display_order"),
         "status": row["status"],
         "is_active": row["is_active"],
         "is_bar": bool(row["is_bar"]) if row.get("is_bar") is not None else False,
@@ -4792,6 +4894,7 @@ def _format_table_simple(row: dict) -> dict:
         "name": row["name"],
         "code": row.get("code"),
         "capacity": row["capacity"],
+        "display_order": row.get("display_order"),
         "status": row["status"],
         "is_active": row["is_active"],
         "created_at": row["created_at"].isoformat(),

--- a/dbdoc/public.tables.md
+++ b/dbdoc/public.tables.md
@@ -16,6 +16,7 @@
 | assigned_member_id | uuid |  | true |  | [public.tenant_members](public.tenant_members.md) | Default waiter assigned to this table (warocol.com#573). NULL = no default. Bars (is_bar = true) should never have this set (enforced in application code, not DB constraint). Full history with snapshots lives in table_member_assignments. |
 | qr_public_token | varchar(64) |  | true |  |  | Opaque public token for Table QR URL (api-warolabs#265). Generated via secrets.token_urlsafe(32) in #266 — not derivable from table_id. NULL until first enable/create. Globally unique when set. |
 | qr_enabled | boolean | false | false |  |  | Per-table QR toggle (api-warolabs#265). When false, public resolve rejects access even if token is set. Default false. |
+| display_order | integer |  | true |  |  | Optional manual display order for regular tenant tables in POS/Operaciones. NULL falls back to legacy name order; bar tables stay pinned by is_bar. |
 
 ## Constraints
 
@@ -34,6 +35,7 @@
 | idx_tables_is_bar | CREATE INDEX idx_tables_is_bar ON public.tables USING btree (tenant_id, is_bar) WHERE (is_bar IS TRUE) |
 | idx_tables_assigned_member | CREATE INDEX idx_tables_assigned_member ON public.tables USING btree (assigned_member_id) WHERE (assigned_member_id IS NOT NULL) |
 | idx_tables_qr_public_token | CREATE UNIQUE INDEX idx_tables_qr_public_token ON public.tables USING btree (qr_public_token) WHERE (qr_public_token IS NOT NULL) |
+| idx_tables_tenant_display_order | CREATE INDEX idx_tables_tenant_display_order ON public.tables USING btree (tenant_id, is_bar, is_active, display_order, name) WHERE (deleted_at IS NULL) |
 
 ## Relations
 

--- a/sql/20260708_add_tables_display_order.sql
+++ b/sql/20260708_add_tables_display_order.sql
@@ -1,0 +1,29 @@
+-- warocol.com#1551 — optional manual POS table order.
+-- Additive: existing tenants keep the current API order via the initial backfill.
+
+ALTER TABLE tables
+    ADD COLUMN IF NOT EXISTS display_order integer;
+
+COMMENT ON COLUMN tables.display_order IS
+    'Optional manual display order for regular tenant tables in POS/Operaciones. NULL falls back to legacy name order; bar tables stay pinned by is_bar.';
+
+WITH ordered AS (
+    SELECT
+        id,
+        ROW_NUMBER() OVER (
+            PARTITION BY tenant_id
+            ORDER BY is_active DESC, name
+        ) AS rn
+    FROM tables
+    WHERE deleted_at IS NULL
+      AND is_bar IS FALSE
+)
+UPDATE tables t
+SET display_order = ordered.rn
+FROM ordered
+WHERE t.id = ordered.id
+  AND t.display_order IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_tables_tenant_display_order
+    ON tables (tenant_id, is_bar, is_active, display_order, name)
+    WHERE deleted_at IS NULL;

--- a/tests/test_tables_order.py
+++ b/tests/test_tables_order.py
@@ -1,0 +1,208 @@
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.exceptions import APIError, NotFoundError
+from app.services import tables_service
+
+
+def _db_context(conn):
+    @asynccontextmanager
+    async def _ctx():
+        yield conn
+
+    return _ctx
+
+
+def _tx():
+    tx = MagicMock()
+    tx.__aenter__ = AsyncMock(return_value=None)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    return tx
+
+
+def _session(tenant_id=None):
+    return SimpleNamespace(user_id=uuid4(), tenant_id=tenant_id or uuid4())
+
+
+def _table_row(table_id, name, *, is_bar=False, display_order=None):
+    return {
+        "id": table_id,
+        "name": name,
+        "code": "BAR" if is_bar else name.replace("Mesa ", "M"),
+        "capacity": None if is_bar else 4,
+        "display_order": display_order,
+        "status": "open" if is_bar else "free",
+        "is_active": True,
+        "is_bar": is_bar,
+        "qr_enabled": False,
+        "qr_public_token": None,
+        "created_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        "assigned_member_id": None,
+        "assigned_member_name": None,
+        "assigned_member_role": None,
+        "session_id": None,
+        "last_closed_at": None,
+        "last_closed_session_id": None,
+        "effective_waiter_member_id": None,
+        "effective_waiter_member_name": None,
+        "effective_waiter_member_role": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_tables_orders_by_display_order_with_name_fallback():
+    tenant_id = uuid4()
+    first_id = uuid4()
+    second_id = uuid4()
+    conn = MagicMock()
+    conn.transaction.return_value = _tx()
+    conn.fetch = AsyncMock(return_value=[
+        _table_row(first_id, "Mesa 10", display_order=1),
+        _table_row(second_id, "Mesa 2", display_order=2),
+    ])
+
+    with (
+        patch("app.services.tables_service.require_valid_session", return_value=_session(tenant_id)),
+        patch("app.services.tables_service.get_db_connection", side_effect=_db_context(conn)),
+        patch("app.services.tables_service._ensure_bar_table", new=AsyncMock()),
+    ):
+        result = await tables_service.list_tables(object())
+
+    query = conn.fetch.await_args.args[0]
+    assert "t.display_order" in query
+    assert "ORDER BY t.is_bar DESC, t.is_active DESC, t.display_order NULLS LAST, t.name" in query
+    assert [row["id"] for row in result["data"]] == [str(first_id), str(second_id)]
+    assert result["data"][0]["display_order"] == 1
+
+
+@pytest.mark.asyncio
+async def test_reorder_tables_rejects_duplicate_ids():
+    table_id = uuid4()
+
+    with patch("app.services.tables_service.require_valid_session", return_value=_session()):
+        with pytest.raises(APIError) as exc:
+            await tables_service.reorder_tables(object(), [table_id, table_id])
+
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_reorder_tables_rejects_bar_table():
+    tenant_id = uuid4()
+    table_id = uuid4()
+    conn = MagicMock()
+    conn.transaction.return_value = _tx()
+    conn.fetch = AsyncMock(return_value=[
+        {"id": table_id, "is_bar": True, "deleted_at": None},
+    ])
+
+    with (
+        patch("app.services.tables_service.require_valid_session", return_value=_session(tenant_id)),
+        patch("app.services.tables_service.get_db_connection", side_effect=_db_context(conn)),
+    ):
+        with pytest.raises(APIError) as exc:
+            await tables_service.reorder_tables(object(), [table_id])
+
+    assert exc.value.status_code == 409
+    conn.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reorder_tables_rejects_missing_or_cross_tenant_id():
+    tenant_id = uuid4()
+    table_id = uuid4()
+    conn = MagicMock()
+    conn.transaction.return_value = _tx()
+    conn.fetch = AsyncMock(return_value=[])
+
+    with (
+        patch("app.services.tables_service.require_valid_session", return_value=_session(tenant_id)),
+        patch("app.services.tables_service.get_db_connection", side_effect=_db_context(conn)),
+    ):
+        with pytest.raises(NotFoundError):
+            await tables_service.reorder_tables(object(), [table_id])
+
+    conn.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reorder_tables_rejects_deleted_table():
+    tenant_id = uuid4()
+    table_id = uuid4()
+    conn = MagicMock()
+    conn.transaction.return_value = _tx()
+    conn.fetch = AsyncMock(return_value=[
+        {"id": table_id, "is_bar": False, "deleted_at": datetime(2026, 1, 1, tzinfo=timezone.utc)},
+    ])
+
+    with (
+        patch("app.services.tables_service.require_valid_session", return_value=_session(tenant_id)),
+        patch("app.services.tables_service.get_db_connection", side_effect=_db_context(conn)),
+    ):
+        with pytest.raises(NotFoundError):
+            await tables_service.reorder_tables(object(), [table_id])
+
+    conn.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reorder_tables_persists_submitted_regular_order():
+    tenant_id = uuid4()
+    first_id = uuid4()
+    second_id = uuid4()
+    conn = MagicMock()
+    conn.transaction.return_value = _tx()
+    conn.fetch = AsyncMock(return_value=[
+        {"id": first_id, "is_bar": False, "deleted_at": None},
+        {"id": second_id, "is_bar": False, "deleted_at": None},
+    ])
+    conn.execute = AsyncMock()
+
+    with (
+        patch("app.services.tables_service.require_valid_session", return_value=_session(tenant_id)),
+        patch("app.services.tables_service.get_db_connection", side_effect=_db_context(conn)),
+    ):
+        result = await tables_service.reorder_tables(object(), [first_id, second_id])
+
+    assert result["data"]["table_ids"] == [str(first_id), str(second_id)]
+    assert conn.execute.await_count == 2
+    update_args = conn.execute.await_args_list[1].args
+    assert update_args[2] == [first_id, second_id]
+
+
+@pytest.mark.asyncio
+async def test_create_table_assigns_tail_display_order():
+    tenant_id = uuid4()
+    table_id = uuid4()
+    conn = MagicMock()
+    conn.transaction.return_value = _tx()
+    conn.fetchval = AsyncMock(side_effect=[7, False])
+    conn.fetchrow = AsyncMock(return_value={
+        "id": table_id,
+        "name": "Mesa 7",
+        "code": "M7",
+        "capacity": 4,
+        "status": "free",
+        "is_active": True,
+        "is_bar": False,
+        "qr_enabled": False,
+        "qr_public_token": None,
+        "display_order": 7,
+        "created_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+    })
+
+    with (
+        patch("app.services.tables_service.require_valid_session", return_value=_session(tenant_id)),
+        patch("app.services.tables_service.get_db_connection", side_effect=_db_context(conn)),
+        patch("app.services.tables_service._resolve_table_code", new=AsyncMock(return_value="M7")),
+        patch("app.services.tables_service.check_plan_quota_growth", new=AsyncMock()),
+    ):
+        result = await tables_service.create_table(object(), "Mesa 7", 4)
+
+    assert result["data"]["display_order"] == 7
+    assert conn.fetchrow.await_args.args[5] == 7


### PR DESCRIPTION
## Summary
- add nullable tables.display_order migration with backfill and ordering index
- expose display_order in table payloads and order GET /tables by bar/active/display_order/name
- add PATCH /tables/reorder with tenant validation, Barra protection, and focused API tests

## Tests
- pytest tests/test_tables_order.py
- pytest tests/test_pos_permissions.py tests/test_quota_enforcement.py

No build run per request.

Closes uno0uno/warocol.com#1551