### PR TITLE
API: ampliar perfil personal y carga de avatar en R2

### DIFF
--- a/app/models/auth.py
+++ b/app/models/auth.py
@@ -1,9 +1,12 @@
 from pydantic import BaseModel, Field, field_validator
 from datetime import datetime
-from typing import Optional, Dict, Any
+from typing import Literal, Optional, Dict, Any
 from uuid import UUID
 
 from app.core.email_utils import normalize_email
+
+PreferredLocale = Literal['es', 'en', 'pt', 'fr', 'de', 'ar', 'hi', 'zh']
+
 
 class User(BaseModel):
     id: UUID
@@ -14,6 +17,14 @@ class User(BaseModel):
 
     class Config:
         populate_by_name = True
+
+
+class ProfileUser(User):
+    user_name: Optional[str] = None
+    description: Optional[str] = None
+    logo_avatar: Optional[str] = None
+    preferred_locale: Optional[PreferredLocale] = None
+
 
 class Session(BaseModel):
     expires_at: datetime = Field(alias='expiresAt')
@@ -33,7 +44,7 @@ class Tenant(BaseModel):
 
 class SessionResponse(BaseModel):
     success: bool = True
-    user: User
+    user: ProfileUser
     session: Session
     has_internal_access: bool = False
     current_tenant: Optional[Tenant] = Field(alias='currentTenant', default=None)
@@ -100,13 +111,39 @@ class SwitchTenantResponse(BaseModel):
 
 
 class UpdateProfileRequest(BaseModel):
-    name: Optional[str] = None
+    name: Optional[str] = Field(default=None, max_length=120)
     user_name: Optional[str] = None
     phone_number: Optional[str] = None
     city: Optional[str] = None
+    description: Optional[str] = Field(default=None, max_length=500)
+    preferred_locale: Optional[PreferredLocale] = None
+
+    @field_validator('name', mode='before')
+    @classmethod
+    def _normalize_name(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError('Name cannot be empty')
+        return normalized
+
+    @field_validator('description', mode='before')
+    @classmethod
+    def _normalize_description(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        normalized = value.strip()
+        return normalized or None
 
 
 class UpdateProfileResponse(BaseModel):
     success: bool = True
     message: str = "Profile updated successfully"
-    user: User
+    user: ProfileUser
+
+
+class ProfileAvatarResponse(BaseModel):
+    success: bool = True
+    url: str
+    logo_avatar: str

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,6 +1,6 @@
 import logging
-from fastapi import APIRouter, Request, Response
-from app.services.auth_service import get_session_data, switch_tenant, update_profile
+from fastapi import APIRouter, File, HTTPException, Request, Response, UploadFile
+from app.services.auth_service import get_session_data, switch_tenant, update_profile, upload_profile_avatar
 from app.services.magic_link_service import send_magic_link, verify_code, verify_token
 from app.models.auth import (
     SessionResponse,
@@ -12,12 +12,30 @@ from app.models.auth import (
     VerifyTokenResponse,
     SwitchTenantRequest,
     SwitchTenantResponse,
+    ProfileAvatarResponse,
     UpdateProfileRequest,
     UpdateProfileResponse
 )
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+ALLOWED_AVATAR_TYPES = {'image/jpeg', 'image/png', 'image/webp'}
+MAX_AVATAR_SIZE = 5 * 1024 * 1024
+
+
+def _matches_avatar_signature(file_bytes: bytes, content_type: str) -> bool:
+    if content_type == 'image/jpeg':
+        return file_bytes.startswith(b'\xff\xd8\xff')
+    if content_type == 'image/png':
+        return file_bytes.startswith(b'\x89PNG\r\n\x1a\n')
+    if content_type == 'image/webp':
+        return (
+            len(file_bytes) >= 12
+            and file_bytes.startswith(b'RIFF')
+            and file_bytes[8:12] == b'WEBP'
+        )
+    return False
 
 @router.get("/session", response_model=SessionResponse)
 async def get_session(request: Request, response: Response):
@@ -101,5 +119,34 @@ async def update_profile_endpoint(request: Request, payload: UpdateProfileReques
         name=payload.name,
         user_name=payload.user_name,
         phone_number=payload.phone_number,
-        city=payload.city
+        city=payload.city,
+        description=payload.description,
+        preferred_locale=payload.preferred_locale,
+        fields_set=payload.model_fields_set,
+    )
+
+
+@router.post('/profile/avatar', response_model=ProfileAvatarResponse)
+async def upload_profile_avatar_endpoint(
+    request: Request,
+    file: UploadFile = File(...),
+):
+    """Upload an avatar for the authenticated user without tenant permissions."""
+    content_type = file.content_type or 'application/octet-stream'
+    if content_type not in ALLOWED_AVATAR_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail='File type not allowed. Use JPEG, PNG, or WebP.',
+        )
+
+    file_bytes = await file.read(MAX_AVATAR_SIZE + 1)
+    if len(file_bytes) > MAX_AVATAR_SIZE:
+        raise HTTPException(status_code=400, detail='File too large. Maximum size is 5MB.')
+    if not file_bytes or not _matches_avatar_signature(file_bytes, content_type):
+        raise HTTPException(status_code=400, detail='File content does not match its image type.')
+
+    return await upload_profile_avatar(
+        request=request,
+        file_bytes=file_bytes,
+        content_type=content_type,
     )

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -1,14 +1,24 @@
 import logging
 import secrets
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Optional, Set
 from fastapi import HTTPException, Request, Response
+from app.config import settings
 from app.database import get_db_connection
 from app.core.security import collect_session_tokens, get_session_token, clear_session_cookie, set_session_cookie, get_client_ip
 from app.core.exceptions import AuthenticationError
 from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES, is_legacy_internal_team_role
 from app.core.middleware import require_valid_session
-from app.models.auth import User, Session, Tenant, SessionResponse, SwitchTenantResponse, UpdateProfileResponse
+from app.models.auth import (
+    ProfileAvatarResponse,
+    ProfileUser,
+    Session,
+    SessionResponse,
+    SwitchTenantResponse,
+    Tenant,
+    UpdateProfileResponse,
+)
+from app.services.aws_s3_service import AWSS3Service
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +55,9 @@ async def get_session_data(request: Request, response: Response) -> SessionRespo
         async with get_db_connection() as conn:
             # Find valid session with analytics tracking (exact query from warolabs.com)
             session_query = """
-                SELECT s.*, p.id as user_id, p.email, p.name, p.created_at as user_created_at
+                SELECT s.*, p.id as user_id, p.email, p.name, p.user_name,
+                       p.description, p.logo_avatar, p.preferred_locale,
+                       p.created_at as user_created_at
                 FROM sessions s
                 JOIN profile p ON s.user_id = p.id
                 WHERE s.id = $1 
@@ -110,10 +122,14 @@ async def get_session_data(request: Request, response: Response) -> SessionRespo
                         raise AuthenticationError("Access denied")
 
             # Build response models
-            user = User(
+            user = ProfileUser(
                 id=session_result['user_id'],
                 email=session_result['email'],
                 name=session_result['name'],
+                user_name=session_result['user_name'],
+                description=session_result['description'],
+                logo_avatar=session_result['logo_avatar'],
+                preferred_locale=session_result['preferred_locale'],
                 createdAt=session_result['user_created_at'],
                 role=user_role
             )
@@ -301,8 +317,16 @@ async def switch_tenant(request: Request, response: Response, tenant_slug: str) 
         raise AuthenticationError("Tenant switch failed")
 
 
-async def update_profile(request: Request, name: Optional[str] = None, user_name: Optional[str] = None,
-                         phone_number: Optional[str] = None, city: Optional[str] = None) -> UpdateProfileResponse:
+async def update_profile(
+    request: Request,
+    name: Optional[str] = None,
+    user_name: Optional[str] = None,
+    phone_number: Optional[str] = None,
+    city: Optional[str] = None,
+    description: Optional[str] = None,
+    preferred_locale: Optional[str] = None,
+    fields_set: Optional[Set[str]] = None,
+) -> UpdateProfileResponse:
     """
     Update the current user's profile information
     """
@@ -317,24 +341,47 @@ async def update_profile(request: Request, name: Optional[str] = None, user_name
             values = []
             param_idx = 1
 
-            if name is not None:
+            provided_fields = fields_set or {
+                field_name
+                for field_name, field_value in {
+                    'name': name,
+                    'user_name': user_name,
+                    'phone_number': phone_number,
+                    'city': city,
+                    'description': description,
+                    'preferred_locale': preferred_locale,
+                }.items()
+                if field_value is not None
+            }
+
+            if 'name' in provided_fields and name is not None:
                 updates.append(f"name = ${param_idx}")
                 values.append(name)
                 param_idx += 1
 
-            if user_name is not None:
+            if 'user_name' in provided_fields and user_name is not None:
                 updates.append(f"user_name = ${param_idx}")
                 values.append(user_name)
                 param_idx += 1
 
-            if phone_number is not None:
+            if 'phone_number' in provided_fields and phone_number is not None:
                 updates.append(f"phone_number = ${param_idx}")
                 values.append(phone_number)
                 param_idx += 1
 
-            if city is not None:
+            if 'city' in provided_fields and city is not None:
                 updates.append(f"city = ${param_idx}")
                 values.append(city)
+                param_idx += 1
+
+            if 'description' in provided_fields:
+                updates.append(f"description = ${param_idx}")
+                values.append(description)
+                param_idx += 1
+
+            if 'preferred_locale' in provided_fields:
+                updates.append(f"preferred_locale = ${param_idx}")
+                values.append(preferred_locale)
                 param_idx += 1
 
             if not updates:
@@ -350,7 +397,8 @@ async def update_profile(request: Request, name: Optional[str] = None, user_name
                 UPDATE profile
                 SET {', '.join(updates)}
                 WHERE id = ${param_idx}
-                RETURNING id, email, name, created_at
+                RETURNING id, email, name, user_name, description, logo_avatar,
+                          preferred_locale, created_at
             """
 
             result = await conn.fetchrow(update_query, *values)
@@ -358,10 +406,14 @@ async def update_profile(request: Request, name: Optional[str] = None, user_name
             if not result:
                 raise AuthenticationError("User not found")
 
-            user = User(
+            user = ProfileUser(
                 id=result['id'],
                 email=result['email'],
                 name=result['name'],
+                user_name=result['user_name'],
+                description=result['description'],
+                logo_avatar=result['logo_avatar'],
+                preferred_locale=result['preferred_locale'],
                 createdAt=result['created_at']
             )
 
@@ -377,3 +429,47 @@ async def update_profile(request: Request, name: Optional[str] = None, user_name
     except Exception as e:
         logger.error(f"❌ Profile update error: {e}", exc_info=True)
         raise AuthenticationError("Error al actualizar perfil")
+
+
+async def upload_profile_avatar(
+    request: Request,
+    file_bytes: bytes,
+    content_type: str,
+) -> ProfileAvatarResponse:
+    """Upload and persist an avatar owned by the authenticated user."""
+    session_context = require_valid_session(request)
+    user_id = session_context.user_id
+
+    s3_service = AWSS3Service()
+    public_url = await s3_service.upload_user_avatar(
+        file_bytes=file_bytes,
+        user_id=str(user_id),
+        content_type=content_type,
+    )
+
+    if public_url is None:
+        if not settings.r2_public_url:
+            raise HTTPException(status_code=503, detail="Public image storage is not configured")
+        raise HTTPException(status_code=500, detail="Failed to upload avatar")
+
+    try:
+        async with get_db_connection() as conn:
+            result = await conn.fetchrow(
+                """
+                UPDATE profile
+                SET logo_avatar = $1, updated_at = NOW()
+                WHERE id = $2
+                RETURNING id
+                """,
+                public_url,
+                user_id,
+            )
+    except Exception as exc:
+        logger.error("Failed to persist avatar for user %s", user_id, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to update avatar") from exc
+
+    if not result:
+        raise AuthenticationError("User not found")
+
+    logger.info("Profile avatar updated for user %s", user_id)
+    return ProfileAvatarResponse(url=public_url, logo_avatar=public_url)

--- a/app/services/aws_s3_service.py
+++ b/app/services/aws_s3_service.py
@@ -15,6 +15,12 @@ import re
 
 logger = logging.getLogger(__name__)
 
+USER_AVATAR_EXTENSIONS = {
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+    'image/webp': 'webp',
+}
+
 class AWSS3Service:
     def __init__(self):
         """Initialize S3 client (Cloudflare R2 compatible)"""
@@ -335,6 +341,25 @@ class AWSS3Service:
             logger.error(f"Unexpected error uploading public asset {normalized_key}: {str(e)}")
             logger.exception(e)
             return None
+
+    async def upload_user_avatar(
+        self,
+        file_bytes: bytes,
+        user_id: str,
+        content_type: str,
+    ) -> Optional[str]:
+        """Upload a personal avatar under a server-generated user namespace."""
+        extension = USER_AVATAR_EXTENSIONS.get(content_type)
+        if extension is None:
+            raise ValueError(f"Unsupported avatar content type: {content_type}")
+
+        s3_key = f"user-profiles/{user_id}/avatar/{uuid.uuid4()}.{extension}"
+        return await self.upload_public_asset(
+            file_bytes=file_bytes,
+            s3_key=s3_key,
+            content_type=content_type,
+            metadata={'user_id': user_id, 'asset_type': 'avatar'},
+        )
 
     async def get_file_metadata(self, s3_key: str) -> Optional[dict]:
         """

--- a/migrations/101_profile_preferred_locale.sql
+++ b/migrations/101_profile_preferred_locale.sql
@@ -1,0 +1,12 @@
+ALTER TABLE profile
+    ADD COLUMN IF NOT EXISTS preferred_locale TEXT;
+
+ALTER TABLE profile
+    DROP CONSTRAINT IF EXISTS profile_preferred_locale_supported;
+
+ALTER TABLE profile
+    ADD CONSTRAINT profile_preferred_locale_supported
+    CHECK (preferred_locale IN ('es', 'en', 'pt', 'fr', 'de', 'ar', 'hi', 'zh'));
+
+COMMENT ON COLUMN profile.preferred_locale IS
+    'Personal frontend UI language. NULL preserves the tenant/default fallback.';

--- a/tests/test_auth_profile.py
+++ b/tests/test_auth_profile.py
@@ -1,0 +1,293 @@
+from datetime import datetime, timedelta, timezone
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+from starlette.datastructures import Headers, UploadFile
+from starlette.responses import Response
+
+from app.core.exceptions import AuthenticationError
+from app.models.auth import UpdateProfileRequest
+from app.routers import auth as auth_router
+from app.services import auth_service
+from app.services.aws_s3_service import AWSS3Service
+
+
+USER_ID = UUID('11111111-1111-4111-8111-111111111111')
+OTHER_USER_ID = UUID('22222222-2222-4222-8222-222222222222')
+AVATAR_URL = f'https://assets.example/user-profiles/{USER_ID}/avatar/avatar.png'
+
+
+class AsyncConnectionContext:
+    def __init__(self, connection):
+        self.connection = connection
+
+    async def __aenter__(self):
+        return self.connection
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+def profile_row(**overrides):
+    row = {
+        'id': USER_ID,
+        'email': 'person@example.com',
+        'name': 'Person Name',
+        'user_name': 'person',
+        'description': 'Personal description',
+        'logo_avatar': AVATAR_URL,
+        'preferred_locale': 'en',
+        'created_at': datetime(2026, 1, 1, tzinfo=timezone.utc),
+    }
+    row.update(overrides)
+    return row
+
+
+def session_row(**overrides):
+    row = {
+        **profile_row(),
+        'user_id': USER_ID,
+        'user_created_at': datetime(2026, 1, 1, tzinfo=timezone.utc),
+        'tenant_id': None,
+        'expires_at': datetime.now(timezone.utc) + timedelta(hours=1),
+        'created_at': datetime.now(timezone.utc),
+        'ip_address': None,
+        'login_method': 'magic_link',
+    }
+    row.update(overrides)
+    return row
+
+
+def upload_file(content: bytes, content_type: str, filename: str = 'avatar.png') -> UploadFile:
+    return UploadFile(
+        file=BytesIO(content),
+        filename=filename,
+        headers=Headers({'content-type': content_type}),
+    )
+
+
+def test_update_profile_request_normalizes_and_validates_fields():
+    payload = UpdateProfileRequest(
+        name='  Person Name  ',
+        description='  A short description  ',
+        preferred_locale='pt',
+    )
+
+    assert payload.name == 'Person Name'
+    assert payload.description == 'A short description'
+    assert payload.preferred_locale == 'pt'
+
+    with pytest.raises(ValidationError):
+        UpdateProfileRequest(name='   ')
+    with pytest.raises(ValidationError):
+        UpdateProfileRequest(preferred_locale='it')
+
+
+def test_update_profile_request_tracks_explicit_null_locale():
+    payload = UpdateProfileRequest.model_validate({
+        'preferred_locale': None,
+        'user_id': str(OTHER_USER_ID),
+        'logo_avatar': 'https://attacker.example/avatar.png',
+    })
+
+    assert 'preferred_locale' in payload.model_fields_set
+    assert payload.preferred_locale is None
+    assert 'user_id' not in payload.model_dump()
+    assert 'logo_avatar' not in payload.model_dump()
+
+
+@pytest.mark.asyncio
+async def test_session_returns_personal_profile_without_active_tenant(monkeypatch):
+    connection = SimpleNamespace(fetchrow=AsyncMock(return_value=session_row()))
+    monkeypatch.setattr(auth_service, 'get_session_token', AsyncMock(return_value='session-token'))
+    monkeypatch.setattr(
+        auth_service,
+        'get_db_connection',
+        lambda: AsyncConnectionContext(connection),
+    )
+
+    result = await auth_service.get_session_data(MagicMock(), Response())
+    payload = result.model_dump(by_alias=True)
+
+    assert payload['currentTenant'] is None
+    assert payload['user']['user_name'] == 'person'
+    assert payload['user']['description'] == 'Personal description'
+    assert payload['user']['logo_avatar'] == AVATAR_URL
+    assert payload['user']['preferred_locale'] == 'en'
+
+
+@pytest.mark.asyncio
+async def test_update_profile_uses_session_user_and_can_clear_nullable_fields(monkeypatch):
+    connection = SimpleNamespace(fetchrow=AsyncMock(return_value=profile_row(
+        description=None,
+        preferred_locale=None,
+    )))
+    monkeypatch.setattr(
+        auth_service,
+        'require_valid_session',
+        lambda request: SimpleNamespace(user_id=USER_ID),
+    )
+    monkeypatch.setattr(
+        auth_service,
+        'get_db_connection',
+        lambda: AsyncConnectionContext(connection),
+    )
+
+    result = await auth_service.update_profile(
+        MagicMock(),
+        description=None,
+        preferred_locale=None,
+        fields_set={'description', 'preferred_locale'},
+    )
+
+    query, description, locale, owner_id = connection.fetchrow.await_args.args
+    assert 'description = $1' in query
+    assert 'preferred_locale = $2' in query
+    assert 'WHERE id = $3' in query
+    assert (description, locale, owner_id) == (None, None, USER_ID)
+    assert owner_id != OTHER_USER_ID
+    assert result.user.preferred_locale is None
+
+
+@pytest.mark.asyncio
+async def test_avatar_endpoint_rejects_spoofed_content_and_oversized_files():
+    with pytest.raises(HTTPException) as spoofed:
+        await auth_router.upload_profile_avatar_endpoint(
+            MagicMock(),
+            upload_file(b'not a png', 'image/png'),
+        )
+    assert spoofed.value.status_code == 400
+
+    oversized_png = b'\x89PNG\r\n\x1a\n' + b'x' * (auth_router.MAX_AVATAR_SIZE + 1)
+    with pytest.raises(HTTPException) as oversized:
+        await auth_router.upload_profile_avatar_endpoint(
+            MagicMock(),
+            upload_file(oversized_png, 'image/png'),
+        )
+    assert oversized.value.status_code == 400
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('content_type', 'image_bytes'),
+    [
+        ('image/jpeg', b'\xff\xd8\xffimage-data'),
+        ('image/png', b'\x89PNG\r\n\x1a\nimage-data'),
+        ('image/webp', b'RIFF\x04\x00\x00\x00WEBPimage-data'),
+    ],
+)
+async def test_avatar_endpoint_accepts_supported_image_without_tenant_dependency(
+    monkeypatch,
+    content_type,
+    image_bytes,
+):
+    upload = AsyncMock(return_value={
+        'success': True,
+        'url': AVATAR_URL,
+        'logo_avatar': AVATAR_URL,
+    })
+    monkeypatch.setattr(auth_router, 'upload_profile_avatar', upload)
+    request = MagicMock()
+
+    result = await auth_router.upload_profile_avatar_endpoint(
+        request,
+        upload_file(image_bytes, content_type),
+    )
+
+    assert result['logo_avatar'] == AVATAR_URL
+    upload.assert_awaited_once_with(
+        request=request,
+        file_bytes=image_bytes,
+        content_type=content_type,
+    )
+
+
+@pytest.mark.asyncio
+async def test_r2_avatar_key_is_generated_from_session_user_and_mime():
+    service = object.__new__(AWSS3Service)
+    service.upload_public_asset = AsyncMock(return_value=AVATAR_URL)
+
+    result = await service.upload_user_avatar(b'png', str(USER_ID), 'image/png')
+
+    assert result == AVATAR_URL
+    kwargs = service.upload_public_asset.await_args.kwargs
+    assert kwargs['s3_key'].startswith(f'user-profiles/{USER_ID}/avatar/')
+    assert kwargs['s3_key'].endswith('.png')
+    assert str(OTHER_USER_ID) not in kwargs['s3_key']
+    assert kwargs['metadata']['user_id'] == str(USER_ID)
+
+
+@pytest.mark.asyncio
+async def test_avatar_upload_persists_server_url_for_session_user(monkeypatch):
+    storage = SimpleNamespace(upload_user_avatar=AsyncMock(return_value=AVATAR_URL))
+    connection = SimpleNamespace(fetchrow=AsyncMock(return_value={'id': USER_ID}))
+    monkeypatch.setattr(auth_service, 'AWSS3Service', lambda: storage)
+    monkeypatch.setattr(
+        auth_service,
+        'require_valid_session',
+        lambda request: SimpleNamespace(user_id=USER_ID),
+    )
+    monkeypatch.setattr(
+        auth_service,
+        'get_db_connection',
+        lambda: AsyncConnectionContext(connection),
+    )
+
+    result = await auth_service.upload_profile_avatar(MagicMock(), b'png', 'image/png')
+
+    storage.upload_user_avatar.assert_awaited_once_with(
+        file_bytes=b'png',
+        user_id=str(USER_ID),
+        content_type='image/png',
+    )
+    query, url, owner_id = connection.fetchrow.await_args.args
+    assert 'WHERE id = $2' in query
+    assert (url, owner_id) == (AVATAR_URL, USER_ID)
+    assert result.logo_avatar == AVATAR_URL
+
+
+@pytest.mark.asyncio
+async def test_avatar_upload_requires_authenticated_session(monkeypatch):
+    def reject_session(request):
+        raise AuthenticationError('Session expired')
+
+    monkeypatch.setattr(auth_service, 'require_valid_session', reject_session)
+    monkeypatch.setattr(
+        auth_service,
+        'AWSS3Service',
+        lambda: pytest.fail('storage must not initialize without a valid session'),
+    )
+
+    with pytest.raises(AuthenticationError):
+        await auth_service.upload_profile_avatar(MagicMock(), b'png', 'image/png')
+
+
+@pytest.mark.asyncio
+async def test_avatar_upload_failure_does_not_write_profile(monkeypatch):
+    storage = SimpleNamespace(upload_user_avatar=AsyncMock(return_value=None))
+    monkeypatch.setattr(auth_service, 'AWSS3Service', lambda: storage)
+    monkeypatch.setattr(
+        auth_service,
+        'require_valid_session',
+        lambda request: SimpleNamespace(user_id=USER_ID),
+    )
+    monkeypatch.setattr(auth_service.settings, 'r2_public_url', 'https://assets.example')
+    database_called = False
+
+    def fail_if_database_is_called():
+        nonlocal database_called
+        database_called = True
+        raise AssertionError('database must not be called after upload failure')
+
+    monkeypatch.setattr(auth_service, 'get_db_connection', fail_if_database_is_called)
+
+    with pytest.raises(HTTPException) as error:
+        await auth_service.upload_profile_avatar(MagicMock(), b'png', 'image/png')
+
+    assert error.value.status_code == 500
+    assert database_called is False


### PR DESCRIPTION
## Summary
- add nullable validated personal locale and expose profile fields in authenticated session/update responses
- add session-owned avatar upload with server-generated R2 keys, MIME/signature/size checks, and persisted URL
- add focused authorization, validation, tenant-independent session, and failure-path tests

## Tests
- `venv/bin/pytest -q tests/test_auth.py tests/test_auth_profile.py` (29 passed)
- `git diff --cached --check`
- Build not run (requested)

Closes #617
