### PR TITLE
Add ingredient analytics report endpoint

### DIFF
--- a/app/routers/analytics.py
+++ b/app/routers/analytics.py
@@ -105,6 +105,26 @@ async def get_ingredient_analytics_history(
     )
 
 
+@router.get("/ingredients/{ingredient_id}/report", dependencies=[Depends(require_module(Module.ANALITICA))])
+async def get_ingredient_analytics_report(
+    ingredient_id: UUID,
+    request: Request,
+    date_from: Optional[str] = Query(None),
+    date_to: Optional[str] = Query(None),
+    limit: int = Query(100, ge=1, le=500)
+):
+    """
+    Get report-ready analytics for one ingredient.
+    """
+    return await analytics_service.get_ingredient_analytics_report(
+        request,
+        ingredient_id=ingredient_id,
+        date_from=date_from,
+        date_to=date_to,
+        limit=limit
+    )
+
+
 @router.get("/alerts", dependencies=[Depends(require_module(Module.ANALITICA))])
 async def get_alerts(
     request: Request,

--- a/app/services/analytics_service.py
+++ b/app/services/analytics_service.py
@@ -65,6 +65,20 @@ def _number_or_zero(value: Any) -> float:
     return float(value or 0)
 
 
+def _serialize_ingredient_series(rows) -> List[Dict[str, Any]]:
+    series = []
+    for row in rows:
+        period = row["period"]
+        series.append({
+            "period": period.isoformat() if hasattr(period, "isoformat") else str(period),
+            "consumed_quantity": _number_or_zero(row["consumed_quantity"]),
+            "estimated_consumed_cost": _number_or_zero(row["estimated_consumed_cost"]),
+            "unit_cost": _number_or_none(row["unit_cost"]),
+            "movement_count": row["movement_count"],
+        })
+    return series
+
+
 def _ingredient_analytics_sort(sort: str) -> str:
     sort_columns = {
         "consumed_quantity_desc": "consumed_quantity DESC NULLS LAST, i.name ASC",
@@ -433,6 +447,439 @@ async def _get_ingredient_analytics_history_for_tenant(
                 "data_coverage": "recorded_movements" if consumption_movements else "no_recorded_consumption",
             },
         }
+
+
+async def _get_ingredient_analytics_report_for_tenant(
+    tenant_id: str,
+    ingredient_id: UUID,
+    *,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+    limit: int = 100,
+) -> dict:
+    """Auth-agnostic report-ready analytics for one ingredient."""
+    async with get_db_connection() as conn:
+        parsed_date_from, parsed_date_to, timezone_name = await _ingredient_analytics_period(
+            conn, tenant_id, date_from, date_to
+        )
+
+        ingredient = await conn.fetchrow("""
+            SELECT id, name, category, unit
+            FROM ingredients
+            WHERE id = $1
+        """, ingredient_id)
+
+        metrics_row = await conn.fetchrow("""
+            WITH consumption AS (
+                SELECT
+                    tim.ingredient_id,
+                    SUM(ABS(tim.quantity_change)) AS consumed_quantity,
+                    COUNT(*) AS movement_count
+                FROM tenant_ingredient_movements tim
+                WHERE tim.tenant_id = $1
+                    AND tim.ingredient_id = $2
+                    AND tim.movement_type = 'consumption'
+                    AND tim.quantity_change < 0
+                    AND DATE(tim.created_at AT TIME ZONE $5) >= $3
+                    AND DATE(tim.created_at AT TIME ZONE $5) <= $4
+                GROUP BY tim.ingredient_id
+            ),
+            purchases AS (
+                SELECT
+                    tpi.ingredient_id,
+                    SUM(tpi.quantity) AS purchase_quantity,
+                    SUM(tpi.quantity * tpi.unit_cost) / NULLIF(SUM(tpi.quantity), 0) AS weighted_avg_cost_per_unit
+                FROM tenant_purchase_items tpi
+                JOIN tenant_purchases tp ON tpi.purchase_id = tp.id
+                WHERE tp.tenant_id = $1
+                    AND tpi.ingredient_id = $2
+                    AND tpi.unit_cost IS NOT NULL
+                    AND tpi.quantity > 0
+                    AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $5) >= $3
+                    AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $5) <= $4
+                GROUP BY tpi.ingredient_id
+            ),
+            purchase_bounds AS (
+                SELECT
+                    (
+                        SELECT tpi.unit_cost
+                        FROM tenant_purchase_items tpi
+                        JOIN tenant_purchases tp ON tpi.purchase_id = tp.id
+                        WHERE tp.tenant_id = $1
+                            AND tpi.ingredient_id = $2
+                            AND tpi.unit_cost IS NOT NULL
+                            AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $5) >= $3
+                            AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $5) <= $4
+                        ORDER BY COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) ASC
+                        LIMIT 1
+                    ) AS first_unit_cost,
+                    (
+                        SELECT tpi.unit_cost
+                        FROM tenant_purchase_items tpi
+                        JOIN tenant_purchases tp ON tpi.purchase_id = tp.id
+                        WHERE tp.tenant_id = $1
+                            AND tpi.ingredient_id = $2
+                            AND tpi.unit_cost IS NOT NULL
+                            AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $5) >= $3
+                            AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $5) <= $4
+                        ORDER BY COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) DESC
+                        LIMIT 1
+                    ) AS latest_purchase_unit_cost
+            ),
+            latest_costs AS (
+                SELECT DISTINCT ON (tim.ingredient_id)
+                    tim.ingredient_id,
+                    tim.cost_per_unit AS latest_cost_per_unit,
+                    tim.created_at AS latest_cost_at
+                FROM tenant_ingredient_movements tim
+                WHERE tim.tenant_id = $1
+                    AND tim.ingredient_id = $2
+                    AND tim.cost_per_unit IS NOT NULL
+                    AND tim.cost_per_unit > 0
+                    AND DATE(tim.created_at AT TIME ZONE $5) <= $4
+                ORDER BY tim.ingredient_id, tim.created_at DESC
+            )
+            SELECT
+                COALESCE(c.consumed_quantity, 0) AS consumed_quantity,
+                COALESCE(c.movement_count, 0) AS movement_count,
+                COALESCE(p.purchase_quantity, 0) AS purchase_quantity,
+                p.weighted_avg_cost_per_unit,
+                lc.latest_cost_per_unit,
+                lc.latest_cost_at,
+                COALESCE(c.consumed_quantity, 0) * COALESCE(p.weighted_avg_cost_per_unit, lc.latest_cost_per_unit, 0)
+                    AS estimated_consumed_cost,
+                CASE
+                    WHEN p.weighted_avg_cost_per_unit IS NOT NULL THEN 'weighted_avg_purchase_cost'
+                    WHEN lc.latest_cost_per_unit IS NOT NULL THEN 'latest_movement_cost'
+                    ELSE 'none'
+                END AS cost_basis,
+                pb.first_unit_cost,
+                pb.latest_purchase_unit_cost,
+                pb.latest_purchase_unit_cost - pb.first_unit_cost AS cost_variation,
+                CASE
+                    WHEN pb.first_unit_cost IS NOT NULL AND pb.first_unit_cost <> 0
+                    THEN (pb.latest_purchase_unit_cost - pb.first_unit_cost) / pb.first_unit_cost
+                    ELSE NULL
+                END AS cost_variation_pct
+            FROM purchase_bounds pb
+            LEFT JOIN consumption c ON c.ingredient_id = $2
+            LEFT JOIN purchases p ON p.ingredient_id = $2
+            LEFT JOIN latest_costs lc ON lc.ingredient_id = $2
+        """, tenant_id, ingredient_id, parsed_date_from, parsed_date_to, timezone_name)
+
+        purchase_rows = await conn.fetch("""
+            SELECT
+                tpi.id AS purchase_item_id,
+                tp.id AS purchase_id,
+                tp.purchase_number,
+                tp.purchase_date,
+                tpi.quantity AS base_quantity,
+                tpi.unit AS base_unit,
+                tpi.purchase_quantity,
+                tpi.purchase_unit,
+                tpi.unit_cost,
+                tpi.total_cost,
+                tpi.received_at
+            FROM tenant_purchase_items tpi
+            JOIN tenant_purchases tp ON tpi.purchase_id = tp.id
+            WHERE tp.tenant_id = $1
+                AND tpi.ingredient_id = $2
+                AND tpi.unit_cost IS NOT NULL
+                AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $4) >= $3
+                AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $4) <= $5
+            ORDER BY COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) DESC
+            LIMIT $6
+        """, tenant_id, ingredient_id, parsed_date_from, timezone_name, parsed_date_to, limit)
+
+        movement_rows = await conn.fetch("""
+            SELECT
+                tim.id,
+                tim.movement_type,
+                tim.quantity_change,
+                tim.unit,
+                tim.previous_stock,
+                tim.new_stock,
+                tim.cost_per_unit,
+                tim.reference_table,
+                tim.reference_id,
+                tim.reason,
+                tim.notes,
+                tim.created_at
+            FROM tenant_ingredient_movements tim
+            WHERE tim.tenant_id = $1
+                AND tim.ingredient_id = $2
+                AND DATE(tim.created_at AT TIME ZONE $4) >= $3
+                AND DATE(tim.created_at AT TIME ZONE $4) <= $5
+            ORDER BY tim.created_at DESC
+            LIMIT $6
+        """, tenant_id, ingredient_id, parsed_date_from, timezone_name, parsed_date_to, limit)
+
+        stock_row = await conn.fetchrow("""
+            SELECT current_stock, minimum_stock, maximum_stock, last_updated, location
+            FROM tenant_inventory
+            WHERE tenant_id = $1 AND ingredient_id = $2
+        """, tenant_id, ingredient_id)
+
+        related_rows = await conn.fetch("""
+            SELECT DISTINCT
+                p.id AS product_id,
+                p.name AS product_name,
+                'direct_recipe' AS relation_type,
+                pr.quantity AS quantity,
+                pr.unit AS unit
+            FROM product_recipes pr
+            JOIN product p ON p.id = pr.product_id
+            WHERE pr.tenant_id = $1
+                AND pr.ingredient_id = $2
+            UNION ALL
+            SELECT DISTINCT
+                p.id AS product_id,
+                p.name AS product_name,
+                'base_recipe' AS relation_type,
+                (pbr.quantity * brt.base_quantity) AS quantity,
+                brt.unit AS unit
+            FROM product_base_recipes pbr
+            JOIN product p ON p.id = pbr.product_id
+            JOIN base_recipe_templates brt ON brt.product_base_type_id = pbr.product_base_type_id
+            WHERE pbr.tenant_id = $1
+                AND brt.ingredient_id = $2
+                AND (brt.tenant_id = $1 OR brt.tenant_id IS NULL)
+            ORDER BY product_name ASC
+            LIMIT $3
+        """, tenant_id, ingredient_id, limit)
+
+        day_rows = await conn.fetch("""
+            WITH basis AS (
+                SELECT COALESCE(
+                    (
+                        SELECT SUM(tpi.quantity * tpi.unit_cost) / NULLIF(SUM(tpi.quantity), 0)
+                        FROM tenant_purchase_items tpi
+                        JOIN tenant_purchases tp ON tpi.purchase_id = tp.id
+                        WHERE tp.tenant_id = $1
+                            AND tpi.ingredient_id = $2
+                            AND tpi.unit_cost IS NOT NULL
+                            AND tpi.quantity > 0
+                            AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $5) >= $3
+                            AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $5) <= $4
+                    ),
+                    (
+                        SELECT tim.cost_per_unit
+                        FROM tenant_ingredient_movements tim
+                        WHERE tim.tenant_id = $1
+                            AND tim.ingredient_id = $2
+                            AND tim.cost_per_unit IS NOT NULL
+                            AND tim.cost_per_unit > 0
+                            AND DATE(tim.created_at AT TIME ZONE $5) <= $4
+                        ORDER BY tim.created_at DESC
+                        LIMIT 1
+                    )
+                ) AS unit_cost
+            ),
+            consumption AS (
+                SELECT
+                    DATE(tim.created_at AT TIME ZONE $5) AS period,
+                    SUM(ABS(tim.quantity_change)) AS consumed_quantity,
+                    AVG(NULLIF(tim.cost_per_unit, 0)) AS unit_cost,
+                    COUNT(*) AS movement_count
+                FROM tenant_ingredient_movements tim
+                WHERE tim.tenant_id = $1
+                    AND tim.ingredient_id = $2
+                    AND tim.movement_type = 'consumption'
+                    AND tim.quantity_change < 0
+                    AND DATE(tim.created_at AT TIME ZONE $5) >= $3
+                    AND DATE(tim.created_at AT TIME ZONE $5) <= $4
+                GROUP BY DATE(tim.created_at AT TIME ZONE $5)
+            )
+            SELECT
+                c.period,
+                c.consumed_quantity,
+                COALESCE(c.unit_cost, b.unit_cost) AS unit_cost,
+                c.consumed_quantity * COALESCE(c.unit_cost, b.unit_cost, 0) AS estimated_consumed_cost,
+                c.movement_count
+            FROM consumption c
+            CROSS JOIN basis b
+            ORDER BY c.period ASC
+        """, tenant_id, ingredient_id, parsed_date_from, parsed_date_to, timezone_name)
+
+        month_rows = await conn.fetch("""
+            WITH basis AS (
+                SELECT COALESCE(
+                    (
+                        SELECT SUM(tpi.quantity * tpi.unit_cost) / NULLIF(SUM(tpi.quantity), 0)
+                        FROM tenant_purchase_items tpi
+                        JOIN tenant_purchases tp ON tpi.purchase_id = tp.id
+                        WHERE tp.tenant_id = $1
+                            AND tpi.ingredient_id = $2
+                            AND tpi.unit_cost IS NOT NULL
+                            AND tpi.quantity > 0
+                            AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $5) >= $3
+                            AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $5) <= $4
+                    ),
+                    (
+                        SELECT tim.cost_per_unit
+                        FROM tenant_ingredient_movements tim
+                        WHERE tim.tenant_id = $1
+                            AND tim.ingredient_id = $2
+                            AND tim.cost_per_unit IS NOT NULL
+                            AND tim.cost_per_unit > 0
+                            AND DATE(tim.created_at AT TIME ZONE $5) <= $4
+                        ORDER BY tim.created_at DESC
+                        LIMIT 1
+                    )
+                ) AS unit_cost
+            ),
+            consumption AS (
+                SELECT
+                    DATE_TRUNC('month', tim.created_at AT TIME ZONE $5)::date AS period,
+                    SUM(ABS(tim.quantity_change)) AS consumed_quantity,
+                    AVG(NULLIF(tim.cost_per_unit, 0)) AS unit_cost,
+                    COUNT(*) AS movement_count
+                FROM tenant_ingredient_movements tim
+                WHERE tim.tenant_id = $1
+                    AND tim.ingredient_id = $2
+                    AND tim.movement_type = 'consumption'
+                    AND tim.quantity_change < 0
+                    AND DATE(tim.created_at AT TIME ZONE $5) >= $3
+                    AND DATE(tim.created_at AT TIME ZONE $5) <= $4
+                GROUP BY DATE_TRUNC('month', tim.created_at AT TIME ZONE $5)::date
+            )
+            SELECT
+                c.period,
+                c.consumed_quantity,
+                COALESCE(c.unit_cost, b.unit_cost) AS unit_cost,
+                c.consumed_quantity * COALESCE(c.unit_cost, b.unit_cost, 0) AS estimated_consumed_cost,
+                c.movement_count
+            FROM consumption c
+            CROSS JOIN basis b
+            ORDER BY c.period ASC
+        """, tenant_id, ingredient_id, parsed_date_from, parsed_date_to, timezone_name)
+
+        purchases = []
+        for row in purchase_rows:
+            purchases.append({
+                "purchase_item_id": str(row["purchase_item_id"]),
+                "purchase_id": str(row["purchase_id"]),
+                "purchase_number": row["purchase_number"],
+                "purchase_date": row["purchase_date"].isoformat() if row["purchase_date"] else None,
+                "base_quantity": _number_or_zero(row["base_quantity"]),
+                "base_unit": row["base_unit"],
+                "purchase_quantity": _number_or_none(row["purchase_quantity"]),
+                "purchase_unit": row["purchase_unit"],
+                "unit_cost": _number_or_none(row["unit_cost"]),
+                "total_cost": _number_or_none(row["total_cost"]),
+                "received_at": row["received_at"].isoformat() if row["received_at"] else None,
+            })
+
+        stock_movements = []
+        consumption_movements = []
+        for row in movement_rows:
+            movement = {
+                "id": str(row["id"]),
+                "movement_type": row["movement_type"],
+                "quantity_change": _number_or_zero(row["quantity_change"]),
+                "consumed_quantity": abs(_number_or_zero(row["quantity_change"])),
+                "unit": row["unit"],
+                "previous_stock": _number_or_none(row["previous_stock"]),
+                "new_stock": _number_or_none(row["new_stock"]),
+                "cost_per_unit": _number_or_none(row["cost_per_unit"]),
+                "reference_table": row["reference_table"],
+                "reference_id": str(row["reference_id"]) if row["reference_id"] else None,
+                "reason": row["reason"],
+                "notes": row["notes"],
+                "created_at": row["created_at"].isoformat() if row["created_at"] else None,
+            }
+            stock_movements.append(movement)
+            if row["movement_type"] == "consumption" and _number_or_zero(row["quantity_change"]) < 0:
+                consumption_movements.append(movement)
+
+        related_products = []
+        for row in related_rows:
+            related_products.append({
+                "product_id": str(row["product_id"]),
+                "product_name": row["product_name"],
+                "relation_type": row["relation_type"],
+                "quantity": _number_or_none(row["quantity"]),
+                "unit": row["unit"],
+            })
+
+        data_coverage = "recorded_movements" if _number_or_zero(metrics_row["movement_count"]) > 0 else "no_recorded_consumption"
+
+        return {
+            "success": True,
+            "data": {
+                "ingredient": {
+                    "id": str(ingredient["id"]) if ingredient else str(ingredient_id),
+                    "name": ingredient["name"] if ingredient else None,
+                    "category": ingredient["category"] if ingredient else None,
+                    "unit": ingredient["unit"] if ingredient else None,
+                },
+                "period": {
+                    "from": parsed_date_from.isoformat(),
+                    "to": parsed_date_to.isoformat(),
+                    "days": (parsed_date_to - parsed_date_from).days + 1,
+                    "timezone": timezone_name,
+                },
+                "metrics": {
+                    "consumed_quantity": _number_or_zero(metrics_row["consumed_quantity"]),
+                    "purchase_quantity": _number_or_zero(metrics_row["purchase_quantity"]),
+                    "estimated_consumed_cost": _number_or_zero(metrics_row["estimated_consumed_cost"]),
+                    "weighted_avg_cost_per_unit": _number_or_none(metrics_row["weighted_avg_cost_per_unit"]),
+                    "latest_cost_per_unit": _number_or_none(metrics_row["latest_cost_per_unit"]),
+                    "latest_cost_at": metrics_row["latest_cost_at"].isoformat() if metrics_row["latest_cost_at"] else None,
+                    "cost_basis": metrics_row["cost_basis"],
+                    "first_unit_cost": _number_or_none(metrics_row["first_unit_cost"]),
+                    "latest_purchase_unit_cost": _number_or_none(metrics_row["latest_purchase_unit_cost"]),
+                    "cost_variation": _number_or_none(metrics_row["cost_variation"]),
+                    "cost_variation_pct": _number_or_none(metrics_row["cost_variation_pct"]),
+                    "movement_count": metrics_row["movement_count"],
+                    "data_coverage": data_coverage,
+                },
+                "series": {
+                    "day": _serialize_ingredient_series(day_rows),
+                    "month": _serialize_ingredient_series(month_rows),
+                },
+                "purchases": purchases,
+                "stock_movements": stock_movements,
+                "consumption_movements": consumption_movements,
+                "stock": {
+                    "current_stock": _number_or_none(stock_row["current_stock"]) if stock_row else None,
+                    "minimum_stock": _number_or_none(stock_row["minimum_stock"]) if stock_row else None,
+                    "maximum_stock": _number_or_none(stock_row["maximum_stock"]) if stock_row else None,
+                    "last_updated": stock_row["last_updated"].isoformat() if stock_row and stock_row["last_updated"] else None,
+                    "location": stock_row["location"] if stock_row else None,
+                },
+                "related_products": related_products,
+                "data_coverage": data_coverage,
+            },
+        }
+
+
+async def get_ingredient_analytics_report(
+    request: Request,
+    ingredient_id: UUID,
+    *,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+    limit: int = 100,
+) -> dict:
+    """Session wrapper for one ingredient analytics report."""
+    try:
+        session_context = require_valid_session(request)
+        tenant_id = session_context.tenant_id
+        if not tenant_id:
+            raise AuthenticationError("Tenant ID is required")
+        return await _get_ingredient_analytics_report_for_tenant(
+            tenant_id,
+            ingredient_id,
+            date_from=date_from,
+            date_to=date_to,
+            limit=limit,
+        )
+    except AuthenticationError as e:
+        raise e
+    except Exception as e:
+        logger.error(f"Error getting ingredient analytics report: {str(e)}")
+        raise APIError(f"Error getting ingredient analytics report: {str(e)}", status_code=500)
 
 
 async def get_ingredient_analytics_history(

--- a/tests/test_analitica_permissions.py
+++ b/tests/test_analitica_permissions.py
@@ -102,3 +102,52 @@ def test_kitchen_role_denied_analitica_endpoint_under_enforce():
 
     assert response.status_code == 403
     assert "analitica" in response.json()["detail"].lower()
+
+
+def test_owner_role_passes_ingredient_report_endpoint_under_enforce():
+    """Owner reaches GET /analytics/ingredients/{id}/report under enforce."""
+    session = _build_session(role="owner")
+    ingredient_id = uuid4()
+    app = FastAPI()
+    app.include_router(analytics_router)
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.routers.analytics.analytics_service.get_ingredient_analytics_report",
+             new=AsyncMock(return_value={"success": True, "data": {"ingredient": {"id": str(ingredient_id)}}}),
+         ) as report:
+        client = TestClient(app)
+        response = client.get(f"/analytics/ingredients/{ingredient_id}/report")
+
+    assert response.status_code == 200
+    report.assert_awaited_once()
+
+
+def test_kitchen_role_denied_ingredient_report_endpoint_under_enforce():
+    """Kitchen role hits 403 on ingredient report because it lacks ANALITICA."""
+    session = _build_session(role="kitchen")
+    ingredient_id = uuid4()
+    app = FastAPI()
+    app.include_router(analytics_router)
+
+    kitchen_modules = frozenset({Module.DESPACHO})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=kitchen_modules),
+         ), \
+         patch(
+             "app.routers.analytics.analytics_service.get_ingredient_analytics_report",
+             new=AsyncMock(return_value={"success": True}),
+         ) as report:
+        client = TestClient(app)
+        response = client.get(f"/analytics/ingredients/{ingredient_id}/report")
+
+    assert response.status_code == 403
+    assert "analitica" in response.json()["detail"].lower()
+    report.assert_not_awaited()

--- a/tests/test_analytics_ingredients.py
+++ b/tests/test_analytics_ingredients.py
@@ -182,6 +182,129 @@ async def test_ingredient_history_returns_purchase_consumption_stock_and_product
 
 
 @pytest.mark.asyncio
+async def test_ingredient_report_returns_metrics_series_and_history():
+    ingredient_id = uuid4()
+    purchase_id = uuid4()
+    purchase_item_id = uuid4()
+    movement_id = uuid4()
+    product_id = uuid4()
+    rows = [
+        [{
+            "purchase_item_id": purchase_item_id,
+            "purchase_id": purchase_id,
+            "purchase_number": "CP-2",
+            "purchase_date": datetime(2026, 1, 5, 10, 0),
+            "base_quantity": Decimal("2000"),
+            "base_unit": "gr",
+            "purchase_quantity": Decimal("2"),
+            "purchase_unit": "kg",
+            "unit_cost": Decimal("6.5"),
+            "total_cost": Decimal("13000"),
+            "received_at": datetime(2026, 1, 5, 10, 15),
+        }],
+        [{
+            "id": movement_id,
+            "movement_type": "consumption",
+            "quantity_change": Decimal("-300"),
+            "unit": "gr",
+            "previous_stock": Decimal("1000"),
+            "new_stock": Decimal("700"),
+            "cost_per_unit": Decimal("6.7"),
+            "reference_table": "orders",
+            "reference_id": uuid4(),
+            "reason": "POS sale",
+            "notes": None,
+            "created_at": datetime(2026, 1, 6, 12, 0),
+        }],
+        [{
+            "product_id": product_id,
+            "product_name": "Hamburguesa",
+            "relation_type": "direct_recipe",
+            "quantity": Decimal("50"),
+            "unit": "gr",
+        }],
+        [{
+            "period": datetime(2026, 1, 6).date(),
+            "consumed_quantity": Decimal("300"),
+            "estimated_consumed_cost": Decimal("1950"),
+            "unit_cost": Decimal("6.5"),
+            "movement_count": 1,
+        }],
+        [{
+            "period": datetime(2026, 1, 1).date(),
+            "consumed_quantity": Decimal("300"),
+            "estimated_consumed_cost": Decimal("1950"),
+            "unit_cost": Decimal("6.5"),
+            "movement_count": 1,
+        }],
+    ]
+    conn, cm = _mock_db(
+        fetch_rows=rows,
+        fetchrow_rows=[
+            {"id": ingredient_id, "name": "Tomate", "category": "Verduras", "unit": "gr"},
+            {
+                "consumed_quantity": Decimal("300"),
+                "movement_count": 1,
+                "purchase_quantity": Decimal("2000"),
+                "weighted_avg_cost_per_unit": Decimal("6.5"),
+                "latest_cost_per_unit": Decimal("6.7"),
+                "latest_cost_at": datetime(2026, 1, 6, 12, 0),
+                "estimated_consumed_cost": Decimal("1950"),
+                "cost_basis": "weighted_avg_purchase_cost",
+                "first_unit_cost": Decimal("6.0"),
+                "latest_purchase_unit_cost": Decimal("6.5"),
+                "cost_variation": Decimal("0.5"),
+                "cost_variation_pct": Decimal("0.0833333333"),
+            },
+            {
+                "current_stock": Decimal("700"),
+                "minimum_stock": Decimal("100"),
+                "maximum_stock": Decimal("2000"),
+                "last_updated": datetime(2026, 1, 6, 12, 5),
+                "location": "Bodega",
+            },
+        ],
+    )
+
+    with patch("app.services.analytics_service.get_db_connection", return_value=cm):
+        result = await analytics_service._get_ingredient_analytics_report_for_tenant(
+            "tenant-1",
+            ingredient_id,
+            date_from="2026-01-01",
+            date_to="2026-01-31",
+            limit=10,
+        )
+
+    metrics_sql = conn.fetchrow.await_args_list[1].args[0]
+    purchase_sql = conn.fetch.await_args_list[0].args[0]
+    day_sql = conn.fetch.await_args_list[3].args[0]
+    month_sql = conn.fetch.await_args_list[4].args[0]
+    assert "tim.movement_type = 'consumption'" in metrics_sql
+    assert "DATE(tim.created_at AT TIME ZONE $5)" in metrics_sql
+    assert "tenant_purchase_items tpi" in purchase_sql
+    assert "DATE(tim.created_at AT TIME ZONE $5) AS period" in day_sql
+    assert "DATE_TRUNC('month', tim.created_at AT TIME ZONE $5)::date AS period" in month_sql
+    assert conn.fetchrow.await_args_list[1].args[5] == "America/Mexico_City"
+
+    data = result["data"]
+    assert data["ingredient"]["id"] == str(ingredient_id)
+    assert data["period"]["timezone"] == "America/Mexico_City"
+    assert data["metrics"]["consumed_quantity"] == 300.0
+    assert data["metrics"]["estimated_consumed_cost"] == 1950.0
+    assert data["metrics"]["weighted_avg_cost_per_unit"] == 6.5
+    assert data["metrics"]["latest_cost_per_unit"] == 6.7
+    assert data["metrics"]["cost_basis"] == "weighted_avg_purchase_cost"
+    assert data["metrics"]["cost_variation"] == 0.5
+    assert data["metrics"]["data_coverage"] == "recorded_movements"
+    assert data["series"]["day"][0]["period"] == "2026-01-06"
+    assert data["series"]["month"][0]["period"] == "2026-01-01"
+    assert data["purchases"][0]["purchase_id"] == str(purchase_id)
+    assert data["consumption_movements"][0]["consumed_quantity"] == 300.0
+    assert data["stock"]["current_stock"] == 700.0
+    assert data["related_products"][0]["product_id"] == str(product_id)
+
+
+@pytest.mark.asyncio
 async def test_ingredient_summary_wrapper_resolves_tenant_before_core():
     session = SimpleNamespace(tenant_id="tenant-wrapper")
 
@@ -207,4 +330,33 @@ async def test_ingredient_summary_wrapper_resolves_tenant_before_core():
         category=None,
         limit=5,
         sort="consumed_quantity_desc",
+    )
+
+
+@pytest.mark.asyncio
+async def test_ingredient_report_wrapper_resolves_tenant_before_core():
+    session = SimpleNamespace(tenant_id="tenant-wrapper")
+    ingredient_id = uuid4()
+
+    with patch("app.services.analytics_service.require_valid_session", return_value=session), \
+         patch(
+             "app.services.analytics_service._get_ingredient_analytics_report_for_tenant",
+             new_callable=AsyncMock,
+         ) as core:
+        core.return_value = {"success": True, "data": {"ingredient": {"id": str(ingredient_id)}}}
+        result = await analytics_service.get_ingredient_analytics_report(
+            object(),
+            ingredient_id,
+            date_from="2026-01-01",
+            date_to="2026-01-31",
+            limit=5,
+        )
+
+    assert result["success"] is True
+    core.assert_awaited_once_with(
+        "tenant-wrapper",
+        ingredient_id,
+        date_from="2026-01-01",
+        date_to="2026-01-31",
+        limit=5,
     )


### PR DESCRIPTION
## Summary
- Add ANALITICA-gated ingredient report endpoint
- Return report metrics, day/month series, history, stock and related products
- Cover report contract and ANALITICA permission gating

## Tests
- pytest tests/test_analytics_ingredients.py tests/test_analitica_permissions.py

Closes uno0uno/warocol.com#1574