### PR TITLE
Persist customer phone during OTP verification

### DIFF
--- a/app/routers/online_verification.py
+++ b/app/routers/online_verification.py
@@ -23,6 +23,7 @@ class VerifyOTPRequest(BaseModel):
     email: EmailStr
     cart_id: Optional[UUID] = None
     otp_code: str
+    phone_number: Optional[str] = None
 
 
 class ResendOTPRequest(BaseModel):
@@ -76,7 +77,8 @@ async def verify_otp(payload: VerifyOTPRequest, response: Response):
     result = await otp_service.verify_otp_code(
         email=payload.email,
         cart_id=payload.cart_id,
-        otp_code=payload.otp_code
+        otp_code=payload.otp_code,
+        phone_number=payload.phone_number,
     )
     # Set long-lived customer session cookie for /mis-pedidos
     if result.get("success") and result.get("customer_id"):

--- a/app/services/otp_service.py
+++ b/app/services/otp_service.py
@@ -137,7 +137,8 @@ WARO Colombia
 async def verify_otp_code(
     email: str,
     cart_id: Optional[UUID],
-    otp_code: str
+    otp_code: str,
+    phone_number: Optional[str] = None,
 ) -> dict:
     """
     Verify OTP code for cart (PUBLIC)
@@ -217,7 +218,7 @@ async def verify_otp_code(
                 )
 
                 # Get or create customer
-                customer_id = await get_or_create_customer(conn, email)
+                customer_id = await get_or_create_customer(conn, email, phone_number)
 
                 pickup_pin = None
                 if cart_id is not None:
@@ -262,32 +263,117 @@ async def verify_otp_code(
         raise APIError(f"Error al verificar OTP: {str(e)}", status_code=500)
 
 
-async def get_or_create_customer(conn, email: str) -> UUID:
+def normalize_phone_number(phone_number: Optional[str]) -> Optional[str]:
+    """Normalize phone format used by customer search/create flows."""
+    if phone_number is None:
+        return None
+
+    normalized = phone_number.strip().replace(' ', '').replace('-', '')
+    return normalized or None
+
+
+def _profile_value_missing(value) -> bool:
+    return value is None or str(value).strip() == ""
+
+
+async def get_or_create_customer(
+    conn,
+    email: str,
+    phone_number: Optional[str] = None,
+) -> UUID:
     """
-    Search for existing customer by email or create new one
+    Search for an existing customer by email/phone or create a new one.
     Returns customer_id (UUID)
     """
     email = normalize_email(email)
-    # Search by email
-    customer_query = """
-        SELECT id FROM profile
+    phone_number = normalize_phone_number(phone_number)
+
+    email_query = """
+        SELECT id, email, phone_number FROM profile
         WHERE lower(trim(email)) = $1
         LIMIT 1
     """
-    customer_row = await conn.fetchrow(customer_query, email)
+    email_row = await conn.fetchrow(email_query, email)
 
-    if customer_row:
-        return customer_row['id']
+    if phone_number is None:
+        if email_row:
+            return email_row['id']
 
-    # Create new customer (phone_number is NOT NULL in schema, use empty string as placeholder)
+        create_customer_query = """
+            INSERT INTO profile (email, phone_number)
+            VALUES ($1, '')
+            RETURNING id
+        """
+        new_customer = await conn.fetchrow(create_customer_query, email)
+
+        logger.info(f"Created new customer with email {email}")
+        return new_customer['id']
+
+    phone_query = """
+        SELECT id, email, phone_number FROM profile
+        WHERE phone_number = $1
+        LIMIT 1
+    """
+    phone_row = await conn.fetchrow(phone_query, phone_number)
+
+    if email_row and phone_row and email_row['id'] != phone_row['id']:
+        raise HTTPException(
+            status_code=409,
+            detail="El correo y el teléfono pertenecen a clientes distintos."
+        )
+
+    if email_row:
+        existing_phone = normalize_phone_number(email_row['phone_number'])
+        if existing_phone is None:
+            await conn.execute(
+                """
+                UPDATE profile
+                SET phone_number = $2, updated_at = now()
+                WHERE id = $1
+                """,
+                email_row['id'],
+                phone_number,
+            )
+            return email_row['id']
+
+        if existing_phone == phone_number:
+            return email_row['id']
+
+        raise HTTPException(
+            status_code=409,
+            detail="El correo ya está asociado a otro teléfono."
+        )
+
+    if phone_row:
+        existing_email = phone_row['email']
+        if _profile_value_missing(existing_email):
+            await conn.execute(
+                """
+                UPDATE profile
+                SET email = $2, updated_at = now()
+                WHERE id = $1
+                """,
+                phone_row['id'],
+                email,
+            )
+            return phone_row['id']
+
+        if normalize_email(existing_email) == email:
+            return phone_row['id']
+
+        raise HTTPException(
+            status_code=409,
+            detail="El teléfono ya está asociado a otro correo."
+        )
+
     create_customer_query = """
         INSERT INTO profile (email, phone_number)
-        VALUES ($1, '')
+        VALUES ($1, $2)
         RETURNING id
     """
-    new_customer = await conn.fetchrow(create_customer_query, email)
+    new_customer = await conn.fetchrow(create_customer_query, email, phone_number)
 
-    logger.info(f"Created new customer with email {email}")
+    logger.info(f"Created new customer with email {email} and phone {phone_number}")
     return new_customer['id']
 
 

--- a/tests/test_otp_customer_resolution.py
+++ b/tests/test_otp_customer_resolution.py
@@ -1,0 +1,160 @@
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.services import otp_service
+
+
+def _profile_row(profile_id=None, email="buyer@example.com", phone_number="3001234567"):
+    return {
+        "id": profile_id or uuid4(),
+        "email": email,
+        "phone_number": phone_number,
+    }
+
+
+def _db_context(conn):
+    @asynccontextmanager
+    async def _ctx():
+        yield conn
+
+    return _ctx
+
+
+def _transaction_context():
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=None)
+    ctx.__aexit__ = AsyncMock(return_value=None)
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_customer_creates_new_profile_with_real_phone():
+    profile_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[None, None, {"id": profile_id}])
+
+    result = await otp_service.get_or_create_customer(
+        conn,
+        " Buyer@Example.com ",
+        "300 123-4567",
+    )
+
+    assert result == profile_id
+    insert_args = conn.fetchrow.await_args_list[2].args
+    assert "INSERT INTO profile" in insert_args[0]
+    assert insert_args[1:] == ("buyer@example.com", "3001234567")
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_customer_backfills_blank_phone_for_email_match():
+    profile_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        _profile_row(profile_id=profile_id, phone_number=""),
+        None,
+    ])
+    conn.execute = AsyncMock()
+
+    result = await otp_service.get_or_create_customer(
+        conn,
+        "buyer@example.com",
+        "300 123-4567",
+    )
+
+    assert result == profile_id
+    update_args = conn.execute.await_args.args
+    assert "UPDATE profile" in update_args[0]
+    assert "phone_number = $2" in update_args[0]
+    assert update_args[1:] == (profile_id, "3001234567")
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_customer_reuses_phone_match_and_backfills_blank_email():
+    profile_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        None,
+        _profile_row(profile_id=profile_id, email="", phone_number="3001234567"),
+    ])
+    conn.execute = AsyncMock()
+
+    result = await otp_service.get_or_create_customer(
+        conn,
+        "Buyer@Example.com",
+        "3001234567",
+    )
+
+    assert result == profile_id
+    update_args = conn.execute.await_args.args
+    assert "UPDATE profile" in update_args[0]
+    assert "email = $2" in update_args[0]
+    assert update_args[1:] == (profile_id, "buyer@example.com")
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_customer_raises_conflict_for_different_email_and_phone_profiles():
+    email_profile_id = uuid4()
+    phone_profile_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        _profile_row(profile_id=email_profile_id, email="buyer@example.com", phone_number=""),
+        _profile_row(profile_id=phone_profile_id, email="other@example.com", phone_number="3001234567"),
+    ])
+
+    with pytest.raises(HTTPException) as exc_info:
+        await otp_service.get_or_create_customer(
+            conn,
+            "buyer@example.com",
+            "3001234567",
+        )
+
+    assert exc_info.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_customer_preserves_legacy_email_only_creation():
+    profile_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[None, {"id": profile_id}])
+
+    result = await otp_service.get_or_create_customer(conn, "Buyer@Example.com")
+
+    assert result == profile_id
+    insert_args = conn.fetchrow.await_args_list[1].args
+    assert "VALUES ($1, '')" in insert_args[0]
+    assert insert_args[1:] == ("buyer@example.com",)
+
+
+@pytest.mark.asyncio
+async def test_verify_otp_code_passes_phone_to_customer_resolution():
+    customer_id = uuid4()
+    otp_row = {
+        "id": uuid4(),
+        "otp_code": "123456",
+        "is_verified": False,
+        "attempts": 0,
+        "max_attempts": 3,
+        "expires_at": datetime.now(timezone.utc) + timedelta(minutes=5),
+    }
+    conn = MagicMock()
+    conn.transaction = MagicMock(return_value=_transaction_context())
+    conn.fetchrow = AsyncMock(return_value=otp_row)
+    conn.execute = AsyncMock()
+
+    with patch("app.services.otp_service.get_db_connection", side_effect=_db_context(conn)), \
+         patch("app.services.otp_service.get_or_create_customer", new=AsyncMock(return_value=customer_id)) as resolver:
+        result = await otp_service.verify_otp_code(
+            email=" Buyer@Example.com ",
+            cart_id=None,
+            otp_code="123456",
+            phone_number="300 123-4567",
+        )
+
+    assert result["success"] is True
+    assert result["customer_id"] == str(customer_id)
+    resolver.assert_awaited_once_with(conn, "buyer@example.com", "300 123-4567")


### PR DESCRIPTION
## Summary
- accept optional phone_number in public OTP verify
- resolve OTP customers by safe email/phone matching and persist real phones for new profiles
- add focused resolver and verify forwarding tests

## Tests
- pytest tests/test_otp_customer_resolution.py
- pytest tests/test_customer_identity_model.py

Refs uno0uno/warocol.com#1558