### PR TITLE
feat(tenant): locale + currency_code prefs (B1 localization)

### DIFF
--- a/app/core/tenant_prefs.py
+++ b/app/core/tenant_prefs.py
@@ -1,0 +1,49 @@
+"""Tenant localization prefs helpers (locale + display currency).
+
+Operational defaults preserve the Colombia product:
+- locale: es
+- currency_code: COP (display only; no FX)
+
+Separate from fiscal/legal Colombia constraints (api-facturacion).
+"""
+from typing import Optional
+
+DEFAULT_TENANT_LOCALE = "es"
+DEFAULT_CURRENCY_CODE = "COP"
+ALLOWED_LOCALES = frozenset({"es", "en"})
+
+
+def validate_locale(value: Optional[str]) -> str:
+    """Return a normalized locale or raise ValueError for user input."""
+    if value is None or not isinstance(value, str) or not value.strip():
+        raise ValueError("locale must be one of: es, en")
+    locale = value.strip().lower()
+    if locale not in ALLOWED_LOCALES:
+        raise ValueError("locale must be one of: es, en")
+    return locale
+
+
+def normalize_locale(value: Optional[str]) -> str:
+    """Return a safe tenant locale, falling back for legacy/invalid values."""
+    try:
+        return validate_locale(value)
+    except ValueError:
+        return DEFAULT_TENANT_LOCALE
+
+
+def validate_currency_code(value: Optional[str]) -> str:
+    """Return a normalized ISO 4217-ish currency code or raise ValueError."""
+    if value is None or not isinstance(value, str) or not value.strip():
+        raise ValueError("currency_code must be a 3-letter ISO code")
+    code = value.strip().upper()
+    if len(code) != 3 or not code.isalpha():
+        raise ValueError("currency_code must be a 3-letter ISO code")
+    return code
+
+
+def normalize_currency_code(value: Optional[str]) -> str:
+    """Return a safe display currency code, falling back for legacy/invalid values."""
+    try:
+        return validate_currency_code(value)
+    except ValueError:
+        return DEFAULT_CURRENCY_CODE

--- a/app/models/tenant_public_profile.py
+++ b/app/models/tenant_public_profile.py
@@ -5,6 +5,12 @@ from uuid import UUID
 from datetime import datetime
 from decimal import Decimal
 from app.core.timezones import DEFAULT_TENANT_TIMEZONE, validate_timezone
+from app.core.tenant_prefs import (
+    DEFAULT_CURRENCY_CODE,
+    DEFAULT_TENANT_LOCALE,
+    validate_currency_code,
+    validate_locale,
+)
 
 class BusinessHours(BaseModel):
     """Business hours for a single day"""
@@ -50,6 +56,14 @@ class TenantPublicProfileBase(BaseModel):
     timezone: str = Field(
         DEFAULT_TENANT_TIMEZONE,
         description="IANA timezone for tenant operational dates and business hours",
+    )
+    locale: str = Field(
+        DEFAULT_TENANT_LOCALE,
+        description="UI/number language preference: es | en. Defaults to es.",
+    )
+    currency_code: str = Field(
+        DEFAULT_CURRENCY_CODE,
+        description="ISO 4217 display currency code. Defaults to COP. Display-only; no FX.",
     )
 
     # Business hours (JSONB)
@@ -190,6 +204,16 @@ class TenantPublicProfileBase(BaseModel):
     def _validate_timezone(cls, v):
         return validate_timezone(v)
 
+    @field_validator('locale')
+    @classmethod
+    def _validate_locale(cls, v):
+        return validate_locale(v)
+
+    @field_validator('currency_code')
+    @classmethod
+    def _validate_currency_code(cls, v):
+        return validate_currency_code(v)
+
     @field_validator('tip_default_percentages')
     @classmethod
     def _validate_tip_presets(cls, v):
@@ -249,6 +273,8 @@ class TenantPublicProfileUpdate(BaseModel):
     latitude: Optional[Decimal] = None
     longitude: Optional[Decimal] = None
     timezone: Optional[str] = None
+    locale: Optional[str] = None
+    currency_code: Optional[str] = None
 
     business_hours: Optional[Dict[str, Any]] = None
     social_media: Optional[Dict[str, str]] = None
@@ -289,6 +315,20 @@ class TenantPublicProfileUpdate(BaseModel):
         if v is None:
             return v
         return validate_timezone(v)
+
+    @field_validator('locale')
+    @classmethod
+    def _validate_locale_update(cls, v):
+        if v is None:
+            return v
+        return validate_locale(v)
+
+    @field_validator('currency_code')
+    @classmethod
+    def _validate_currency_code_update(cls, v):
+        if v is None:
+            return v
+        return validate_currency_code(v)
 
     @field_validator('tip_default_percentages')
     @classmethod

--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -139,9 +139,12 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
 
     return {
         'display_name': row['display_name'],
-        'timezone': normalize_timezone(row['timezone']),
-        'locale': normalize_locale(row['locale']),
-        'currency_code': normalize_currency_code(row['currency_code']),
+        'timezone': normalize_timezone(row['timezone'] if 'timezone' in row else None),
+        # Prefer .get-style access so unit mocks without prefs columns don't KeyError.
+        'locale': normalize_locale(row['locale'] if 'locale' in row else None),
+        'currency_code': normalize_currency_code(
+            row['currency_code'] if 'currency_code' in row else None
+        ),
         'kds_enabled': bool(row['kds_enabled']) if row['kds_enabled'] is not None else False,
         'comandas_enabled': bool(row['comandas_enabled']) if row['comandas_enabled'] is not None else False,
         'expediter_enabled': bool(row['expediter_enabled']) if row['expediter_enabled'] is not None else False,

--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -18,6 +18,7 @@ from app.config import settings
 from app.database import get_db_connection
 from app.core.platform_legal import get_platform_legal_for_print
 from app.core.timezones import normalize_timezone
+from app.core.tenant_prefs import normalize_currency_code, normalize_locale
 from app.services.invoicing_readiness_service import get_readiness
 from app.services.open_priced_service import fetch_open_sale_product
 from app.services.promotions_service import (
@@ -32,6 +33,8 @@ _CONTEXT_QUERY = """
 SELECT
     tpp.display_name,
     tpp.timezone,
+    tpp.locale,
+    tpp.currency_code,
     tpp.kds_enabled,
     tpp.comandas_enabled,
     tpp.expediter_enabled,
@@ -81,10 +84,15 @@ LEFT JOIN tenant_tax_config       ttc ON ttc.tenant_id = t.id
 WHERE t.id = $1
 """
 
-_CONTEXT_QUERY_WITHOUT_TIMEZONE = _CONTEXT_QUERY.replace(
-    "    tpp.timezone,\n",
-    "    NULL AS timezone,\n",
+# Fallback when additive prefs columns are not migrated yet (timezone, locale, currency_code).
+_CONTEXT_QUERY_WITHOUT_PREFS = (
+    _CONTEXT_QUERY
+    .replace("    tpp.timezone,\n", "    NULL AS timezone,\n")
+    .replace("    tpp.locale,\n", "    NULL AS locale,\n")
+    .replace("    tpp.currency_code,\n", "    NULL AS currency_code,\n")
 )
+# Backward-compatible alias used by older call sites / greps.
+_CONTEXT_QUERY_WITHOUT_TIMEZONE = _CONTEXT_QUERY_WITHOUT_PREFS
 
 
 _MEMBERS_QUERY = """
@@ -116,10 +124,11 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
             row = await conn.fetchrow(_CONTEXT_QUERY, tenant_id)
         except asyncpg.UndefinedColumnError:
             logger.warning(
-                "tenant_public_profiles.timezone missing in POS context query; "
-                "using default timezone. Apply sql/20260626_tenant_timezone.sql."
+                "tenant_public_profiles locale/currency/timezone prefs missing in POS "
+                "context query; using defaults. Apply sql/20260626_tenant_timezone.sql "
+                "and sql/20260710_tenant_locale_currency.sql."
             )
-            row = await conn.fetchrow(_CONTEXT_QUERY_WITHOUT_TIMEZONE, tenant_id)
+            row = await conn.fetchrow(_CONTEXT_QUERY_WITHOUT_PREFS, tenant_id)
         if row is None:
             return None
         members_rows = await conn.fetch(_MEMBERS_QUERY, tenant_id)
@@ -131,6 +140,8 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
     return {
         'display_name': row['display_name'],
         'timezone': normalize_timezone(row['timezone']),
+        'locale': normalize_locale(row['locale']),
+        'currency_code': normalize_currency_code(row['currency_code']),
         'kds_enabled': bool(row['kds_enabled']) if row['kds_enabled'] is not None else False,
         'comandas_enabled': bool(row['comandas_enabled']) if row['comandas_enabled'] is not None else False,
         'expediter_enabled': bool(row['expediter_enabled']) if row['expediter_enabled'] is not None else False,

--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -363,10 +363,25 @@ async def update_public_profile(
 
             if 'timezone' in data_dict:
                 data_dict['timezone'] = validate_timezone(data_dict['timezone'])
+            # Explicit null → Colombia defaults; invalid strings → 400 (not 500).
             if 'locale' in data_dict:
-                data_dict['locale'] = validate_locale(data_dict['locale'])
+                if data_dict['locale'] is None:
+                    data_dict['locale'] = DEFAULT_TENANT_LOCALE
+                else:
+                    try:
+                        data_dict['locale'] = validate_locale(data_dict['locale'])
+                    except ValueError as exc:
+                        raise HTTPException(status_code=400, detail=str(exc)) from exc
             if 'currency_code' in data_dict:
-                data_dict['currency_code'] = validate_currency_code(data_dict['currency_code'])
+                if data_dict['currency_code'] is None:
+                    data_dict['currency_code'] = DEFAULT_CURRENCY_CODE
+                else:
+                    try:
+                        data_dict['currency_code'] = validate_currency_code(
+                            data_dict['currency_code']
+                        )
+                    except ValueError as exc:
+                        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
             _jsonb_fields = {'business_hours', 'social_media'}
             for field, value in data_dict.items():

--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -10,6 +10,14 @@ from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError
 from app.core.timezones import DEFAULT_TENANT_TIMEZONE, normalize_timezone, validate_timezone
+from app.core.tenant_prefs import (
+    DEFAULT_CURRENCY_CODE,
+    DEFAULT_TENANT_LOCALE,
+    normalize_currency_code,
+    normalize_locale,
+    validate_currency_code,
+    validate_locale,
+)
 from app.models.tenant_public_profile import (
     TenantPublicProfile,
     TenantPublicProfileCreate,
@@ -37,6 +45,8 @@ def _profile_from_row(row) -> TenantPublicProfile:
         except Exception:
             profile_data['social_media'] = None
     profile_data['timezone'] = normalize_timezone(profile_data.get('timezone'))
+    profile_data['locale'] = normalize_locale(profile_data.get('locale'))
+    profile_data['currency_code'] = normalize_currency_code(profile_data.get('currency_code'))
     return TenantPublicProfile(**profile_data)
 
 
@@ -82,6 +92,7 @@ async def upsert_public_profile(
                         display_name, description, logo_url, banner_url,
                         phone_number, email, address,
                         city, neighborhood, latitude, longitude, timezone,
+                        locale, currency_code,
                         business_hours, social_media,
                         seo_title, seo_description,
                         accepts_online_orders, min_order_amount, online_order_max_amount, estimated_preparation_time,
@@ -92,7 +103,7 @@ async def upsert_public_profile(
                         minimum_consumption_enabled, minimum_consumption_amount, minimum_consumption_restrictive,
                         updated_at
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, CURRENT_TIMESTAMP)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, CURRENT_TIMESTAMP)
                     ON CONFLICT (tenant_id)
                     DO UPDATE SET
                         slug = EXCLUDED.slug,
@@ -109,6 +120,8 @@ async def upsert_public_profile(
                         latitude = EXCLUDED.latitude,
                         longitude = EXCLUDED.longitude,
                         timezone = EXCLUDED.timezone,
+                        locale = EXCLUDED.locale,
+                        currency_code = EXCLUDED.currency_code,
                         business_hours = EXCLUDED.business_hours,
                         social_media = EXCLUDED.social_media,
                         seo_title = EXCLUDED.seo_title,
@@ -146,6 +159,8 @@ async def upsert_public_profile(
                     profile_data.latitude,
                     profile_data.longitude,
                     profile_data.timezone,
+                    profile_data.locale,
+                    profile_data.currency_code,
                     json.dumps(profile_data.business_hours) if profile_data.business_hours is not None else None,
                     json.dumps(profile_data.social_media) if profile_data.social_media is not None else None,
                     profile_data.seo_title,
@@ -239,13 +254,14 @@ async def update_public_profile(
                         phone_number, email, address,
                         country, city, city_slug, neighborhood,
                         business_hours, social_media, timezone,
+                        locale, currency_code,
                         accepts_online_orders, min_order_amount, online_order_max_amount, estimated_preparation_time,
                         is_manually_open,
                         comandas_enabled, kds_enabled,
                         auto_select_generic_enabled,
                         expediter_enabled,
                         minimum_consumption_enabled, minimum_consumption_amount, minimum_consumption_restrictive
-                    ) VALUES ($1, $2, $3, FALSE, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28)
+                    ) VALUES ($1, $2, $3, FALSE, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30)
                     RETURNING *
                 """
                 result = await conn.fetchrow(
@@ -266,6 +282,8 @@ async def update_public_profile(
                     json.dumps(data_dict['business_hours']) if data_dict.get('business_hours') is not None else None,
                     json.dumps(data_dict['social_media']) if data_dict.get('social_media') is not None else None,
                     data_dict.get('timezone', DEFAULT_TENANT_TIMEZONE),
+                    data_dict.get('locale', DEFAULT_TENANT_LOCALE),
+                    data_dict.get('currency_code', DEFAULT_CURRENCY_CODE),
                     # Default True so new tenants are immediately able to
                     # receive online orders — the platform's core value
                     # prop (warocol.com#626). Operators can still toggle
@@ -345,6 +363,10 @@ async def update_public_profile(
 
             if 'timezone' in data_dict:
                 data_dict['timezone'] = validate_timezone(data_dict['timezone'])
+            if 'locale' in data_dict:
+                data_dict['locale'] = validate_locale(data_dict['locale'])
+            if 'currency_code' in data_dict:
+                data_dict['currency_code'] = validate_currency_code(data_dict['currency_code'])
 
             _jsonb_fields = {'business_hours', 'social_media'}
             for field, value in data_dict.items():

--- a/sql/20260710_tenant_locale_currency.sql
+++ b/sql/20260710_tenant_locale_currency.sql
@@ -1,0 +1,36 @@
+-- Tenant locale + display currency prefs (warocol.com#1599 / epic #1598 B1).
+-- Additive only. Defaults preserve Colombia product feel (es + COP).
+
+ALTER TABLE tenant_public_profiles
+    ADD COLUMN IF NOT EXISTS locale TEXT NOT NULL DEFAULT 'es';
+
+ALTER TABLE tenant_public_profiles
+    ADD COLUMN IF NOT EXISTS currency_code TEXT NOT NULL DEFAULT 'COP';
+
+UPDATE tenant_public_profiles
+SET locale = 'es'
+WHERE locale IS NULL OR btrim(locale) = '';
+
+UPDATE tenant_public_profiles
+SET currency_code = 'COP'
+WHERE currency_code IS NULL OR btrim(currency_code) = '';
+
+ALTER TABLE tenant_public_profiles
+    DROP CONSTRAINT IF EXISTS tenant_public_profiles_locale_allowed;
+
+ALTER TABLE tenant_public_profiles
+    ADD CONSTRAINT tenant_public_profiles_locale_allowed
+    CHECK (locale IN ('es', 'en'));
+
+ALTER TABLE tenant_public_profiles
+    DROP CONSTRAINT IF EXISTS tenant_public_profiles_currency_code_non_blank;
+
+ALTER TABLE tenant_public_profiles
+    ADD CONSTRAINT tenant_public_profiles_currency_code_non_blank
+    CHECK (btrim(currency_code) <> '' AND char_length(btrim(currency_code)) = 3);
+
+COMMENT ON COLUMN tenant_public_profiles.locale IS
+    'UI/number language preference: es | en. Defaults to es (Colombia product).';
+
+COMMENT ON COLUMN tenant_public_profiles.currency_code IS
+    'ISO 4217 display currency code. Defaults to COP. Display-only; no FX.';

--- a/tests/test_tenant_locale_currency.py
+++ b/tests/test_tenant_locale_currency.py
@@ -1,0 +1,86 @@
+"""Tenant locale + currency prefs (warocol.com#1599 / epic #1598 B1)."""
+import pytest
+from pydantic import ValidationError
+
+from app.core.tenant_prefs import (
+    DEFAULT_CURRENCY_CODE,
+    DEFAULT_TENANT_LOCALE,
+    normalize_currency_code,
+    normalize_locale,
+    validate_currency_code,
+    validate_locale,
+)
+from app.models.tenant_public_profile import (
+    TenantPublicProfileBase,
+    TenantPublicProfileUpdate,
+)
+
+
+def test_validate_locale_accepts_es_en_and_normalizes_case():
+    assert validate_locale("es") == "es"
+    assert validate_locale("EN") == "en"
+    assert validate_locale(" Es ") == "es"
+
+
+def test_validate_locale_rejects_unknown():
+    with pytest.raises(ValueError, match="locale must be one of"):
+        validate_locale("fr")
+    with pytest.raises(ValueError, match="locale must be one of"):
+        validate_locale("")
+    with pytest.raises(ValueError, match="locale must be one of"):
+        validate_locale(None)
+
+
+def test_normalize_locale_defaults_for_missing_or_junk():
+    assert normalize_locale(None) == DEFAULT_TENANT_LOCALE
+    assert normalize_locale("") == DEFAULT_TENANT_LOCALE
+    assert normalize_locale("xx") == DEFAULT_TENANT_LOCALE
+    assert normalize_locale("en") == "en"
+
+
+def test_validate_currency_code_accepts_iso_and_uppercases():
+    assert validate_currency_code("COP") == "COP"
+    assert validate_currency_code("usd") == "USD"
+    assert validate_currency_code(" MxN ") == "MXN"
+
+
+def test_validate_currency_code_rejects_invalid():
+    with pytest.raises(ValueError, match="3-letter"):
+        validate_currency_code("CO")
+    with pytest.raises(ValueError, match="3-letter"):
+        validate_currency_code("123")
+    with pytest.raises(ValueError, match="3-letter"):
+        validate_currency_code(None)
+
+
+def test_normalize_currency_code_defaults_for_missing_or_junk():
+    assert normalize_currency_code(None) == DEFAULT_CURRENCY_CODE
+    assert normalize_currency_code("") == DEFAULT_CURRENCY_CODE
+    assert normalize_currency_code("XX") == DEFAULT_CURRENCY_CODE  # not alpha length ok? XX is alpha len2
+    assert normalize_currency_code("ZZZ") == "ZZZ"  # open allowlist for display later
+    assert normalize_currency_code("cop") == "COP"
+
+
+def test_profile_base_defaults_are_colombia_product():
+    # Minimal required fields for base model
+    profile = TenantPublicProfileBase(slug="demo", display_name="Demo")
+    assert profile.locale == "es"
+    assert profile.currency_code == "COP"
+    assert profile.timezone == "America/Bogota"
+
+
+def test_profile_base_rejects_invalid_locale():
+    with pytest.raises(ValidationError):
+        TenantPublicProfileBase(slug="demo", display_name="Demo", locale="fr")
+
+
+def test_profile_update_round_trip_fields():
+    update = TenantPublicProfileUpdate(locale="en", currency_code="usd")
+    dumped = update.model_dump(exclude_unset=True)
+    assert dumped["locale"] == "en"
+    assert dumped["currency_code"] == "USD"
+
+
+def test_profile_update_rejects_bad_currency():
+    with pytest.raises(ValidationError):
+        TenantPublicProfileUpdate(currency_code="peso")

--- a/tests/test_tenant_timezones.py
+++ b/tests/test_tenant_timezones.py
@@ -104,6 +104,8 @@ def _pos_context_row(timezone_name):
     return {
         "display_name": "Demo",
         "timezone": timezone_name,
+        "locale": None,
+        "currency_code": None,
         "kds_enabled": None,
         "comandas_enabled": None,
         "expediter_enabled": None,


### PR DESCRIPTION
## Summary
- Additive `locale` (es|en) and `currency_code` (ISO, default COP) on `tenant_public_profiles`
- Exposed on public profile models/services and `GET /pos/restaurant-context`
- Defaults preserve Colombia product behavior when unset

## Tracker
- Batch: [uno0uno/warocol.com#1599](https://github.com/uno0uno/warocol.com/issues/1599)
- Epic: [uno0uno/warocol.com#1598](https://github.com/uno0uno/warocol.com/issues/1598)

## Test plan
- [x] `pytest tests/test_tenant_locale_currency.py -q` (10 passed)
- [ ] Apply `sql/20260710_tenant_locale_currency.sql` on deploy DB
- [ ] PATCH public-profile with `locale`/`currency_code` and confirm GET + restaurant-context

## Notes
- No frontend, no api-facturacion, no FX
- Migration required before SELECT of new columns in prod (fallback nulls + normalize if missing)