### PR TITLE
Guard sale customer association before invoicing

### DIFF
--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -356,6 +356,10 @@ class UpdateOrderStatusRequest(BaseModel):
     customer_id: Optional[str] = Field(None, description="UUID of customer to associate when required by payment method")
 
 
+class AssociateOrderCustomerRequest(BaseModel):
+    customer_id: UUID = Field(..., description="UUID of customer to associate before electronic invoicing")
+
+
 class BulkUpdateStatusRequest(BaseModel):
     order_ids: List[str] = Field(..., min_length=1)
     status: str = Field(..., description="completed | cancelled | pending")
@@ -395,6 +399,22 @@ async def update_order_status(
         body.status,
         body.payment_method,
         body.payment_method_id,
+        body.customer_id,
+    )
+
+
+@router.patch("/{order_id}/customer", dependencies=[Depends(require_module(Module.VENTAS))])
+async def associate_order_customer(
+    request: Request,
+    order_id: UUID,
+    body: AssociateOrderCustomerRequest,
+):
+    """
+    Associate or change the customer before an electronic invoice exists.
+    """
+    return await orders_service.associate_order_customer(
+        request,
+        order_id,
         body.customer_id,
     )
 

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -1433,6 +1433,93 @@ async def update_order_status(
         raise APIError(f"Error al actualizar estado: {str(e)}", status_code=500)
 
 
+async def associate_order_customer(
+    request: Request,
+    order_id: UUID,
+    customer_id: UUID,
+) -> dict:
+    """Associate an order with a tenant customer before electronic invoicing."""
+    try:
+        session_context = require_valid_session(request)
+        tenant_id = session_context.tenant_id
+
+        if not tenant_id:
+            raise AuthenticationError("Tenant ID is required")
+
+        async with get_db_connection() as conn:
+            order_row = await conn.fetchrow(
+                """
+                SELECT id
+                FROM orders
+                WHERE id = $1
+                  AND tenant_id = $2
+                  AND (pos_cart_id IS NOT NULL OR table_session_id IS NOT NULL OR extra_attributes->>'source' = 'manual')
+                """,
+                order_id,
+                tenant_id,
+            )
+            if not order_row:
+                raise APIError("Order not found", status_code=404)
+
+            invoice_row = await conn.fetchrow(
+                """
+                SELECT id
+                FROM electronic_invoices
+                WHERE order_id = $1
+                  AND tenant_id = $2
+                LIMIT 1
+                """,
+                order_id,
+                tenant_id,
+            )
+            if invoice_row:
+                raise APIError(
+                    "No se puede cambiar el cliente porque la venta ya tiene factura electrónica.",
+                    status_code=409,
+                    details={"code": "invoice_exists"},
+                )
+
+            customer_row = await conn.fetchrow(
+                """
+                SELECT p.id
+                FROM profile p
+                JOIN tenant_customers tc ON tc.profile_id = p.id
+                WHERE p.id = $1
+                  AND tc.tenant_id = $2
+                  AND tc.is_active = true
+                LIMIT 1
+                """,
+                customer_id,
+                tenant_id,
+            )
+            if not customer_row:
+                raise APIError("Customer not found", status_code=404)
+
+            await conn.execute(
+                """
+                UPDATE orders
+                SET customer_id = $1
+                WHERE id = $2
+                  AND tenant_id = $3
+                """,
+                customer_id,
+                order_id,
+                tenant_id,
+            )
+
+        return {
+            "success": True,
+            "message": "Cliente asociado a la venta",
+            "customer_id": str(customer_id),
+        }
+
+    except (AuthenticationError, APIError) as e:
+        raise e
+    except Exception as e:
+        logger.error(f"Error associating order customer: {str(e)}")
+        raise APIError(f"Error al asociar cliente: {str(e)}", status_code=500)
+
+
 async def _order_inventory_already_consumed_before_completion(
     conn,
     *,

--- a/tests/test_order_customer_association.py
+++ b/tests/test_order_customer_association.py
@@ -1,0 +1,111 @@
+"""Tests for associating a sale customer before electronic invoicing (#1582)."""
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.core.exceptions import APIError
+from app.services import orders_service
+
+
+_TENANT_ID = UUID("93b3e582-34fa-44a6-8d0f-bf82a3608727")
+_ORDER_ID = uuid4()
+_CUSTOMER_ID = uuid4()
+
+
+class _ConnCtx:
+    def __init__(self, fetchrow_responses):
+        self._frows = iter(fetchrow_responses)
+        self.conn = MagicMock()
+        self.conn.fetchrow = AsyncMock(side_effect=lambda *a, **k: next(self._frows))
+        self.conn.execute = AsyncMock()
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, *_):
+        return False
+
+
+def _patch_session():
+    fake = MagicMock()
+    fake.tenant_id = _TENANT_ID
+    return patch(
+        "app.services.orders_service.require_valid_session",
+        return_value=fake,
+    )
+
+
+def _patch_db(ctx):
+    return patch(
+        "app.services.orders_service.get_db_connection",
+        lambda *args, **kwargs: ctx,
+    )
+
+
+@pytest.mark.asyncio
+async def test_associate_order_customer_updates_when_no_invoice_exists():
+    request = MagicMock()
+    ctx = _ConnCtx([
+        {"id": _ORDER_ID},
+        None,
+        {"id": _CUSTOMER_ID},
+    ])
+
+    with _patch_session(), _patch_db(ctx):
+        result = await orders_service.associate_order_customer(
+            request,
+            _ORDER_ID,
+            _CUSTOMER_ID,
+        )
+
+    assert result == {
+        "success": True,
+        "message": "Cliente asociado a la venta",
+        "customer_id": str(_CUSTOMER_ID),
+    }
+    ctx.conn.execute.assert_awaited_once()
+    assert ctx.conn.execute.await_args.args[1:] == (_CUSTOMER_ID, _ORDER_ID, _TENANT_ID)
+
+
+@pytest.mark.asyncio
+async def test_associate_order_customer_blocks_when_invoice_exists():
+    request = MagicMock()
+    ctx = _ConnCtx([
+        {"id": _ORDER_ID},
+        {"id": uuid4()},
+    ])
+
+    with _patch_session(), _patch_db(ctx):
+        with pytest.raises(APIError) as exc_info:
+            await orders_service.associate_order_customer(
+                request,
+                _ORDER_ID,
+                _CUSTOMER_ID,
+            )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.details == {"code": "invoice_exists"}
+    ctx.conn.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_associate_order_customer_requires_tenant_customer():
+    request = MagicMock()
+    ctx = _ConnCtx([
+        {"id": _ORDER_ID},
+        None,
+        None,
+    ])
+
+    with _patch_session(), _patch_db(ctx):
+        with pytest.raises(APIError) as exc_info:
+            await orders_service.associate_order_customer(
+                request,
+                _ORDER_ID,
+                _CUSTOMER_ID,
+            )
+
+    assert exc_info.value.status_code == 404
+    assert "Customer not found" in str(exc_info.value)
+    ctx.conn.execute.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Add PATCH /orders/{order_id}/customer for associating a tenant customer before FE exists
- Block reassignment when any electronic invoice row exists for the order
- Cover success, invoice-exists, and tenant-customer guard cases

## Tests
- pytest tests/test_order_customer_association.py -q

Refs uno0uno/warocol.com#1582