### PR TITLE
Store checkout phone on online carts

### DIFF
--- a/app/models/online_cart.py
+++ b/app/models/online_cart.py
@@ -134,6 +134,7 @@ class OnlineOrderItem(BaseModel):
     order_type: str
     delivery_instructions: Optional[str]
     verified_email: Optional[str]
+    customer_phone: Optional[str]
 
 
 class OnlineOrdersResponse(BaseModel):

--- a/app/routers/v1_ordering.py
+++ b/app/routers/v1_ordering.py
@@ -266,6 +266,7 @@ class V1VerifyOTPRequest(BaseModel):
     email: EmailStr
     cart_id: Optional[UUID] = None
     otp_code: str
+    phone_number: Optional[str] = None
 
 
 class V1ResendOTPRequest(BaseModel):
@@ -303,6 +304,7 @@ async def v1_verify_otp(request: Request, body: V1VerifyOTPRequest, response: Re
         email=body.email,
         cart_id=body.cart_id,
         otp_code=body.otp_code,
+        phone_number=body.phone_number,
     )
     if result.get("success") and result.get("customer_id"):
         jwt_token = create_customer_jwt(

--- a/app/services/online_orders_service.py
+++ b/app/services/online_orders_service.py
@@ -235,9 +235,11 @@ async def get_online_orders_list(
                     o.status,
                     oc.order_type,
                     oc.delivery_instructions,
-                    oc.verified_email
+                    oc.verified_email,
+                    COALESCE(NULLIF(oc.customer_phone, ''), NULLIF(p.phone_number, '')) AS customer_phone
                 FROM orders o
                 JOIN online_carts oc ON oc.id = o.online_cart_id
+                LEFT JOIN profile p ON p.id = o.customer_id
                 WHERE {where_clause}
                 ORDER BY {sort_col} {sort_dir}
                 LIMIT ${limit_param} OFFSET ${offset_param}
@@ -256,6 +258,7 @@ async def get_online_orders_list(
                         "order_type": r['order_type'],
                         "delivery_instructions": r['delivery_instructions'],
                         "verified_email": r['verified_email'],
+                        "customer_phone": r['customer_phone'],
                     }
                     for r in rows
                 ],
@@ -304,6 +307,7 @@ async def get_online_order_by_id(
                     oc.order_type,
                     oc.delivery_instructions,
                     oc.verified_email,
+                    COALESCE(NULLIF(oc.customer_phone, ''), NULLIF(p.phone_number, '')) AS customer_phone,
                     ap.address_line1,
                     ap.address_line2,
                     ap.city,
@@ -311,6 +315,7 @@ async def get_online_order_by_id(
                     ap.label AS address_label
                 FROM orders o
                 JOIN online_carts oc ON oc.id = o.online_cart_id
+                LEFT JOIN profile p ON p.id = o.customer_id
                 LEFT JOIN addresses_profile ap ON ap.id = oc.delivery_address_id
                 WHERE o.id = $1
                   AND o.tenant_id = $2
@@ -377,6 +382,7 @@ async def get_online_order_by_id(
                     "order_type": row['order_type'],
                     "delivery_instructions": row['delivery_instructions'],
                     "verified_email": row['verified_email'],
+                    "customer_phone": row['customer_phone'],
                     "delivery_address": delivery_address,
                     "items": [
                         {

--- a/app/services/otp_service.py
+++ b/app/services/otp_service.py
@@ -151,6 +151,13 @@ async def verify_otp_code(
     """
     try:
         email = normalize_email(email)
+        normalized_phone = normalize_phone_number(phone_number)
+        if cart_id is not None and normalized_phone is None:
+            raise HTTPException(
+                status_code=400,
+                detail="El teléfono es requerido para verificar pedidos en línea."
+            )
+
         async with get_db_connection() as conn:
             async with conn.transaction():
                 # Get latest OTP for this email + cart
@@ -218,7 +225,7 @@ async def verify_otp_code(
                 )
 
                 # Get or create customer
-                customer_id = await get_or_create_customer(conn, email, phone_number)
+                customer_id = await get_or_create_customer(conn, email, normalized_phone)
 
                 pickup_pin = None
                 if cart_id is not None:
@@ -228,11 +235,12 @@ async def verify_otp_code(
                         SET is_verified = true,
                             verified_email = $1,
                             customer_id = $2,
+                            customer_phone = $3,
                             updated_at = now()
-                        WHERE id = $3
+                        WHERE id = $4
                         RETURNING id, order_type
                     """
-                    cart_row = await conn.fetchrow(cart_update_query, email, customer_id, cart_id)
+                    cart_row = await conn.fetchrow(cart_update_query, email, customer_id, normalized_phone, cart_id)
 
                     if not cart_row:
                         raise HTTPException(status_code=404, detail="Carrito no encontrado")
@@ -282,7 +290,7 @@ async def get_or_create_customer(
     phone_number: Optional[str] = None,
 ) -> UUID:
     """
-    Search for an existing customer by email/phone or create a new one.
+    Search for an existing customer by email or create a new one.
     Returns customer_id (UUID)
     """
     email = normalize_email(email)
@@ -295,36 +303,9 @@ async def get_or_create_customer(
     """
     email_row = await conn.fetchrow(email_query, email)
 
-    if phone_number is None:
-        if email_row:
-            return email_row['id']
-
-        create_customer_query = """
-            INSERT INTO profile (email, phone_number)
-            VALUES ($1, '')
-            RETURNING id
-        """
-        new_customer = await conn.fetchrow(create_customer_query, email)
-
-        logger.info(f"Created new customer with email {email}")
-        return new_customer['id']
-
-    phone_query = """
-        SELECT id, email, phone_number FROM profile
-        WHERE phone_number = $1
-        LIMIT 1
-    """
-    phone_row = await conn.fetchrow(phone_query, phone_number)
-
-    if email_row and phone_row and email_row['id'] != phone_row['id']:
-        raise HTTPException(
-            status_code=409,
-            detail="El correo y el teléfono pertenecen a clientes distintos."
-        )
-
     if email_row:
         existing_phone = normalize_phone_number(email_row['phone_number'])
-        if existing_phone is None:
+        if phone_number is not None and existing_phone is None:
             await conn.execute(
                 """
                 UPDATE profile
@@ -334,44 +315,14 @@ async def get_or_create_customer(
                 email_row['id'],
                 phone_number,
             )
-            return email_row['id']
-
-        if existing_phone == phone_number:
-            return email_row['id']
-
-        raise HTTPException(
-            status_code=409,
-            detail="El correo ya está asociado a otro teléfono."
-        )
-
-    if phone_row:
-        existing_email = phone_row['email']
-        if _profile_value_missing(existing_email):
-            await conn.execute(
-                """
-                UPDATE profile
-                SET email = $2, updated_at = now()
-                WHERE id = $1
-                """,
-                phone_row['id'],
-                email,
-            )
-            return phone_row['id']
-
-        if normalize_email(existing_email) == email:
-            return phone_row['id']
-
-        raise HTTPException(
-            status_code=409,
-            detail="El teléfono ya está asociado a otro correo."
-        )
+        return email_row['id']
 
     create_customer_query = """
         INSERT INTO profile (email, phone_number)
         VALUES ($1, $2)
         RETURNING id
     """
-    new_customer = await conn.fetchrow(create_customer_query, email, phone_number)
+    new_customer = await conn.fetchrow(create_customer_query, email, phone_number or '')
 
     logger.info(f"Created new customer with email {email} and phone {phone_number}")
     return new_customer['id']

--- a/migrations/097_add_customer_phone_to_online_carts.sql
+++ b/migrations/097_add_customer_phone_to_online_carts.sql
@@ -1,0 +1,4 @@
+-- Store the phone number captured during public checkout for this specific order.
+-- Phone numbers are contact data, not unique customer identity.
+ALTER TABLE online_carts
+ADD COLUMN IF NOT EXISTS customer_phone varchar;

--- a/tests/test_online_order_status.py
+++ b/tests/test_online_order_status.py
@@ -141,6 +141,7 @@ class TestOnlineOrderItemNotesContract:
                     "order_type": "delivery",
                     "delivery_instructions": None,
                     "verified_email": "cliente@example.com",
+                    "customer_phone": "3001234567",
                     "address_line1": "Calle 1",
                     "address_line2": None,
                     "city": "Bogota",
@@ -182,6 +183,7 @@ class TestOnlineOrderItemNotesContract:
             )
 
         item = result["data"]["items"][0]
+        assert result["data"]["customer_phone"] == "3001234567"
         assert item["notes"] == "Sin cebolla"
         assert item["modifiers"][0]["name"] == "Queso"
 

--- a/tests/test_otp_customer_resolution.py
+++ b/tests/test_otp_customer_resolution.py
@@ -36,7 +36,7 @@ def _transaction_context():
 async def test_get_or_create_customer_creates_new_profile_with_real_phone():
     profile_id = uuid4()
     conn = MagicMock()
-    conn.fetchrow = AsyncMock(side_effect=[None, None, {"id": profile_id}])
+    conn.fetchrow = AsyncMock(side_effect=[None, {"id": profile_id}])
 
     result = await otp_service.get_or_create_customer(
         conn,
@@ -45,7 +45,7 @@ async def test_get_or_create_customer_creates_new_profile_with_real_phone():
     )
 
     assert result == profile_id
-    insert_args = conn.fetchrow.await_args_list[2].args
+    insert_args = conn.fetchrow.await_args_list[1].args
     assert "INSERT INTO profile" in insert_args[0]
     assert insert_args[1:] == ("buyer@example.com", "3001234567")
 
@@ -56,7 +56,6 @@ async def test_get_or_create_customer_backfills_blank_phone_for_email_match():
     conn = MagicMock()
     conn.fetchrow = AsyncMock(side_effect=[
         _profile_row(profile_id=profile_id, phone_number=""),
-        None,
     ])
     conn.execute = AsyncMock()
 
@@ -74,13 +73,10 @@ async def test_get_or_create_customer_backfills_blank_phone_for_email_match():
 
 
 @pytest.mark.asyncio
-async def test_get_or_create_customer_reuses_phone_match_and_backfills_blank_email():
+async def test_get_or_create_customer_does_not_overwrite_existing_profile_phone():
     profile_id = uuid4()
     conn = MagicMock()
-    conn.fetchrow = AsyncMock(side_effect=[
-        None,
-        _profile_row(profile_id=profile_id, email="", phone_number="3001234567"),
-    ])
+    conn.fetchrow = AsyncMock(return_value=_profile_row(profile_id=profile_id, phone_number="3009999999"))
     conn.execute = AsyncMock()
 
     result = await otp_service.get_or_create_customer(
@@ -90,30 +86,28 @@ async def test_get_or_create_customer_reuses_phone_match_and_backfills_blank_ema
     )
 
     assert result == profile_id
-    update_args = conn.execute.await_args.args
-    assert "UPDATE profile" in update_args[0]
-    assert "email = $2" in update_args[0]
-    assert update_args[1:] == (profile_id, "buyer@example.com")
+    conn.execute.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_get_or_create_customer_raises_conflict_for_different_email_and_phone_profiles():
+async def test_get_or_create_customer_email_match_wins_when_phone_is_duplicated_elsewhere():
     email_profile_id = uuid4()
-    phone_profile_id = uuid4()
     conn = MagicMock()
-    conn.fetchrow = AsyncMock(side_effect=[
-        _profile_row(profile_id=email_profile_id, email="buyer@example.com", phone_number=""),
-        _profile_row(profile_id=phone_profile_id, email="other@example.com", phone_number="3001234567"),
-    ])
+    conn.fetchrow = AsyncMock(return_value=_profile_row(
+        profile_id=email_profile_id,
+        email="buyer@example.com",
+        phone_number="3009999999",
+    ))
 
-    with pytest.raises(HTTPException) as exc_info:
-        await otp_service.get_or_create_customer(
-            conn,
-            "buyer@example.com",
-            "3001234567",
-        )
+    result = await otp_service.get_or_create_customer(
+        conn,
+        "buyer@example.com",
+        "3001234567",
+    )
 
-    assert exc_info.value.status_code == 409
+    assert result == email_profile_id
+    assert conn.fetchrow.await_count == 1
+    assert "phone_number = $1" not in conn.fetchrow.await_args.args[0]
 
 
 @pytest.mark.asyncio
@@ -126,8 +120,8 @@ async def test_get_or_create_customer_preserves_legacy_email_only_creation():
 
     assert result == profile_id
     insert_args = conn.fetchrow.await_args_list[1].args
-    assert "VALUES ($1, '')" in insert_args[0]
-    assert insert_args[1:] == ("buyer@example.com",)
+    assert "INSERT INTO profile" in insert_args[0]
+    assert insert_args[1:] == ("buyer@example.com", "")
 
 
 @pytest.mark.asyncio
@@ -157,4 +151,50 @@ async def test_verify_otp_code_passes_phone_to_customer_resolution():
 
     assert result["success"] is True
     assert result["customer_id"] == str(customer_id)
-    resolver.assert_awaited_once_with(conn, "buyer@example.com", "300 123-4567")
+    resolver.assert_awaited_once_with(conn, "buyer@example.com", "3001234567")
+
+
+@pytest.mark.asyncio
+async def test_verify_otp_code_requires_phone_for_cart_checkout():
+    with pytest.raises(HTTPException) as exc_info:
+        await otp_service.verify_otp_code(
+            email="buyer@example.com",
+            cart_id=uuid4(),
+            otp_code="123456",
+            phone_number=None,
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_verify_otp_code_saves_customer_phone_on_cart():
+    customer_id = uuid4()
+    cart_id = uuid4()
+    otp_row = {
+        "id": uuid4(),
+        "otp_code": "123456",
+        "is_verified": False,
+        "attempts": 0,
+        "max_attempts": 3,
+        "expires_at": datetime.now(timezone.utc) + timedelta(minutes=5),
+    }
+    cart_row = {"id": cart_id, "order_type": "delivery"}
+    conn = MagicMock()
+    conn.transaction = MagicMock(return_value=_transaction_context())
+    conn.fetchrow = AsyncMock(side_effect=[otp_row, cart_row])
+    conn.execute = AsyncMock()
+
+    with patch("app.services.otp_service.get_db_connection", side_effect=_db_context(conn)), \
+         patch("app.services.otp_service.get_or_create_customer", new=AsyncMock(return_value=customer_id)):
+        result = await otp_service.verify_otp_code(
+            email="buyer@example.com",
+            cart_id=cart_id,
+            otp_code="123456",
+            phone_number="300 123-4567",
+        )
+
+    assert result["success"] is True
+    cart_update_args = conn.fetchrow.await_args_list[1].args
+    assert "customer_phone = $3" in cart_update_args[0]
+    assert cart_update_args[1:] == ("buyer@example.com", customer_id, "3001234567", cart_id)


### PR DESCRIPTION
## Summary
- store public checkout phone on `online_carts.customer_phone`
- resolve OTP customers by verified email without treating phone as unique identity
- expose `customer_phone` in online order list/detail payloads

## Tests
- `pytest tests/test_otp_customer_resolution.py tests/test_online_order_status.py`

No build run per request.
