### PR TITLE
fix(billing): disable Matias PDF for POS/Ventas email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,3 +85,6 @@ FACTURADOR_LEGAL_ROLE_LABEL=Facturador técnico DIAN
 FACTURADOR_LEGAL_NOT_ISSUER_DISCLAIMER=No es el emisor de esta venta
 FACTURADOR_LEGAL_CITY=
 FACTURADOR_LEGAL_SUPPORT_EMAIL=
+
+# FE graphic PDF (Matias). false = do not attach/expect PDF in POS/Ventas
+INVOICE_PDF_ENABLED=false

--- a/app/config.py
+++ b/app/config.py
@@ -118,6 +118,10 @@ class Settings(BaseSettings):
     # (api-facturacion#21) can recover the order.
     dian_short_circuit_grace_minutes: int = Field(default=5, alias='DIAN_SHORT_CIRCUIT_GRACE_MINUTES')
 
+    # When false (default): POS/Ventas do not expect/attach Matias PDF.
+    # Mirror of api_facturacion INVOICE_PDF_ENABLED. Email sends text+XML only.
+    invoice_pdf_enabled: bool = Field(default=False, alias='INVOICE_PDF_ENABLED')
+
     # ── Platform legal identity for receipt/print footers (source of truth) ──
     # WARO = POS software / technology platform (not the tenant FE issuer).
     # Empty env → empty print fields (no PII hardcode in repo for production).

--- a/app/services/email_helpers.py
+++ b/app/services/email_helpers.py
@@ -3,6 +3,7 @@ Email helper functions for sending formatted emails
 """
 from typing import List, Dict, Any, Optional
 from datetime import datetime
+from app.config import settings
 from app.services.aws_ses_service import AWSSESService
 from app.database import get_db_connection
 from app.services.email_sender import resolve_sender_email_for_tenant
@@ -564,19 +565,24 @@ async def send_pos_receipt_email(
                     track_id = str(inv_row["id"])
                     s3 = AWSS3Service()
 
-                    if inv_row.get("r2_pdf_key"):
-                        pdf_bytes = await s3.get_object_bytes(inv_row["r2_pdf_key"])
-                        if pdf_bytes:
-                            attachment_status["pdf"] = True
-                            attachments.append({
-                                "data": pdf_bytes,
-                                "filename": f"{invoice_prefix}-{invoice_number}.pdf",
-                                "content_type": "application/pdf",
-                            })
+                    # PDF optional: Matias often omits graphic PDF; POS/Ventas use
+                    # thermal + text/XML. Controlled by INVOICE_PDF_ENABLED.
+                    if settings.invoice_pdf_enabled:
+                        if inv_row.get("r2_pdf_key"):
+                            pdf_bytes = await s3.get_object_bytes(inv_row["r2_pdf_key"])
+                            if pdf_bytes:
+                                attachment_status["pdf"] = True
+                                attachments.append({
+                                    "data": pdf_bytes,
+                                    "filename": f"{invoice_prefix}-{invoice_number}.pdf",
+                                    "content_type": "application/pdf",
+                                })
+                            else:
+                                attachment_warnings.append("invoice_pdf_unavailable")
                         else:
-                            attachment_warnings.append("invoice_pdf_unavailable")
+                            attachment_warnings.append("invoice_pdf_missing")
                     else:
-                        attachment_warnings.append("invoice_pdf_missing")
+                        attachment_status["pdf"] = False
 
                     if inv_row.get("r2_xml_key"):
                         xml_bytes = await s3.get_object_bytes(inv_row["r2_xml_key"])

--- a/app/services/facturacion_service.py
+++ b/app/services/facturacion_service.py
@@ -494,7 +494,11 @@ async def get_order_invoice(
         return None
 
     pdf_presigned_url: Optional[str] = None
-    if row['status'] == 'accepted' and row['r2_pdf_key']:
+    if (
+        settings.invoice_pdf_enabled
+        and row['status'] == 'accepted'
+        and row['r2_pdf_key']
+    ):
         try:
             s3 = AWSS3Service()
             pdf_presigned_url = await s3.get_presigned_url(row['r2_pdf_key'], expiration=3600)
@@ -512,6 +516,22 @@ async def get_order_invoice(
         provider="matias",
         serialize_datetimes=True,
     )
+    attachments = presentation.get('attachments') or {
+        'pdf': bool(row['r2_pdf_key']),
+        'xml': bool(row['r2_xml_key']),
+    }
+    if not settings.invoice_pdf_enabled:
+        attachments = {**attachments, 'pdf': False}
+
+    # Hide Matias "missing PDF" noise when PDF is intentionally disabled
+    error_message = row['error_message']
+    if (
+        not settings.invoice_pdf_enabled
+        and error_message
+        and 'did not return PDF' in str(error_message)
+        and 'XML' not in str(error_message)
+    ):
+        error_message = None
 
     return {
         'id': str(row['id']),
@@ -521,13 +541,11 @@ async def get_order_invoice(
         'cufe': row['cufe'],
         'status': row['status'],
         'pdf_presigned_url': pdf_presigned_url,
-        'error_message': row['error_message'],
+        'pdf_enabled': bool(settings.invoice_pdf_enabled),
+        'error_message': error_message,
         'emitted_at': row['emitted_at'].isoformat() if row['emitted_at'] else None,
         'created_at': row['created_at'].isoformat() if row['created_at'] else None,
         'dian_url': presentation.get('dian_url'),
-        'attachments': presentation.get('attachments') or {
-            'pdf': bool(row['r2_pdf_key']),
-            'xml': bool(row['r2_xml_key']),
-        },
+        'attachments': attachments,
         'presentation': presentation,
     }

--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -14,6 +14,7 @@ from uuid import UUID
 
 import asyncpg
 
+from app.config import settings
 from app.database import get_db_connection
 from app.core.platform_legal import get_platform_legal_for_print
 from app.core.timezones import normalize_timezone
@@ -202,6 +203,8 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
         'invoicing_ready': invoicing_ready,
         # WARO software + Matias facturador labels for tickets (env-driven; not tenant issuer)
         'platform_legal': get_platform_legal_for_print(),
+        # When false, POS/Ventas must not offer download/attach of Matias PDF
+        'invoice_pdf_enabled': bool(settings.invoice_pdf_enabled),
         'open_sale_product': open_sale_product,
         'members': [
             {

--- a/app/templates/pos_receipt_template.py
+++ b/app/templates/pos_receipt_template.py
@@ -257,8 +257,9 @@ def get_pos_receipt_text(
             attachment_lines.append("XML adjunto")
         if attachment_lines:
             invoice_lines.append("Archivos: " + ", ".join(attachment_lines))
-        elif attachment_status:
-            invoice_lines.append("Archivos: PDF/XML aún no disponibles en el repositorio fiscal.")
+        elif attachment_status.get("xml") is False and not attachment_status.get("pdf"):
+            # PDF disabled env: do not alarm about missing graphic PDF
+            invoice_lines.append("Archivos: XML fiscal cuando esté disponible; PDF gráfico no se envía.")
 
         invoice_lines.extend([
             f"CUFE: {invoice_cufe}",


### PR DESCRIPTION
## Summary
- `INVOICE_PDF_ENABLED=false` by default: no PDF attach on send-email, no PDF presign when disabled.
- Expose `invoice_pdf_enabled` on POS restaurant-context.
- Avoid treating missing Matias graphic PDF as an emission failure noise.

## Test plan
- [x] pytest email/receipt/platform tests
- [ ] Deploy + recreate with env; emit FE and send email without PDF