### PR TITLE
feat(i18n): persist tenant-wide UI locale

### DIFF
--- a/app/core/tenant_prefs.py
+++ b/app/core/tenant_prefs.py
@@ -11,6 +11,8 @@ from typing import Optional
 DEFAULT_TENANT_LOCALE = "es"
 DEFAULT_CURRENCY_CODE = "COP"
 ALLOWED_LOCALES = frozenset({"es", "en"})
+DEFAULT_TENANT_UI_LOCALE = "es"
+ALLOWED_UI_LOCALES = frozenset({"es", "en", "pt", "fr", "de", "hi", "zh", "ar"})
 
 
 def validate_locale(value: Optional[str]) -> str:
@@ -29,6 +31,28 @@ def normalize_locale(value: Optional[str]) -> str:
         return validate_locale(value)
     except ValueError:
         return DEFAULT_TENANT_LOCALE
+
+
+def validate_ui_locale(value: Optional[str]) -> str:
+    """Validate the tenant-wide frontend locale without changing receipt locale."""
+    if value is None or not isinstance(value, str) or not value.strip():
+        raise ValueError(
+            "ui_locale must be one of: es, en, pt, fr, de, hi, zh, ar"
+        )
+    locale = value.strip().lower()
+    if locale not in ALLOWED_UI_LOCALES:
+        raise ValueError(
+            "ui_locale must be one of: es, en, pt, fr, de, hi, zh, ar"
+        )
+    return locale
+
+
+def normalize_ui_locale(value: Optional[str]) -> str:
+    """Return a safe frontend locale, falling back to Spanish."""
+    try:
+        return validate_ui_locale(value)
+    except ValueError:
+        return DEFAULT_TENANT_UI_LOCALE
 
 
 def validate_currency_code(value: Optional[str]) -> str:

--- a/app/models/auth.py
+++ b/app/models/auth.py
@@ -29,6 +29,7 @@ class Tenant(BaseModel):
     id: UUID
     name: str
     slug: str
+    ui_locale: str = "es"
 
 class SessionResponse(BaseModel):
     success: bool = True

--- a/app/routers/operaciones_context.py
+++ b/app/routers/operaciones_context.py
@@ -29,6 +29,7 @@ from app.services.operaciones_context_service import (
     update_tables_label,
     update_tip_config,
     update_toggle,
+    update_ui_locale,
 )
 from app.services.promotions_service import (
     DEFAULT_PROMO_CONFLICT_STRATEGY,
@@ -41,6 +42,17 @@ router = APIRouter(prefix="/operaciones", tags=["Operaciones Context"])
 
 class ToggleRequest(BaseModel):
     enabled: bool
+
+
+class UiLocaleRequest(BaseModel):
+    locale: str
+
+    @field_validator("locale")
+    @classmethod
+    def _validate_locale(cls, value: str) -> str:
+        from app.core.tenant_prefs import validate_ui_locale
+
+        return validate_ui_locale(value)
 
 
 class TablesLabelRequest(BaseModel):
@@ -148,6 +160,16 @@ async def get_operaciones_restaurant_context(request: Request):
     if payload is None:
         raise HTTPException(status_code=404, detail="Tenant not found")
     return {"success": True, "data": payload}
+
+
+@router.patch(
+    "/ui-locale",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def patch_ui_locale(request: Request, body: UiLocaleRequest):
+    """Persist the frontend language shared by every member of the tenant."""
+    session = require_valid_session(request)
+    return await update_ui_locale(session.tenant_id, body.locale)
 
 
 @router.patch(

--- a/app/services/operaciones_context_service.py
+++ b/app/services/operaciones_context_service.py
@@ -21,6 +21,7 @@ from uuid import UUID
 from fastapi import HTTPException
 
 from app.database import get_db_connection
+from app.core.tenant_prefs import validate_ui_locale
 from app.services.promotions_service import (
     ALLOWED_PROMO_CONFLICT_STRATEGIES,
     validate_promo_type_block_map,
@@ -100,6 +101,35 @@ async def update_toggle(
         await conn.execute(query, tenant_id, enabled)
 
     return {"success": True, "data": {column_name: enabled}}
+
+
+async def update_ui_locale(
+    tenant_id: UUID,
+    locale: str,
+) -> Dict[str, Any]:
+    """Persist the tenant-wide frontend locale without touching receipt locale."""
+    try:
+        normalized = validate_ui_locale(locale)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    query = """
+        INSERT INTO tenant_public_profiles (tenant_id, slug, display_name, ui_locale)
+        SELECT t.id, t.slug, t.name, $2
+        FROM tenants t
+        WHERE t.id = $1
+        ON CONFLICT (tenant_id) DO UPDATE
+            SET ui_locale = EXCLUDED.ui_locale,
+                updated_at = now()
+        RETURNING ui_locale
+    """
+
+    async with get_db_connection() as conn:
+        row = await conn.fetchrow(query, tenant_id, normalized)
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+    return {"success": True, "data": {"ui_locale": row["ui_locale"]}}
 
 
 async def set_open_sale_enabled(

--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -89,7 +89,13 @@ LEFT JOIN tenant_tax_config       ttc ON ttc.tenant_id = t.id
 WHERE t.id = $1
 """
 
-# Fallback when additive prefs columns are not migrated yet.
+# Preserve existing preferences when only migration 100 (ui_locale) is pending.
+_CONTEXT_QUERY_WITHOUT_UI_LOCALE = _CONTEXT_QUERY.replace(
+    "    tpp.ui_locale,\n",
+    "    NULL AS ui_locale,\n",
+)
+
+# Legacy fallback when older preference migrations are also pending.
 _CONTEXT_QUERY_WITHOUT_PREFS = (
     _CONTEXT_QUERY
     .replace("    tpp.timezone,\n", "    NULL AS timezone,\n")
@@ -130,11 +136,20 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
             row = await conn.fetchrow(_CONTEXT_QUERY, tenant_id)
         except asyncpg.UndefinedColumnError:
             logger.warning(
-                "tenant_public_profiles UI/locale/currency/timezone prefs missing in POS "
-                "context query; using defaults. Apply sql/20260626_tenant_timezone.sql "
-                "and migrations 099/100 for locale preferences."
+                "tenant_public_profiles.ui_locale missing in POS context; "
+                "preserving existing tenant preferences until migration 100."
             )
-            row = await conn.fetchrow(_CONTEXT_QUERY_WITHOUT_PREFS, tenant_id)
+            try:
+                row = await conn.fetchrow(
+                    _CONTEXT_QUERY_WITHOUT_UI_LOCALE,
+                    tenant_id,
+                )
+            except asyncpg.UndefinedColumnError:
+                logger.warning(
+                    "Older tenant preference columns also missing in POS context; "
+                    "using safe defaults until migrations 095/099 are applied."
+                )
+                row = await conn.fetchrow(_CONTEXT_QUERY_WITHOUT_PREFS, tenant_id)
         if row is None:
             return None
         members_rows = await conn.fetch(_MEMBERS_QUERY, tenant_id)

--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -18,7 +18,11 @@ from app.config import settings
 from app.database import get_db_connection
 from app.core.platform_legal import get_platform_legal_for_print
 from app.core.timezones import normalize_timezone
-from app.core.tenant_prefs import normalize_currency_code, normalize_locale
+from app.core.tenant_prefs import (
+    normalize_currency_code,
+    normalize_locale,
+    normalize_ui_locale,
+)
 from app.services.invoicing_readiness_service import get_readiness
 from app.services.open_priced_service import fetch_open_sale_product
 from app.services.promotions_service import (
@@ -34,6 +38,7 @@ SELECT
     tpp.display_name,
     tpp.timezone,
     tpp.locale,
+    tpp.ui_locale,
     tpp.currency_code,
     tpp.kds_enabled,
     tpp.comandas_enabled,
@@ -84,11 +89,12 @@ LEFT JOIN tenant_tax_config       ttc ON ttc.tenant_id = t.id
 WHERE t.id = $1
 """
 
-# Fallback when additive prefs columns are not migrated yet (timezone, locale, currency_code).
+# Fallback when additive prefs columns are not migrated yet.
 _CONTEXT_QUERY_WITHOUT_PREFS = (
     _CONTEXT_QUERY
     .replace("    tpp.timezone,\n", "    NULL AS timezone,\n")
     .replace("    tpp.locale,\n", "    NULL AS locale,\n")
+    .replace("    tpp.ui_locale,\n", "    NULL AS ui_locale,\n")
     .replace("    tpp.currency_code,\n", "    NULL AS currency_code,\n")
 )
 # Backward-compatible alias used by older call sites / greps.
@@ -124,9 +130,9 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
             row = await conn.fetchrow(_CONTEXT_QUERY, tenant_id)
         except asyncpg.UndefinedColumnError:
             logger.warning(
-                "tenant_public_profiles locale/currency/timezone prefs missing in POS "
+                "tenant_public_profiles UI/locale/currency/timezone prefs missing in POS "
                 "context query; using defaults. Apply sql/20260626_tenant_timezone.sql "
-                "and sql/20260710_tenant_locale_currency.sql."
+                "and migrations 099/100 for locale preferences."
             )
             row = await conn.fetchrow(_CONTEXT_QUERY_WITHOUT_PREFS, tenant_id)
         if row is None:
@@ -142,6 +148,9 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
         'timezone': normalize_timezone(row['timezone'] if 'timezone' in row else None),
         # Prefer .get-style access so unit mocks without prefs columns don't KeyError.
         'locale': normalize_locale(row['locale'] if 'locale' in row else None),
+        'ui_locale': normalize_ui_locale(
+            row['ui_locale'] if 'ui_locale' in row else None
+        ),
         'currency_code': normalize_currency_code(
             row['currency_code'] if 'currency_code' in row else None
         ),

--- a/app/services/tenants_service.py
+++ b/app/services/tenants_service.py
@@ -1,4 +1,5 @@
 import logging
+import asyncpg
 from datetime import datetime
 from fastapi import Request
 from app.database import get_db_connection
@@ -10,8 +11,32 @@ from app.models.tenant import (
     TenantMembersResponse, TenantMemberDetail, TenantMemberProfile,
     DeleteMemberResponse, UpdateMemberRoleResponse, PendingInvitation,
 )
+from app.core.tenant_prefs import normalize_ui_locale
 
 logger = logging.getLogger(__name__)
+
+_USER_TENANTS_QUERY = """
+    SELECT DISTINCT
+      t.id,
+      t.name,
+      t.slug,
+      tpp.ui_locale
+    FROM tenants t
+    INNER JOIN tenant_members tm ON t.id = tm.tenant_id
+    LEFT JOIN tenant_public_profiles tpp ON tpp.tenant_id = t.id
+    WHERE tm.user_id = $1
+      AND tm.is_active = true
+      AND tm.role = ANY($2::text[])
+    ORDER BY t.name
+"""
+
+_USER_TENANTS_QUERY_WITHOUT_UI_LOCALE = _USER_TENANTS_QUERY.replace(
+    "      tpp.ui_locale\n",
+    "      NULL AS ui_locale\n",
+).replace(
+    "    LEFT JOIN tenant_public_profiles tpp ON tpp.tenant_id = t.id\n",
+    "",
+)
 
 async def get_user_tenants(request: Request) -> UserTenantsResponse:
     """
@@ -28,20 +53,21 @@ async def get_user_tenants(request: Request) -> UserTenantsResponse:
             # Terminated members keep their row with the old role; without the
             # is_active filter, the sidebar tenant switcher shows tenants the
             # user can't actually access. See docs/permissions-router-mapping.md §9.
-            query = """
-                SELECT DISTINCT
-                  t.id,
-                  t.name,
-                  t.slug
-                FROM tenants t
-                INNER JOIN tenant_members tm ON t.id = tm.tenant_id
-                WHERE tm.user_id = $1
-                  AND tm.is_active = true
-                  AND tm.role = ANY($2::text[])
-                ORDER BY t.name
-            """
-
-            tenant_rows = await conn.fetch(query, user_id, list(LEGACY_INTERNAL_TEAM_ROLES))
+            try:
+                tenant_rows = await conn.fetch(
+                    _USER_TENANTS_QUERY,
+                    user_id,
+                    list(LEGACY_INTERNAL_TEAM_ROLES),
+                )
+            except asyncpg.UndefinedColumnError:
+                logger.warning(
+                    "tenant_public_profiles.ui_locale missing; returning es until migration 100"
+                )
+                tenant_rows = await conn.fetch(
+                    _USER_TENANTS_QUERY_WITHOUT_UI_LOCALE,
+                    user_id,
+                    list(LEGACY_INTERNAL_TEAM_ROLES),
+                )
             
             
             # Convert to Tenant models
@@ -50,7 +76,10 @@ async def get_user_tenants(request: Request) -> UserTenantsResponse:
                 tenant = Tenant(
                     id=row['id'],
                     name=row['name'],
-                    slug=row['slug']
+                    slug=row['slug'],
+                    ui_locale=normalize_ui_locale(
+                        row['ui_locale'] if 'ui_locale' in row else None
+                    ),
                 )
                 tenants.append(tenant)
             

--- a/app/services/tenants_service.py
+++ b/app/services/tenants_service.py
@@ -48,7 +48,7 @@ async def get_user_tenants(request: Request) -> UserTenantsResponse:
         user_id = session_context.user_id
         
         
-        async with get_db_connection() as conn:
+        async with get_db_connection(use_transaction=False) as conn:
             # Get tenants where the user has an ACTIVE membership (#201).
             # Terminated members keep their row with the old role; without the
             # is_active filter, the sidebar tenant switcher shows tenants the

--- a/migrations/100_tenant_ui_locale.sql
+++ b/migrations/100_tenant_ui_locale.sql
@@ -1,0 +1,24 @@
+-- Tenant-wide dashboard language. Kept separate from `locale`, which remains
+-- the es/en source for backend-rendered receipts and emails.
+
+ALTER TABLE tenant_public_profiles
+    ADD COLUMN IF NOT EXISTS ui_locale TEXT NOT NULL DEFAULT 'es';
+
+UPDATE tenant_public_profiles
+SET ui_locale = 'es'
+WHERE ui_locale IS NULL
+   OR btrim(ui_locale) = ''
+   OR lower(ui_locale) NOT IN ('es', 'en', 'pt', 'fr', 'de', 'hi', 'zh', 'ar');
+
+UPDATE tenant_public_profiles
+SET ui_locale = lower(ui_locale);
+
+ALTER TABLE tenant_public_profiles
+    DROP CONSTRAINT IF EXISTS tenant_public_profiles_ui_locale_supported;
+
+ALTER TABLE tenant_public_profiles
+    ADD CONSTRAINT tenant_public_profiles_ui_locale_supported
+    CHECK (ui_locale IN ('es', 'en', 'pt', 'fr', 'de', 'hi', 'zh', 'ar'));
+
+COMMENT ON COLUMN tenant_public_profiles.ui_locale IS
+    'Tenant-wide frontend UI language. Independent from receipt/email locale.';

--- a/migrations/100_tenant_ui_locale.sql
+++ b/migrations/100_tenant_ui_locale.sql
@@ -2,16 +2,26 @@
 -- the es/en source for backend-rendered receipts and emails.
 
 ALTER TABLE tenant_public_profiles
-    ADD COLUMN IF NOT EXISTS ui_locale TEXT NOT NULL DEFAULT 'es';
+    ADD COLUMN IF NOT EXISTS ui_locale TEXT;
+
+UPDATE tenant_public_profiles
+SET ui_locale = CASE
+    WHEN lower(locale) IN ('es', 'en') THEN lower(locale)
+    ELSE 'es'
+END
+WHERE ui_locale IS NULL OR btrim(ui_locale) = '';
 
 UPDATE tenant_public_profiles
 SET ui_locale = 'es'
-WHERE ui_locale IS NULL
-   OR btrim(ui_locale) = ''
-   OR lower(ui_locale) NOT IN ('es', 'en', 'pt', 'fr', 'de', 'hi', 'zh', 'ar');
+WHERE lower(btrim(ui_locale)) NOT IN ('es', 'en', 'pt', 'fr', 'de', 'hi', 'zh', 'ar');
 
 UPDATE tenant_public_profiles
-SET ui_locale = lower(ui_locale);
+SET ui_locale = lower(btrim(ui_locale))
+WHERE ui_locale <> lower(btrim(ui_locale));
+
+ALTER TABLE tenant_public_profiles
+    ALTER COLUMN ui_locale SET DEFAULT 'es',
+    ALTER COLUMN ui_locale SET NOT NULL;
 
 ALTER TABLE tenant_public_profiles
     DROP CONSTRAINT IF EXISTS tenant_public_profiles_ui_locale_supported;

--- a/tests/test_operaciones_context_permissions.py
+++ b/tests/test_operaciones_context_permissions.py
@@ -221,6 +221,73 @@ def test_supervisor_passes_toggle_open_sale_under_enforce():
     assert args[1] is True
 
 
+def test_supervisor_updates_tenant_ui_locale_under_enforce():
+    """OPERACIONES members can update the locale shared by the tenant."""
+    session = _build_session(role="supervisor")
+    app = FastAPI()
+    app.include_router(operaciones_context_router)
+    modules = frozenset({Module.POS, Module.VENTAS, Module.OPERACIONES})
+    locale_stub = AsyncMock(
+        return_value={"success": True, "data": {"ui_locale": "en"}}
+    )
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.operaciones_context.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=modules),
+         ), \
+         patch(
+             "app.routers.operaciones_context.update_ui_locale",
+             new=locale_stub,
+         ):
+        client = TestClient(app)
+        response = client.patch("/operaciones/ui-locale", json={"locale": "EN"})
+
+    assert response.status_code == 200
+    assert response.json()["data"]["ui_locale"] == "en"
+    args, _ = locale_stub.call_args
+    assert args == (session.tenant_id, "en")
+
+
+def test_ui_locale_rejects_unknown_code_before_service():
+    session = _build_session(role="supervisor")
+    app = FastAPI()
+    app.include_router(operaciones_context_router)
+    modules = frozenset({Module.OPERACIONES})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.operaciones_context.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=modules),
+         ):
+        client = TestClient(app)
+        response = client.patch("/operaciones/ui-locale", json={"locale": "xx"})
+
+    assert response.status_code == 422
+
+
+def test_cashier_cannot_update_tenant_ui_locale():
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(operaciones_context_router)
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.operaciones_context.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=frozenset({Module.POS})),
+         ):
+        client = TestClient(app)
+        response = client.patch("/operaciones/ui-locale", json={"locale": "en"})
+
+    assert response.status_code == 403
+
+
 @pytest.mark.asyncio
 async def test_update_toggle_rejects_unknown_column():
     """Whitelist guard: unknown column name raises 422 before any SQL."""

--- a/tests/test_tenant_ui_locale.py
+++ b/tests/test_tenant_ui_locale.py
@@ -1,0 +1,86 @@
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.tenant_prefs import normalize_ui_locale, validate_ui_locale
+from app.services.operaciones_context_service import update_ui_locale
+from app.services.pos_context_service import (
+    _CONTEXT_QUERY,
+    _CONTEXT_QUERY_WITHOUT_PREFS,
+)
+from app.services.tenants_service import (
+    _USER_TENANTS_QUERY,
+    _USER_TENANTS_QUERY_WITHOUT_UI_LOCALE,
+    get_user_tenants,
+)
+
+
+def test_ui_locale_validation_is_independent_and_complete():
+    for code in ("es", "en", "pt", "fr", "de", "hi", "zh", "ar"):
+        assert validate_ui_locale(code.upper()) == code
+    assert normalize_ui_locale("xx") == "es"
+    with pytest.raises(ValueError):
+        validate_ui_locale("xx")
+
+
+def test_context_and_tenant_queries_have_legacy_fallbacks():
+    assert "tpp.ui_locale" in _CONTEXT_QUERY
+    assert "NULL AS ui_locale" in _CONTEXT_QUERY_WITHOUT_PREFS
+    assert "tpp.ui_locale" in _USER_TENANTS_QUERY
+    assert "NULL AS ui_locale" in _USER_TENANTS_QUERY_WITHOUT_UI_LOCALE
+    assert "tenant_public_profiles tpp" not in _USER_TENANTS_QUERY_WITHOUT_UI_LOCALE
+
+
+@pytest.mark.asyncio
+async def test_update_ui_locale_scopes_upsert_to_tenant():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={"ui_locale": "fr"})
+
+    @asynccontextmanager
+    async def db_context():
+        yield conn
+
+    with patch(
+        "app.services.operaciones_context_service.get_db_connection",
+        side_effect=db_context,
+    ):
+        result = await update_ui_locale(tenant_id, "FR")
+
+    assert result == {"success": True, "data": {"ui_locale": "fr"}}
+    query, passed_tenant_id, locale = conn.fetchrow.await_args.args
+    assert "WHERE t.id = $1" in query
+    assert passed_tenant_id == tenant_id
+    assert locale == "fr"
+
+
+@pytest.mark.asyncio
+async def test_user_tenant_list_exposes_normalized_ui_locale():
+    user_id = uuid4()
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[{
+        "id": uuid4(),
+        "name": "Demo",
+        "slug": "demo",
+        "ui_locale": "DE",
+    }])
+
+    @asynccontextmanager
+    async def db_context():
+        yield conn
+
+    session = SimpleNamespace(user_id=user_id)
+    with patch(
+        "app.services.tenants_service.require_valid_session",
+        return_value=session,
+    ), patch(
+        "app.services.tenants_service.get_db_connection",
+        side_effect=db_context,
+    ):
+        response = await get_user_tenants(MagicMock())
+
+    assert response.data[0].ui_locale == "de"
+    assert conn.fetch.await_args.args[1] == user_id

--- a/tests/test_tenant_ui_locale.py
+++ b/tests/test_tenant_ui_locale.py
@@ -1,15 +1,19 @@
 from contextlib import asynccontextmanager
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+import asyncpg
 
 from app.core.tenant_prefs import normalize_ui_locale, validate_ui_locale
 from app.services.operaciones_context_service import update_ui_locale
 from app.services.pos_context_service import (
     _CONTEXT_QUERY,
+    _CONTEXT_QUERY_WITHOUT_UI_LOCALE,
     _CONTEXT_QUERY_WITHOUT_PREFS,
+    get_restaurant_context,
 )
 from app.services.tenants_service import (
     _USER_TENANTS_QUERY,
@@ -28,10 +32,21 @@ def test_ui_locale_validation_is_independent_and_complete():
 
 def test_context_and_tenant_queries_have_legacy_fallbacks():
     assert "tpp.ui_locale" in _CONTEXT_QUERY
+    assert "NULL AS ui_locale" in _CONTEXT_QUERY_WITHOUT_UI_LOCALE
+    assert "tpp.timezone" in _CONTEXT_QUERY_WITHOUT_UI_LOCALE
+    assert "tpp.locale" in _CONTEXT_QUERY_WITHOUT_UI_LOCALE
+    assert "tpp.currency_code" in _CONTEXT_QUERY_WITHOUT_UI_LOCALE
     assert "NULL AS ui_locale" in _CONTEXT_QUERY_WITHOUT_PREFS
     assert "tpp.ui_locale" in _USER_TENANTS_QUERY
     assert "NULL AS ui_locale" in _USER_TENANTS_QUERY_WITHOUT_UI_LOCALE
     assert "tenant_public_profiles tpp" not in _USER_TENANTS_QUERY_WITHOUT_UI_LOCALE
+
+
+def test_migration_backfills_existing_tenant_locale_before_not_null():
+    sql = Path("migrations/100_tenant_ui_locale.sql").read_text()
+    assert "ADD COLUMN IF NOT EXISTS ui_locale TEXT;" in sql
+    assert "WHEN lower(locale) IN ('es', 'en') THEN lower(locale)" in sql
+    assert sql.index("SET ui_locale = CASE") < sql.index("ALTER COLUMN ui_locale SET NOT NULL")
 
 
 @pytest.mark.asyncio
@@ -41,7 +56,7 @@ async def test_update_ui_locale_scopes_upsert_to_tenant():
     conn.fetchrow = AsyncMock(return_value={"ui_locale": "fr"})
 
     @asynccontextmanager
-    async def db_context():
+    async def db_context(*_args, **_kwargs):
         yield conn
 
     with patch(
@@ -69,7 +84,7 @@ async def test_user_tenant_list_exposes_normalized_ui_locale():
     }])
 
     @asynccontextmanager
-    async def db_context():
+    async def db_context(*_args, **_kwargs):
         yield conn
 
     session = SimpleNamespace(user_id=user_id)
@@ -84,3 +99,78 @@ async def test_user_tenant_list_exposes_normalized_ui_locale():
 
     assert response.data[0].ui_locale == "de"
     assert conn.fetch.await_args.args[1] == user_id
+
+
+@pytest.mark.asyncio
+async def test_user_tenant_list_recovers_without_ui_locale_column():
+    user_id = uuid4()
+    row = {"id": uuid4(), "name": "Demo", "slug": "demo", "ui_locale": None}
+    conn = MagicMock()
+    conn.fetch = AsyncMock(side_effect=[
+        asyncpg.UndefinedColumnError("ui_locale missing"),
+        [row],
+    ])
+
+    @asynccontextmanager
+    async def db_context(*_args, **_kwargs):
+        yield conn
+
+    session = SimpleNamespace(user_id=user_id)
+    with patch(
+        "app.services.tenants_service.require_valid_session",
+        return_value=session,
+    ), patch(
+        "app.services.tenants_service.get_db_connection",
+        side_effect=db_context,
+    ) as get_connection:
+        response = await get_user_tenants(MagicMock())
+
+    assert response.data[0].ui_locale == "es"
+    assert conn.fetch.await_count == 2
+    assert conn.fetch.await_args_list[1].args[0] == _USER_TENANTS_QUERY_WITHOUT_UI_LOCALE
+    get_connection.assert_called_once_with(use_transaction=False)
+
+
+@pytest.mark.asyncio
+async def test_pos_context_first_fallback_preserves_existing_preferences():
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        asyncpg.UndefinedColumnError("ui_locale missing"),
+        None,
+    ])
+
+    @asynccontextmanager
+    async def db_context(*_args, **_kwargs):
+        yield conn
+
+    with patch(
+        "app.services.pos_context_service.get_db_connection",
+        side_effect=db_context,
+    ):
+        result = await get_restaurant_context(uuid4())
+
+    assert result is None
+    assert conn.fetchrow.await_args_list[1].args[0] == _CONTEXT_QUERY_WITHOUT_UI_LOCALE
+
+
+@pytest.mark.asyncio
+async def test_pos_context_uses_general_fallback_for_older_missing_prefs():
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        asyncpg.UndefinedColumnError("ui_locale missing"),
+        asyncpg.UndefinedColumnError("locale missing"),
+        None,
+    ])
+
+    @asynccontextmanager
+    async def db_context(*_args, **_kwargs):
+        yield conn
+
+    with patch(
+        "app.services.pos_context_service.get_db_connection",
+        side_effect=db_context,
+    ):
+        result = await get_restaurant_context(uuid4())
+
+    assert result is None
+    assert conn.fetchrow.await_args_list[2].args[0] == _CONTEXT_QUERY_WITHOUT_PREFS


### PR DESCRIPTION
## Summary

- add additive `tenant_public_profiles.ui_locale` migration, isolated from receipt/email `locale`
- preserve the existing `es/en` tenant locale during the backfill
- expose the normalized setting through tenant and restaurant contexts
- add an OPERACIONES-gated tenant-scoped PATCH endpoint
- keep rolling-deployment fallbacks functional without discarding existing timezone, currency, or fiscal locale preferences

## Tests

- `venv/bin/pytest -q tests/test_operaciones_context_permissions.py tests/test_tenant_ui_locale.py` (20 passed)
- `git diff --check`

Refs uno0uno/warocol.com#1626

Merge before the coordinated frontend PR. This PR does not apply the migration, run a build, or deploy anything.