### PR TITLE
Tenant country and safe base-currency locking

### DIFF
--- a/app/core/localization.py
+++ b/app/core/localization.py
@@ -14,6 +14,10 @@ import asyncpg
 from babel.dates import format_datetime as babel_format_datetime
 from babel.numbers import format_decimal
 
+from app.core.tenant_prefs import (
+    SUPPORTED_CURRENCY_CODES,
+    currency_minor_units,
+)
 from app.core.timezones import DEFAULT_TENANT_TIMEZONE, get_zoneinfo, normalize_timezone
 
 logger = logging.getLogger(__name__)
@@ -21,7 +25,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_LOCALE = "es"
 DEFAULT_CURRENCY = "COP"
 SUPPORTED_LOCALES = {"es", "en"}
-SUPPORTED_CURRENCIES = {"COP"}
+SUPPORTED_CURRENCIES = SUPPORTED_CURRENCY_CODES
 LOCALES_DIR = Path(__file__).resolve().parents[1] / "locales"
 
 
@@ -41,7 +45,7 @@ def normalize_locale(value: Optional[str]) -> str:
 
 
 def normalize_currency(value: Optional[str]) -> str:
-    """Return a supported currency code. Initial rollout supports COP only."""
+    """Return a supported base-currency code."""
     if not isinstance(value, str):
         return DEFAULT_CURRENCY
     normalized = value.strip().upper()
@@ -64,23 +68,28 @@ def get_translator(locale: Optional[str]):
 
 
 async def resolve_tenant_locale_settings(conn, tenant_id: Any) -> TenantLocaleSettings:
-    """Resolve locale, currency and timezone from tenant_public_profiles."""
+    """Resolve locale/timezone plus authoritative tenant base currency."""
     if not tenant_id:
         return TenantLocaleSettings()
     try:
         result = conn.fetchrow(
             """
-            SELECT locale, currency_code, timezone
-            FROM tenant_public_profiles
-            WHERE tenant_id = $1
+            SELECT
+                tpp.locale,
+                COALESCE(tfp.base_currency_code, tpp.currency_code, 'COP') AS currency_code,
+                tpp.timezone
+            FROM tenants t
+            LEFT JOIN tenant_public_profiles tpp ON tpp.tenant_id = t.id
+            LEFT JOIN tenant_financial_profiles tfp ON tfp.tenant_id = t.id
+            WHERE t.id = $1
             """,
             tenant_id,
         )
         row = await result if isawaitable(result) else result
-    except asyncpg.UndefinedColumnError:
+    except (asyncpg.UndefinedColumnError, asyncpg.UndefinedTableError):
         logger.warning(
-            "tenant_public_profiles locale/currency columns missing; using defaults. "
-            "Apply migrations/099_tenant_locale_currency.sql."
+            "Tenant locale/financial profile schema missing; using CO/COP defaults. "
+            "Apply migrations 099 and 103."
         )
         return TenantLocaleSettings()
     except Exception as exc:
@@ -110,6 +119,11 @@ def format_money(amount: Any, locale: Optional[str] = None, currency: Optional[s
     if code == "COP":
         return f"${number}"
     return f"{code} {number}"
+
+
+def get_currency_minor_units(currency: Optional[str]) -> int:
+    """Expose supported ISO minor units to localization consumers."""
+    return currency_minor_units(currency)
 
 
 def format_datetime(value: datetime, locale: Optional[str] = None, timezone_name: Optional[str] = None) -> str:

--- a/app/core/tenant_prefs.py
+++ b/app/core/tenant_prefs.py
@@ -1,4 +1,4 @@
-"""Tenant localization prefs helpers (locale + display currency).
+"""Tenant localization and financial country/currency helpers.
 
 Operational defaults preserve the Colombia product:
 - locale: es
@@ -6,6 +6,7 @@ Operational defaults preserve the Colombia product:
 
 Separate from fiscal/legal Colombia constraints (api-facturacion).
 """
+from decimal import Decimal, InvalidOperation
 from typing import Optional
 
 DEFAULT_TENANT_LOCALE = "es"
@@ -13,6 +14,42 @@ DEFAULT_CURRENCY_CODE = "COP"
 ALLOWED_LOCALES = frozenset({"es", "en"})
 DEFAULT_TENANT_UI_LOCALE = "es"
 ALLOWED_UI_LOCALES = frozenset({"es", "en", "pt", "fr", "de", "hi", "zh", "ar"})
+
+# Financial country/currency catalog. Panama is the only supported country with
+# more than one possible base currency. Keep this server-side so clients cannot
+# invent combinations that change the meaning of historical amounts.
+COUNTRY_CURRENCY_PAIRS = {
+    "US": ("USD",),
+    "CA": ("CAD",),
+    "GB": ("GBP",),
+    "AU": ("AUD",),
+    "NZ": ("NZD",),
+    "BR": ("BRL",),
+    "DE": ("EUR",),
+    "FR": ("EUR",),
+    "NL": ("EUR",),
+    "SG": ("SGD",),
+    "AE": ("AED",),
+    "IN": ("INR",),
+    "CN": ("CNY",),
+    "MX": ("MXN",),
+    "ES": ("EUR",),
+    "CO": ("COP",),
+    "CR": ("CRC",),
+    "UY": ("UYU",),
+    "CL": ("CLP",),
+    "PE": ("PEN",),
+    "AR": ("ARS",),
+    "DO": ("DOP",),
+    "PA": ("USD", "PAB"),
+}
+SUPPORTED_CURRENCY_MINOR_UNITS = {
+    code: (0 if code == "CLP" else 2)
+    for codes in COUNTRY_CURRENCY_PAIRS.values()
+    for code in codes
+}
+SUPPORTED_COUNTRY_CODES = frozenset(COUNTRY_CURRENCY_PAIRS)
+SUPPORTED_CURRENCY_CODES = frozenset(SUPPORTED_CURRENCY_MINOR_UNITS)
 
 
 def validate_locale(value: Optional[str]) -> str:
@@ -56,12 +93,13 @@ def normalize_ui_locale(value: Optional[str]) -> str:
 
 
 def validate_currency_code(value: Optional[str]) -> str:
-    """Return a normalized ISO 4217-ish currency code or raise ValueError."""
+    """Return a supported normalized ISO 4217 currency code."""
     if value is None or not isinstance(value, str) or not value.strip():
         raise ValueError("currency_code must be a 3-letter ISO code")
     code = value.strip().upper()
-    if len(code) != 3 or not code.isalpha():
-        raise ValueError("currency_code must be a 3-letter ISO code")
+    if len(code) != 3 or not code.isalpha() or code not in SUPPORTED_CURRENCY_CODES:
+        supported = ", ".join(sorted(SUPPORTED_CURRENCY_CODES))
+        raise ValueError(f"currency_code must be one of: {supported}")
     return code
 
 
@@ -71,3 +109,43 @@ def normalize_currency_code(value: Optional[str]) -> str:
         return validate_currency_code(value)
     except ValueError:
         return DEFAULT_CURRENCY_CODE
+
+
+def validate_country_code(value: Optional[str]) -> str:
+    """Return a supported normalized ISO 3166-1 alpha-2 country code."""
+    if value is None or not isinstance(value, str) or not value.strip():
+        raise ValueError("country_code is required")
+    code = value.strip().upper()
+    if code not in SUPPORTED_COUNTRY_CODES:
+        supported = ", ".join(sorted(SUPPORTED_COUNTRY_CODES))
+        raise ValueError(f"country_code must be one of: {supported}")
+    return code
+
+
+def validate_country_currency_pair(country: Optional[str], currency: Optional[str]) -> tuple[str, str]:
+    """Validate and normalize an allowed financial country/base-currency pair."""
+    country_code = validate_country_code(country)
+    currency_code = validate_currency_code(currency)
+    if currency_code not in COUNTRY_CURRENCY_PAIRS[country_code]:
+        allowed = ", ".join(COUNTRY_CURRENCY_PAIRS[country_code])
+        raise ValueError(f"base_currency_code for {country_code} must be one of: {allowed}")
+    return country_code, currency_code
+
+
+def currency_minor_units(currency: Optional[str]) -> int:
+    """Return ISO minor units for a supported currency, defaulting safely to COP."""
+    code = normalize_currency_code(currency)
+    return SUPPORTED_CURRENCY_MINOR_UNITS[code]
+
+
+def validate_currency_amount(value, currency: Optional[str]) -> Decimal:
+    """Reject amounts with more fractional digits than the base currency allows."""
+    try:
+        amount = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise ValueError("amount must be a decimal value") from exc
+    units = currency_minor_units(currency)
+    quantum = Decimal(1).scaleb(-units)
+    if amount != amount.quantize(quantum):
+        raise ValueError(f"{normalize_currency_code(currency)} supports {units} decimal places")
+    return amount

--- a/app/models/tenant_financial_profile.py
+++ b/app/models/tenant_financial_profile.py
@@ -1,0 +1,69 @@
+"""Tenant financial country, base-currency and lock-state API models."""
+from datetime import datetime
+from typing import Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, field_validator, model_validator
+
+from app.core.tenant_prefs import validate_country_currency_pair
+
+
+class TenantFinancialProfileUpdate(BaseModel):
+    country_code: str
+    base_currency_code: str
+
+    @field_validator("country_code", "base_currency_code")
+    @classmethod
+    def _normalize_codes(cls, value: str) -> str:
+        return value.strip().upper() if isinstance(value, str) else value
+
+    @model_validator(mode="after")
+    def _validate_pair(self):
+        self.country_code, self.base_currency_code = validate_country_currency_pair(
+            self.country_code, self.base_currency_code
+        )
+        return self
+
+
+class TenantFinancialProfile(BaseModel):
+    tenant_id: UUID
+    country_code: str
+    base_currency_code: str
+    accounting_localization: str
+    document_mode: str
+    fiscal_provider: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class CountryCurrencyOption(BaseModel):
+    country_code: str
+    currency_codes: list[str]
+
+
+class CurrencyMetadata(BaseModel):
+    currency_code: str
+    minor_units: int
+
+
+class FinancialCapabilities(BaseModel):
+    colombia_puc: bool
+    colombia_payroll: bool
+    matias_dian: bool
+    cop_wallet: bool
+    wompi: bool
+    fixed_cop_discounts: bool
+
+
+class FinancialEligibility(BaseModel):
+    eligible: bool
+    lock_type: Literal["none", "temporary", "permanent"]
+    reason_codes: list[str]
+
+
+class TenantFinancialProfileResponse(BaseModel):
+    profile: TenantFinancialProfile
+    catalog: list[CountryCurrencyOption]
+    currencies: list[CurrencyMetadata]
+    capabilities: FinancialCapabilities
+    eligibility: FinancialEligibility

--- a/app/models/tenant_public_profile.py
+++ b/app/models/tenant_public_profile.py
@@ -11,6 +11,7 @@ from app.core.tenant_prefs import (
     validate_currency_code,
     validate_locale,
 )
+from app.models.tenant_financial_profile import TenantFinancialProfileResponse
 
 class BusinessHours(BaseModel):
     """Business hours for a single day"""
@@ -254,6 +255,14 @@ class TenantPublicProfileCreate(TenantPublicProfileBase):
     tenant_id: UUID = Field(..., description="Tenant ID")
     is_active: bool = Field(False, description="Whether the public profile is active")
 
+    @model_validator(mode='after')
+    def _financial_fields_are_not_mutable_here(self):
+        if self.currency_code != DEFAULT_CURRENCY_CODE or self.country not in (None, 'Colombia'):
+            raise ValueError(
+                "country and currency_code are read-only here; use /financial-profile"
+            )
+        return self
+
 class TenantPublicProfileUpdate(BaseModel):
     """Update tenant public profile (all fields optional)"""
     slug: Optional[str] = Field(None, min_length=1, max_length=255)
@@ -364,6 +373,14 @@ class TenantPublicProfileUpdate(BaseModel):
                 )
         return self
 
+    @model_validator(mode='after')
+    def _financial_fields_are_not_mutable_here(self):
+        if self.country is not None or self.currency_code is not None:
+            raise ValueError(
+                "country and currency_code are read-only here; use /financial-profile"
+            )
+        return self
+
 class TenantPublicProfile(TenantPublicProfileBase):
     """Complete tenant public profile with all fields"""
     id: UUID
@@ -374,6 +391,12 @@ class TenantPublicProfile(TenantPublicProfileBase):
 
     # Calculated fields
     is_currently_open: Optional[bool] = Field(None, description="Calculated: is restaurant currently open")
+    country_code: Optional[str] = Field(
+        None, description="Authoritative ISO country code from the financial profile"
+    )
+    base_currency_code: Optional[str] = Field(
+        None, description="Authoritative tenant base currency"
+    )
 
     class Config:
         from_attributes = True
@@ -382,6 +405,7 @@ class TenantPublicProfileResponse(BaseModel):
     """Single tenant public profile response"""
     success: bool = True
     data: TenantPublicProfile
+    financial: Optional[TenantFinancialProfileResponse] = None
 
 class TenantPublicProfilesListResponse(BaseModel):
     """List of tenant public profiles response"""

--- a/app/routers/tenant_config.py
+++ b/app/routers/tenant_config.py
@@ -16,11 +16,41 @@ from app.models.tenant_public_profile import (
     ToggleProfileRequest,
     ToggleProfileResponse
 )
+from app.models.tenant_financial_profile import (
+    TenantFinancialProfileResponse,
+    TenantFinancialProfileUpdate,
+)
+from app.services import tenant_financial_profile_service
 from app.models.tax_config import TaxConfigUpdate
 from app.core.exceptions import AuthenticationError
 from typing import Optional
 
 router = APIRouter()
+
+
+@router.get(
+    "/financial-profile",
+    response_model=TenantFinancialProfileResponse,
+    dependencies=[Depends(require_module(Module.MI_NEGOCIO))],
+)
+async def get_financial_profile_endpoint(request: Request):
+    """Return authoritative base currency, capabilities and safe lock state."""
+    return await tenant_financial_profile_service.get_financial_profile(request)
+
+
+@router.put(
+    "/financial-profile",
+    response_model=TenantFinancialProfileResponse,
+    dependencies=[Depends(require_module(Module.MI_NEGOCIO))],
+)
+async def update_financial_profile_endpoint(
+    request: Request,
+    profile_data: TenantFinancialProfileUpdate = Body(...),
+):
+    """Atomically change country/base currency when tenant activity allows it."""
+    return await tenant_financial_profile_service.update_financial_profile(
+        request, profile_data
+    )
 
 
 @router.get("/public-profile", response_model=Optional[TenantPublicProfileResponse], dependencies=[Depends(require_module(Module.MI_NEGOCIO))])

--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -26,6 +26,7 @@ from app.models.tenant_public_profile import (
     ToggleProfileResponse
 )
 from app.services import public_restaurant_service
+from app.services import tenant_financial_profile_service
 from app.services.aws_s3_service import AWSS3Service
 import logging
 
@@ -535,6 +536,14 @@ async def get_own_public_profile(request: Request) -> Optional[TenantPublicProfi
                 return None
 
             profile = _profile_from_row(result)
+            financial = await tenant_financial_profile_service.build_financial_response(
+                conn, tenant_id
+            )
+            # Keep the legacy display field aligned on reads without making
+            # tenant_public_profiles a second financial source of truth.
+            profile.currency_code = financial.profile.base_currency_code
+            profile.country_code = financial.profile.country_code
+            profile.base_currency_code = financial.profile.base_currency_code
             profile.is_currently_open = public_restaurant_service.is_currently_open(
                 profile.business_hours,
                 profile.is_manually_open,
@@ -543,7 +552,8 @@ async def get_own_public_profile(request: Request) -> Optional[TenantPublicProfi
 
             return TenantPublicProfileResponse(
                 success=True,
-                data=profile
+                data=profile,
+                financial=financial,
             )
 
     except AuthenticationError:

--- a/app/services/tenant_financial_profile_service.py
+++ b/app/services/tenant_financial_profile_service.py
@@ -1,0 +1,225 @@
+"""Authoritative tenant financial profile and safe country/currency mutation."""
+from typing import Any
+
+from fastapi import HTTPException, Request
+
+from app.core.exceptions import AuthenticationError
+from app.core.middleware import require_valid_session
+from app.core.tenant_prefs import (
+    COUNTRY_CURRENCY_PAIRS,
+    SUPPORTED_CURRENCY_MINOR_UNITS,
+    validate_country_currency_pair,
+)
+from app.database import get_db_connection
+from app.models.tenant_financial_profile import (
+    CountryCurrencyOption,
+    CurrencyMetadata,
+    FinancialCapabilities,
+    FinancialEligibility,
+    TenantFinancialProfile,
+    TenantFinancialProfileResponse,
+    TenantFinancialProfileUpdate,
+)
+
+PERMANENT_REASON = "PERMANENT_FINANCIAL_ACTIVITY"
+TEMPORARY_REASON = "TEMPORARY_OPERATIONAL_ACTIVITY"
+
+_DEFAULT_PROFILE_INSERT = """
+    INSERT INTO tenant_financial_profiles (
+        tenant_id, country_code, base_currency_code,
+        accounting_localization, document_mode, fiscal_provider
+    )
+    SELECT id, 'CO', 'COP', 'WARO_CO_PUC_V1', 'fiscal_integrated', 'matias'
+    FROM tenants
+    WHERE id = $1
+    ON CONFLICT (tenant_id) DO NOTHING
+"""
+
+_BLOCKERS_QUERY = """
+    SELECT
+        (
+            EXISTS (
+                SELECT 1 FROM orders
+                WHERE tenant_id = $1 AND status = 'completed'
+            )
+            OR EXISTS (SELECT 1 FROM order_payments WHERE tenant_id = $1)
+            OR EXISTS (
+                SELECT 1 FROM tenant_journal_entries
+                WHERE tenant_id = $1 AND status IN ('posted', 'voided')
+            )
+            OR EXISTS (SELECT 1 FROM electronic_invoices WHERE tenant_id = $1)
+            OR EXISTS (SELECT 1 FROM customer_wallet_movements WHERE tenant_id = $1)
+        ) AS permanent_activity,
+        (
+            EXISTS (
+                SELECT 1 FROM orders
+                WHERE tenant_id = $1 AND status = 'pending'
+            )
+            OR EXISTS (
+                SELECT 1 FROM table_sessions
+                WHERE tenant_id = $1 AND closed_at IS NULL
+            )
+            OR EXISTS (
+                SELECT 1 FROM pos_carts
+                WHERE tenant_id = $1 AND status = 'active'
+            )
+            OR EXISTS (
+                SELECT 1 FROM cash_shift_openings
+                WHERE tenant_id = $1 AND status = 'open'
+            )
+        ) AS temporary_activity
+"""
+
+
+def _financial_mode(country_code: str) -> tuple[str, str, str | None]:
+    if country_code == "CO":
+        return "WARO_CO_PUC_V1", "fiscal_integrated", "matias"
+    return "WARO_HOSPITALITY_GLOBAL_V1", "waro_commercial", None
+
+
+def _capabilities(country_code: str) -> FinancialCapabilities:
+    colombia = country_code == "CO"
+    return FinancialCapabilities(
+        colombia_puc=colombia,
+        colombia_payroll=colombia,
+        matias_dian=colombia,
+        cop_wallet=colombia,
+        wompi=colombia,
+        fixed_cop_discounts=colombia,
+    )
+
+
+def _catalog() -> list[CountryCurrencyOption]:
+    return [
+        CountryCurrencyOption(country_code=country, currency_codes=list(currencies))
+        for country, currencies in COUNTRY_CURRENCY_PAIRS.items()
+    ]
+
+
+def _currencies() -> list[CurrencyMetadata]:
+    return [
+        CurrencyMetadata(currency_code=code, minor_units=minor_units)
+        for code, minor_units in sorted(SUPPORTED_CURRENCY_MINOR_UNITS.items())
+    ]
+
+
+def _eligibility(blockers: Any) -> FinancialEligibility:
+    permanent = bool(blockers and blockers.get("permanent_activity"))
+    temporary = bool(blockers and blockers.get("temporary_activity"))
+    if permanent:
+        return FinancialEligibility(
+            eligible=False,
+            lock_type="permanent",
+            reason_codes=[PERMANENT_REASON],
+        )
+    if temporary:
+        return FinancialEligibility(
+            eligible=False,
+            lock_type="temporary",
+            reason_codes=[TEMPORARY_REASON],
+        )
+    return FinancialEligibility(eligible=True, lock_type="none", reason_codes=[])
+
+
+def _response(profile_row: Any, blockers: Any) -> TenantFinancialProfileResponse:
+    profile = TenantFinancialProfile(**dict(profile_row))
+    return TenantFinancialProfileResponse(
+        profile=profile,
+        catalog=_catalog(),
+        currencies=_currencies(),
+        capabilities=_capabilities(profile.country_code),
+        eligibility=_eligibility(blockers),
+    )
+
+
+async def build_financial_response(
+    conn, tenant_id, *, lock_tenant: bool = False
+) -> TenantFinancialProfileResponse:
+    """Read/create a tenant profile and calculate non-sensitive lock state."""
+    if lock_tenant:
+        tenant = await conn.fetchrow(
+            "SELECT id FROM tenants WHERE id = $1 FOR UPDATE", tenant_id
+        )
+        if not tenant:
+            raise HTTPException(status_code=404, detail="Tenant not found")
+
+    await conn.execute(_DEFAULT_PROFILE_INSERT, tenant_id)
+    suffix = " FOR UPDATE" if lock_tenant else ""
+    profile = await conn.fetchrow(
+        """
+        SELECT tenant_id, country_code, base_currency_code,
+               accounting_localization, document_mode, fiscal_provider,
+               created_at, updated_at
+        FROM tenant_financial_profiles
+        WHERE tenant_id = $1
+        """ + suffix,
+        tenant_id,
+    )
+    if not profile:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+    blockers = await conn.fetchrow(_BLOCKERS_QUERY, tenant_id)
+    return _response(profile, blockers)
+
+
+async def get_financial_profile(request: Request) -> TenantFinancialProfileResponse:
+    session = require_valid_session(request)
+    if not session.tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+    async with get_db_connection() as conn:
+        return await build_financial_response(conn, session.tenant_id)
+
+
+async def update_financial_profile(
+    request: Request, data: TenantFinancialProfileUpdate
+) -> TenantFinancialProfileResponse:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    country_code, currency_code = validate_country_currency_pair(
+        data.country_code, data.base_currency_code
+    )
+    accounting_localization, document_mode, fiscal_provider = _financial_mode(country_code)
+
+    async with get_db_connection() as conn:
+        async with conn.transaction():
+            current = await build_financial_response(conn, tenant_id, lock_tenant=True)
+            same_pair = (
+                current.profile.country_code == country_code
+                and current.profile.base_currency_code == currency_code
+            )
+            if same_pair:
+                return current
+            if not current.eligibility.eligible:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "code": "FINANCIAL_PROFILE_LOCKED",
+                        "lock_type": current.eligibility.lock_type,
+                        "reason_codes": current.eligibility.reason_codes,
+                    },
+                )
+
+            row = await conn.fetchrow(
+                """
+                UPDATE tenant_financial_profiles
+                SET country_code = $2,
+                    base_currency_code = $3,
+                    accounting_localization = $4,
+                    document_mode = $5,
+                    fiscal_provider = $6,
+                    updated_at = NOW()
+                WHERE tenant_id = $1
+                RETURNING tenant_id, country_code, base_currency_code,
+                          accounting_localization, document_mode, fiscal_provider,
+                          created_at, updated_at
+                """,
+                tenant_id,
+                country_code,
+                currency_code,
+                accounting_localization,
+                document_mode,
+                fiscal_provider,
+            )
+            return _response(row, {"permanent_activity": False, "temporary_activity": False})

--- a/migrations/103_tenant_financial_profiles.sql
+++ b/migrations/103_tenant_financial_profiles.sql
@@ -1,0 +1,86 @@
+-- Issue #622: authoritative financial country and base currency per tenant.
+-- Additive and idempotent. Existing tenants remain Colombia/COP and no
+-- historical amount, order, payment, journal or invoice is rewritten.
+
+CREATE TABLE IF NOT EXISTS tenant_financial_profiles (
+    tenant_id UUID PRIMARY KEY REFERENCES tenants(id) ON DELETE CASCADE,
+    country_code CHAR(2) NOT NULL DEFAULT 'CO',
+    base_currency_code CHAR(3) NOT NULL DEFAULT 'COP',
+    accounting_localization VARCHAR(50) NOT NULL DEFAULT 'WARO_CO_PUC_V1',
+    document_mode VARCHAR(30) NOT NULL DEFAULT 'fiscal_integrated',
+    fiscal_provider VARCHAR(30) DEFAULT 'matias',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT tenant_financial_profiles_country_supported CHECK (
+        country_code IN (
+            'US','CA','GB','AU','NZ','BR','DE','FR','NL','SG','AE','IN',
+            'CN','MX','ES','CO','CR','UY','CL','PE','AR','DO','PA'
+        )
+    ),
+    CONSTRAINT tenant_financial_profiles_currency_supported CHECK (
+        base_currency_code IN (
+            'USD','CAD','GBP','AUD','NZD','BRL','EUR','SGD','AED','INR',
+            'CNY','MXN','COP','CRC','UYU','CLP','PEN','ARS','DOP','PAB'
+        )
+    ),
+    CONSTRAINT tenant_financial_profiles_pair_supported CHECK (
+        (country_code = 'US' AND base_currency_code = 'USD') OR
+        (country_code = 'CA' AND base_currency_code = 'CAD') OR
+        (country_code = 'GB' AND base_currency_code = 'GBP') OR
+        (country_code = 'AU' AND base_currency_code = 'AUD') OR
+        (country_code = 'NZ' AND base_currency_code = 'NZD') OR
+        (country_code = 'BR' AND base_currency_code = 'BRL') OR
+        (country_code IN ('DE','FR','NL','ES') AND base_currency_code = 'EUR') OR
+        (country_code = 'SG' AND base_currency_code = 'SGD') OR
+        (country_code = 'AE' AND base_currency_code = 'AED') OR
+        (country_code = 'IN' AND base_currency_code = 'INR') OR
+        (country_code = 'CN' AND base_currency_code = 'CNY') OR
+        (country_code = 'MX' AND base_currency_code = 'MXN') OR
+        (country_code = 'CO' AND base_currency_code = 'COP') OR
+        (country_code = 'CR' AND base_currency_code = 'CRC') OR
+        (country_code = 'UY' AND base_currency_code = 'UYU') OR
+        (country_code = 'CL' AND base_currency_code = 'CLP') OR
+        (country_code = 'PE' AND base_currency_code = 'PEN') OR
+        (country_code = 'AR' AND base_currency_code = 'ARS') OR
+        (country_code = 'DO' AND base_currency_code = 'DOP') OR
+        (country_code = 'PA' AND base_currency_code IN ('USD','PAB'))
+    ),
+    CONSTRAINT tenant_financial_profiles_mode_supported CHECK (
+        (country_code = 'CO'
+            AND accounting_localization = 'WARO_CO_PUC_V1'
+            AND document_mode = 'fiscal_integrated'
+            AND fiscal_provider = 'matias')
+        OR
+        (country_code <> 'CO'
+            AND accounting_localization = 'WARO_HOSPITALITY_GLOBAL_V1'
+            AND document_mode = 'waro_commercial'
+            AND fiscal_provider IS NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_financial_profiles_country_currency
+    ON tenant_financial_profiles(country_code, base_currency_code);
+
+INSERT INTO tenant_financial_profiles (
+    tenant_id,
+    country_code,
+    base_currency_code,
+    accounting_localization,
+    document_mode,
+    fiscal_provider
+)
+SELECT
+    id,
+    'CO',
+    'COP',
+    'WARO_CO_PUC_V1',
+    'fiscal_integrated',
+    'matias'
+FROM tenants
+ON CONFLICT (tenant_id) DO NOTHING;
+
+COMMENT ON TABLE tenant_financial_profiles IS
+    'Authoritative country/base currency configuration. Changes are guarded by tenant activity locks.';
+COMMENT ON COLUMN tenant_financial_profiles.base_currency_code IS
+    'Single base currency for all generic monetary amounts; no FX or per-transaction currency.';

--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -8,6 +8,7 @@ from app.core.localization import (
     DEFAULT_LOCALE,
     format_datetime,
     format_money,
+    get_currency_minor_units,
     normalize_currency,
     normalize_locale,
     resolve_tenant_locale_settings,
@@ -30,7 +31,10 @@ def test_normalize_locale_and_currency_fallbacks():
     assert normalize_locale("es_CO") == "es"
     assert normalize_locale("fr") == DEFAULT_LOCALE
     assert normalize_currency("cop") == "COP"
-    assert normalize_currency("USD") == DEFAULT_CURRENCY
+    assert normalize_currency("USD") == "USD"
+    assert normalize_currency("ZZZ") == DEFAULT_CURRENCY
+    assert get_currency_minor_units("CLP") == 0
+    assert get_currency_minor_units("USD") == 2
 
 
 @pytest.mark.asyncio
@@ -47,7 +51,7 @@ async def test_resolve_tenant_locale_settings_uses_profile_values():
 @pytest.mark.asyncio
 async def test_resolve_tenant_locale_settings_falls_back_for_invalid_or_missing_columns():
     settings = await resolve_tenant_locale_settings(
-        FakeConn({"locale": "legacy", "currency_code": "USD", "timezone": "Bad/Zone"}),
+        FakeConn({"locale": "legacy", "currency_code": "ZZZ", "timezone": "Bad/Zone"}),
         "tenant-1",
     )
     assert settings.locale == "es"

--- a/tests/test_tenant_financial_profile.py
+++ b/tests/test_tenant_financial_profile.py
@@ -1,0 +1,193 @@
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from app.core.tenant_prefs import (
+    COUNTRY_CURRENCY_PAIRS,
+    SUPPORTED_CURRENCY_MINOR_UNITS,
+    validate_currency_amount,
+)
+from app.models.tenant_financial_profile import TenantFinancialProfileUpdate
+from app.services import tenant_financial_profile_service as service
+
+
+def _profile(tenant_id, country="CO", currency="COP"):
+    colombia = country == "CO"
+    return {
+        "tenant_id": tenant_id,
+        "country_code": country,
+        "base_currency_code": currency,
+        "accounting_localization": (
+            "WARO_CO_PUC_V1" if colombia else "WARO_HOSPITALITY_GLOBAL_V1"
+        ),
+        "document_mode": "fiscal_integrated" if colombia else "waro_commercial",
+        "fiscal_provider": "matias" if colombia else None,
+        "created_at": None,
+        "updated_at": None,
+    }
+
+
+class _Transaction:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class FakeConn:
+    def __init__(self, tenant_id, blockers=None, update_row=None):
+        self.tenant_id = tenant_id
+        self.blockers = blockers or {
+            "permanent_activity": False,
+            "temporary_activity": False,
+        }
+        self.update_row = update_row
+        self.queries = []
+
+    def transaction(self):
+        return _Transaction()
+
+    async def execute(self, query, *args):
+        self.queries.append((query, args))
+        return "INSERT 0 1"
+
+    async def fetchrow(self, query, *args):
+        self.queries.append((query, args))
+        if "FROM tenants WHERE id" in query:
+            return {"id": self.tenant_id}
+        if "FROM tenant_financial_profiles" in query:
+            return _profile(self.tenant_id)
+        if "AS permanent_activity" in query:
+            return self.blockers
+        if "UPDATE tenant_financial_profiles" in query:
+            return self.update_row
+        raise AssertionError(f"Unexpected query: {query}")
+
+
+def _db_context(conn):
+    @asynccontextmanager
+    async def _ctx():
+        yield conn
+
+    return _ctx
+
+
+def test_catalog_has_23_countries_20_currencies_and_panama_choices():
+    assert len(COUNTRY_CURRENCY_PAIRS) == 23
+    assert len(SUPPORTED_CURRENCY_MINOR_UNITS) == 20
+    assert COUNTRY_CURRENCY_PAIRS["PA"] == ("USD", "PAB")
+    assert SUPPORTED_CURRENCY_MINOR_UNITS["CLP"] == 0
+
+
+def test_country_currency_model_normalizes_and_rejects_invalid_pairs():
+    assert TenantFinancialProfileUpdate(
+        country_code=" pa ", base_currency_code="pab"
+    ).model_dump() == {"country_code": "PA", "base_currency_code": "PAB"}
+    with pytest.raises(ValidationError, match="base_currency_code for CO"):
+        TenantFinancialProfileUpdate(country_code="CO", base_currency_code="USD")
+
+
+def test_clp_rejects_fractional_amounts_but_two_minor_unit_currency_accepts_them():
+    assert validate_currency_amount("1200", "CLP") == 1200
+    with pytest.raises(ValueError, match="CLP supports 0"):
+        validate_currency_amount("1200.50", "CLP")
+    assert validate_currency_amount("12.50", "USD") == pytest.approx(12.5)
+
+
+def test_permanent_blocker_wins_and_reason_does_not_expose_rows():
+    eligibility = service._eligibility(
+        {"permanent_activity": True, "temporary_activity": True}
+    )
+    assert eligibility.lock_type == "permanent"
+    assert eligibility.reason_codes == [service.PERMANENT_REASON]
+    assert eligibility.model_dump() == {
+        "eligible": False,
+        "lock_type": "permanent",
+        "reason_codes": ["PERMANENT_FINANCIAL_ACTIVITY"],
+    }
+
+
+def test_temporary_activity_uses_distinct_reversible_lock():
+    eligibility = service._eligibility(
+        {"permanent_activity": False, "temporary_activity": True}
+    )
+    assert eligibility.model_dump() == {
+        "eligible": False,
+        "lock_type": "temporary",
+        "reason_codes": ["TEMPORARY_OPERATIONAL_ACTIVITY"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_locks_tenant_and_derives_global_mode_server_side():
+    tenant_id = uuid4()
+    conn = FakeConn(tenant_id, update_row=_profile(tenant_id, "US", "USD"))
+    request = object()
+    session = SimpleNamespace(tenant_id=tenant_id)
+
+    with patch.object(service, "require_valid_session", return_value=session), patch.object(
+        service, "get_db_connection", side_effect=_db_context(conn)
+    ):
+        result = await service.update_financial_profile(
+            request,
+            TenantFinancialProfileUpdate(country_code="US", base_currency_code="USD"),
+        )
+
+    assert result.profile.accounting_localization == "WARO_HOSPITALITY_GLOBAL_V1"
+    assert result.profile.document_mode == "waro_commercial"
+    assert result.profile.fiscal_provider is None
+    assert result.capabilities.matias_dian is False
+    lock_query = next(query for query, _ in conn.queries if "FROM tenants WHERE id" in query)
+    assert "FOR UPDATE" in lock_query
+    assert all(args == (tenant_id,) for _, args in conn.queries[:-1])
+
+
+@pytest.mark.asyncio
+async def test_permanent_lock_rejects_change_but_allows_idempotent_retry():
+    tenant_id = uuid4()
+    blockers = {"permanent_activity": True, "temporary_activity": False}
+    session = SimpleNamespace(tenant_id=tenant_id)
+
+    locked_conn = FakeConn(tenant_id, blockers=blockers)
+    with patch.object(service, "require_valid_session", return_value=session), patch.object(
+        service, "get_db_connection", side_effect=_db_context(locked_conn)
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await service.update_financial_profile(
+                object(),
+                TenantFinancialProfileUpdate(country_code="US", base_currency_code="USD"),
+            )
+    assert exc.value.status_code == 409
+    assert exc.value.detail["lock_type"] == "permanent"
+
+    retry_conn = FakeConn(tenant_id, blockers=blockers)
+    with patch.object(service, "require_valid_session", return_value=session), patch.object(
+        service, "get_db_connection", side_effect=_db_context(retry_conn)
+    ):
+        retry = await service.update_financial_profile(
+            object(),
+            TenantFinancialProfileUpdate(country_code="CO", base_currency_code="COP"),
+        )
+    assert retry.profile.base_currency_code == "COP"
+    assert retry.eligibility.lock_type == "permanent"
+
+
+def test_migration_is_idempotent_and_does_not_rewrite_history():
+    sql = Path("migrations/103_tenant_financial_profiles.sql").read_text()
+    assert "CREATE TABLE IF NOT EXISTS tenant_financial_profiles" in sql
+    assert "CREATE INDEX IF NOT EXISTS" in sql
+    assert "ON CONFLICT (tenant_id) DO NOTHING" in sql
+    for table in ("orders", "order_payments", "tenant_journal_entries", "electronic_invoices"):
+        assert f"UPDATE {table}" not in sql
+
+
+def test_blocker_query_is_tenant_scoped_and_ignores_null_legacy_rows():
+    assert service._BLOCKERS_QUERY.count("tenant_id = $1") == 9
+    assert "tenant_id IS NULL" not in service._BLOCKERS_QUERY

--- a/tests/test_tenant_locale_currency.py
+++ b/tests/test_tenant_locale_currency.py
@@ -42,22 +42,25 @@ def test_validate_currency_code_accepts_iso_and_uppercases():
     assert validate_currency_code("COP") == "COP"
     assert validate_currency_code("usd") == "USD"
     assert validate_currency_code(" MxN ") == "MXN"
+    assert validate_currency_code("clp") == "CLP"
 
 
 def test_validate_currency_code_rejects_invalid():
-    with pytest.raises(ValueError, match="3-letter"):
+    with pytest.raises(ValueError):
         validate_currency_code("CO")
-    with pytest.raises(ValueError, match="3-letter"):
+    with pytest.raises(ValueError):
         validate_currency_code("123")
     with pytest.raises(ValueError, match="3-letter"):
         validate_currency_code(None)
+    with pytest.raises(ValueError, match="must be one of"):
+        validate_currency_code("ZZZ")
 
 
 def test_normalize_currency_code_defaults_for_missing_or_junk():
     assert normalize_currency_code(None) == DEFAULT_CURRENCY_CODE
     assert normalize_currency_code("") == DEFAULT_CURRENCY_CODE
     assert normalize_currency_code("XX") == DEFAULT_CURRENCY_CODE  # not alpha length ok? XX is alpha len2
-    assert normalize_currency_code("ZZZ") == "ZZZ"  # open allowlist for display later
+    assert normalize_currency_code("ZZZ") == DEFAULT_CURRENCY_CODE
     assert normalize_currency_code("cop") == "COP"
 
 
@@ -75,12 +78,15 @@ def test_profile_base_rejects_invalid_locale():
 
 
 def test_profile_update_round_trip_fields():
-    update = TenantPublicProfileUpdate(locale="en", currency_code="usd")
+    update = TenantPublicProfileUpdate(locale="en")
     dumped = update.model_dump(exclude_unset=True)
     assert dumped["locale"] == "en"
-    assert dumped["currency_code"] == "USD"
 
 
-def test_profile_update_rejects_bad_currency():
+def test_profile_update_rejects_financial_fields():
     with pytest.raises(ValidationError):
         TenantPublicProfileUpdate(currency_code="peso")
+    with pytest.raises(ValidationError, match="financial-profile"):
+        TenantPublicProfileUpdate(currency_code="USD")
+    with pytest.raises(ValidationError, match="financial-profile"):
+        TenantPublicProfileUpdate(country="United States")


### PR DESCRIPTION
## Summary
- add an authoritative country/base-currency profile and 23-country catalog
- expose financial capabilities and non-sensitive temporary/permanent lock reasons
- preserve existing tenants as CO/COP with an idempotent migration

## Tests
- 69 targeted/regression tests passed
- Ruff passed
- migration 103 applied twice in ephemeral PostgreSQL
- build skipped as requested

Closes #622