### PR TITLE
Enrich electronic invoice email details

### DIFF
--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -474,7 +474,8 @@ async def emit_order_invoice(
     Returns 403 if the tenant is not ready for electronic invoicing
     (issue #130: missing dev flag, fiscal data, or active resolution).
 
-    Returns: { order_id, invoice_number, prefix, cufe, status, pdf_presigned_url }
+    Returns invoice identifiers, status, PDF URL when available, and optional
+    fiscal presentation fields for receipt/email rendering.
     """
     session_context = require_valid_session(request)
     return await facturacion_service.emit_invoice(
@@ -492,7 +493,8 @@ async def get_order_invoice(
     """
     Get the current electronic invoice for an order.
 
-    Returns invoice status, CUFE, and a fresh presigned PDF URL (1h TTL).
+    Returns invoice status, CUFE, a fresh presigned PDF URL (1h TTL), safe
+    attachment flags, and optional fiscal presentation fields.
     Returns 404 if no invoice has been emitted for this order yet.
     """
     session_context = require_valid_session(request)
@@ -540,5 +542,5 @@ async def send_order_invoice_email(
     order_id: UUID,
     body: SendInvoiceEmailBody,
 ):
-    """Send the WARO-branded receipt email for this order's accepted invoice (warocol.com#603)."""
+    """Send the fiscal receipt email for this order's accepted invoice."""
     return await orders_service.send_invoice_email(request, order_id, body.email)

--- a/app/services/email_helpers.py
+++ b/app/services/email_helpers.py
@@ -489,12 +489,14 @@ async def send_pos_receipt_email(
     invoice_prefix: Optional[str] = None,
     invoice_number: Optional[int] = None,
     invoice_cufe: Optional[str] = None,
+    invoice_presentation: Optional[Dict[str, Any]] = None,
     tip_amount: float = 0.0,
     tip_label: Optional[str] = None,
     promo_savings: float = 0.0,
     promo_breakdown: Optional[List[Dict[str, Any]]] = None,
     waro_redemption_summary: Optional[Dict[str, Any]] = None,
-) -> bool:
+    return_details: bool = False,
+) -> Any:
     """
     Send a POS receipt email to the customer after a point-of-sale order completes.
 
@@ -511,6 +513,12 @@ async def send_pos_receipt_email(
         logger.warning(
             f"Receipt email skipped: invalid customer_email={customer_email!r} for order #{order_number}"
         )
+        if return_details:
+            return {
+                "success": False,
+                "attachments": {"pdf": False, "xml": False},
+                "attachment_warnings": ["invalid_email"],
+            }
         return False
 
     resolved_tip_label = (tip_label or "Propina").strip()[:40] or "Propina"
@@ -527,34 +535,10 @@ async def send_pos_receipt_email(
             logger.warning(f"Could not fetch receipt tip label for tenant {tenant_id}: {_tip_err}")
 
     try:
-        text_body = get_pos_receipt_text(
-            order_number=order_number,
-            total_amount=total_amount,
-            payment_method=payment_method,
-            items=items,
-            order_date=order_date,
-            business_name=business_name,
-            business_address=business_address,
-            business_city=business_city,
-            business_phone=business_phone,
-            discount_amount=discount_amount,
-            subtotal=subtotal,
-            standard_tax=standard_tax,
-            liquor_tax=liquor_tax,
-            standard_tax_label=standard_tax_label,
-            invoice_prefix=invoice_prefix,
-            invoice_number=invoice_number,
-            invoice_cufe=invoice_cufe,
-            tip_amount=tip_amount,
-            tip_label=resolved_tip_label,
-            promo_savings=promo_savings,
-            promo_breakdown=promo_breakdown,
-            waro_redemption_summary=waro_redemption_summary,
-        )
-        subject = get_pos_receipt_subject(order_number, business_name=business_name)
-
         ses_service = AWSSESService()
         attachments: List[dict] = []
+        attachment_status = {"pdf": False, "xml": False}
+        attachment_warnings: List[str] = []
 
         # Attach DIAN document (PDF/XML) when we have invoice identifiers and tenant context.
         # Tenant context is required to avoid leaking invoice files.
@@ -583,27 +567,76 @@ async def send_pos_receipt_email(
                     if inv_row.get("r2_pdf_key"):
                         pdf_bytes = await s3.get_object_bytes(inv_row["r2_pdf_key"])
                         if pdf_bytes:
+                            attachment_status["pdf"] = True
                             attachments.append({
                                 "data": pdf_bytes,
                                 "filename": f"{invoice_prefix}-{invoice_number}.pdf",
                                 "content_type": "application/pdf",
                             })
+                        else:
+                            attachment_warnings.append("invoice_pdf_unavailable")
+                    else:
+                        attachment_warnings.append("invoice_pdf_missing")
 
                     if inv_row.get("r2_xml_key"):
                         xml_bytes = await s3.get_object_bytes(inv_row["r2_xml_key"])
                         if xml_bytes:
+                            attachment_status["xml"] = True
                             attachments.append({
                                 "data": xml_bytes,
                                 "filename": f"{invoice_prefix}-{invoice_number}.xml",
                                 "content_type": "application/xml",
                             })
+                        else:
+                            attachment_warnings.append("invoice_xml_unavailable")
+                    else:
+                        attachment_warnings.append("invoice_xml_missing")
 
                     if not attachments:
                         logger.info(
                             f"Receipt email: invoice exists but has no files yet (track_id={track_id})"
                         )
+                else:
+                    attachment_warnings.append("invoice_record_not_found")
             except Exception as _att_err:
+                attachment_warnings.append("invoice_attachments_unavailable")
                 logger.warning(f"Could not attach invoice files to receipt email: {_att_err}")
+
+        presentation = dict(invoice_presentation or {})
+        if invoice_prefix and invoice_number:
+            presentation["attachments"] = attachment_status
+
+        text_body = get_pos_receipt_text(
+            order_number=order_number,
+            total_amount=total_amount,
+            payment_method=payment_method,
+            items=items,
+            order_date=order_date,
+            business_name=business_name,
+            business_address=business_address,
+            business_city=business_city,
+            business_phone=business_phone,
+            discount_amount=discount_amount,
+            subtotal=subtotal,
+            standard_tax=standard_tax,
+            liquor_tax=liquor_tax,
+            standard_tax_label=standard_tax_label,
+            invoice_prefix=invoice_prefix,
+            invoice_number=invoice_number,
+            invoice_cufe=invoice_cufe,
+            invoice_presentation=presentation,
+            tip_amount=tip_amount,
+            tip_label=resolved_tip_label,
+            promo_savings=promo_savings,
+            promo_breakdown=promo_breakdown,
+            waro_redemption_summary=waro_redemption_summary,
+        )
+        subject = get_pos_receipt_subject(
+            order_number,
+            business_name=business_name,
+            invoice_prefix=invoice_prefix,
+            invoice_number=invoice_number,
+        )
 
         if attachments:
             success = await ses_service.send_email_with_attachments(
@@ -629,8 +662,20 @@ async def send_pos_receipt_email(
         else:
             logger.warning(f"SES returned failure for POS receipt email #{order_number}")
 
+        if return_details:
+            return {
+                "success": success,
+                "attachments": attachment_status,
+                "attachment_warnings": attachment_warnings,
+            }
         return success
 
     except Exception as e:
         logger.error(f"Error sending POS receipt email for order #{order_number}: {e}")
+        if return_details:
+            return {
+                "success": False,
+                "attachments": {"pdf": False, "xml": False},
+                "attachment_warnings": ["email_send_error"],
+            }
         return False

--- a/app/services/facturacion_service.py
+++ b/app/services/facturacion_service.py
@@ -30,6 +30,33 @@ from app.services.aws_s3_service import AWSS3Service
 logger = logging.getLogger(__name__)
 
 
+def _row_get(row: Any, key: str, default: Any = None) -> Any:
+    if not row:
+        return default
+    if hasattr(row, "get"):
+        return row.get(key, default)
+    try:
+        return row[key]
+    except (KeyError, IndexError):
+        return default
+
+
+def _date_iso(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    return value.isoformat()
+
+
+def _datetime_iso(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
 async def emit_invoice(
     order_id: str,
     tenant_id: str,
@@ -423,11 +450,39 @@ async def get_order_invoice(
     """
     async with get_db_connection(use_transaction=False) as conn:
         row = await conn.fetchrow(
-            """SELECT id, invoice_number, prefix, cufe, status,
-                      r2_pdf_key, error_message, emitted_at, created_at
-               FROM electronic_invoices
-               WHERE order_id = $1 AND tenant_id = $2
-               ORDER BY created_at DESC
+            """SELECT ei.id, ei.invoice_number, ei.prefix, ei.cufe, ei.status,
+                      ei.r2_pdf_key, ei.r2_xml_key, ei.error_message, ei.emitted_at, ei.created_at,
+                      o.payment_method, o.payment_status,
+                      c.name AS customer_name,
+                      c.email AS customer_email,
+                      c.fiscal_id_type AS customer_fiscal_id_type,
+                      c.fiscal_id AS customer_fiscal_id,
+                      c.fiscal_business_name AS customer_fiscal_business_name,
+                      c.fiscal_email AS customer_fiscal_email,
+                      COALESCE(tpp.display_name, t.name) AS display_name,
+                      tpp.address, tpp.city, tpp.phone_number,
+                      fd.business_name AS fiscal_business_name,
+                      fd.nit, fd.fiscal_address, fd.city AS fiscal_city,
+                      fd.phone AS fiscal_phone, fd.email AS fiscal_email,
+                      dr.resolution_number, dr.date_from, dr.date_to,
+                      dr.from_number, dr.to_number
+               FROM electronic_invoices ei
+               LEFT JOIN orders o ON o.id = ei.order_id AND o.tenant_id = ei.tenant_id
+               LEFT JOIN profile c ON c.id = o.customer_id
+               LEFT JOIN tenants t ON t.id = ei.tenant_id
+               LEFT JOIN tenant_public_profiles tpp ON tpp.tenant_id = ei.tenant_id
+               LEFT JOIN tenant_fiscal_data fd ON fd.tenant_id = ei.tenant_id
+               LEFT JOIN LATERAL (
+                   SELECT resolution_number, date_from, date_to, from_number, to_number
+                   FROM dian_resolutions
+                   WHERE tenant_id = ei.tenant_id
+                     AND prefix = ei.prefix
+                     AND is_active = true
+                   ORDER BY created_at DESC
+                   LIMIT 1
+               ) dr ON true
+               WHERE ei.order_id = $1 AND ei.tenant_id = $2
+               ORDER BY ei.created_at DESC
                LIMIT 1""",
             UUID(order_id), UUID(tenant_id),
         )
@@ -454,4 +509,53 @@ async def get_order_invoice(
         'error_message': row['error_message'],
         'emitted_at': row['emitted_at'].isoformat() if row['emitted_at'] else None,
         'created_at': row['created_at'].isoformat() if row['created_at'] else None,
+        'dian_url': (
+            f"https://catalogo-vpfe.dian.gov.co/document/searchqr?documentkey={row['cufe']}"
+            if row['cufe']
+            else None
+        ),
+        'attachments': {
+            'pdf': bool(row['r2_pdf_key']),
+            'xml': bool(row['r2_xml_key']),
+        },
+        'presentation': {
+            'number': f"{row['prefix']}-{row['invoice_number']}",
+            'status': row['status'],
+            'emitted_at': _datetime_iso(row['emitted_at']),
+            'issuer': {
+                'name': _row_get(row, 'fiscal_business_name') or _row_get(row, 'display_name'),
+                'fiscal_id_type': 'NIT' if _row_get(row, 'nit') else None,
+                'fiscal_id': _row_get(row, 'nit'),
+                'address': _row_get(row, 'fiscal_address') or _row_get(row, 'address'),
+                'city': _row_get(row, 'fiscal_city') or _row_get(row, 'city'),
+                'phone': _row_get(row, 'fiscal_phone') or _row_get(row, 'phone_number'),
+                'email': _row_get(row, 'fiscal_email'),
+            },
+            'acquirer': {
+                'name': (
+                    _row_get(row, 'customer_fiscal_business_name')
+                    or _row_get(row, 'customer_name')
+                    or 'Consumidor final'
+                ),
+                'fiscal_id_type': _row_get(row, 'customer_fiscal_id_type'),
+                'fiscal_id': _row_get(row, 'customer_fiscal_id'),
+                'email': _row_get(row, 'customer_fiscal_email') or _row_get(row, 'customer_email'),
+            },
+            'payment': {
+                'method': _row_get(row, 'payment_method'),
+                'status': _row_get(row, 'payment_status'),
+            },
+            'resolution': (
+                {
+                    'number': _row_get(row, 'resolution_number'),
+                    'prefix': row['prefix'],
+                    'from_number': _row_get(row, 'from_number'),
+                    'to_number': _row_get(row, 'to_number'),
+                    'date_from': _date_iso(_row_get(row, 'date_from')),
+                    'date_to': _date_iso(_row_get(row, 'date_to')),
+                }
+                if _row_get(row, 'resolution_number')
+                else None
+            ),
+        },
     }

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -289,6 +289,111 @@ def _compute_tax_breakdown(
     return float(standard_tax), float(liquor_tax), standard_tax_label
 
 
+def _row_get(row: Any, key: str, default: Any = None) -> Any:
+    if not row:
+        return default
+    if hasattr(row, "get"):
+        return row.get(key, default)
+    try:
+        return row[key]
+    except (KeyError, IndexError):
+        return default
+
+
+def _iso_datetime(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _invoice_attachment_flags(invoice_row: Any) -> Dict[str, bool]:
+    return {
+        "pdf": bool(_row_get(invoice_row, "r2_pdf_key")),
+        "xml": bool(_row_get(invoice_row, "r2_xml_key")),
+    }
+
+
+def _tax_detail_rows(
+    items_rows: List[Any],
+    standard_tax: float,
+    liquor_tax: float,
+    standard_tax_label: str,
+) -> List[Dict[str, Any]]:
+    std_base = sum(float(r["subtotal"]) for r in items_rows if r["tax_category"] == "standard")
+    liq_base = sum(float(r["subtotal"]) for r in items_rows if r["tax_category"] == "liquor")
+    rows: List[Dict[str, Any]] = []
+    if standard_tax > 0:
+        rows.append({"label": standard_tax_label, "base": std_base, "amount": standard_tax})
+    if liquor_tax > 0:
+        rows.append({"label": "IVA licores 5%", "base": liq_base, "amount": liquor_tax})
+    return rows
+
+
+def _build_invoice_presentation(
+    invoice_row: Any,
+    order_row: Any,
+    profile_row: Any,
+    resolution_row: Any,
+    tax_details: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    cufe = _row_get(invoice_row, "cufe")
+    invoice_prefix = _row_get(invoice_row, "prefix")
+    invoice_number = _row_get(invoice_row, "invoice_number")
+    return {
+        "number": f"{invoice_prefix}-{invoice_number}",
+        "prefix": invoice_prefix,
+        "invoice_number": invoice_number,
+        "cufe": cufe,
+        "status": _row_get(invoice_row, "status"),
+        "emitted_at": _row_get(invoice_row, "emitted_at"),
+        "created_at": _row_get(invoice_row, "created_at"),
+        "dian_url": (
+            f"https://catalogo-vpfe.dian.gov.co/document/searchqr?documentkey={cufe}"
+            if cufe
+            else None
+        ),
+        "issuer": {
+            "name": _row_get(profile_row, "fiscal_business_name") or _row_get(profile_row, "display_name"),
+            "fiscal_id_type": "NIT" if _row_get(profile_row, "nit") else None,
+            "fiscal_id": _row_get(profile_row, "nit"),
+            "address": _row_get(profile_row, "fiscal_address") or _row_get(profile_row, "address"),
+            "city": _row_get(profile_row, "fiscal_city") or _row_get(profile_row, "city"),
+            "phone": _row_get(profile_row, "fiscal_phone") or _row_get(profile_row, "phone_number"),
+            "email": _row_get(profile_row, "fiscal_email"),
+        },
+        "acquirer": {
+            "name": (
+                _row_get(order_row, "customer_fiscal_business_name")
+                or _row_get(order_row, "customer_name")
+                or "Consumidor final"
+            ),
+            "fiscal_id_type": _row_get(order_row, "customer_fiscal_id_type"),
+            "fiscal_id": _row_get(order_row, "customer_fiscal_id"),
+            "email": _row_get(order_row, "customer_fiscal_email") or _row_get(order_row, "customer_email"),
+        },
+        "payment": {
+            "method": _row_get(order_row, "payment_method"),
+            "status": _row_get(order_row, "payment_status"),
+        },
+        "resolution": (
+            {
+                "number": _row_get(resolution_row, "resolution_number"),
+                "prefix": _row_get(resolution_row, "prefix"),
+                "from_number": _row_get(resolution_row, "from_number"),
+                "to_number": _row_get(resolution_row, "to_number"),
+                "date_from": _date_iso(_row_get(resolution_row, "date_from")),
+                "date_to": _date_iso(_row_get(resolution_row, "date_to")),
+            }
+            if resolution_row
+            else None
+        ),
+        "tax_details": tax_details,
+        "attachments": _invoice_attachment_flags(invoice_row),
+    }
+
+
 async def get_orders_list(
     request: Request,
     limit: int = 50,
@@ -4028,10 +4133,17 @@ async def send_invoice_email(
     async with get_db_connection() as conn:
         # 1. Order header (also enforces tenant ownership).
         order_row = await conn.fetchrow(
-            """SELECT id, order_number, order_date, total_amount, payment_method,
-                      discount_amount
-               FROM orders
-               WHERE id = $1 AND tenant_id = $2""",
+            """SELECT o.id, o.order_number, o.order_date, o.total_amount, o.payment_method,
+                      o.payment_status, o.discount_amount,
+                      c.name AS customer_name,
+                      c.email AS customer_email,
+                      c.fiscal_id_type AS customer_fiscal_id_type,
+                      c.fiscal_id AS customer_fiscal_id,
+                      c.fiscal_business_name AS customer_fiscal_business_name,
+                      c.fiscal_email AS customer_fiscal_email
+               FROM orders o
+               LEFT JOIN profile c ON c.id = o.customer_id
+               WHERE o.id = $1 AND o.tenant_id = $2""",
             order_id, tenant_id,
         )
         if not order_row:
@@ -4040,7 +4152,8 @@ async def send_invoice_email(
         # 2. Invoice header — must exist and be accepted. PDF attachment is optional:
         # accepted Matias invoices may exist before the local R2 PDF key is stored.
         invoice_row = await conn.fetchrow(
-            """SELECT prefix, invoice_number, cufe, status, r2_pdf_key
+            """SELECT prefix, invoice_number, cufe, status, r2_pdf_key, r2_xml_key,
+                      emitted_at, created_at
                FROM electronic_invoices
                WHERE order_id = $1 AND tenant_id = $2
                ORDER BY created_at DESC
@@ -4102,11 +4215,27 @@ async def send_invoice_email(
         # 5. Business profile for the email header.
         profile_row = await conn.fetchrow(
             """SELECT COALESCE(p.display_name, t.name) AS display_name,
-                      p.address, p.city, p.phone_number
+                      p.address, p.city, p.phone_number,
+                      fd.business_name AS fiscal_business_name,
+                      fd.nit, fd.fiscal_address, fd.city AS fiscal_city,
+                      fd.phone AS fiscal_phone, fd.email AS fiscal_email
                FROM tenants t
                LEFT JOIN tenant_public_profiles p ON p.tenant_id = t.id
+               LEFT JOIN tenant_fiscal_data fd ON fd.tenant_id = t.id
                WHERE t.id = $1""",
             tenant_id,
+        )
+
+        resolution_row = await conn.fetchrow(
+            """SELECT resolution_number, prefix, date_from, date_to,
+                      from_number, to_number
+               FROM dian_resolutions
+               WHERE tenant_id = $1
+                 AND prefix = $2
+                 AND is_active = true
+               ORDER BY created_at DESC
+               LIMIT 1""",
+            tenant_id, invoice_row['prefix'],
         )
 
     discount_amount = float(order_row['discount_amount']) if order_row['discount_amount'] is not None else 0.0
@@ -4120,7 +4249,16 @@ async def send_invoice_email(
         else 0.0
     )
 
-    success = await send_pos_receipt_email(
+    tax_details = _tax_detail_rows(items_for_tax, std_tax, liq_tax, tax_label)
+    invoice_presentation = _build_invoice_presentation(
+        invoice_row,
+        order_row,
+        profile_row,
+        resolution_row,
+        tax_details,
+    )
+
+    send_result = await send_pos_receipt_email(
         customer_email=recipient_email,
         order_number=int(order_row['order_number']),
         total_amount=float(order_row['total_amount']),
@@ -4143,7 +4281,17 @@ async def send_invoice_email(
         invoice_prefix=invoice_row['prefix'],
         invoice_number=int(invoice_row['invoice_number']),
         invoice_cufe=invoice_row['cufe'],
+        invoice_presentation=invoice_presentation,
+        return_details=True,
     )
+    if isinstance(send_result, dict):
+        success = bool(send_result.get("success"))
+        attachment_status = send_result.get("attachments") or _invoice_attachment_flags(invoice_row)
+        attachment_warnings = send_result.get("attachment_warnings") or []
+    else:
+        success = bool(send_result)
+        attachment_status = _invoice_attachment_flags(invoice_row)
+        attachment_warnings = []
 
     if not success:
         raise HTTPException(
@@ -4151,4 +4299,9 @@ async def send_invoice_email(
             detail="No se pudo enviar el correo. Intentá nuevamente en unos segundos.",
         )
 
-    return {'success': True, 'sent_to': recipient_email}
+    return {
+        'success': True,
+        'sent_to': recipient_email,
+        'attachments': attachment_status,
+        'attachment_warnings': attachment_warnings,
+    }

--- a/app/templates/pos_receipt_template.py
+++ b/app/templates/pos_receipt_template.py
@@ -48,8 +48,45 @@ def _format_bogota_date(dt: datetime) -> str:
     return f"{local.day} de {month} de {local.year}, {hour}:{local.minute:02d} {ampm}"
 
 
-def get_pos_receipt_subject(order_number: int, business_name: Optional[str] = None) -> str:
+def _clean(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _append_party(lines: List[str], title: str, party: Optional[Dict[str, Any]]) -> None:
+    if not party:
+        return
+    name = _clean(party.get("name"))
+    fiscal_id = _clean(party.get("fiscal_id"))
+    if not name and not fiscal_id:
+        return
+    lines.append(title)
+    if name:
+        lines.append(f"  {name}")
+    if fiscal_id:
+        id_type = _clean(party.get("fiscal_id_type"))
+        label = f"{id_type}: {fiscal_id}" if id_type else f"ID: {fiscal_id}"
+        lines.append(f"  {label}")
+    address = _clean(party.get("address"))
+    city = _clean(party.get("city"))
+    if address:
+        lines.append(f"  {address}{', ' + city if city else ''}")
+    email = _clean(party.get("email"))
+    if email:
+        lines.append(f"  Email: {email}")
+
+
+def get_pos_receipt_subject(
+    order_number: int,
+    business_name: Optional[str] = None,
+    invoice_prefix: Optional[str] = None,
+    invoice_number: Optional[int] = None,
+) -> str:
     name = business_name or "WARO"
+    if invoice_prefix and invoice_number:
+        return f"Factura electrónica {invoice_prefix}-{invoice_number} — {name}"
     return f"Recibo de compra #{order_number} — {name}"
 
 
@@ -71,6 +108,7 @@ def get_pos_receipt_text(
     invoice_prefix: Optional[str] = None,
     invoice_number: Optional[int] = None,
     invoice_cufe: Optional[str] = None,
+    invoice_presentation: Optional[Dict[str, Any]] = None,
     tip_amount: float = 0.0,
     tip_label: str = "Propina",
     promo_savings: float = 0.0,
@@ -159,14 +197,73 @@ def get_pos_receipt_text(
     # DIAN invoice section (optional)
     invoice_block = ""
     if invoice_prefix and invoice_number and invoice_cufe:
-        dian_url = f"https://catalogo-vpfe.dian.gov.co/document/searchqr?documentkey={invoice_cufe}"
-        invoice_block = f"""
-================================
-FACTURA ELECTRÓNICA
-{invoice_prefix}-{invoice_number}
-CUFE: {invoice_cufe}
-Verificar: {dian_url}
-================================"""
+        presentation = invoice_presentation or {}
+        dian_url = (
+            _clean(presentation.get("dian_url"))
+            or f"https://catalogo-vpfe.dian.gov.co/document/searchqr?documentkey={invoice_cufe}"
+        )
+        invoice_lines = [
+            "================================",
+            "FACTURA ELECTRÓNICA DE VENTA",
+            "Representación gráfica para verificación contable.",
+            f"Número: {invoice_prefix}-{invoice_number}",
+        ]
+        status = _clean(presentation.get("status"))
+        if status:
+            invoice_lines.append(f"Estado DIAN: {status}")
+        emitted_at = presentation.get("emitted_at")
+        if isinstance(emitted_at, datetime):
+            invoice_lines.append(f"Emisión: {_format_bogota_date(emitted_at)}")
+        elif _clean(emitted_at):
+            invoice_lines.append(f"Emisión: {_clean(emitted_at)}")
+
+        _append_party(invoice_lines, "Emisor:", presentation.get("issuer"))
+        _append_party(invoice_lines, "Adquirente:", presentation.get("acquirer"))
+
+        resolution = presentation.get("resolution") or {}
+        if resolution:
+            res_lines = []
+            number = _clean(resolution.get("number"))
+            prefix = _clean(resolution.get("prefix"))
+            from_number = resolution.get("from_number")
+            to_number = resolution.get("to_number")
+            date_from = _clean(resolution.get("date_from"))
+            date_to = _clean(resolution.get("date_to"))
+            if number:
+                res_lines.append(f"Resolución DIAN: {number}")
+            if prefix or from_number or to_number:
+                res_lines.append(f"Rango: {prefix or invoice_prefix} {from_number or ''}-{to_number or ''}".strip())
+            if date_from or date_to:
+                res_lines.append(f"Vigencia: {date_from or 'N/D'} a {date_to or 'N/D'}")
+            invoice_lines.extend(res_lines)
+
+        tax_details = presentation.get("tax_details") or []
+        if tax_details:
+            invoice_lines.append("Impuestos:")
+            for tax in tax_details:
+                label = _clean(tax.get("label")) or "Impuesto"
+                amount = float(tax.get("amount") or 0)
+                base = tax.get("base")
+                base_text = f" base {_format_cop(float(base))}" if base is not None else ""
+                invoice_lines.append(f"  {label}{base_text}: {_format_cop(amount)}")
+
+        attachment_status = presentation.get("attachments") or {}
+        attachment_lines = []
+        if attachment_status.get("pdf"):
+            attachment_lines.append("PDF adjunto")
+        if attachment_status.get("xml"):
+            attachment_lines.append("XML adjunto")
+        if attachment_lines:
+            invoice_lines.append("Archivos: " + ", ".join(attachment_lines))
+        elif attachment_status:
+            invoice_lines.append("Archivos: PDF/XML aún no disponibles en el repositorio fiscal.")
+
+        invoice_lines.extend([
+            f"CUFE: {invoice_cufe}",
+            f"Verificar en DIAN: {dian_url}",
+            "================================",
+        ])
+        invoice_block = "\n" + "\n".join(invoice_lines)
 
     return f"""\
 {header_block}

--- a/tests/test_invoice_send_email.py
+++ b/tests/test_invoice_send_email.py
@@ -50,17 +50,31 @@ def _order_row(discount: float = 0.0):
         'order_date': datetime(2026, 5, 13, 20, 43, tzinfo=timezone.utc),
         'total_amount': 200.0,
         'payment_method': 'cash',
+        'payment_status': 'paid',
         'discount_amount': discount,
+        'customer_name': 'Restaurante Cliente SAS',
+        'customer_email': 'cliente@example.com',
+        'customer_fiscal_id_type': 'NIT',
+        'customer_fiscal_id': '900123456',
+        'customer_fiscal_business_name': 'Restaurante Cliente SAS',
+        'customer_fiscal_email': 'contabilidad@example.com',
     }
 
 
-def _invoice_row(status: str = 'accepted', r2_pdf_key: str = 'lzt/5462/test.pdf'):
+def _invoice_row(
+    status: str = 'accepted',
+    r2_pdf_key: str = 'lzt/5462/test.pdf',
+    r2_xml_key: str = 'lzt/5462/test.xml',
+):
     return {
         'prefix': 'LZT',
         'invoice_number': 5462,
         'cufe': 'TEST_CUFE',
         'status': status,
         'r2_pdf_key': r2_pdf_key,
+        'r2_xml_key': r2_xml_key,
+        'emitted_at': datetime(2026, 5, 13, 20, 44, tzinfo=timezone.utc),
+        'created_at': datetime(2026, 5, 13, 20, 43, tzinfo=timezone.utc),
     }
 
 
@@ -70,6 +84,23 @@ def _profile_row():
         'address': 'Calle 123 #45-67',
         'city': 'Bogotá',
         'phone_number': '+57 320 1234567',
+        'fiscal_business_name': 'Waro Colombia SAS',
+        'nit': '901234567',
+        'fiscal_address': 'Carrera 10 #20-30',
+        'fiscal_city': 'Bogotá',
+        'fiscal_phone': '+57 601 1234567',
+        'fiscal_email': 'facturacion@warocol.com',
+    }
+
+
+def _resolution_row():
+    return {
+        'resolution_number': '18760000001',
+        'prefix': 'LZT',
+        'date_from': datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+        'date_to': datetime(2026, 12, 31, tzinfo=timezone.utc).date(),
+        'from_number': 1,
+        'to_number': 9999,
     }
 
 
@@ -114,7 +145,7 @@ async def test_send_invoice_email_happy_path():
     """Owned order + accepted invoice + PDF → 200, helper called with full payload."""
     request = MagicMock()
 
-    fetchrow = [_order_row(), _invoice_row(), _waro_inferred_row(), _profile_row()]
+    fetchrow = [_order_row(), _invoice_row(), _waro_inferred_row(), _profile_row(), _resolution_row()]
     fetch = [
         [],  # tax items (empty → no tax)
         [],  # promo summary (no applied promos)
@@ -130,7 +161,12 @@ async def test_send_invoice_email_happy_path():
     ):
         result = await orders_service.send_invoice_email(request, _ORDER_ID, _RECIPIENT)
 
-    assert result == {'success': True, 'sent_to': _RECIPIENT}
+    assert result == {
+        'success': True,
+        'sent_to': _RECIPIENT,
+        'attachments': {'pdf': True, 'xml': True},
+        'attachment_warnings': [],
+    }
     helper_mock.assert_awaited_once()
     kwargs = helper_mock.await_args.kwargs
     assert kwargs['customer_email'] == _RECIPIENT
@@ -138,8 +174,13 @@ async def test_send_invoice_email_happy_path():
     assert kwargs['invoice_prefix'] == 'LZT'
     assert kwargs['invoice_number'] == 5462
     assert kwargs['invoice_cufe'] == 'TEST_CUFE'
+    assert kwargs['return_details'] is True
     assert kwargs['tenant_id'] == str(_TENANT_ID)
     assert kwargs['business_name'] == 'Waro Colombia'
+    assert kwargs['invoice_presentation']['issuer']['fiscal_id'] == '901234567'
+    assert kwargs['invoice_presentation']['acquirer']['fiscal_id'] == '900123456'
+    assert kwargs['invoice_presentation']['resolution']['number'] == '18760000001'
+    assert kwargs['invoice_presentation']['attachments'] == {'pdf': True, 'xml': True}
     # items shape: list of dicts with product.name + quantity + subtotal + modifiers
     assert len(kwargs['items']) == 1
     assert kwargs['items'][0]['product']['name'] == 'tomate barranca'
@@ -222,10 +263,20 @@ async def test_send_invoice_email_rejects_non_accepted():
 async def test_send_invoice_email_allows_missing_pdf():
     """Invoice accepted but r2_pdf_key is NULL → email still sends."""
     request = MagicMock()
-    helper_mock = AsyncMock(return_value=True)
+    helper_mock = AsyncMock(return_value={
+        'success': True,
+        'attachments': {'pdf': False, 'xml': True},
+        'attachment_warnings': ['invoice_pdf_missing'],
+    })
 
     with _patch_session(), _patch_db(
-        fetchrow=[_order_row(), _invoice_row(r2_pdf_key=None), _waro_inferred_row(), _profile_row()],
+        fetchrow=[
+            _order_row(),
+            _invoice_row(r2_pdf_key=None),
+            _waro_inferred_row(),
+            _profile_row(),
+            _resolution_row(),
+        ],
         fetch=[
             [],
             [],
@@ -239,7 +290,12 @@ async def test_send_invoice_email_allows_missing_pdf():
     ):
         result = await orders_service.send_invoice_email(request, _ORDER_ID, _RECIPIENT)
 
-    assert result == {'success': True, 'sent_to': _RECIPIENT}
+    assert result == {
+        'success': True,
+        'sent_to': _RECIPIENT,
+        'attachments': {'pdf': False, 'xml': True},
+        'attachment_warnings': ['invoice_pdf_missing'],
+    }
     helper_mock.assert_awaited_once()
     assert helper_mock.await_args.kwargs['invoice_prefix'] == 'LZT'
     assert helper_mock.await_args.kwargs['invoice_number'] == 5462
@@ -251,7 +307,13 @@ async def test_send_invoice_email_missing_pdf_still_surfaces_ses_failure():
     request = MagicMock()
 
     with _patch_session(), _patch_db(
-        fetchrow=[_order_row(), _invoice_row(r2_pdf_key=None), _waro_inferred_row(), _profile_row()],
+        fetchrow=[
+            _order_row(),
+            _invoice_row(r2_pdf_key=None),
+            _waro_inferred_row(),
+            _profile_row(),
+            _resolution_row(),
+        ],
         fetch=[
             [],
             [],
@@ -277,7 +339,7 @@ async def test_send_invoice_email_ses_failure_502():
     """send_pos_receipt_email returns False → 502."""
     request = MagicMock()
 
-    fetchrow = [_order_row(), _invoice_row(), _waro_inferred_row(), _profile_row()]
+    fetchrow = [_order_row(), _invoice_row(), _waro_inferred_row(), _profile_row(), _resolution_row()]
     fetch = [
         [],
         [],

--- a/tests/test_pos_receipt_template.py
+++ b/tests/test_pos_receipt_template.py
@@ -115,3 +115,60 @@ def test_pos_receipt_keeps_checkout_discount_stack_separate():
     assert "IVA: $3.000" in text
     assert "Propina: $7.000" in text
     assert "TOTAL COBRADO: $90.000" in text
+
+
+def test_pos_receipt_renders_fiscal_invoice_presentation():
+    text = get_pos_receipt_text(
+        order_number=47,
+        total_amount=120000,
+        payment_method="cash",
+        items=[{"quantity": 1, "subtotal": 120000, "product": {"name": "Cena"}}],
+        order_date=datetime(2026, 7, 1, 18, 0, tzinfo=timezone.utc),
+        invoice_prefix="LZT",
+        invoice_number=5462,
+        invoice_cufe="CUFE123",
+        invoice_presentation={
+            "status": "accepted",
+            "emitted_at": datetime(2026, 7, 1, 18, 5, tzinfo=timezone.utc),
+            "dian_url": "https://catalogo-vpfe.dian.gov.co/document/searchqr?documentkey=CUFE123",
+            "issuer": {
+                "name": "Waro Colombia SAS",
+                "fiscal_id_type": "NIT",
+                "fiscal_id": "901234567",
+                "address": "Carrera 10 #20-30",
+                "city": "Bogotá",
+                "email": "facturacion@warocol.com",
+            },
+            "acquirer": {
+                "name": "Restaurante Cliente SAS",
+                "fiscal_id_type": "NIT",
+                "fiscal_id": "900123456",
+                "email": "contabilidad@example.com",
+            },
+            "resolution": {
+                "number": "18760000001",
+                "prefix": "LZT",
+                "from_number": 1,
+                "to_number": 9999,
+                "date_from": "2026-01-01",
+                "date_to": "2026-12-31",
+            },
+            "tax_details": [
+                {"label": "IVA 19%", "base": 100000, "amount": 19000},
+            ],
+            "attachments": {"pdf": True, "xml": True},
+        },
+    )
+
+    assert "FACTURA ELECTRÓNICA DE VENTA" in text
+    assert "Representación gráfica para verificación contable." in text
+    assert "Número: LZT-5462" in text
+    assert "Estado DIAN: accepted" in text
+    assert "Emisor:" in text
+    assert "Waro Colombia SAS" in text
+    assert "Adquirente:" in text
+    assert "Restaurante Cliente SAS" in text
+    assert "Resolución DIAN: 18760000001" in text
+    assert "IVA 19% base $100.000: $19.000" in text
+    assert "Archivos: PDF adjunto, XML adjunto" in text
+    assert "Verificar en DIAN: https://catalogo-vpfe.dian.gov.co/document/searchqr?documentkey=CUFE123" in text


### PR DESCRIPTION
## Summary
- Add fiscal presentation metadata to accepted invoice email flow and /orders/{id}/invoice response
- Render accountant-friendly FE email text with issuer/acquirer, CUFE, DIAN URL, resolution, taxes, and attachment state
- Return safe PDF/XML attachment status and warnings without exposing R2 keys

## Tests
- pytest tests/test_invoice_send_email.py tests/test_pos_receipt_template.py
- pytest tests/test_document_email.py tests/test_invoicing_readiness.py

Closes uno0uno/warocol.com#1588