### PR TITLE
feat(analytics): add ingredient consumption metrics API

### DIFF
--- a/app/routers/analytics.py
+++ b/app/routers/analytics.py
@@ -61,6 +61,50 @@ async def get_food_cost(
     )
 
 
+@router.get("/ingredients/summary", dependencies=[Depends(require_module(Module.ANALITICA))])
+async def get_ingredient_analytics_summary(
+    request: Request,
+    date_from: Optional[str] = Query(None),
+    date_to: Optional[str] = Query(None),
+    ingredient_id: Optional[UUID] = Query(None),
+    category: Optional[str] = Query(None),
+    limit: int = Query(100, ge=1, le=500),
+    sort: str = Query("consumed_quantity_desc")
+):
+    """
+    Get ingredient consumption and purchase-cost metrics for analytics.
+    """
+    return await analytics_service.get_ingredient_analytics_summary(
+        request,
+        date_from=date_from,
+        date_to=date_to,
+        ingredient_id=ingredient_id,
+        category=category,
+        limit=limit,
+        sort=sort
+    )
+
+
+@router.get("/ingredients/{ingredient_id}/history", dependencies=[Depends(require_module(Module.ANALITICA))])
+async def get_ingredient_analytics_history(
+    ingredient_id: UUID,
+    request: Request,
+    date_from: Optional[str] = Query(None),
+    date_to: Optional[str] = Query(None),
+    limit: int = Query(100, ge=1, le=500)
+):
+    """
+    Get purchase cost history and consumption movements for one ingredient.
+    """
+    return await analytics_service.get_ingredient_analytics_history(
+        request,
+        ingredient_id=ingredient_id,
+        date_from=date_from,
+        date_to=date_to,
+        limit=limit
+    )
+
+
 @router.get("/alerts", dependencies=[Depends(require_module(Module.ANALITICA))])
 async def get_alerts(
     request: Request,

--- a/app/services/analytics_service.py
+++ b/app/services/analytics_service.py
@@ -55,6 +55,414 @@ def parse_date(date_str: Optional[str]) -> Optional[date]:
         return None
 
 
+def _number_or_none(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _number_or_zero(value: Any) -> float:
+    return float(value or 0)
+
+
+def _ingredient_analytics_sort(sort: str) -> str:
+    sort_columns = {
+        "consumed_quantity_desc": "consumed_quantity DESC NULLS LAST, i.name ASC",
+        "consumed_quantity_asc": "consumed_quantity ASC NULLS LAST, i.name ASC",
+        "estimated_consumed_cost_desc": "estimated_consumed_cost DESC NULLS LAST, i.name ASC",
+        "estimated_consumed_cost_asc": "estimated_consumed_cost ASC NULLS LAST, i.name ASC",
+        "latest_cost_per_unit_desc": "lc.latest_cost_per_unit DESC NULLS LAST, i.name ASC",
+        "weighted_avg_cost_per_unit_desc": "p.weighted_avg_cost_per_unit DESC NULLS LAST, i.name ASC",
+        "ingredient_name_asc": "i.name ASC",
+        "ingredient_name_desc": "i.name DESC",
+    }
+    return sort_columns.get(sort, sort_columns["consumed_quantity_desc"])
+
+
+async def _ingredient_analytics_period(
+    conn,
+    tenant_id: str,
+    date_from: Optional[str],
+    date_to: Optional[str],
+) -> tuple[date, date, str]:
+    timezone_name = await resolve_tenant_timezone(conn, tenant_id)
+    parsed_date_from = parse_date(date_from)
+    parsed_date_to = parse_date(date_to)
+    if not parsed_date_from or not parsed_date_to:
+        today = tenant_today(timezone_name)
+        parsed_date_to = today
+        parsed_date_from = today.replace(month=1, day=1)
+    return parsed_date_from, parsed_date_to, timezone_name
+
+
+async def _get_ingredient_analytics_summary_for_tenant(
+    tenant_id: str,
+    *,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+    ingredient_id: Optional[UUID] = None,
+    category: Optional[str] = None,
+    limit: int = 100,
+    sort: str = "consumed_quantity_desc",
+) -> dict:
+    """Auth-agnostic ingredient consumption and purchase-cost summary."""
+    async with get_db_connection() as conn:
+        parsed_date_from, parsed_date_to, timezone_name = await _ingredient_analytics_period(
+            conn, tenant_id, date_from, date_to
+        )
+        order_by = _ingredient_analytics_sort(sort)
+
+        query = f"""
+            WITH consumption AS (
+                SELECT
+                    tim.ingredient_id,
+                    SUM(ABS(tim.quantity_change)) AS consumed_quantity,
+                    COUNT(*) AS movement_count
+                FROM tenant_ingredient_movements tim
+                WHERE tim.tenant_id = $1
+                    AND tim.movement_type = 'consumption'
+                    AND tim.quantity_change < 0
+                    AND DATE(tim.created_at AT TIME ZONE $4) >= $2
+                    AND DATE(tim.created_at AT TIME ZONE $4) <= $3
+                GROUP BY tim.ingredient_id
+            ),
+            purchases AS (
+                SELECT
+                    tpi.ingredient_id,
+                    SUM(tpi.quantity) AS purchase_quantity,
+                    SUM(tpi.quantity * tpi.unit_cost) / NULLIF(SUM(tpi.quantity), 0) AS weighted_avg_cost_per_unit
+                FROM tenant_purchase_items tpi
+                JOIN tenant_purchases tp ON tpi.purchase_id = tp.id
+                WHERE tp.tenant_id = $1
+                    AND tpi.unit_cost IS NOT NULL
+                    AND tpi.quantity > 0
+                    AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $4) >= $2
+                    AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $4) <= $3
+                GROUP BY tpi.ingredient_id
+            ),
+            latest_costs AS (
+                SELECT DISTINCT ON (tim.ingredient_id)
+                    tim.ingredient_id,
+                    tim.cost_per_unit AS latest_cost_per_unit,
+                    tim.created_at AS latest_cost_at
+                FROM tenant_ingredient_movements tim
+                WHERE tim.tenant_id = $1
+                    AND tim.cost_per_unit IS NOT NULL
+                    AND tim.cost_per_unit > 0
+                    AND DATE(tim.created_at AT TIME ZONE $4) <= $3
+                ORDER BY tim.ingredient_id, tim.created_at DESC
+            )
+            SELECT
+                i.id AS ingredient_id,
+                i.name AS ingredient_name,
+                i.category,
+                i.unit,
+                c.consumed_quantity,
+                p.purchase_quantity,
+                lc.latest_cost_per_unit,
+                lc.latest_cost_at,
+                p.weighted_avg_cost_per_unit,
+                COALESCE(c.consumed_quantity, 0) * COALESCE(p.weighted_avg_cost_per_unit, lc.latest_cost_per_unit, 0)
+                    AS estimated_consumed_cost,
+                COALESCE(c.movement_count, 0) AS movement_count,
+                CASE
+                    WHEN COALESCE(c.movement_count, 0) > 0 THEN 'recorded_movements'
+                    ELSE 'no_recorded_consumption'
+                END AS data_coverage
+            FROM ingredients i
+            LEFT JOIN consumption c ON c.ingredient_id = i.id
+            LEFT JOIN purchases p ON p.ingredient_id = i.id
+            LEFT JOIN latest_costs lc ON lc.ingredient_id = i.id
+            WHERE (c.ingredient_id IS NOT NULL OR p.ingredient_id IS NOT NULL)
+                AND ($5::uuid IS NULL OR i.id = $5::uuid)
+                AND ($6::text IS NULL OR i.category = $6::text)
+            ORDER BY {order_by}
+            LIMIT $7
+        """
+
+        rows = await conn.fetch(
+            query,
+            tenant_id,
+            parsed_date_from,
+            parsed_date_to,
+            timezone_name,
+            ingredient_id,
+            category,
+            limit,
+        )
+
+        items = []
+        for row in rows:
+            items.append({
+                "ingredient_id": str(row["ingredient_id"]),
+                "ingredient_name": row["ingredient_name"],
+                "category": row["category"],
+                "unit": row["unit"],
+                "consumed_quantity": _number_or_zero(row["consumed_quantity"]),
+                "purchase_quantity": _number_or_zero(row["purchase_quantity"]),
+                "latest_cost_per_unit": _number_or_none(row["latest_cost_per_unit"]),
+                "latest_cost_at": row["latest_cost_at"].isoformat() if row["latest_cost_at"] else None,
+                "weighted_avg_cost_per_unit": _number_or_none(row["weighted_avg_cost_per_unit"]),
+                "estimated_consumed_cost": _number_or_zero(row["estimated_consumed_cost"]),
+                "movement_count": row["movement_count"],
+                "data_coverage": row["data_coverage"],
+            })
+
+        return {
+            "success": True,
+            "data": {
+                "items": items,
+                "period": {
+                    "from": parsed_date_from.isoformat(),
+                    "to": parsed_date_to.isoformat(),
+                    "days": (parsed_date_to - parsed_date_from).days + 1,
+                },
+                "filters": {
+                    "ingredient_id": str(ingredient_id) if ingredient_id else None,
+                    "category": category,
+                    "sort": sort,
+                    "limit": limit,
+                },
+            },
+        }
+
+
+async def get_ingredient_analytics_summary(
+    request: Request,
+    *,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+    ingredient_id: Optional[UUID] = None,
+    category: Optional[str] = None,
+    limit: int = 100,
+    sort: str = "consumed_quantity_desc",
+) -> dict:
+    """Session wrapper for ingredient analytics summary."""
+    try:
+        session_context = require_valid_session(request)
+        tenant_id = session_context.tenant_id
+        if not tenant_id:
+            raise AuthenticationError("Tenant ID is required")
+        return await _get_ingredient_analytics_summary_for_tenant(
+            tenant_id,
+            date_from=date_from,
+            date_to=date_to,
+            ingredient_id=ingredient_id,
+            category=category,
+            limit=limit,
+            sort=sort,
+        )
+    except AuthenticationError as e:
+        raise e
+    except Exception as e:
+        logger.error(f"Error getting ingredient analytics summary: {str(e)}")
+        raise APIError(f"Error getting ingredient analytics summary: {str(e)}", status_code=500)
+
+
+async def _get_ingredient_analytics_history_for_tenant(
+    tenant_id: str,
+    ingredient_id: UUID,
+    *,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+    limit: int = 100,
+) -> dict:
+    """Auth-agnostic purchase/consumption history for one ingredient."""
+    async with get_db_connection() as conn:
+        parsed_date_from, parsed_date_to, timezone_name = await _ingredient_analytics_period(
+            conn, tenant_id, date_from, date_to
+        )
+
+        ingredient = await conn.fetchrow("""
+            SELECT id, name, category, unit
+            FROM ingredients
+            WHERE id = $1
+        """, ingredient_id)
+
+        purchase_rows = await conn.fetch("""
+            SELECT
+                tpi.id AS purchase_item_id,
+                tp.id AS purchase_id,
+                tp.purchase_number,
+                tp.purchase_date,
+                tpi.quantity AS base_quantity,
+                tpi.unit AS base_unit,
+                tpi.purchase_quantity,
+                tpi.purchase_unit,
+                tpi.unit_cost,
+                tpi.total_cost,
+                tpi.received_at
+            FROM tenant_purchase_items tpi
+            JOIN tenant_purchases tp ON tpi.purchase_id = tp.id
+            WHERE tp.tenant_id = $1
+                AND tpi.ingredient_id = $2
+                AND tpi.unit_cost IS NOT NULL
+                AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $4) >= $3
+                AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $4) <= $5
+            ORDER BY COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) DESC
+            LIMIT $6
+        """, tenant_id, ingredient_id, parsed_date_from, timezone_name, parsed_date_to, limit)
+
+        movement_rows = await conn.fetch("""
+            SELECT
+                tim.id,
+                tim.movement_type,
+                tim.quantity_change,
+                tim.unit,
+                tim.previous_stock,
+                tim.new_stock,
+                tim.cost_per_unit,
+                tim.reference_table,
+                tim.reference_id,
+                tim.reason,
+                tim.notes,
+                tim.created_at
+            FROM tenant_ingredient_movements tim
+            WHERE tim.tenant_id = $1
+                AND tim.ingredient_id = $2
+                AND tim.movement_type = 'consumption'
+                AND tim.quantity_change < 0
+                AND DATE(tim.created_at AT TIME ZONE $4) >= $3
+                AND DATE(tim.created_at AT TIME ZONE $4) <= $5
+            ORDER BY tim.created_at DESC
+            LIMIT $6
+        """, tenant_id, ingredient_id, parsed_date_from, timezone_name, parsed_date_to, limit)
+
+        stock_row = await conn.fetchrow("""
+            SELECT current_stock, minimum_stock, maximum_stock, last_updated, location
+            FROM tenant_inventory
+            WHERE tenant_id = $1 AND ingredient_id = $2
+        """, tenant_id, ingredient_id)
+
+        related_rows = await conn.fetch("""
+            SELECT DISTINCT
+                p.id AS product_id,
+                p.name AS product_name,
+                'direct_recipe' AS relation_type,
+                pr.quantity AS quantity,
+                pr.unit AS unit
+            FROM product_recipes pr
+            JOIN product p ON p.id = pr.product_id
+            WHERE pr.tenant_id = $1
+                AND pr.ingredient_id = $2
+            UNION ALL
+            SELECT DISTINCT
+                p.id AS product_id,
+                p.name AS product_name,
+                'base_recipe' AS relation_type,
+                (pbr.quantity * brt.base_quantity) AS quantity,
+                brt.unit AS unit
+            FROM product_base_recipes pbr
+            JOIN product p ON p.id = pbr.product_id
+            JOIN base_recipe_templates brt ON brt.product_base_type_id = pbr.product_base_type_id
+            WHERE pbr.tenant_id = $1
+                AND brt.ingredient_id = $2
+                AND (brt.tenant_id = $1 OR brt.tenant_id IS NULL)
+            ORDER BY product_name ASC
+            LIMIT $3
+        """, tenant_id, ingredient_id, limit)
+
+        purchases = []
+        for row in purchase_rows:
+            purchases.append({
+                "purchase_item_id": str(row["purchase_item_id"]),
+                "purchase_id": str(row["purchase_id"]),
+                "purchase_number": row["purchase_number"],
+                "purchase_date": row["purchase_date"].isoformat() if row["purchase_date"] else None,
+                "base_quantity": _number_or_zero(row["base_quantity"]),
+                "base_unit": row["base_unit"],
+                "purchase_quantity": _number_or_none(row["purchase_quantity"]),
+                "purchase_unit": row["purchase_unit"],
+                "unit_cost": _number_or_none(row["unit_cost"]),
+                "total_cost": _number_or_none(row["total_cost"]),
+                "received_at": row["received_at"].isoformat() if row["received_at"] else None,
+            })
+
+        consumption_movements = []
+        for row in movement_rows:
+            consumption_movements.append({
+                "id": str(row["id"]),
+                "movement_type": row["movement_type"],
+                "quantity_change": _number_or_zero(row["quantity_change"]),
+                "consumed_quantity": abs(_number_or_zero(row["quantity_change"])),
+                "unit": row["unit"],
+                "previous_stock": _number_or_none(row["previous_stock"]),
+                "new_stock": _number_or_none(row["new_stock"]),
+                "cost_per_unit": _number_or_none(row["cost_per_unit"]),
+                "reference_table": row["reference_table"],
+                "reference_id": str(row["reference_id"]) if row["reference_id"] else None,
+                "reason": row["reason"],
+                "notes": row["notes"],
+                "created_at": row["created_at"].isoformat() if row["created_at"] else None,
+            })
+
+        related_products = []
+        for row in related_rows:
+            related_products.append({
+                "product_id": str(row["product_id"]),
+                "product_name": row["product_name"],
+                "relation_type": row["relation_type"],
+                "quantity": _number_or_none(row["quantity"]),
+                "unit": row["unit"],
+            })
+
+        return {
+            "success": True,
+            "data": {
+                "ingredient": {
+                    "id": str(ingredient["id"]) if ingredient else str(ingredient_id),
+                    "name": ingredient["name"] if ingredient else None,
+                    "category": ingredient["category"] if ingredient else None,
+                    "unit": ingredient["unit"] if ingredient else None,
+                },
+                "purchases": purchases,
+                "consumption_movements": consumption_movements,
+                "stock": {
+                    "current_stock": _number_or_none(stock_row["current_stock"]) if stock_row else None,
+                    "minimum_stock": _number_or_none(stock_row["minimum_stock"]) if stock_row else None,
+                    "maximum_stock": _number_or_none(stock_row["maximum_stock"]) if stock_row else None,
+                    "last_updated": stock_row["last_updated"].isoformat() if stock_row and stock_row["last_updated"] else None,
+                    "location": stock_row["location"] if stock_row else None,
+                },
+                "related_products": related_products,
+                "period": {
+                    "from": parsed_date_from.isoformat(),
+                    "to": parsed_date_to.isoformat(),
+                    "days": (parsed_date_to - parsed_date_from).days + 1,
+                },
+                "data_coverage": "recorded_movements" if consumption_movements else "no_recorded_consumption",
+            },
+        }
+
+
+async def get_ingredient_analytics_history(
+    request: Request,
+    ingredient_id: UUID,
+    *,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+    limit: int = 100,
+) -> dict:
+    """Session wrapper for one ingredient analytics history."""
+    try:
+        session_context = require_valid_session(request)
+        tenant_id = session_context.tenant_id
+        if not tenant_id:
+            raise AuthenticationError("Tenant ID is required")
+        return await _get_ingredient_analytics_history_for_tenant(
+            tenant_id,
+            ingredient_id,
+            date_from=date_from,
+            date_to=date_to,
+            limit=limit,
+        )
+    except AuthenticationError as e:
+        raise e
+    except Exception as e:
+        logger.error(f"Error getting ingredient analytics history: {str(e)}")
+        raise APIError(f"Error getting ingredient analytics history: {str(e)}", status_code=500)
+
+
 async def _get_menu_analysis_for_tenant(
     tenant_id: str,
     date_from: Optional[str] = None,

--- a/tests/test_analytics_ingredients.py
+++ b/tests/test_analytics_ingredients.py
@@ -1,0 +1,210 @@
+"""Ingredient analytics API contracts (#1565)."""
+from datetime import datetime
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services import analytics_service
+
+
+def _mock_db(fetch_rows=None, fetchrow_rows=None):
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value="America/Mexico_City")
+    conn.fetch = AsyncMock(side_effect=list(fetch_rows or []))
+    conn.fetchrow = AsyncMock(side_effect=list(fetchrow_rows or []))
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=conn)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return conn, cm
+
+
+@pytest.mark.asyncio
+async def test_ingredient_summary_uses_recorded_consumption_and_purchase_costs():
+    ingredient_id = uuid4()
+    rows = [{
+        "ingredient_id": ingredient_id,
+        "ingredient_name": "Tomate",
+        "category": "Verduras",
+        "unit": "gr",
+        "consumed_quantity": Decimal("1234.5"),
+        "purchase_quantity": Decimal("2000"),
+        "latest_cost_per_unit": Decimal("6.6171"),
+        "latest_cost_at": datetime(2026, 1, 20, 12, 0),
+        "weighted_avg_cost_per_unit": Decimal("6.42"),
+        "estimated_consumed_cost": Decimal("7925.49"),
+        "movement_count": 12,
+        "data_coverage": "recorded_movements",
+    }]
+    conn, cm = _mock_db(fetch_rows=[rows])
+
+    with patch("app.services.analytics_service.get_db_connection", return_value=cm):
+        result = await analytics_service._get_ingredient_analytics_summary_for_tenant(
+            "tenant-1",
+            date_from="2026-01-01",
+            date_to="2026-01-31",
+            ingredient_id=ingredient_id,
+            category="Verduras",
+            limit=25,
+            sort="estimated_consumed_cost_desc",
+        )
+
+    sql = conn.fetch.await_args.args[0]
+    args = conn.fetch.await_args.args
+    assert "tenant_ingredient_movements tim" in sql
+    assert "tim.movement_type = 'consumption'" in sql
+    assert "tim.quantity_change < 0" in sql
+    assert "tenant_purchase_items tpi" in sql
+    assert "SUM(tpi.quantity * tpi.unit_cost) / NULLIF(SUM(tpi.quantity), 0)" in sql
+    assert "p.costo_calculado" not in sql
+    assert "p.costo_percibido" not in sql
+    assert "p.price * 0.40" not in sql
+    assert "ORDER BY estimated_consumed_cost DESC NULLS LAST" in sql
+    assert args[4] == "America/Mexico_City"
+    assert args[5] == ingredient_id
+    assert args[6] == "Verduras"
+    assert args[7] == 25
+
+    item = result["data"]["items"][0]
+    assert item["ingredient_id"] == str(ingredient_id)
+    assert item["consumed_quantity"] == 1234.5
+    assert item["purchase_quantity"] == 2000.0
+    assert item["latest_cost_per_unit"] == 6.6171
+    assert item["weighted_avg_cost_per_unit"] == 6.42
+    assert item["estimated_consumed_cost"] == 7925.49
+    assert item["movement_count"] == 12
+    assert item["data_coverage"] == "recorded_movements"
+
+
+@pytest.mark.asyncio
+async def test_ingredient_summary_defaults_period_and_whitelists_sort():
+    conn, cm = _mock_db(fetch_rows=[[]])
+
+    with patch("app.services.analytics_service.get_db_connection", return_value=cm), \
+         patch("app.services.analytics_service.tenant_today", return_value=datetime(2026, 7, 9).date()):
+        await analytics_service._get_ingredient_analytics_summary_for_tenant(
+            "tenant-1",
+            sort="unsafe desc; drop table product",
+        )
+
+    sql = conn.fetch.await_args.args[0]
+    args = conn.fetch.await_args.args
+    assert "unsafe desc" not in sql
+    assert "ORDER BY consumed_quantity DESC NULLS LAST" in sql
+    assert args[2].isoformat() == "2026-01-01"
+    assert args[3].isoformat() == "2026-07-09"
+
+
+@pytest.mark.asyncio
+async def test_ingredient_history_returns_purchase_consumption_stock_and_products():
+    ingredient_id = uuid4()
+    purchase_id = uuid4()
+    purchase_item_id = uuid4()
+    movement_id = uuid4()
+    product_id = uuid4()
+    rows = [
+        [{
+            "purchase_item_id": purchase_item_id,
+            "purchase_id": purchase_id,
+            "purchase_number": "CP-1",
+            "purchase_date": datetime(2026, 1, 5, 10, 0),
+            "base_quantity": Decimal("1345"),
+            "base_unit": "gr",
+            "purchase_quantity": Decimal("1.345"),
+            "purchase_unit": "kg",
+            "unit_cost": Decimal("6.6171"),
+            "total_cost": Decimal("8900"),
+            "received_at": datetime(2026, 1, 5, 10, 15),
+        }],
+        [{
+            "id": movement_id,
+            "movement_type": "consumption",
+            "quantity_change": Decimal("-250"),
+            "unit": "gr",
+            "previous_stock": Decimal("1000"),
+            "new_stock": Decimal("750"),
+            "cost_per_unit": Decimal("6.6171"),
+            "reference_table": "orders",
+            "reference_id": uuid4(),
+            "reason": "POS sale",
+            "notes": None,
+            "created_at": datetime(2026, 1, 6, 12, 0),
+        }],
+        [{
+            "product_id": product_id,
+            "product_name": "Hamburguesa",
+            "relation_type": "direct_recipe",
+            "quantity": Decimal("50"),
+            "unit": "gr",
+        }],
+    ]
+    conn, cm = _mock_db(
+        fetch_rows=rows,
+        fetchrow_rows=[
+            {"id": ingredient_id, "name": "Tomate", "category": "Verduras", "unit": "gr"},
+            {
+                "current_stock": Decimal("750"),
+                "minimum_stock": Decimal("100"),
+                "maximum_stock": Decimal("2000"),
+                "last_updated": datetime(2026, 1, 6, 12, 5),
+                "location": "Bodega",
+            },
+        ],
+    )
+
+    with patch("app.services.analytics_service.get_db_connection", return_value=cm):
+        result = await analytics_service._get_ingredient_analytics_history_for_tenant(
+            "tenant-1",
+            ingredient_id,
+            date_from="2026-01-01",
+            date_to="2026-01-31",
+            limit=10,
+        )
+
+    purchase_sql = conn.fetch.await_args_list[0].args[0]
+    movement_sql = conn.fetch.await_args_list[1].args[0]
+    related_sql = conn.fetch.await_args_list[2].args[0]
+    assert "tenant_purchase_items tpi" in purchase_sql
+    assert "tim.movement_type = 'consumption'" in movement_sql
+    assert "product_recipes pr" in related_sql
+    assert "base_recipe_templates brt" in related_sql
+
+    data = result["data"]
+    assert data["ingredient"]["id"] == str(ingredient_id)
+    assert data["purchases"][0]["unit_cost"] == 6.6171
+    assert data["consumption_movements"][0]["consumed_quantity"] == 250.0
+    assert data["stock"]["current_stock"] == 750.0
+    assert data["related_products"][0]["product_id"] == str(product_id)
+    assert data["data_coverage"] == "recorded_movements"
+
+
+@pytest.mark.asyncio
+async def test_ingredient_summary_wrapper_resolves_tenant_before_core():
+    session = SimpleNamespace(tenant_id="tenant-wrapper")
+
+    with patch("app.services.analytics_service.require_valid_session", return_value=session), \
+         patch(
+             "app.services.analytics_service._get_ingredient_analytics_summary_for_tenant",
+             new_callable=AsyncMock,
+         ) as core:
+        core.return_value = {"success": True, "data": {"items": []}}
+        result = await analytics_service.get_ingredient_analytics_summary(
+            object(),
+            date_from="2026-01-01",
+            date_to="2026-01-31",
+            limit=5,
+        )
+
+    assert result["success"] is True
+    core.assert_awaited_once_with(
+        "tenant-wrapper",
+        date_from="2026-01-01",
+        date_to="2026-01-31",
+        ingredient_id=None,
+        category=None,
+        limit=5,
+        sort="consumed_quantity_desc",
+    )


### PR DESCRIPTION
Summary:
- Add ANALITICA-gated ingredient summary and history endpoints.
- Aggregate recorded consumption movements and purchase/base-unit costs without product-cost fallbacks.
- Add focused contract/calculation tests.

Tests:
- pytest tests/test_analytics_ingredients.py tests/test_analytics_dual_cost.py tests/test_inventory.py tests/test_direct_purchase_decimal.py

Closes uno0uno/warocol.com#1565