### PR TITLE
feat: return table reorder message

### DIFF
--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -613,6 +613,7 @@ async def reorder_tables(request: Request, table_ids: List[UUID]) -> dict:
 
         return {
             "success": True,
+            "message": "Orden de mesas actualizado",
             "data": {
                 "table_ids": [str(table_id) for table_id in unique_ids],
             },

--- a/tests/test_tables_order.py
+++ b/tests/test_tables_order.py
@@ -169,6 +169,7 @@ async def test_reorder_tables_persists_submitted_regular_order():
     ):
         result = await tables_service.reorder_tables(object(), [first_id, second_id])
 
+    assert result["message"] == "Orden de mesas actualizado"
     assert result["data"]["table_ids"] == [str(first_id), str(second_id)]
     assert conn.execute.await_count == 2
     update_args = conn.execute.await_args_list[1].args


### PR DESCRIPTION
## Summary\n- Return a success message from the table reorder endpoint for UI toast feedback\n- Cover the response message in the table order service test\n\n## Tests\n- venv/bin/python -m pytest tests/test_tables_order.py -q