### PR TITLE
Fix manual credit payment status

### DIFF
--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -3652,6 +3652,16 @@ async def create_manual_order(
         customer_uuid = UUID(customer_id) if customer_id else None
         payment_method_uuid = UUID(payment_method_id) if payment_method_id else None
         split_payments = payments or []
+        uses_credit = payment_method == "credit" or any(
+            payment.get("payment_method") == "credit"
+            for payment in split_payments
+        )
+
+        if uses_credit and not customer_uuid:
+            raise APIError(
+                "El pago a crédito requiere un cliente identificado",
+                status_code=400,
+            )
 
         if payment_method == "customer_wallet":
             if not customer_uuid:
@@ -3680,6 +3690,20 @@ async def create_manual_order(
             async with conn.transaction():
                 # Guard: block creation if order_date falls in a closed monthly accounting period (#362)
                 await assert_order_not_in_closed_monthly_period(conn, tenant_id, order_datetime)
+
+                if uses_credit and customer_uuid:
+                    customer_check = await conn.fetchrow(
+                        "SELECT phone_number FROM profile WHERE id = $1",
+                        customer_uuid,
+                    )
+                    if (
+                        not customer_check
+                        or customer_check["phone_number"] == "0000000000"
+                    ):
+                        raise APIError(
+                            "El pago a crédito requiere un cliente identificado (no anónimo)",
+                            status_code=400,
+                        )
 
                 if payment_method == "customer_wallet" and customer_uuid:
                     from app.services.customer_wallet_service import assert_wallet_customer_identified
@@ -3731,14 +3755,20 @@ async def create_manual_order(
                             status_code=400,
                         )
 
+                payment_status = (
+                    "paid"
+                    if split_payments
+                    else ("credit" if payment_method == "credit" else "paid")
+                )
+
                 order_row = await conn.fetchrow(
                     """
                     INSERT INTO orders (
                         tenant_id, customer_id, payment_method, payment_method_id,
-                        order_date, total_amount, status,
+                        order_date, total_amount, status, payment_status,
                         discount_type, discount_value, discount_amount, extra_attributes
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, 'completed', $7, $8, $9, $10)
+                    VALUES ($1, $2, $3, $4, $5, $6, 'completed', $7, $8, $9, $10, $11)
                     RETURNING id, order_number, order_date, created_at
                     """,
                     tenant_id,
@@ -3747,6 +3777,7 @@ async def create_manual_order(
                     payment_method_uuid,
                     order_datetime,
                     total_amount,
+                    payment_status,
                     normalized_discount_type,
                     normalized_discount_value,
                     discount_amount or None,
@@ -3981,6 +4012,7 @@ async def create_manual_order(
                 "status": "completed",
                 "payment_method": payment_method,
                 "payment_method_id": str(payment_method_uuid) if payment_method_uuid else None,
+                "payment_status": payment_status,
                 "discount_type": normalized_discount_type,
                 "discount_value": normalized_discount_value,
                 "discount_amount": float(discount_amount),

--- a/migrations/102_backfill_manual_order_payment_status.sql
+++ b/migrations/102_backfill_manual_order_payment_status.sql
@@ -1,0 +1,70 @@
+-- Issue #619: manual orders historically omitted orders.payment_status.
+-- Only repair rows whose persisted payment evidence makes the target status unambiguous.
+
+-- Pure credit: no credit collection and no active split tender means the full
+-- completed order remains receivable. Require a real, non-anonymous customer so
+-- the repaired row can safely participate in cartera.
+UPDATE orders AS o
+SET payment_status = 'credit'
+WHERE o.extra_attributes->>'source' = 'manual'
+  AND o.status = 'completed'
+  AND o.payment_status IS NULL
+  AND o.payment_method = 'credit'
+  AND o.credit_paid_amount = 0
+  AND EXISTS (
+      SELECT 1
+      FROM profile AS p
+      WHERE p.id = o.customer_id
+        AND p.phone_number IS DISTINCT FROM '0000000000'
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM order_payments AS op
+      WHERE op.order_id = o.id
+        AND op.voided_at IS NULL
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM credit_payments AS cp
+      WHERE cp.order_id = o.id
+  );
+
+-- Paid manual orders are either single non-credit tenders (which intentionally
+-- have no order_payments rows) or split tenders whose active rows cover the
+-- complete order total. Voided/incomplete splits remain untouched for review.
+UPDATE orders AS o
+SET payment_status = 'paid'
+WHERE o.extra_attributes->>'source' = 'manual'
+  AND o.status = 'completed'
+  AND o.payment_status IS NULL
+  AND (
+      (
+          o.payment_method IS NOT NULL
+          AND o.payment_method <> 'credit'
+          AND NOT EXISTS (
+              SELECT 1
+              FROM order_payments AS op
+              WHERE op.order_id = o.id
+          )
+      )
+      OR
+      (
+          EXISTS (
+              SELECT 1
+              FROM order_payments AS op
+              WHERE op.order_id = o.id
+                AND op.voided_at IS NULL
+          )
+          AND ABS(
+              COALESCE(
+                  (
+                      SELECT SUM(op.amount)
+                      FROM order_payments AS op
+                      WHERE op.order_id = o.id
+                        AND op.voided_at IS NULL
+                  ),
+                  0
+              ) - o.total_amount
+          ) <= 0.01
+      )
+  );

--- a/tests/test_manual_order_gl_cogs.py
+++ b/tests/test_manual_order_gl_cogs.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime, timezone
 from decimal import Decimal
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -879,6 +880,13 @@ async def test_create_manual_order_captures_snapshots_and_posts_gl_cogs():
         )
 
     assert result["success"] is True
+    order_insert = next(
+        call.args
+        for call in conn.fetchrow.await_args_list
+        if "INSERT INTO orders" in call.args[0]
+    )
+    assert order_insert[7] == "paid"
+    assert result["data"]["payment_status"] == "paid"
     capture_snapshot.assert_awaited_once_with(
         conn,
         order_item_id,
@@ -898,6 +906,173 @@ async def test_create_manual_order_captures_snapshots_and_posts_gl_cogs():
         order_date=date(2026, 6, 7),
         order_number=14798,
     )
+
+
+@pytest.mark.asyncio
+async def test_create_manual_credit_persists_credit_status_for_identified_customer():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    customer_id = uuid4()
+    order_id = uuid4()
+    order_item_id = uuid4()
+    product_id = uuid4()
+    order_date = datetime(2026, 7, 13, 18, 42, tzinfo=timezone.utc)
+
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {"phone_number": "3001234567"},
+            {
+                "id": order_id,
+                "order_number": 16484,
+                "order_date": order_date,
+                "created_at": order_date,
+            },
+            {"id": order_item_id},
+        ]
+    )
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value="America/Bogota")
+    conn.execute = AsyncMock()
+    conn.transaction = MagicMock(return_value=_AsyncContext())
+
+    with patch(
+        "app.services.orders_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id, user_id=user_id),
+    ), patch(
+        "app.services.orders_service.get_db_connection",
+        return_value=_AsyncContext(conn),
+    ), patch(
+        "app.services.orders_service.assert_order_not_in_closed_monthly_period",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.orders_service._pos_modifier_inventory_helpers",
+        return_value=(AsyncMock(), None, None),
+    ), patch(
+        "app.services.orders_service._pos_order_item_ingredient_snapshot_helper",
+        return_value=AsyncMock(),
+    ), patch(
+        "app.services.orders_service._get_tenant_tax_config",
+        new=AsyncMock(return_value={"inc_enabled": True}),
+    ), patch(
+        "app.services.orders_service._post_order_gl_entry",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.orders_service._post_order_cogs_gl_entry",
+        new=AsyncMock(),
+    ):
+        result = await orders_service.create_manual_order(
+            Request({"type": "http"}),
+            order_date="2026-07-13T18:42:00+00:00",
+            payment_method="credit",
+            customer_id=str(customer_id),
+            items=[
+                {
+                    "product_id": str(product_id),
+                    "quantity": 1,
+                    "unit_price": 270000,
+                    "modifiers": [],
+                }
+            ],
+        )
+
+    order_insert = next(
+        call.args
+        for call in conn.fetchrow.await_args_list
+        if "INSERT INTO orders" in call.args[0]
+    )
+    assert order_insert[7] == "credit"
+    assert result["data"]["payment_status"] == "credit"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payment_method", "payments"),
+    [
+        ("credit", None),
+        (
+            "cash",
+            [
+                {
+                    "amount": 1000,
+                    "payment_method": "credit",
+                    "payment_method_id": None,
+                }
+            ],
+        ),
+    ],
+)
+async def test_create_manual_credit_tender_requires_customer(
+    payment_method,
+    payments,
+):
+    tenant_id = uuid4()
+    get_connection = MagicMock()
+
+    with patch(
+        "app.services.orders_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id, user_id=uuid4()),
+    ), patch(
+        "app.services.orders_service.get_db_connection",
+        get_connection,
+    ):
+        with pytest.raises(APIError) as exc:
+            await orders_service.create_manual_order(
+                Request({"type": "http"}),
+                order_date="2026-07-13T18:42:00+00:00",
+                payment_method=payment_method,
+                payments=payments,
+                items=[
+                    {
+                        "product_id": str(uuid4()),
+                        "quantity": 1,
+                        "unit_price": 1000,
+                        "modifiers": [],
+                    }
+                ],
+            )
+
+    assert exc.value.status_code == 400
+    assert "cliente identificado" in str(exc.value)
+    get_connection.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_manual_credit_rejects_anonymous_customer():
+    tenant_id = uuid4()
+    conn = AsyncMock()
+    conn.fetchval = AsyncMock(return_value="America/Bogota")
+    conn.fetchrow = AsyncMock(return_value={"phone_number": "0000000000"})
+    conn.transaction = MagicMock(return_value=_AsyncContext())
+
+    with patch(
+        "app.services.orders_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id, user_id=uuid4()),
+    ), patch(
+        "app.services.orders_service.get_db_connection",
+        return_value=_AsyncContext(conn),
+    ), patch(
+        "app.services.orders_service.assert_order_not_in_closed_monthly_period",
+        new=AsyncMock(),
+    ):
+        with pytest.raises(APIError) as exc:
+            await orders_service.create_manual_order(
+                Request({"type": "http"}),
+                order_date="2026-07-13T18:42:00+00:00",
+                payment_method="credit",
+                customer_id=str(uuid4()),
+                items=[
+                    {
+                        "product_id": str(uuid4()),
+                        "quantity": 1,
+                        "unit_price": 1000,
+                        "modifiers": [],
+                    }
+                ],
+            )
+
+    assert exc.value.status_code == 400
+    assert "no anónimo" in str(exc.value)
 
 
 @pytest.mark.asyncio
@@ -990,6 +1165,13 @@ async def test_create_manual_order_persists_split_payments_for_gl():
         if "INSERT INTO order_payments" in call.args[0]
     ]
     assert result["success"] is True
+    order_insert = next(
+        call.args
+        for call in conn.fetchrow.await_args_list
+        if "INSERT INTO orders" in call.args[0]
+    )
+    assert order_insert[7] == "paid"
+    assert result["data"]["payment_status"] == "paid"
     assert len(payment_inserts) == 2
     assert payment_inserts[0][3] == 42000
     assert payment_inserts[0][4] == "digital"
@@ -999,6 +1181,23 @@ async def test_create_manual_order_persists_split_payments_for_gl():
     assert payment_inserts[1][5] == str(card_method_id)
     assert post_gl.await_args.kwargs["payment_splits"][0]["amount"] == 42000
     assert post_gl.await_args.kwargs["payment_splits"][1]["payment_method"] == "card"
+
+
+def test_manual_order_payment_status_backfill_is_scoped_and_non_destructive():
+    sql = Path("migrations/102_backfill_manual_order_payment_status.sql").read_text()
+    normalized = " ".join(sql.lower().split())
+
+    assert "set payment_status = 'credit'" in normalized
+    assert "set payment_status = 'paid'" in normalized
+    assert normalized.count("payment_status is null") == 2
+    assert "extra_attributes->>'source' = 'manual'" in normalized
+    assert "o.status = 'completed'" in normalized
+    assert "o.credit_paid_amount = 0" in normalized
+    assert "op.voided_at is null" in normalized
+    assert "select sum(op.amount)" in normalized
+    assert "insert into order_payments" not in normalized
+    assert "update credit_payments" not in normalized
+    assert "tenant_journal_entries" not in normalized
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- persist credit/paid payment status when creating manual orders
- require an identified non-anonymous customer for manual credit tenders
- add an idempotent, evidence-based backfill for historical manual orders
- preserve existing payments, credit collections, and GL journal entries

## Tests

- venv/bin/pytest -q tests/test_manual_order_gl_cogs.py
- venv/bin/pytest -q tests/test_credit_payment_methods.py tests/test_emit_short_circuit.py
- ruff check tests/test_manual_order_gl_cogs.py
- ruff check app/services/orders_service.py --ignore F401

No build was run. Migration 102 was not applied to production.

Closes #619
