### PR TITLE
Normalize fiscal IDs for customer profiles

### DIFF
--- a/app/models/customer.py
+++ b/app/models/customer.py
@@ -1,8 +1,8 @@
 """
 Customer Models - Pydantic schemas for customer management
 """
-from pydantic import BaseModel, Field, model_validator
-from typing import Optional, List, Literal
+from pydantic import BaseModel, Field, field_validator, model_validator
+from typing import Any, Optional, List, Literal
 from uuid import UUID
 from datetime import datetime
 
@@ -12,12 +12,25 @@ from datetime import datetime
 FiscalIdType = Literal['CC', 'CE', 'NIT', 'PA', 'TI']
 
 
+def normalize_fiscal_id(value: Any) -> Optional[str]:
+    """Keep only Matias/DIAN-safe alphanumeric document characters."""
+    if value is None:
+        return None
+    normalized = ''.join(ch for ch in str(value).strip().upper() if ch.isalnum())
+    return normalized or None
+
+
 class FiscalDataMixin(BaseModel):
     """Optional fiscal fields used when emitting an identified electronic invoice."""
     fiscal_id_type: Optional[FiscalIdType] = Field(None, description="DIAN doc type: CC, CE, NIT, PA, TI")
     fiscal_id: Optional[str] = Field(None, max_length=30, description="Document number (NIT without DV)")
     fiscal_business_name: Optional[str] = Field(None, max_length=255, description="Razón social or legal name")
     fiscal_email: Optional[str] = Field(None, description="Email used for the invoice (overrides general email)")
+
+    @field_validator('fiscal_id', mode='before')
+    @classmethod
+    def normalize_fiscal_id_field(cls, value):
+        return normalize_fiscal_id(value)
 
     @model_validator(mode='after')
     def validate_fiscal_triplet(self):

--- a/app/services/customers_service.py
+++ b/app/services/customers_service.py
@@ -18,7 +18,8 @@ from app.models.customer import (
     CustomerUpdateResponse,
     TopProduct,
     CustomerInsights,
-    CustomerInsightsResponse
+    CustomerInsightsResponse,
+    normalize_fiscal_id,
 )
 from uuid import UUID
 import json
@@ -169,7 +170,7 @@ async def search_or_create_customer(
                         """,
                         existing_customer['id'],
                         customer_data.fiscal_id_type,
-                        customer_data.fiscal_id,
+                        normalize_fiscal_id(customer_data.fiscal_id),
                         customer_data.fiscal_business_name,
                         customer_data.fiscal_email,
                     )
@@ -242,7 +243,7 @@ async def search_or_create_customer(
                     customer_data.name,
                     email,
                     customer_data.fiscal_id_type,
-                    customer_data.fiscal_id,
+                    normalize_fiscal_id(customer_data.fiscal_id),
                     customer_data.fiscal_business_name,
                     customer_data.fiscal_email,
                 )
@@ -576,7 +577,7 @@ async def update_customer(
             if update_data.fiscal_id_type is not None:
                 fields['fiscal_id_type'] = update_data.fiscal_id_type
             if update_data.fiscal_id is not None:
-                fields['fiscal_id'] = update_data.fiscal_id.strip() or None
+                fields['fiscal_id'] = normalize_fiscal_id(update_data.fiscal_id)
             if update_data.fiscal_business_name is not None:
                 fields['fiscal_business_name'] = update_data.fiscal_business_name.strip() or None
             if update_data.fiscal_email is not None:

--- a/tests/test_customer_identity_model.py
+++ b/tests/test_customer_identity_model.py
@@ -48,6 +48,24 @@ def _patch_customer_service_db(conn, tenant_id):
     )
 
 
+def test_customer_models_normalize_fiscal_id_for_invoicing():
+    created = CustomerSearchOrCreate(
+        phone_number="3001234567",
+        name="Buyer",
+        fiscal_id_type="NIT",
+        fiscal_id="900.123.456-7",
+        fiscal_business_name="ACME SAS",
+    )
+    updated = CustomerUpdate(
+        fiscal_id_type="CC",
+        fiscal_id=" 1.063-279-307 ",
+        fiscal_business_name="JUAN PEREZ",
+    )
+
+    assert created.fiscal_id == "9001234567"
+    assert updated.fiscal_id == "1063279307"
+
+
 @pytest.mark.asyncio
 async def test_search_or_create_customer_upserts_customer_relationship_without_touching_team_role():
     tenant_id = uuid4()


### PR DESCRIPTION
## Summary
- Normalize customer fiscal IDs through the Pydantic customer models
- Persist normalized fiscal IDs on search/create and customer update flows
- Add regression coverage for NIT/CC values with separators

## Tests
- pytest tests/test_customer_identity_model.py -q