### PR TITLE
Add ingredient analytics history filters

### DIFF
--- a/app/routers/analytics.py
+++ b/app/routers/analytics.py
@@ -68,6 +68,9 @@ async def get_ingredient_analytics_summary(
     date_to: Optional[str] = Query(None),
     ingredient_id: Optional[UUID] = Query(None),
     category: Optional[str] = Query(None),
+    unit: Optional[str] = Query(None),
+    quantity_min: Optional[float] = Query(None),
+    quantity_max: Optional[float] = Query(None),
     limit: int = Query(100, ge=1, le=500),
     sort: str = Query("consumed_quantity_desc")
 ):
@@ -80,6 +83,9 @@ async def get_ingredient_analytics_summary(
         date_to=date_to,
         ingredient_id=ingredient_id,
         category=category,
+        unit=unit,
+        quantity_min=quantity_min,
+        quantity_max=quantity_max,
         limit=limit,
         sort=sort
     )
@@ -111,7 +117,13 @@ async def get_ingredient_analytics_report(
     request: Request,
     date_from: Optional[str] = Query(None),
     date_to: Optional[str] = Query(None),
-    limit: int = Query(100, ge=1, le=500)
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    history_type: Optional[str] = Query(None),
+    record_kind: Optional[str] = Query(None),
+    unit: Optional[str] = Query(None),
+    quantity_min: Optional[float] = Query(None),
+    quantity_max: Optional[float] = Query(None),
 ):
     """
     Get report-ready analytics for one ingredient.
@@ -121,7 +133,13 @@ async def get_ingredient_analytics_report(
         ingredient_id=ingredient_id,
         date_from=date_from,
         date_to=date_to,
-        limit=limit
+        limit=limit,
+        offset=offset,
+        history_type=history_type,
+        record_kind=record_kind,
+        unit=unit,
+        quantity_min=quantity_min,
+        quantity_max=quantity_max,
     )
 
 

--- a/app/services/analytics_service.py
+++ b/app/services/analytics_service.py
@@ -116,6 +116,9 @@ async def _get_ingredient_analytics_summary_for_tenant(
     date_to: Optional[str] = None,
     ingredient_id: Optional[UUID] = None,
     category: Optional[str] = None,
+    unit: Optional[str] = None,
+    quantity_min: Optional[float] = None,
+    quantity_max: Optional[float] = None,
     limit: int = 100,
     sort: str = "consumed_quantity_desc",
 ) -> dict:
@@ -190,8 +193,11 @@ async def _get_ingredient_analytics_summary_for_tenant(
             WHERE (c.ingredient_id IS NOT NULL OR p.ingredient_id IS NOT NULL)
                 AND ($5::uuid IS NULL OR i.id = $5::uuid)
                 AND ($6::text IS NULL OR i.category = $6::text)
+                AND ($7::text IS NULL OR i.unit = $7::text)
+                AND ($8::numeric IS NULL OR COALESCE(c.consumed_quantity, 0) >= $8::numeric)
+                AND ($9::numeric IS NULL OR COALESCE(c.consumed_quantity, 0) <= $9::numeric)
             ORDER BY {order_by}
-            LIMIT $7
+            LIMIT $10
         """
 
         rows = await conn.fetch(
@@ -202,6 +208,9 @@ async def _get_ingredient_analytics_summary_for_tenant(
             timezone_name,
             ingredient_id,
             category,
+            unit,
+            quantity_min,
+            quantity_max,
             limit,
         )
 
@@ -234,6 +243,9 @@ async def _get_ingredient_analytics_summary_for_tenant(
                 "filters": {
                     "ingredient_id": str(ingredient_id) if ingredient_id else None,
                     "category": category,
+                    "unit": unit,
+                    "quantity_min": quantity_min,
+                    "quantity_max": quantity_max,
                     "sort": sort,
                     "limit": limit,
                 },
@@ -248,6 +260,9 @@ async def get_ingredient_analytics_summary(
     date_to: Optional[str] = None,
     ingredient_id: Optional[UUID] = None,
     category: Optional[str] = None,
+    unit: Optional[str] = None,
+    quantity_min: Optional[float] = None,
+    quantity_max: Optional[float] = None,
     limit: int = 100,
     sort: str = "consumed_quantity_desc",
 ) -> dict:
@@ -263,6 +278,9 @@ async def get_ingredient_analytics_summary(
             date_to=date_to,
             ingredient_id=ingredient_id,
             category=category,
+            unit=unit,
+            quantity_min=quantity_min,
+            quantity_max=quantity_max,
             limit=limit,
             sort=sort,
         )
@@ -298,6 +316,7 @@ async def _get_ingredient_analytics_history_for_tenant(
                 tpi.id AS purchase_item_id,
                 tp.id AS purchase_id,
                 tp.purchase_number,
+                tp.is_direct_entry,
                 tp.purchase_date,
                 tpi.quantity AS base_quantity,
                 tpi.unit AS base_unit,
@@ -328,10 +347,15 @@ async def _get_ingredient_analytics_history_for_tenant(
                 tim.cost_per_unit,
                 tim.reference_table,
                 tim.reference_id,
+                o.order_number AS reference_order_number,
                 tim.reason,
                 tim.notes,
                 tim.created_at
             FROM tenant_ingredient_movements tim
+            LEFT JOIN orders o
+                ON tim.reference_table = 'orders'
+                AND tim.reference_id = o.id
+                AND o.tenant_id = tim.tenant_id
             WHERE tim.tenant_id = $1
                 AND tim.ingredient_id = $2
                 AND tim.movement_type = 'consumption'
@@ -374,7 +398,7 @@ async def _get_ingredient_analytics_history_for_tenant(
                 AND (brt.tenant_id = $1 OR brt.tenant_id IS NULL)
             ORDER BY product_name ASC
             LIMIT $3
-        """, tenant_id, ingredient_id, limit)
+        """, tenant_id, ingredient_id, 100)
 
         purchases = []
         for row in purchase_rows:
@@ -382,6 +406,7 @@ async def _get_ingredient_analytics_history_for_tenant(
                 "purchase_item_id": str(row["purchase_item_id"]),
                 "purchase_id": str(row["purchase_id"]),
                 "purchase_number": row["purchase_number"],
+                "is_direct_entry": bool(row["is_direct_entry"]) if row["is_direct_entry"] is not None else None,
                 "purchase_date": row["purchase_date"].isoformat() if row["purchase_date"] else None,
                 "base_quantity": _number_or_zero(row["base_quantity"]),
                 "base_unit": row["base_unit"],
@@ -405,6 +430,7 @@ async def _get_ingredient_analytics_history_for_tenant(
                 "cost_per_unit": _number_or_none(row["cost_per_unit"]),
                 "reference_table": row["reference_table"],
                 "reference_id": str(row["reference_id"]) if row["reference_id"] else None,
+                "reference_order_number": int(row["reference_order_number"]) if row["reference_order_number"] else None,
                 "reason": row["reason"],
                 "notes": row["notes"],
                 "created_at": row["created_at"].isoformat() if row["created_at"] else None,
@@ -456,6 +482,12 @@ async def _get_ingredient_analytics_report_for_tenant(
     date_from: Optional[str] = None,
     date_to: Optional[str] = None,
     limit: int = 100,
+    offset: int = 0,
+    history_type: Optional[str] = None,
+    record_kind: Optional[str] = None,
+    unit: Optional[str] = None,
+    quantity_min: Optional[float] = None,
+    quantity_max: Optional[float] = None,
 ) -> dict:
     """Auth-agnostic report-ready analytics for one ingredient."""
     async with get_db_connection() as conn:
@@ -567,52 +599,173 @@ async def _get_ingredient_analytics_report_for_tenant(
             LEFT JOIN latest_costs lc ON lc.ingredient_id = $2
         """, tenant_id, ingredient_id, parsed_date_from, parsed_date_to, timezone_name)
 
-        purchase_rows = await conn.fetch("""
-            SELECT
-                tpi.id AS purchase_item_id,
-                tp.id AS purchase_id,
-                tp.purchase_number,
-                tp.purchase_date,
-                tpi.quantity AS base_quantity,
-                tpi.unit AS base_unit,
-                tpi.purchase_quantity,
-                tpi.purchase_unit,
-                tpi.unit_cost,
-                tpi.total_cost,
-                tpi.received_at
-            FROM tenant_purchase_items tpi
-            JOIN tenant_purchases tp ON tpi.purchase_id = tp.id
-            WHERE tp.tenant_id = $1
-                AND tpi.ingredient_id = $2
-                AND tpi.unit_cost IS NOT NULL
-                AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $4) >= $3
-                AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $4) <= $5
-            ORDER BY COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) DESC
-            LIMIT $6
-        """, tenant_id, ingredient_id, parsed_date_from, timezone_name, parsed_date_to, limit)
+        history_type_filter = history_type if history_type in {
+            "purchase",
+            "consumption",
+            "entry",
+            "adjustment",
+            "loss",
+            "movement",
+        } else None
+        record_kind_filter = record_kind if record_kind in {"purchase", "order", "none"} else None
 
-        movement_rows = await conn.fetch("""
-            SELECT
-                tim.id,
-                tim.movement_type,
-                tim.quantity_change,
-                tim.unit,
-                tim.previous_stock,
-                tim.new_stock,
-                tim.cost_per_unit,
-                tim.reference_table,
-                tim.reference_id,
-                tim.reason,
-                tim.notes,
-                tim.created_at
-            FROM tenant_ingredient_movements tim
-            WHERE tim.tenant_id = $1
-                AND tim.ingredient_id = $2
-                AND DATE(tim.created_at AT TIME ZONE $4) >= $3
-                AND DATE(tim.created_at AT TIME ZONE $4) <= $5
-            ORDER BY tim.created_at DESC
-            LIMIT $6
-        """, tenant_id, ingredient_id, parsed_date_from, timezone_name, parsed_date_to, limit)
+        history_count_row = await conn.fetchrow("""
+            WITH history AS (
+                SELECT
+                    'purchase' AS history_type,
+                    NULL::text AS movement_type,
+                    COALESCE(tpi.purchase_quantity, tpi.quantity) AS quantity_value,
+                    COALESCE(tpi.purchase_unit, tpi.unit) AS history_unit,
+                    'purchase' AS record_kind
+                FROM tenant_purchase_items tpi
+                JOIN tenant_purchases tp ON tpi.purchase_id = tp.id
+                WHERE tp.tenant_id = $1
+                    AND tpi.ingredient_id = $2
+                    AND tpi.unit_cost IS NOT NULL
+                    AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $4) >= $3
+                    AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $4) <= $5
+                UNION ALL
+                SELECT
+                    'movement' AS history_type,
+                    tim.movement_type,
+                    CASE
+                        WHEN tim.movement_type = 'consumption' AND tim.quantity_change < 0 THEN ABS(tim.quantity_change)
+                        ELSE tim.quantity_change
+                    END AS quantity_value,
+                    tim.unit AS history_unit,
+                    CASE
+                        WHEN tim.reference_table = 'orders' AND tim.reference_id IS NOT NULL THEN 'order'
+                        ELSE 'none'
+                    END AS record_kind
+                FROM tenant_ingredient_movements tim
+                WHERE tim.tenant_id = $1
+                    AND tim.ingredient_id = $2
+                    AND DATE(tim.created_at AT TIME ZONE $4) >= $3
+                    AND DATE(tim.created_at AT TIME ZONE $4) <= $5
+            )
+            SELECT COUNT(*) AS total_count
+            FROM history
+            WHERE (
+                $6::text IS NULL
+                OR ($6 = 'purchase' AND history_type = 'purchase')
+                OR ($6 = 'consumption' AND history_type = 'movement' AND movement_type = 'consumption')
+                OR ($6 = 'entry' AND history_type = 'movement' AND movement_type = 'purchase')
+                OR ($6 = 'adjustment' AND history_type = 'movement' AND movement_type = 'adjustment')
+                OR ($6 = 'loss' AND history_type = 'movement' AND movement_type = 'loss')
+                OR ($6 = 'movement' AND history_type = 'movement' AND COALESCE(movement_type, '') NOT IN ('consumption', 'purchase', 'adjustment', 'loss'))
+            )
+            AND ($7::text IS NULL OR record_kind = $7)
+            AND ($8::text IS NULL OR history_unit = $8::text)
+            AND ($9::numeric IS NULL OR quantity_value >= $9::numeric)
+            AND ($10::numeric IS NULL OR quantity_value <= $10::numeric)
+        """, tenant_id, ingredient_id, parsed_date_from, timezone_name, parsed_date_to, history_type_filter, record_kind_filter, unit, quantity_min, quantity_max)
+
+        history_rows = await conn.fetch("""
+            WITH history AS (
+                SELECT
+                    'purchase' AS history_type,
+                    COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AS event_at,
+                    tpi.id AS purchase_item_id,
+                    tp.id AS purchase_id,
+                    tp.purchase_number,
+                    tp.is_direct_entry,
+                    tp.purchase_date,
+                    tpi.quantity AS base_quantity,
+                    tpi.unit AS base_unit,
+                    tpi.purchase_quantity,
+                    tpi.purchase_unit,
+                    COALESCE(tpi.purchase_quantity, tpi.quantity) AS quantity_value,
+                    COALESCE(tpi.purchase_unit, tpi.unit) AS history_unit,
+                    tpi.unit_cost,
+                    tpi.total_cost,
+                    tpi.received_at,
+                    NULL::uuid AS movement_id,
+                    NULL::text AS movement_type,
+                    NULL::numeric AS quantity_change,
+                    NULL::text AS movement_unit,
+                    NULL::numeric AS previous_stock,
+                    NULL::numeric AS new_stock,
+                    NULL::numeric AS movement_cost_per_unit,
+                    NULL::text AS reference_table,
+                    NULL::uuid AS reference_id,
+                    NULL::integer AS reference_order_number,
+                    NULL::text AS reason,
+                    NULL::text AS notes,
+                    NULL::timestamptz AS movement_created_at
+                FROM tenant_purchase_items tpi
+                JOIN tenant_purchases tp ON tpi.purchase_id = tp.id
+                WHERE tp.tenant_id = $1
+                    AND tpi.ingredient_id = $2
+                    AND tpi.unit_cost IS NOT NULL
+                    AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $4) >= $3
+                    AND DATE(COALESCE(tpi.received_at, tp.purchase_date, tpi.created_at) AT TIME ZONE $4) <= $5
+                UNION ALL
+                SELECT
+                    'movement' AS history_type,
+                    tim.created_at AS event_at,
+                    NULL::uuid AS purchase_item_id,
+                    NULL::uuid AS purchase_id,
+                    NULL::text AS purchase_number,
+                    NULL::boolean AS is_direct_entry,
+                    NULL::timestamptz AS purchase_date,
+                    NULL::numeric AS base_quantity,
+                    NULL::text AS base_unit,
+                    NULL::numeric AS purchase_quantity,
+                    NULL::text AS purchase_unit,
+                    CASE
+                        WHEN tim.movement_type = 'consumption' AND tim.quantity_change < 0 THEN ABS(tim.quantity_change)
+                        ELSE tim.quantity_change
+                    END AS quantity_value,
+                    tim.unit AS history_unit,
+                    NULL::numeric AS unit_cost,
+                    NULL::numeric AS total_cost,
+                    NULL::timestamptz AS received_at,
+                    tim.id AS movement_id,
+                    tim.movement_type,
+                    tim.quantity_change,
+                    tim.unit AS movement_unit,
+                    tim.previous_stock,
+                    tim.new_stock,
+                    tim.cost_per_unit AS movement_cost_per_unit,
+                    tim.reference_table,
+                    tim.reference_id,
+                    o.order_number AS reference_order_number,
+                    tim.reason,
+                    tim.notes,
+                    tim.created_at AS movement_created_at
+                FROM tenant_ingredient_movements tim
+                LEFT JOIN orders o
+                    ON tim.reference_table = 'orders'
+                    AND tim.reference_id = o.id
+                    AND o.tenant_id = tim.tenant_id
+                WHERE tim.tenant_id = $1
+                    AND tim.ingredient_id = $2
+                    AND DATE(tim.created_at AT TIME ZONE $4) >= $3
+                    AND DATE(tim.created_at AT TIME ZONE $4) <= $5
+            )
+            SELECT *
+            FROM history
+            WHERE (
+                $6::text IS NULL
+                OR ($6 = 'purchase' AND history_type = 'purchase')
+                OR ($6 = 'consumption' AND history_type = 'movement' AND movement_type = 'consumption')
+                OR ($6 = 'entry' AND history_type = 'movement' AND movement_type = 'purchase')
+                OR ($6 = 'adjustment' AND history_type = 'movement' AND movement_type = 'adjustment')
+                OR ($6 = 'loss' AND history_type = 'movement' AND movement_type = 'loss')
+                OR ($6 = 'movement' AND history_type = 'movement' AND COALESCE(movement_type, '') NOT IN ('consumption', 'purchase', 'adjustment', 'loss'))
+            )
+            AND (
+                $7::text IS NULL
+                OR ($7 = 'purchase' AND history_type = 'purchase')
+                OR ($7 = 'order' AND history_type = 'movement' AND reference_table = 'orders' AND reference_id IS NOT NULL)
+                OR ($7 = 'none' AND history_type = 'movement' AND (reference_table IS NULL OR reference_table <> 'orders' OR reference_id IS NULL))
+            )
+            AND ($8::text IS NULL OR history_unit = $8::text)
+            AND ($9::numeric IS NULL OR quantity_value >= $9::numeric)
+            AND ($10::numeric IS NULL OR quantity_value <= $10::numeric)
+            ORDER BY event_at DESC NULLS LAST
+            LIMIT $11 OFFSET $12
+        """, tenant_id, ingredient_id, parsed_date_from, timezone_name, parsed_date_to, history_type_filter, record_kind_filter, unit, quantity_min, quantity_max, limit, offset)
 
         stock_row = await conn.fetchrow("""
             SELECT current_stock, minimum_stock, maximum_stock, last_updated, location
@@ -755,38 +908,41 @@ async def _get_ingredient_analytics_report_for_tenant(
         """, tenant_id, ingredient_id, parsed_date_from, parsed_date_to, timezone_name)
 
         purchases = []
-        for row in purchase_rows:
-            purchases.append({
-                "purchase_item_id": str(row["purchase_item_id"]),
-                "purchase_id": str(row["purchase_id"]),
-                "purchase_number": row["purchase_number"],
-                "purchase_date": row["purchase_date"].isoformat() if row["purchase_date"] else None,
-                "base_quantity": _number_or_zero(row["base_quantity"]),
-                "base_unit": row["base_unit"],
-                "purchase_quantity": _number_or_none(row["purchase_quantity"]),
-                "purchase_unit": row["purchase_unit"],
-                "unit_cost": _number_or_none(row["unit_cost"]),
-                "total_cost": _number_or_none(row["total_cost"]),
-                "received_at": row["received_at"].isoformat() if row["received_at"] else None,
-            })
-
         stock_movements = []
         consumption_movements = []
-        for row in movement_rows:
+        for row in history_rows:
+            if row["history_type"] == "purchase":
+                purchases.append({
+                    "purchase_item_id": str(row["purchase_item_id"]),
+                    "purchase_id": str(row["purchase_id"]),
+                    "purchase_number": row["purchase_number"],
+                    "is_direct_entry": bool(row["is_direct_entry"]) if row["is_direct_entry"] is not None else None,
+                    "purchase_date": row["purchase_date"].isoformat() if row["purchase_date"] else None,
+                    "base_quantity": _number_or_zero(row["base_quantity"]),
+                    "base_unit": row["base_unit"],
+                    "purchase_quantity": _number_or_none(row["purchase_quantity"]),
+                    "purchase_unit": row["purchase_unit"],
+                    "unit_cost": _number_or_none(row["unit_cost"]),
+                    "total_cost": _number_or_none(row["total_cost"]),
+                    "received_at": row["received_at"].isoformat() if row["received_at"] else None,
+                })
+                continue
+
             movement = {
-                "id": str(row["id"]),
+                "id": str(row["movement_id"]),
                 "movement_type": row["movement_type"],
                 "quantity_change": _number_or_zero(row["quantity_change"]),
                 "consumed_quantity": abs(_number_or_zero(row["quantity_change"])),
-                "unit": row["unit"],
+                "unit": row["movement_unit"],
                 "previous_stock": _number_or_none(row["previous_stock"]),
                 "new_stock": _number_or_none(row["new_stock"]),
-                "cost_per_unit": _number_or_none(row["cost_per_unit"]),
+                "cost_per_unit": _number_or_none(row["movement_cost_per_unit"]),
                 "reference_table": row["reference_table"],
                 "reference_id": str(row["reference_id"]) if row["reference_id"] else None,
+                "reference_order_number": int(row["reference_order_number"]) if row["reference_order_number"] else None,
                 "reason": row["reason"],
                 "notes": row["notes"],
-                "created_at": row["created_at"].isoformat() if row["created_at"] else None,
+                "created_at": row["movement_created_at"].isoformat() if row["movement_created_at"] else None,
             }
             stock_movements.append(movement)
             if row["movement_type"] == "consumption" and _number_or_zero(row["quantity_change"]) < 0:
@@ -849,6 +1005,17 @@ async def _get_ingredient_analytics_report_for_tenant(
                     "location": stock_row["location"] if stock_row else None,
                 },
                 "related_products": related_products,
+                "history_pagination": {
+                    "limit": limit,
+                    "offset": offset,
+                    "total": int(history_count_row["total_count"]) if history_count_row else 0,
+                    "has_more": (offset + limit) < (int(history_count_row["total_count"]) if history_count_row else 0),
+                    "history_type": history_type_filter,
+                    "record_kind": record_kind_filter,
+                    "unit": unit,
+                    "quantity_min": quantity_min,
+                    "quantity_max": quantity_max,
+                },
                 "data_coverage": data_coverage,
             },
         }
@@ -861,6 +1028,12 @@ async def get_ingredient_analytics_report(
     date_from: Optional[str] = None,
     date_to: Optional[str] = None,
     limit: int = 100,
+    offset: int = 0,
+    history_type: Optional[str] = None,
+    record_kind: Optional[str] = None,
+    unit: Optional[str] = None,
+    quantity_min: Optional[float] = None,
+    quantity_max: Optional[float] = None,
 ) -> dict:
     """Session wrapper for one ingredient analytics report."""
     try:
@@ -874,6 +1047,12 @@ async def get_ingredient_analytics_report(
             date_from=date_from,
             date_to=date_to,
             limit=limit,
+            offset=offset,
+            history_type=history_type,
+            record_kind=record_kind,
+            unit=unit,
+            quantity_min=quantity_min,
+            quantity_max=quantity_max,
         )
     except AuthenticationError as e:
         raise e

--- a/tests/test_analytics_ingredients.py
+++ b/tests/test_analytics_ingredients.py
@@ -48,6 +48,9 @@ async def test_ingredient_summary_uses_recorded_consumption_and_purchase_costs()
             date_to="2026-01-31",
             ingredient_id=ingredient_id,
             category="Verduras",
+            unit="gr",
+            quantity_min=100,
+            quantity_max=2000,
             limit=25,
             sort="estimated_consumed_cost_desc",
         )
@@ -66,7 +69,10 @@ async def test_ingredient_summary_uses_recorded_consumption_and_purchase_costs()
     assert args[4] == "America/Mexico_City"
     assert args[5] == ingredient_id
     assert args[6] == "Verduras"
-    assert args[7] == 25
+    assert args[7] == "gr"
+    assert args[8] == 100
+    assert args[9] == 2000
+    assert args[10] == 25
 
     item = result["data"]["items"][0]
     assert item["ingredient_id"] == str(ingredient_id)
@@ -110,6 +116,7 @@ async def test_ingredient_history_returns_purchase_consumption_stock_and_product
             "purchase_item_id": purchase_item_id,
             "purchase_id": purchase_id,
             "purchase_number": "CP-1",
+            "is_direct_entry": True,
             "purchase_date": datetime(2026, 1, 5, 10, 0),
             "base_quantity": Decimal("1345"),
             "base_unit": "gr",
@@ -129,6 +136,7 @@ async def test_ingredient_history_returns_purchase_consumption_stock_and_product
             "cost_per_unit": Decimal("6.6171"),
             "reference_table": "orders",
             "reference_id": uuid4(),
+            "reference_order_number": 16208,
             "reason": "POS sale",
             "notes": None,
             "created_at": datetime(2026, 1, 6, 12, 0),
@@ -168,14 +176,19 @@ async def test_ingredient_history_returns_purchase_consumption_stock_and_product
     movement_sql = conn.fetch.await_args_list[1].args[0]
     related_sql = conn.fetch.await_args_list[2].args[0]
     assert "tenant_purchase_items tpi" in purchase_sql
+    assert "tp.is_direct_entry" in purchase_sql
     assert "tim.movement_type = 'consumption'" in movement_sql
+    assert "LEFT JOIN orders o" in movement_sql
+    assert "o.order_number AS reference_order_number" in movement_sql
     assert "product_recipes pr" in related_sql
     assert "base_recipe_templates brt" in related_sql
 
     data = result["data"]
     assert data["ingredient"]["id"] == str(ingredient_id)
     assert data["purchases"][0]["unit_cost"] == 6.6171
+    assert data["purchases"][0]["is_direct_entry"] is True
     assert data["consumption_movements"][0]["consumed_quantity"] == 250.0
+    assert data["consumption_movements"][0]["reference_order_number"] == 16208
     assert data["stock"]["current_stock"] == 750.0
     assert data["related_products"][0]["product_id"] == str(product_id)
     assert data["data_coverage"] == "recorded_movements"
@@ -189,33 +202,39 @@ async def test_ingredient_report_returns_metrics_series_and_history():
     movement_id = uuid4()
     product_id = uuid4()
     rows = [
-        [{
-            "purchase_item_id": purchase_item_id,
-            "purchase_id": purchase_id,
-            "purchase_number": "CP-2",
-            "purchase_date": datetime(2026, 1, 5, 10, 0),
-            "base_quantity": Decimal("2000"),
-            "base_unit": "gr",
-            "purchase_quantity": Decimal("2"),
-            "purchase_unit": "kg",
-            "unit_cost": Decimal("6.5"),
-            "total_cost": Decimal("13000"),
-            "received_at": datetime(2026, 1, 5, 10, 15),
-        }],
-        [{
-            "id": movement_id,
-            "movement_type": "consumption",
-            "quantity_change": Decimal("-300"),
-            "unit": "gr",
-            "previous_stock": Decimal("1000"),
-            "new_stock": Decimal("700"),
-            "cost_per_unit": Decimal("6.7"),
-            "reference_table": "orders",
-            "reference_id": uuid4(),
-            "reason": "POS sale",
-            "notes": None,
-            "created_at": datetime(2026, 1, 6, 12, 0),
-        }],
+        [
+            {
+                "history_type": "purchase",
+                "purchase_item_id": purchase_item_id,
+                "purchase_id": purchase_id,
+                "purchase_number": "CP-2",
+                "is_direct_entry": True,
+                "purchase_date": datetime(2026, 1, 5, 10, 0),
+                "base_quantity": Decimal("2000"),
+                "base_unit": "gr",
+                "purchase_quantity": Decimal("2"),
+                "purchase_unit": "kg",
+                "unit_cost": Decimal("6.5"),
+                "total_cost": Decimal("13000"),
+                "received_at": datetime(2026, 1, 5, 10, 15),
+            },
+            {
+                "history_type": "movement",
+                "movement_id": movement_id,
+                "movement_type": "consumption",
+                "quantity_change": Decimal("-300"),
+                "movement_unit": "gr",
+                "previous_stock": Decimal("1000"),
+                "new_stock": Decimal("700"),
+                "movement_cost_per_unit": Decimal("6.7"),
+                "reference_table": "orders",
+                "reference_id": uuid4(),
+                "reference_order_number": 16208,
+                "reason": "POS sale",
+                "notes": None,
+                "movement_created_at": datetime(2026, 1, 6, 12, 0),
+            },
+        ],
         [{
             "product_id": product_id,
             "product_name": "Hamburguesa",
@@ -256,6 +275,7 @@ async def test_ingredient_report_returns_metrics_series_and_history():
                 "cost_variation": Decimal("0.5"),
                 "cost_variation_pct": Decimal("0.0833333333"),
             },
+            {"total_count": 2},
             {
                 "current_stock": Decimal("700"),
                 "minimum_stock": Decimal("100"),
@@ -273,15 +293,36 @@ async def test_ingredient_report_returns_metrics_series_and_history():
             date_from="2026-01-01",
             date_to="2026-01-31",
             limit=10,
+            offset=10,
+            history_type="consumption",
+            record_kind="order",
+            unit="gr",
+            quantity_min=100,
+            quantity_max=500,
         )
 
     metrics_sql = conn.fetchrow.await_args_list[1].args[0]
-    purchase_sql = conn.fetch.await_args_list[0].args[0]
-    day_sql = conn.fetch.await_args_list[3].args[0]
-    month_sql = conn.fetch.await_args_list[4].args[0]
+    count_sql = conn.fetchrow.await_args_list[2].args[0]
+    history_sql = conn.fetch.await_args_list[0].args[0]
+    day_sql = conn.fetch.await_args_list[2].args[0]
+    month_sql = conn.fetch.await_args_list[3].args[0]
     assert "tim.movement_type = 'consumption'" in metrics_sql
     assert "DATE(tim.created_at AT TIME ZONE $5)" in metrics_sql
-    assert "tenant_purchase_items tpi" in purchase_sql
+    assert "tenant_purchase_items tpi" in count_sql
+    assert "WITH history AS" in history_sql
+    assert "tp.is_direct_entry" in history_sql
+    assert "LEFT JOIN orders o" in history_sql
+    assert "o.order_number AS reference_order_number" in history_sql
+    assert "$6::text IS NULL" in count_sql
+    assert "$7::text IS NULL" in count_sql
+    assert "LIMIT $11 OFFSET $12" in history_sql
+    assert conn.fetch.await_args_list[0].args[6] == "consumption"
+    assert conn.fetch.await_args_list[0].args[7] == "order"
+    assert conn.fetch.await_args_list[0].args[8] == "gr"
+    assert conn.fetch.await_args_list[0].args[9] == 100
+    assert conn.fetch.await_args_list[0].args[10] == 500
+    assert conn.fetch.await_args_list[0].args[11] == 10
+    assert conn.fetch.await_args_list[0].args[12] == 10
     assert "DATE(tim.created_at AT TIME ZONE $5) AS period" in day_sql
     assert "DATE_TRUNC('month', tim.created_at AT TIME ZONE $5)::date AS period" in month_sql
     assert conn.fetchrow.await_args_list[1].args[5] == "America/Mexico_City"
@@ -299,9 +340,22 @@ async def test_ingredient_report_returns_metrics_series_and_history():
     assert data["series"]["day"][0]["period"] == "2026-01-06"
     assert data["series"]["month"][0]["period"] == "2026-01-01"
     assert data["purchases"][0]["purchase_id"] == str(purchase_id)
+    assert data["purchases"][0]["is_direct_entry"] is True
     assert data["consumption_movements"][0]["consumed_quantity"] == 300.0
+    assert data["consumption_movements"][0]["reference_order_number"] == 16208
     assert data["stock"]["current_stock"] == 700.0
     assert data["related_products"][0]["product_id"] == str(product_id)
+    assert data["history_pagination"] == {
+        "limit": 10,
+        "offset": 10,
+        "total": 2,
+        "has_more": False,
+        "history_type": "consumption",
+        "record_kind": "order",
+        "unit": "gr",
+        "quantity_min": 100,
+        "quantity_max": 500,
+    }
 
 
 @pytest.mark.asyncio
@@ -318,6 +372,9 @@ async def test_ingredient_summary_wrapper_resolves_tenant_before_core():
             object(),
             date_from="2026-01-01",
             date_to="2026-01-31",
+            unit="gr",
+            quantity_min=10,
+            quantity_max=250,
             limit=5,
         )
 
@@ -328,6 +385,9 @@ async def test_ingredient_summary_wrapper_resolves_tenant_before_core():
         date_to="2026-01-31",
         ingredient_id=None,
         category=None,
+        unit="gr",
+        quantity_min=10,
+        quantity_max=250,
         limit=5,
         sort="consumed_quantity_desc",
     )
@@ -350,6 +410,12 @@ async def test_ingredient_report_wrapper_resolves_tenant_before_core():
             date_from="2026-01-01",
             date_to="2026-01-31",
             limit=5,
+            offset=15,
+            history_type="purchase",
+            record_kind="purchase",
+            unit="kg",
+            quantity_min=1,
+            quantity_max=5,
         )
 
     assert result["success"] is True
@@ -359,4 +425,10 @@ async def test_ingredient_report_wrapper_resolves_tenant_before_core():
         date_from="2026-01-01",
         date_to="2026-01-31",
         limit=5,
+        offset=15,
+        history_type="purchase",
+        record_kind="purchase",
+        unit="kg",
+        quantity_min=1,
+        quantity_max=5,
     )


### PR DESCRIPTION
Adds backend support for paginated ingredient history filters by type, record, unit, and quantity range, plus order/purchase references and tests.