### PR TITLE
fix(tz): tenant operational timezone on waros analytics and promo lock

### DIFF
--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -7,13 +7,11 @@ from decimal import Decimal
 from typing import Any, Dict, List, Optional, Sequence
 from uuid import UUID
 from datetime import date, datetime
-from zoneinfo import ZoneInfo
 from fastapi import Request
-_BOG = ZoneInfo("America/Bogota")
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError
-from app.core.timezones import local_date_for_tenant, resolve_tenant_timezone
+from app.core.timezones import get_zoneinfo, local_date_for_tenant, resolve_tenant_timezone
 from app.services.waros_service import evaluate_and_award
 from app.services.orders_service import _get_order_waro_redemption_summary
 from app.services.email_helpers import send_pos_receipt_email
@@ -170,7 +168,9 @@ async def _refresh_cart_item_promotion_lock(
 
     from app.services.promotions_service import evaluate_checkout_promotions
 
-    locked_at = datetime.now(_BOG)
+    # Operational tenant TZ (explicit → profile → America/Bogota); not fiscal CO time.
+    tenant_timezone = await resolve_tenant_timezone(conn, tenant_id)
+    locked_at = datetime.now(get_zoneinfo(tenant_timezone))
     promo_lines = _cart_items_to_promo_lines(items)
     checkout_eval = await evaluate_checkout_promotions(
         conn,

--- a/app/services/waros_service.py
+++ b/app/services/waros_service.py
@@ -11,6 +11,7 @@ from uuid import UUID
 from fastapi import HTTPException, Request
 
 from app.core.middleware import require_valid_session
+from app.core.timezones import resolve_tenant_timezone
 from app.database import get_db_connection
 
 logger = logging.getLogger(__name__)
@@ -1768,10 +1769,15 @@ async def _get_waros_analytics_for_tenant(
 
         elif group_by in ("day", "week"):
             trunc = "day" if group_by == "day" else "week"
+            # Operational tenant TZ for report buckets (not fiscal Colombia time).
+            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
+            period_params = list(date_params)
+            period_params.append(timezone_name)
+            tz_param = len(period_params)
             rows = await conn.fetch(
                 f"""
                 SELECT
-                    date_trunc('{trunc}', created_at AT TIME ZONE 'America/Bogota') AS period,
+                    date_trunc('{trunc}', created_at AT TIME ZONE ${tz_param}) AS period,
                     COALESCE(SUM(CASE WHEN transaction_type IN ('earned', 'manual') AND waros_amount > 0
                                    THEN waros_amount ELSE 0 END), 0) AS total_earned,
                     COALESCE(SUM(CASE WHEN transaction_type = 'redeemed'
@@ -1783,7 +1789,7 @@ async def _get_waros_analytics_for_tenant(
                 GROUP BY period
                 ORDER BY period DESC
                 """,
-                *date_params,
+                *period_params,
             )
             groups = [
                 {

--- a/app/services/waros_service.py
+++ b/app/services/waros_service.py
@@ -1687,22 +1687,34 @@ async def _get_waros_analytics_for_tenant(
     parsed_from = _parse_date(date_from) if date_from else None
     parsed_to = _parse_date(date_to) if date_to else None
 
-    # Build date filter
-    date_conditions: List[str] = []
-    date_params: List[Any] = [tenant_id]
-
-    if parsed_from:
-        date_params.append(parsed_from)
-        date_conditions.append(f"AND created_at >= ${len(date_params)}")
-    if parsed_to:
-        date_params.append(parsed_to)
-        date_conditions.append(f"AND created_at < (${len(date_params)}::date + INTERVAL '1 day')")
-
-    date_filter = " ".join(date_conditions)
-    # Qualified version for queries that JOIN with other tables having created_at
-    date_filter_wt = date_filter.replace("created_at", "wt.created_at")
-
     async with get_db_connection(use_transaction=False) as conn:
+        # Operational tenant TZ for filters + day/week buckets (not fiscal Colombia time).
+        timezone_name = await resolve_tenant_timezone(conn, tenant_id)
+
+        # $1 = tenant. When date range is set, bind timezone next so filters use
+        # DATE(created_at AT TIME ZONE $tz) (tenant-local calendar, not session TZ).
+        date_params: List[Any] = [tenant_id]
+        date_conditions: List[str] = []
+        filter_tz_param: Optional[int] = None
+
+        if parsed_from or parsed_to:
+            date_params.append(timezone_name)
+            filter_tz_param = len(date_params)
+            if parsed_from:
+                date_params.append(parsed_from)
+                date_conditions.append(
+                    f"AND DATE(created_at AT TIME ZONE ${filter_tz_param}) >= ${len(date_params)}"
+                )
+            if parsed_to:
+                date_params.append(parsed_to)
+                date_conditions.append(
+                    f"AND DATE(created_at AT TIME ZONE ${filter_tz_param}) <= ${len(date_params)}"
+                )
+
+        date_filter = " ".join(date_conditions)
+        # Qualified version for queries that JOIN with other tables having created_at
+        date_filter_wt = date_filter.replace("created_at", "wt.created_at")
+
         # Summary row: totals across all transaction types
         summary_row = await conn.fetchrow(
             f"""
@@ -1769,15 +1781,17 @@ async def _get_waros_analytics_for_tenant(
 
         elif group_by in ("day", "week"):
             trunc = "day" if group_by == "day" else "week"
-            # Operational tenant TZ for report buckets (not fiscal Colombia time).
-            timezone_name = await resolve_tenant_timezone(conn, tenant_id)
-            period_params = list(date_params)
-            period_params.append(timezone_name)
-            tz_param = len(period_params)
+            # Buckets share the filter timezone bind when present; else append $2.
+            if filter_tz_param is not None:
+                bucket_params = list(date_params)
+                bucket_tz_param = filter_tz_param
+            else:
+                bucket_params = [tenant_id, timezone_name]
+                bucket_tz_param = 2
             rows = await conn.fetch(
                 f"""
                 SELECT
-                    date_trunc('{trunc}', created_at AT TIME ZONE ${tz_param}) AS period,
+                    date_trunc('{trunc}', created_at AT TIME ZONE ${bucket_tz_param}) AS period,
                     COALESCE(SUM(CASE WHEN transaction_type IN ('earned', 'manual') AND waros_amount > 0
                                    THEN waros_amount ELSE 0 END), 0) AS total_earned,
                     COALESCE(SUM(CASE WHEN transaction_type = 'redeemed'
@@ -1789,7 +1803,7 @@ async def _get_waros_analytics_for_tenant(
                 GROUP BY period
                 ORDER BY period DESC
                 """,
-                *period_params,
+                *bucket_params,
             )
             groups = [
                 {

--- a/tests/test_tenant_timezones.py
+++ b/tests/test_tenant_timezones.py
@@ -16,7 +16,7 @@ from app.core.timezones import (
     tenant_today,
 )
 from app.models.tenant_public_profile import TenantPublicProfileUpdate
-from app.services import pos_context_service, tenant_config_service
+from app.services import pos_cart_service, pos_context_service, tenant_config_service
 
 
 def test_normalize_timezone_falls_back_for_missing_or_invalid_values():
@@ -192,3 +192,66 @@ async def test_pos_context_falls_back_when_timezone_column_is_missing():
         payload = await pos_context_service.get_restaurant_context(tenant_id)
 
     assert payload["timezone"] == DEFAULT_TENANT_TIMEZONE
+
+
+@pytest.mark.asyncio
+async def test_promo_lock_uses_resolved_tenant_timezone_for_locked_at():
+    """POS promo lock is operational TZ (tenant), not hard-coded Bogota."""
+    tenant_id = uuid4()
+    cart_id = uuid4()
+    item_id = uuid4()
+    product_id = uuid4()
+    promo_id = uuid4()
+
+    item = {
+        "id": str(item_id),
+        "product_id": str(product_id),
+        "product": {"id": str(product_id)},
+        "category_id": None,
+        "quantity": 1,
+        "subtotal": 10000,
+        "tax_category": "standard",
+        "promo_opt_out": False,
+        "locked_promotion_id": None,
+    }
+
+    conn = AsyncMock()
+    conn.execute = AsyncMock()
+    captured_at: list[datetime] = []
+
+    async def _evaluate(conn_arg, tenant_arg, lines, *, at=None):
+        captured_at.append(at)
+        return {
+            "lines": [
+                {
+                    "id": str(item_id),
+                    "promotion_id": str(promo_id),
+                    "promotion_name": "Happy hour",
+                    "promo_type": "percent_off",
+                    "promo_savings": 1000,
+                }
+            ]
+        }
+
+    with patch(
+        "app.services.pos_cart_service.get_cart_items",
+        new=AsyncMock(return_value=[item]),
+    ), patch(
+        "app.services.pos_cart_service.resolve_tenant_timezone",
+        new=AsyncMock(return_value="America/Mexico_City"),
+    ), patch(
+        "app.services.promotions_service.evaluate_checkout_promotions",
+        new=AsyncMock(side_effect=_evaluate),
+    ):
+        await pos_cart_service._refresh_cart_item_promotion_lock(
+            conn, tenant_id, cart_id, item_id
+        )
+
+    assert len(captured_at) == 1
+    locked_at = captured_at[0]
+    assert locked_at is not None
+    assert locked_at.tzinfo is not None
+    assert locked_at.tzinfo.key == "America/Mexico_City"
+    # Stored lock timestamp matches the evaluate `at` argument.
+    lock_write = conn.execute.await_args_list[-1]
+    assert lock_write.args[2] is locked_at

--- a/tests/test_waros_analytics_timezone.py
+++ b/tests/test_waros_analytics_timezone.py
@@ -53,8 +53,8 @@ async def test_waros_day_analytics_uses_resolved_tenant_timezone_in_sql():
     sql, args = fetch_calls[0]
     assert "America/Bogota" not in sql
     assert "AT TIME ZONE $" in sql
-    assert "America/Mexico_City" in args
     assert args[0] == tenant_id
+    assert args[1] == "America/Mexico_City"
 
 
 @pytest.mark.asyncio
@@ -97,6 +97,9 @@ async def test_waros_week_analytics_binds_tenant_timezone_after_date_filters():
     assert result["groups"][0]["period"] == date(2026, 7, 6).isoformat()
     sql, args = fetch_calls[0]
     assert "date_trunc('week'" in sql
-    assert args[-1] == "America/New_York"
+    assert "DATE(created_at AT TIME ZONE $2)" in sql
+    assert "date_trunc('week', created_at AT TIME ZONE $2)" in sql.replace("\n", " ")
+    assert args[0] == tenant_id
+    assert args[1] == "America/New_York"
     assert date(2026, 7, 1) in args
     assert date(2026, 7, 10) in args

--- a/tests/test_waros_analytics_timezone.py
+++ b/tests/test_waros_analytics_timezone.py
@@ -1,0 +1,102 @@
+"""Operational TZ second stage for WaRos analytics buckets (warocol.com#1600)."""
+from contextlib import asynccontextmanager
+from datetime import date, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.services.waros_service import _get_waros_analytics_for_tenant
+
+
+def _summary_row():
+    return {
+        "total_issued": 0,
+        "total_redeemed": 0,
+        "active_members": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_waros_day_analytics_uses_resolved_tenant_timezone_in_sql():
+    tenant_id = str(uuid4())
+    fetch_calls: list[tuple] = []
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_summary_row())
+
+    async def _fetch(sql, *args):
+        fetch_calls.append((sql, args))
+        return []
+
+    conn.fetch = AsyncMock(side_effect=_fetch)
+
+    @asynccontextmanager
+    async def _ctx(*_, **__):
+        yield conn
+
+    with patch("app.services.waros_service.get_db_connection", side_effect=_ctx), patch(
+        "app.services.waros_service.resolve_tenant_timezone",
+        new=AsyncMock(return_value="America/Mexico_City"),
+    ):
+        result = await _get_waros_analytics_for_tenant(
+            tenant_id,
+            group_by="day",
+            date_from=None,
+            date_to=None,
+        )
+
+    assert result["group_by"] == "day"
+    assert result["groups"] == []
+    assert len(fetch_calls) == 1
+    sql, args = fetch_calls[0]
+    assert "America/Bogota" not in sql
+    assert "AT TIME ZONE $" in sql
+    assert "America/Mexico_City" in args
+    assert args[0] == tenant_id
+
+
+@pytest.mark.asyncio
+async def test_waros_week_analytics_binds_tenant_timezone_after_date_filters():
+    tenant_id = str(uuid4())
+    fetch_calls: list[tuple] = []
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_summary_row())
+
+    async def _fetch(sql, *args):
+        fetch_calls.append((sql, args))
+        period = datetime(2026, 7, 6, tzinfo=ZoneInfo("UTC"))
+        return [
+            {
+                "period": period,
+                "total_earned": 10,
+                "total_redeemed": 2,
+                "active_members": 1,
+            }
+        ]
+
+    conn.fetch = AsyncMock(side_effect=_fetch)
+
+    @asynccontextmanager
+    async def _ctx(*_, **__):
+        yield conn
+
+    with patch("app.services.waros_service.get_db_connection", side_effect=_ctx), patch(
+        "app.services.waros_service.resolve_tenant_timezone",
+        new=AsyncMock(return_value="America/New_York"),
+    ):
+        result = await _get_waros_analytics_for_tenant(
+            tenant_id,
+            group_by="week",
+            date_from="2026-07-01",
+            date_to="2026-07-10",
+        )
+
+    assert result["groups"][0]["period"] == date(2026, 7, 6).isoformat()
+    sql, args = fetch_calls[0]
+    assert "date_trunc('week'" in sql
+    assert args[-1] == "America/New_York"
+    assert date(2026, 7, 1) in args
+    assert date(2026, 7, 10) in args


### PR DESCRIPTION
## Summary
- WaRos day/week analytics buckets resolve tenant timezone (`explicit → tenant profile → America/Bogota`) instead of SQL literal Bogota.
- POS promo `locked_at` uses the same operational resolve chain (removed module `_BOG`).
- Targeted tests cover non-Bogota tenant SQL bind and promo lock tzinfo.

## Fiscal vs operational
- **Operational (this PR):** report period buckets, promo lock local time.
- **Fiscal (out of scope):** `api_facturacion` DIAN/Matias Colombia time — unchanged.
- Customer-facing receipt/confirmation email templates left on Bogota brand on purpose.

## Files
- `app/services/waros_service.py`
- `app/services/pos_cart_service.py`
- `tests/test_waros_analytics_timezone.py`
- `tests/test_tenant_timezones.py`

## Test plan
- [x] `pytest tests/test_tenant_timezones.py tests/test_waros_analytics_timezone.py -q` (13 passed)
- [ ] Smoke: waros analytics day/week for tenant with non-Bogota profile
- [ ] Smoke: POS promo lock near midnight with tenant TZ ≠ Bogota

Refs uno0uno/warocol.com#1600
Epic: uno0uno/warocol.com#1598