### PR TITLE
Localized CO PUC and WARO Hospitality templates

### DIFF
--- a/migrations/022_create_account_templates.sql
+++ b/migrations/022_create_account_templates.sql
@@ -1,10 +1,40 @@
--- Migration 022: Create account_templates table
--- System-level PUC (Plan Único de Cuentas) reference table.
--- Shared across all tenants. Read-only for tenants.
--- Seeded separately in migration 022b (seed data).
+-- Migration 022: Create versioned accounting localizations and templates.
+-- Migration 104 upgrades databases that already ran the original CO-only form.
+
+CREATE TABLE IF NOT EXISTS accounting_localizations (
+    id VARCHAR(50) PRIMARY KEY,
+    country_code CHAR(2),
+    version INT NOT NULL CHECK (version > 0),
+    display_name VARCHAR(120) NOT NULL,
+    description TEXT NOT NULL,
+    is_fiscal BOOLEAN NOT NULL DEFAULT false,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT accounting_localizations_country_scope CHECK (
+        (id = 'WARO_CO_PUC_V1' AND country_code = 'CO' AND is_fiscal = true)
+        OR
+        (id = 'WARO_HOSPITALITY_GLOBAL_V1' AND country_code IS NULL AND is_fiscal = false)
+    )
+);
+
+INSERT INTO accounting_localizations (
+    id, country_code, version, display_name, description, is_fiscal, is_active
+) VALUES
+    (
+        'WARO_CO_PUC_V1', 'CO', 1, 'WARO Colombia PUC',
+        'Plan de cuentas colombiano usado por la operacion fiscal de WARO en Colombia.',
+        true, true
+    ),
+    (
+        'WARO_HOSPITALITY_GLOBAL_V1', NULL, 1, 'WARO Hospitality Global',
+        'Plantilla gerencial no fiscal; no representa NIIF, GAAP ni cumplimiento legal local.',
+        false, true
+    )
+ON CONFLICT (id) DO NOTHING;
 
 CREATE TABLE IF NOT EXISTS account_templates (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    localization_id VARCHAR(50) NOT NULL DEFAULT 'WARO_CO_PUC_V1',
     code VARCHAR(10) NOT NULL UNIQUE,
     standard_name VARCHAR(200) NOT NULL,
     account_class VARCHAR(1) NOT NULL
@@ -14,22 +44,39 @@ CREATE TABLE IF NOT EXISTS account_templates (
     normal_balance VARCHAR(6) NOT NULL
         CHECK (normal_balance IN ('debit','credit')),
     level INT NOT NULL CHECK (level IN (1,2,4,6,8)),
+    -- parent_code remains as bootstrap metadata. Migration 104 removes its
+    -- global FK once repeated codes exist and parent_template_id is populated.
     parent_code VARCHAR(10) REFERENCES account_templates(code),
+    parent_template_id UUID,
     is_detail BOOLEAN NOT NULL DEFAULT false,
     niif_group VARCHAR(10),
     is_active BOOLEAN NOT NULL DEFAULT true,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_account_templates_localization_code
+        UNIQUE (localization_id, code),
+    CONSTRAINT uq_account_templates_localization_id_id
+        UNIQUE (localization_id, id),
+    CONSTRAINT fk_account_templates_localization
+        FOREIGN KEY (localization_id)
+        REFERENCES accounting_localizations(id),
+    CONSTRAINT fk_account_templates_localized_parent
+        FOREIGN KEY (localization_id, parent_template_id)
+        REFERENCES account_templates(localization_id, id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_account_templates_parent
-    ON account_templates(parent_code);
+    ON account_templates(parent_template_id);
+CREATE INDEX IF NOT EXISTS idx_account_templates_localization_parent_code
+    ON account_templates(localization_id, parent_code);
 CREATE INDEX IF NOT EXISTS idx_account_templates_class
-    ON account_templates(account_class);
+    ON account_templates(localization_id, account_class);
 CREATE INDEX IF NOT EXISTS idx_account_templates_active
-    ON account_templates(is_active) WHERE is_active = true;
+    ON account_templates(localization_id, is_active) WHERE is_active = true;
 
-COMMENT ON TABLE account_templates IS 'System-level PUC colombiano account reference. Shared across all tenants. Never scoped by tenant_id.';
-COMMENT ON COLUMN account_templates.code IS 'PUC account code: 1=class, 11=group, 1105=account, 110505=sub-account';
+COMMENT ON TABLE account_templates IS 'Versioned system account templates. Tenant charts copy exactly one accounting localization.';
+COMMENT ON COLUMN account_templates.localization_id IS 'Accounting localization and version owning this template row.';
+COMMENT ON COLUMN account_templates.code IS 'Account code unique inside one accounting localization.';
+COMMENT ON COLUMN account_templates.parent_template_id IS 'Localized UUID hierarchy; never resolved globally by code.';
 COMMENT ON COLUMN account_templates.level IS '1=class(1digit), 2=group(2digits), 4=account(4digits), 6=subaccount(6digits), 8=auxiliary(8digits)';
 COMMENT ON COLUMN account_templates.is_detail IS 'true = journal lines can be posted directly to this account';
 COMMENT ON COLUMN account_templates.niif_group IS 'grupo1, grupo2, grupo3 or NULL (applies to all)';

--- a/migrations/025_seed_puc_account_templates.sql
+++ b/migrations/025_seed_puc_account_templates.sql
@@ -7,7 +7,7 @@
 --   Part C: Account rows    (level=4, parent_code=group code) — 31 rows
 --   Total: 52 rows in account_templates
 --
--- All inserts use ON CONFLICT (code) DO NOTHING — safe to re-run.
+-- All inserts are scoped to WARO_CO_PUC_V1 and safe to re-run.
 -- Note: inventory uses code 1435 (official Decreto 2650), not 1430.
 
 -- ─────────────────────────────────────────────
@@ -21,7 +21,7 @@ VALUES
   ('4', 'Ingresos',                                 '4', 'income',    'credit', 1, NULL, false, 'grupo2', true),
   ('5', 'Gastos operacionales de administración',   '5', 'expense',   'debit',  1, NULL, false, 'grupo2', true),
   ('6', 'Costos de ventas',                         '6', 'cogs',      'debit',  1, NULL, false, 'grupo2', true)
-ON CONFLICT (code) DO NOTHING;
+ON CONFLICT (localization_id, code) DO NOTHING;
 
 -- ─────────────────────────────────────────────
 -- PART B: Groups (level=2)
@@ -49,7 +49,7 @@ VALUES
   -- Class 6 — Costos
   ('61', 'Costo de materia prima y suministros',            '6', 'cogs',      'debit',  2, '6', false, 'grupo2', true),
   ('62', 'Costo de mano de obra',                           '6', 'cogs',      'debit',  2, '6', false, 'grupo2', true)
-ON CONFLICT (code) DO NOTHING;
+ON CONFLICT (localization_id, code) DO NOTHING;
 
 -- ─────────────────────────────────────────────
 -- PART C: Accounts (level=4, is_detail=true)
@@ -101,11 +101,22 @@ VALUES
   -- Class 6 — Costos de ventas
   ('6135', 'Costos de materia prima (food cost)',             '6', 'cogs',      'debit',  4, '61', true, 'grupo2', true),
   ('6205', 'Costos de mano de obra directa',                  '6', 'cogs',      'debit',  4, '62', true, 'grupo2', true)
-ON CONFLICT (code) DO NOTHING;
+ON CONFLICT (localization_id, code) DO NOTHING;
+
+-- Populate the UUID hierarchy available in the final bootstrap schema.
+UPDATE account_templates child
+SET parent_template_id = parent.id
+FROM account_templates parent
+WHERE child.localization_id = 'WARO_CO_PUC_V1'
+  AND parent.localization_id = child.localization_id
+  AND parent.code = child.parent_code
+  AND child.parent_code IS NOT NULL
+  AND child.parent_template_id IS DISTINCT FROM parent.id;
 
 -- ─────────────────────────────────────────────
 -- PART D: Function seed_tenant_accounts(p_tenant_id)
--- Copies all active account_templates into tenant_accounts for a given tenant.
+-- Copies the CO templates into tenant_accounts for a given tenant. Migration
+-- 104 replaces this bootstrap function with localization-aware overloads.
 -- Called here for existing tenants; call from API on new company creation.
 -- Safe to call multiple times — ON CONFLICT (tenant_id, code) DO NOTHING.
 -- ─────────────────────────────────────────────
@@ -131,22 +142,22 @@ BEGIN
     true,   -- is_system: seeded rows cannot be deleted via API
     true    -- is_active
   FROM account_templates at
-  WHERE at.is_active = true
+  WHERE at.localization_id = 'WARO_CO_PUC_V1'
+    AND at.is_active = true
   ON CONFLICT (tenant_id, code) DO NOTHING;
 
-  -- Step 2: Resolve parent_id (UUID FK) by joining through parent_code string
-  -- Each child template has a parent_code; find the corresponding tenant_account row.
+  -- Step 2: Resolve parent_id through localized template UUIDs.
   UPDATE tenant_accounts child_ta
   SET parent_id = parent_ta.id
   FROM account_templates child_at
-  JOIN account_templates parent_at ON parent_at.code = child_at.parent_code
   JOIN tenant_accounts parent_ta
     ON parent_ta.tenant_id = p_tenant_id
-   AND parent_ta.code = parent_at.code
+   AND parent_ta.template_id = child_at.parent_template_id
   WHERE child_ta.tenant_id = p_tenant_id
     AND child_ta.template_id = child_at.id
     AND child_ta.parent_id IS NULL
-    AND child_at.parent_code IS NOT NULL;
+    AND child_at.localization_id = 'WARO_CO_PUC_V1'
+    AND child_at.parent_template_id IS NOT NULL;
 END;
 $$ LANGUAGE plpgsql;
 

--- a/migrations/029_order_gl_and_tax_fixes.sql
+++ b/migrations/029_order_gl_and_tax_fixes.sql
@@ -43,7 +43,8 @@ ALTER TABLE tenant_journal_entries
 -- ─────────────────────────────────────────────
 UPDATE account_templates
     SET standard_name = 'Impuesto de industria y comercio retenido'
-    WHERE code = '2368';
+    WHERE localization_id = 'WARO_CO_PUC_V1'
+      AND code = '2368';
 
 UPDATE tenant_accounts
     SET name = 'Impuesto de industria y comercio retenido'
@@ -60,7 +61,7 @@ INSERT INTO account_templates (
 ) VALUES (
     '24', 'Impuestos, gravámenes y tasas',
     '2', 'liability', 'credit', 2, '2', false, 'grupo2', true
-) ON CONFLICT (code) DO NOTHING;
+) ON CONFLICT (localization_id, code) DO NOTHING;
 
 -- ─────────────────────────────────────────────
 -- 4. Add 2495 "Impoconsumo por pagar (INC)"
@@ -75,7 +76,7 @@ INSERT INTO account_templates (
 ) VALUES (
     '2495', 'Impoconsumo por pagar (INC)',
     '2', 'liability', 'credit', 4, '24', true, 'grupo2', true
-) ON CONFLICT (code) DO NOTHING;
+) ON CONFLICT (localization_id, code) DO NOTHING;
 
 -- ─────────────────────────────────────────────
 -- 5. Add 2408 "IVA por pagar"
@@ -89,7 +90,7 @@ INSERT INTO account_templates (
 ) VALUES (
     '2408', 'Impuesto sobre las ventas por pagar (IVA)',
     '2', 'liability', 'credit', 4, '24', true, 'grupo2', true
-) ON CONFLICT (code) DO NOTHING;
+) ON CONFLICT (localization_id, code) DO NOTHING;
 
 -- ─────────────────────────────────────────────
 -- 6. Re-seed all existing tenants

--- a/migrations/104_accounting_localizations.sql
+++ b/migrations/104_accounting_localizations.sql
@@ -1,0 +1,311 @@
+-- Issue #624: versioned accounting localizations and localized account templates.
+-- Existing PUC template IDs and tenant account references are preserved.
+
+CREATE TABLE IF NOT EXISTS accounting_localizations (
+    id VARCHAR(50) PRIMARY KEY,
+    country_code CHAR(2),
+    version INT NOT NULL CHECK (version > 0),
+    display_name VARCHAR(120) NOT NULL,
+    description TEXT NOT NULL,
+    is_fiscal BOOLEAN NOT NULL DEFAULT false,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT accounting_localizations_country_scope CHECK (
+        (id = 'WARO_CO_PUC_V1' AND country_code = 'CO' AND is_fiscal = true)
+        OR
+        (id = 'WARO_HOSPITALITY_GLOBAL_V1' AND country_code IS NULL AND is_fiscal = false)
+    )
+);
+
+INSERT INTO accounting_localizations (
+    id, country_code, version, display_name, description, is_fiscal, is_active
+) VALUES
+    (
+        'WARO_CO_PUC_V1', 'CO', 1, 'WARO Colombia PUC',
+        'Plan de cuentas colombiano usado por la operacion fiscal de WARO en Colombia.',
+        true, true
+    ),
+    (
+        'WARO_HOSPITALITY_GLOBAL_V1', NULL, 1, 'WARO Hospitality Global',
+        'Plantilla gerencial no fiscal; no representa NIIF, GAAP ni cumplimiento legal local.',
+        false, true
+    )
+ON CONFLICT (id) DO UPDATE SET
+    country_code = EXCLUDED.country_code,
+    version = EXCLUDED.version,
+    display_name = EXCLUDED.display_name,
+    description = EXCLUDED.description,
+    is_fiscal = EXCLUDED.is_fiscal,
+    is_active = EXCLUDED.is_active;
+
+ALTER TABLE account_templates
+    ADD COLUMN IF NOT EXISTS localization_id VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS parent_template_id UUID;
+
+-- Every pre-existing row is the Colombian PUC. This update changes neither its
+-- primary key nor any tenant_accounts.template_id reference.
+UPDATE account_templates
+SET localization_id = 'WARO_CO_PUC_V1'
+WHERE localization_id IS NULL;
+
+ALTER TABLE account_templates
+    ALTER COLUMN localization_id SET DEFAULT 'WARO_CO_PUC_V1',
+    ALTER COLUMN localization_id SET NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'account_templates'::regclass
+          AND conname = 'fk_account_templates_localization'
+    ) THEN
+        ALTER TABLE account_templates
+            ADD CONSTRAINT fk_account_templates_localization
+            FOREIGN KEY (localization_id) REFERENCES accounting_localizations(id);
+    END IF;
+END $$;
+
+-- Remove identities that assume code is globally unique before adding Global.
+ALTER TABLE account_templates
+    DROP CONSTRAINT IF EXISTS account_templates_parent_code_fkey,
+    DROP CONSTRAINT IF EXISTS account_templates_code_key;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'account_templates'::regclass
+          AND conname = 'uq_account_templates_localization_code'
+    ) THEN
+        ALTER TABLE account_templates
+            ADD CONSTRAINT uq_account_templates_localization_code
+            UNIQUE (localization_id, code);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'account_templates'::regclass
+          AND conname = 'uq_account_templates_localization_id_id'
+    ) THEN
+        ALTER TABLE account_templates
+            ADD CONSTRAINT uq_account_templates_localization_id_id
+            UNIQUE (localization_id, id);
+    END IF;
+END $$;
+
+UPDATE account_templates child
+SET parent_template_id = parent.id
+FROM account_templates parent
+WHERE parent.localization_id = child.localization_id
+  AND parent.code = child.parent_code
+  AND child.parent_code IS NOT NULL
+  AND child.parent_template_id IS DISTINCT FROM parent.id;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'account_templates'::regclass
+          AND conname = 'fk_account_templates_localized_parent'
+    ) THEN
+        ALTER TABLE account_templates
+            ADD CONSTRAINT fk_account_templates_localized_parent
+            FOREIGN KEY (localization_id, parent_template_id)
+            REFERENCES account_templates(localization_id, id);
+    END IF;
+END $$;
+
+DROP INDEX IF EXISTS idx_account_templates_parent;
+CREATE INDEX IF NOT EXISTS idx_account_templates_parent
+    ON account_templates(parent_template_id);
+CREATE INDEX IF NOT EXISTS idx_account_templates_localization_parent_code
+    ON account_templates(localization_id, parent_code);
+CREATE INDEX IF NOT EXISTS idx_account_templates_localization_class
+    ON account_templates(localization_id, account_class);
+CREATE INDEX IF NOT EXISTS idx_account_templates_localization_active
+    ON account_templates(localization_id, is_active) WHERE is_active = true;
+
+-- Minimal non-statutory hospitality chart. Repeated class codes are deliberate:
+-- uniqueness and hierarchy are local to WARO_HOSPITALITY_GLOBAL_V1.
+INSERT INTO account_templates (
+    localization_id, code, standard_name, account_class, account_type,
+    normal_balance, level, parent_code, is_detail, niif_group, is_active
+) VALUES
+    ('WARO_HOSPITALITY_GLOBAL_V1', '1',    'Assets',                     '1', 'asset',     'debit',  1, NULL, false, NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '10',   'Current assets',             '1', 'asset',     'debit',  2, '1',  false, NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '1000', 'Cash',                       '1', 'asset',     'debit',  4, '10', true,  NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '1010', 'Bank',                       '1', 'asset',     'debit',  4, '10', true,  NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '1100', 'Accounts receivable',        '1', 'asset',     'debit',  4, '10', true,  NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '1200', 'Inventory',                  '1', 'asset',     'debit',  4, '10', true,  NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '2',    'Liabilities',                '2', 'liability', 'credit', 1, NULL, false, NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '20',   'Current liabilities',        '2', 'liability', 'credit', 2, '2',  false, NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '2000', 'Accounts payable',           '2', 'liability', 'credit', 4, '20', true,  NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '2100', 'Tax payable',                '2', 'liability', 'credit', 4, '20', true,  NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '2200', 'Customer advances',          '2', 'liability', 'credit', 4, '20', true,  NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '4',    'Revenue',                    '4', 'income',    'credit', 1, NULL, false, NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '40',   'Operating revenue',          '4', 'income',    'credit', 2, '4',  false, NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '4000', 'Sales revenue',              '4', 'income',    'credit', 4, '40', true,  NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '5',    'Expenses',                   '5', 'expense',   'debit',  1, NULL, false, NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '50',   'Operating expenses',         '5', 'expense',   'debit',  2, '5',  false, NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '5000', 'Payroll expense',            '5', 'expense',   'debit',  4, '50', true,  NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '6',    'Cost of goods sold',         '6', 'cogs',      'debit',  1, NULL, false, NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '60',   'Cost of goods sold details', '6', 'cogs',      'debit',  2, '6',  false, NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '6000', 'Cost of goods sold',         '6', 'cogs',      'debit',  4, '60', true,  NULL, true)
+ON CONFLICT (localization_id, code) DO UPDATE SET
+    standard_name = EXCLUDED.standard_name,
+    account_class = EXCLUDED.account_class,
+    account_type = EXCLUDED.account_type,
+    normal_balance = EXCLUDED.normal_balance,
+    level = EXCLUDED.level,
+    parent_code = EXCLUDED.parent_code,
+    is_detail = EXCLUDED.is_detail,
+    niif_group = EXCLUDED.niif_group,
+    is_active = EXCLUDED.is_active;
+
+UPDATE account_templates child
+SET parent_template_id = parent.id
+FROM account_templates parent
+WHERE parent.localization_id = child.localization_id
+  AND parent.code = child.parent_code
+  AND child.parent_code IS NOT NULL
+  AND child.parent_template_id IS DISTINCT FROM parent.id;
+
+CREATE TABLE IF NOT EXISTS account_template_role_defaults (
+    localization_id VARCHAR(50) NOT NULL,
+    role VARCHAR(40) NOT NULL CHECK (role IN (
+        'CASH', 'BANK', 'ACCOUNTS_RECEIVABLE', 'INVENTORY',
+        'ACCOUNTS_PAYABLE', 'SALES_REVENUE', 'TAX_PAYABLE', 'COGS',
+        'PAYROLL_EXPENSE', 'CUSTOMER_ADVANCES'
+    )),
+    account_template_id UUID NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (localization_id, role),
+    CONSTRAINT fk_account_template_role_localization
+        FOREIGN KEY (localization_id) REFERENCES accounting_localizations(id),
+    CONSTRAINT fk_account_template_role_template
+        FOREIGN KEY (localization_id, account_template_id)
+        REFERENCES account_templates(localization_id, id)
+);
+
+WITH role_codes(role, code) AS (
+    VALUES
+        ('CASH', '1105'),
+        ('BANK', '1110'),
+        ('ACCOUNTS_RECEIVABLE', '1305'),
+        ('INVENTORY', '1435'),
+        ('ACCOUNTS_PAYABLE', '2205'),
+        ('SALES_REVENUE', '4175'),
+        ('COGS', '6135'),
+        ('PAYROLL_EXPENSE', '5105'),
+        ('CUSTOMER_ADVANCES', '2810')
+)
+INSERT INTO account_template_role_defaults (localization_id, role, account_template_id)
+SELECT 'WARO_CO_PUC_V1', role_codes.role, templates.id
+FROM role_codes
+JOIN account_templates templates
+  ON templates.localization_id = 'WARO_CO_PUC_V1'
+ AND templates.code = role_codes.code
+ON CONFLICT (localization_id, role) DO UPDATE
+SET account_template_id = EXCLUDED.account_template_id;
+
+WITH role_codes(role, code) AS (
+    VALUES
+        ('CASH', '1000'),
+        ('BANK', '1010'),
+        ('ACCOUNTS_RECEIVABLE', '1100'),
+        ('INVENTORY', '1200'),
+        ('ACCOUNTS_PAYABLE', '2000'),
+        ('TAX_PAYABLE', '2100'),
+        ('CUSTOMER_ADVANCES', '2200'),
+        ('SALES_REVENUE', '4000'),
+        ('PAYROLL_EXPENSE', '5000'),
+        ('COGS', '6000')
+)
+INSERT INTO account_template_role_defaults (localization_id, role, account_template_id)
+SELECT 'WARO_HOSPITALITY_GLOBAL_V1', role_codes.role, templates.id
+FROM role_codes
+JOIN account_templates templates
+  ON templates.localization_id = 'WARO_HOSPITALITY_GLOBAL_V1'
+ AND templates.code = role_codes.code
+ON CONFLICT (localization_id, role) DO UPDATE
+SET account_template_id = EXCLUDED.account_template_id;
+
+CREATE OR REPLACE FUNCTION seed_tenant_accounts(
+    p_tenant_id UUID,
+    p_localization_id VARCHAR(50)
+)
+RETURNS VOID AS $$
+DECLARE
+    v_profile_localization VARCHAR(50);
+BEGIN
+    SELECT accounting_localization
+    INTO v_profile_localization
+    FROM tenant_financial_profiles
+    WHERE tenant_id = p_tenant_id;
+
+    IF v_profile_localization IS NULL THEN
+        RAISE EXCEPTION 'Tenant % has no financial profile', p_tenant_id;
+    END IF;
+
+    IF v_profile_localization <> p_localization_id THEN
+        RAISE EXCEPTION 'Localization % does not match tenant % profile %',
+            p_localization_id, p_tenant_id, v_profile_localization;
+    END IF;
+
+    INSERT INTO tenant_accounts (
+        tenant_id, template_id, code, name,
+        account_class, account_type, normal_balance,
+        level, is_detail, is_system, is_active
+    )
+    SELECT
+        p_tenant_id, templates.id, templates.code, templates.standard_name,
+        templates.account_class, templates.account_type, templates.normal_balance,
+        templates.level, templates.is_detail, true, true
+    FROM account_templates templates
+    WHERE templates.localization_id = p_localization_id
+      AND templates.is_active = true
+    ON CONFLICT (tenant_id, code) DO NOTHING;
+
+    UPDATE tenant_accounts child_account
+    SET parent_id = parent_account.id
+    FROM account_templates child_template
+    JOIN account_templates parent_template
+      ON parent_template.localization_id = child_template.localization_id
+     AND parent_template.id = child_template.parent_template_id
+    JOIN tenant_accounts parent_account
+      ON parent_account.tenant_id = p_tenant_id
+     AND parent_account.code = parent_template.code
+    WHERE child_account.tenant_id = p_tenant_id
+      AND child_account.template_id = child_template.id
+      AND child_template.localization_id = p_localization_id
+      AND child_account.parent_id IS DISTINCT FROM parent_account.id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Compatibility entry point for callers that already know only the tenant.
+CREATE OR REPLACE FUNCTION seed_tenant_accounts(p_tenant_id UUID)
+RETURNS VOID AS $$
+DECLARE
+    v_localization_id VARCHAR(50);
+BEGIN
+    SELECT accounting_localization
+    INTO v_localization_id
+    FROM tenant_financial_profiles
+    WHERE tenant_id = p_tenant_id;
+
+    IF v_localization_id IS NULL THEN
+        RAISE EXCEPTION 'Tenant % has no financial profile', p_tenant_id;
+    END IF;
+
+    PERFORM seed_tenant_accounts(p_tenant_id, v_localization_id);
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON TABLE accounting_localizations IS
+    'Versioned accounting template catalogs. Global is managerial and non-statutory.';
+COMMENT ON TABLE account_template_role_defaults IS
+    'Semantic role defaults per localization; tax-specific CO bindings remain separate.';
+COMMENT ON COLUMN account_templates.parent_code IS
+    'Human-readable bootstrap metadata; parent_template_id is the authoritative hierarchy.';
+COMMENT ON COLUMN account_templates.parent_template_id IS
+    'Parent template UUID constrained to the same accounting localization.';

--- a/tests/sql/accounting_localizations.sql
+++ b/tests/sql/accounting_localizations.sql
@@ -1,0 +1,161 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- The script expects a disposable database with migrations through 103. It is
+-- transaction-wrapped and leaves no fixtures or migration changes behind.
+\ir ../../migrations/104_accounting_localizations.sql
+
+CREATE TEMP TABLE co_templates_before AS
+SELECT id, code, standard_name, parent_code, parent_template_id
+FROM account_templates
+WHERE localization_id = 'WARO_CO_PUC_V1';
+
+CREATE TEMP TABLE journal_lines_before AS
+SELECT id, account_id
+FROM tenant_journal_lines;
+
+-- A second application must be a no-op for identities and historical links.
+\ir ../../migrations/104_accounting_localizations.sql
+
+DO $$
+BEGIN
+    IF EXISTS (
+        (SELECT id, code, standard_name, parent_code, parent_template_id
+         FROM co_templates_before
+         EXCEPT
+         SELECT id, code, standard_name, parent_code, parent_template_id
+         FROM account_templates
+         WHERE localization_id = 'WARO_CO_PUC_V1')
+        UNION ALL
+        (SELECT id, code, standard_name, parent_code, parent_template_id
+         FROM account_templates
+         WHERE localization_id = 'WARO_CO_PUC_V1'
+         EXCEPT
+         SELECT id, code, standard_name, parent_code, parent_template_id
+         FROM co_templates_before)
+    ) THEN
+        RAISE EXCEPTION 'CO templates changed on idempotent migration';
+    END IF;
+
+    IF EXISTS (
+        (SELECT id, account_id FROM journal_lines_before
+         EXCEPT SELECT id, account_id FROM tenant_journal_lines)
+        UNION ALL
+        (SELECT id, account_id FROM tenant_journal_lines
+         EXCEPT SELECT id, account_id FROM journal_lines_before)
+    ) THEN
+        RAISE EXCEPTION 'Historical journal account_id changed';
+    END IF;
+
+    IF (SELECT COUNT(*) FROM account_template_role_defaults
+        WHERE localization_id = 'WARO_CO_PUC_V1') <> 9 THEN
+        RAISE EXCEPTION 'CO must have nine generic defaults; tax remains specific';
+    END IF;
+
+    IF (SELECT COUNT(*) FROM account_template_role_defaults
+        WHERE localization_id = 'WARO_HOSPITALITY_GLOBAL_V1') <> 10 THEN
+        RAISE EXCEPTION 'Global must have ten semantic defaults';
+    END IF;
+END $$;
+
+-- Temp tables shadow production tenant data while exercising the real function.
+CREATE TEMP TABLE tenant_financial_profiles (
+    tenant_id UUID PRIMARY KEY,
+    accounting_localization VARCHAR(50) NOT NULL
+);
+
+CREATE TEMP TABLE tenant_accounts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+    template_id UUID,
+    code VARCHAR(10) NOT NULL,
+    name VARCHAR(200) NOT NULL,
+    account_class VARCHAR(1) NOT NULL,
+    account_type VARCHAR(30) NOT NULL,
+    normal_balance VARCHAR(6) NOT NULL,
+    level INT NOT NULL,
+    parent_id UUID,
+    is_detail BOOLEAN NOT NULL DEFAULT false,
+    is_system BOOLEAN NOT NULL DEFAULT false,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    UNIQUE (tenant_id, code)
+);
+
+INSERT INTO tenant_financial_profiles VALUES
+    ('00000000-0000-0000-0000-000000000624', 'WARO_CO_PUC_V1'),
+    ('00000000-0000-0000-0000-000000000625', 'WARO_HOSPITALITY_GLOBAL_V1');
+
+INSERT INTO tenant_accounts (
+    tenant_id, template_id, code, name, account_class, account_type,
+    normal_balance, level, is_detail, is_system, is_active
+) VALUES (
+    '00000000-0000-0000-0000-000000000625', NULL, '1000', 'Custom cash',
+    '1', 'asset', 'debit', 4, true, false, true
+);
+
+SELECT seed_tenant_accounts(
+    '00000000-0000-0000-0000-000000000624', 'WARO_CO_PUC_V1'
+);
+SELECT seed_tenant_accounts(
+    '00000000-0000-0000-0000-000000000625', 'WARO_HOSPITALITY_GLOBAL_V1'
+);
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM tenant_accounts accounts
+        JOIN account_templates templates ON templates.id = accounts.template_id
+        WHERE accounts.tenant_id = '00000000-0000-0000-0000-000000000624'
+          AND templates.localization_id <> 'WARO_CO_PUC_V1'
+    ) THEN
+        RAISE EXCEPTION 'CO tenant received another localization';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM tenant_accounts accounts
+        JOIN account_templates templates ON templates.id = accounts.template_id
+        WHERE accounts.tenant_id = '00000000-0000-0000-0000-000000000625'
+          AND templates.localization_id <> 'WARO_HOSPITALITY_GLOBAL_V1'
+    ) THEN
+        RAISE EXCEPTION 'Global tenant received CO templates';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM tenant_accounts
+        WHERE tenant_id = '00000000-0000-0000-0000-000000000625'
+          AND code = '1000' AND name = 'Custom cash' AND template_id IS NULL
+    ) THEN
+        RAISE EXCEPTION 'Custom conflicting account was overwritten';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM tenant_accounts accounts
+        JOIN account_templates templates ON templates.id = accounts.template_id
+        WHERE accounts.tenant_id IN (
+            '00000000-0000-0000-0000-000000000624',
+            '00000000-0000-0000-0000-000000000625'
+        )
+          AND templates.parent_template_id IS NOT NULL
+          AND accounts.parent_id IS NULL
+    ) THEN
+        RAISE EXCEPTION 'Seeded hierarchy contains an orphan';
+    END IF;
+
+    BEGIN
+        PERFORM seed_tenant_accounts(
+            '00000000-0000-0000-0000-000000000625', 'WARO_CO_PUC_V1'
+        );
+        RAISE EXCEPTION 'Mismatched localization was accepted';
+    EXCEPTION
+        WHEN raise_exception THEN
+            IF SQLERRM = 'Mismatched localization was accepted' THEN
+                RAISE;
+            END IF;
+    END;
+END $$;
+
+ROLLBACK;

--- a/tests/test_accounting_localizations.py
+++ b/tests/test_accounting_localizations.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION_022 = (ROOT / "migrations/022_create_account_templates.sql").read_text()
+MIGRATION_025 = (ROOT / "migrations/025_seed_puc_account_templates.sql").read_text()
+MIGRATION_029 = (ROOT / "migrations/029_order_gl_and_tax_fixes.sql").read_text()
+MIGRATION_104 = (ROOT / "migrations/104_accounting_localizations.sql").read_text()
+
+
+def test_bootstrap_schema_is_localized_and_versioned():
+    assert "CREATE TABLE IF NOT EXISTS accounting_localizations" in MIGRATION_022
+    assert "version INT NOT NULL" in MIGRATION_022
+    assert "localization_id VARCHAR(50)" in MIGRATION_022
+    assert "UNIQUE (localization_id, code)" in MIGRATION_022
+    assert "FOREIGN KEY (localization_id, parent_template_id)" in MIGRATION_022
+    assert "no representa NIIF, GAAP ni cumplimiento legal local" in MIGRATION_022
+
+
+def test_upgrade_backfills_co_before_removing_global_code_identity():
+    backfill = MIGRATION_104.index("UPDATE account_templates\nSET localization_id")
+    drop_global_unique = MIGRATION_104.index("DROP CONSTRAINT IF EXISTS account_templates_code_key")
+    global_seed = MIGRATION_104.index("Minimal non-statutory hospitality chart")
+    assert backfill < drop_global_unique < global_seed
+    assert "WHERE localization_id IS NULL" in MIGRATION_104
+    assert "DELETE FROM tenant_accounts" not in MIGRATION_104
+    assert "UPDATE tenant_journal_lines" not in MIGRATION_104
+    assert "FOR t_id IN SELECT id FROM tenants" not in MIGRATION_104
+
+
+def test_global_chart_is_managerial_and_contains_only_generic_role_accounts():
+    for code, name in (
+        ("1000", "Cash"),
+        ("1010", "Bank"),
+        ("1100", "Accounts receivable"),
+        ("1200", "Inventory"),
+        ("2000", "Accounts payable"),
+        ("2100", "Tax payable"),
+        ("2200", "Customer advances"),
+        ("4000", "Sales revenue"),
+        ("5000", "Payroll expense"),
+        ("6000", "Cost of goods sold"),
+    ):
+        assert f"'{code}', '{name}'" in MIGRATION_104
+    global_seed = MIGRATION_104.split("Minimal non-statutory hospitality chart", 1)[1]
+    global_seed = global_seed.split("CREATE TABLE IF NOT EXISTS account_template_role_defaults", 1)[0]
+    for colombian_term in ("Impoconsumo", "IVA por pagar", "Cesant", "Retenci"):
+        assert colombian_term not in global_seed
+
+
+def test_semantic_roles_are_scoped_and_co_tax_stays_specific():
+    roles = (
+        "CASH",
+        "BANK",
+        "ACCOUNTS_RECEIVABLE",
+        "INVENTORY",
+        "ACCOUNTS_PAYABLE",
+        "SALES_REVENUE",
+        "TAX_PAYABLE",
+        "COGS",
+        "PAYROLL_EXPENSE",
+        "CUSTOMER_ADVANCES",
+    )
+    for role in roles:
+        assert f"'{role}'" in MIGRATION_104
+    co_roles = MIGRATION_104.split("WITH role_codes(role, code) AS (", 1)[1]
+    co_roles = co_roles.split("WITH role_codes(role, code) AS (", 1)[0]
+    assert "('TAX_PAYABLE'" not in co_roles
+    assert "('CUSTOMER_ADVANCES', '2810')" in co_roles
+
+
+def test_seed_function_requires_profile_localization_and_is_tenant_scoped():
+    assert "p_localization_id VARCHAR(50)" in MIGRATION_104
+    assert "v_profile_localization <> p_localization_id" in MIGRATION_104
+    assert "templates.localization_id = p_localization_id" in MIGRATION_104
+    assert "ON CONFLICT (tenant_id, code) DO NOTHING" in MIGRATION_104
+    assert "parent_template.id = child_template.parent_template_id" in MIGRATION_104
+    assert "parent_account.tenant_id = p_tenant_id" in MIGRATION_104
+
+
+def test_historical_bootstrap_conflicts_are_localization_aware():
+    assert MIGRATION_025.count("ON CONFLICT (localization_id, code) DO NOTHING") == 3
+    assert "at.localization_id = 'WARO_CO_PUC_V1'" in MIGRATION_025
+    assert MIGRATION_029.count("ON CONFLICT (localization_id, code) DO NOTHING") == 3
+    assert "WHERE localization_id = 'WARO_CO_PUC_V1'" in MIGRATION_029


### PR DESCRIPTION
## Summary
- version account templates by accounting localization while preserving existing CO template IDs
- add the non-fiscal WARO Hospitality Global chart and semantic role defaults
- seed tenant accounts only from the localization authorized by the financial profile

Depends on #625.

## Tests
- `venv/bin/pytest -q tests/test_accounting_localizations.py tests/test_tenant_financial_profile.py`
- PostgreSQL ephemeral upgrade, idempotency, bootstrap, tenant isolation and historical account-link checks
- Ruff unavailable in the repository environment

Closes #624