### PR TITLE
feat: resolve automatic journals by semantic roles

### DIFF
--- a/app/models/accounting.py
+++ b/app/models/accounting.py
@@ -53,6 +53,33 @@ class TenantAccountUpdate(BaseModel):
         populate_by_name = True
 
 
+class AccountRoleOverrideUpdate(BaseModel):
+    account_id: UUID = Field(alias='accountId')
+
+    class Config:
+        populate_by_name = True
+
+
+class AccountRoleBinding(BaseModel):
+    role: str
+    colombia_only: bool = Field(alias='colombiaOnly')
+    account_id: Optional[UUID] = Field(None, alias='accountId')
+    code: Optional[str] = None
+    name: Optional[str] = None
+    source: str
+
+    class Config:
+        populate_by_name = True
+
+
+class AccountRoleBindingsResponse(BaseModel):
+    success: bool = True
+    data: List[AccountRoleBinding]
+
+    class Config:
+        populate_by_name = True
+
+
 class TenantAccount(TenantAccountBase):
     id: UUID
     tenant_id: UUID = Field(alias='tenantId')
@@ -284,6 +311,8 @@ class PLPeriodData(BaseModel):
 
 class PLStatementResponse(BaseModel):
     success: bool = True
+    base_currency_code: str = Field(alias='baseCurrencyCode')
+    accounting_localization: str = Field(alias='accountingLocalization')
     current: PLPeriodData
     previous: Optional[PLPeriodData] = None
 

--- a/app/models/payment_method.py
+++ b/app/models/payment_method.py
@@ -5,6 +5,7 @@ Issue: https://github.com/uno0uno/warocol.com/issues/331
 """
 from pydantic import BaseModel, ConfigDict
 from typing import Optional, List
+from uuid import UUID
 
 
 # ── Response models ────────────────────────────────────────────────────────────
@@ -20,6 +21,7 @@ class PaymentMethodGroup(BaseModel):
     isActive: bool
     sortOrder: int
     glAccountCode: Optional[str] = None
+    glAccountId: Optional[str] = None
 
 
 class PaymentMethodGroupWithCount(PaymentMethodGroup):
@@ -37,6 +39,7 @@ class PaymentMethod(BaseModel):
     isActive: bool
     sortOrder: int
     glAccountCode: Optional[str] = None
+    glAccountId: Optional[str] = None
 
 
 class PaymentMethodGroupWithMethods(PaymentMethodGroup):
@@ -49,6 +52,7 @@ class PosPaymentMethod(BaseModel):
     id: str
     name: str
     glAccountCode: Optional[str] = None
+    glAccountId: Optional[str] = None
 
 
 class PosPaymentMethodGroup(BaseModel):
@@ -57,6 +61,7 @@ class PosPaymentMethodGroup(BaseModel):
     slug: str
     triggersCartera: bool
     glAccountCode: Optional[str] = None
+    glAccountId: Optional[str] = None
     methods: List[PosPaymentMethod] = []
 
 
@@ -75,6 +80,7 @@ class PatchGroupRequest(BaseModel):
     sortOrder: Optional[int] = None
     triggersCartera: Optional[bool] = None
     glAccountCode: Optional[str] = None
+    glAccountId: Optional[UUID] = None
 
 
 class CreateMethodRequest(BaseModel):
@@ -85,6 +91,7 @@ class CreateMethodRequest(BaseModel):
     # in /finanzas/metodos-pago/{groupId} creates the sub-account first and
     # passes its code in here so the method is linked in one round-trip.
     glAccountCode: Optional[str] = None
+    glAccountId: Optional[UUID] = None
 
 
 class PatchMethodRequest(BaseModel):
@@ -93,3 +100,4 @@ class PatchMethodRequest(BaseModel):
     isActive: Optional[bool] = None
     sortOrder: Optional[int] = None
     glAccountCode: Optional[str] = None
+    glAccountId: Optional[UUID] = None

--- a/app/models/tax_config.py
+++ b/app/models/tax_config.py
@@ -1,6 +1,7 @@
 """Pydantic v2 models for tenant tax configuration."""
 from decimal import Decimal
 from datetime import datetime
+from typing import Optional
 from uuid import UUID
 from pydantic import BaseModel, ConfigDict
 
@@ -13,14 +14,17 @@ class TaxConfigResponse(BaseModel):
     inc_applicable: bool
     inc_rate: Decimal
     inc_gl_account_code: str
+    inc_gl_account_id: Optional[UUID] = None
     inc_included_in_price: bool
     iva_applicable: bool
     iva_rate: Decimal
     iva_gl_account_code: str
+    iva_gl_account_id: Optional[UUID] = None
     iva_included_in_price: bool
     liquor_tax_applicable: bool
     liquor_tax_rate: Decimal
     liquor_tax_gl_account_code: str
+    liquor_tax_gl_account_id: Optional[UUID] = None
     created_at: datetime
     updated_at: datetime
 
@@ -31,3 +35,6 @@ class TaxConfigUpdate(BaseModel):
     iva_applicable: bool
     iva_included_in_price: bool
     liquor_tax_applicable: bool
+    inc_gl_account_id: Optional[UUID] = None
+    iva_gl_account_id: Optional[UUID] = None
+    liquor_tax_gl_account_id: Optional[UUID] = None

--- a/app/routers/accounting.py
+++ b/app/routers/accounting.py
@@ -4,6 +4,9 @@ from fastapi import Depends, APIRouter, Request, Query
 from app.core.permissions import Module, require_module
 from app.services.accounting_service import (
     get_accounts,
+    get_account_role_bindings,
+    update_account_role_binding,
+    remove_account_role_binding,
     create_account,
     update_account,
     delete_account,
@@ -22,6 +25,8 @@ from app.models.accounting import (
     TenantAccountUpdate,
     TenantAccountResponse,
     TenantAccountsListResponse,
+    AccountRoleBindingsResponse,
+    AccountRoleOverrideUpdate,
     JournalEntryCreate,
     JournalEntryResponse,
     JournalEntriesListResponse,
@@ -44,10 +49,30 @@ async def list_accounts_endpoint(
 ):
     """
     Get the full chart of accounts for the authenticated tenant.
-    Optional query filters: class (PUC class digit), type, active.
+    Optional query filters: semantic account class, type, active.
     Requires valid session cookie with selected tenant.
     """
     return await get_accounts(request, account_class=account_class, account_type=account_type, active=active)
+
+
+@router.get("/account-roles", response_model=AccountRoleBindingsResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
+async def list_account_roles_endpoint(request: Request):
+    """List effective semantic account bindings for the tenant localization."""
+    return await get_account_role_bindings(request)
+
+
+@router.put("/account-roles/{role}", response_model=AccountRoleBindingsResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
+async def update_account_role_endpoint(
+    request: Request, role: str, body: AccountRoleOverrideUpdate
+):
+    """Override a role with an active account owned by this tenant."""
+    return await update_account_role_binding(request, role, body.account_id)
+
+
+@router.delete("/account-roles/{role}", response_model=AccountRoleBindingsResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
+async def delete_account_role_endpoint(request: Request, role: str):
+    """Remove a tenant override and return to the localization default."""
+    return await remove_account_role_binding(request, role)
 
 
 @router.post("/accounts", response_model=TenantAccountResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
@@ -196,10 +221,10 @@ async def get_pl_statement_endpoint(
     COGS     = expenses with expense_type='cogs' + received purchases in the month.
     Opex     = expenses by category (RENT, UTILITIES, MAINTENANCE, other).
     Payroll  = confirmed salary_payments for the period.
-    Provisions = Colombian law rates applied to latest employee salary configs.
+    Provisions = Colombian law rates only when the tenant capability enables them.
 
     If comparePrevious=true, also returns the prior calendar month data.
-    All values in COP (Colombian pesos). Returns zeros for periods with no activity.
+    Values use baseCurrencyCode from the response. Returns zeros for empty periods.
     """
     return await get_pl_statement(
         request,
@@ -235,7 +260,7 @@ async def post_provisions_endpoint(
 ):
     """
     Calculate and post 4 GL entries for nómina provisions (one per provision type).
-    Debit: 5105 Gastos de personal. Credit: 2610/2615/2620/2625.
+    Accounts are resolved from semantic payroll expense/payable roles.
     If provision entries for this period were already posted, they are voided first.
     source_module = 'nomina'. Safe to re-run.
     """

--- a/app/routers/salaries.py
+++ b/app/routers/salaries.py
@@ -5,6 +5,7 @@ Handles employee salary configuration and payment registration
 import logging
 from fastapi import APIRouter, Request, UploadFile, File, Form, HTTPException, Depends
 from app.core.permissions import Module, require_module
+from app.services.account_role_service import require_colombia_payroll_capability
 from typing import List, Optional
 from uuid import UUID
 from decimal import Decimal
@@ -77,7 +78,7 @@ from app.models.salary import (
 )
 
 logger = logging.getLogger(__name__)
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_colombia_payroll_capability)])
 
 
 # =============================================================================

--- a/app/services/account_role_service.py
+++ b/app/services/account_role_service.py
@@ -1,0 +1,398 @@
+"""Resolve tenant GL accounts by semantic role instead of localization codes."""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from app.core.exceptions import APIError
+from app.core.middleware import require_valid_session
+from app.database import get_db_connection
+
+
+class AccountRole:
+    CASH = "CASH"
+    BANK = "BANK"
+    ACCOUNTS_RECEIVABLE = "ACCOUNTS_RECEIVABLE"
+    INVENTORY = "INVENTORY"
+    ACCOUNTS_PAYABLE = "ACCOUNTS_PAYABLE"
+    SALES_REVENUE = "SALES_REVENUE"
+    TAX_PAYABLE = "TAX_PAYABLE"
+    COGS = "COGS"
+    PAYROLL_EXPENSE = "PAYROLL_EXPENSE"
+    CUSTOMER_ADVANCES = "CUSTOMER_ADVANCES"
+    INC_PAYABLE = "INC_PAYABLE"
+    IVA_PAYABLE = "IVA_PAYABLE"
+    LIQUOR_TAX_PAYABLE = "LIQUOR_TAX_PAYABLE"
+    CONTRACTOR_EXPENSE = "CONTRACTOR_EXPENSE"
+    WITHHOLDING_PAYABLE = "WITHHOLDING_PAYABLE"
+    EMPLOYEE_SS_PAYABLE = "EMPLOYEE_SS_PAYABLE"
+    EMPLOYER_SS_PAYABLE = "EMPLOYER_SS_PAYABLE"
+    EMPLOYER_SS_EXPENSE = "EMPLOYER_SS_EXPENSE"
+    PRIMA_EXPENSE = "PRIMA_EXPENSE"
+    PRIMA_PAYABLE = "PRIMA_PAYABLE"
+    CESANTIAS_EXPENSE = "CESANTIAS_EXPENSE"
+    CESANTIAS_PAYABLE = "CESANTIAS_PAYABLE"
+    CESANTIAS_INTEREST_EXPENSE = "CESANTIAS_INTEREST_EXPENSE"
+    CESANTIAS_INTEREST_PAYABLE = "CESANTIAS_INTEREST_PAYABLE"
+    VACATION_EXPENSE = "VACATION_EXPENSE"
+    VACATION_PAYABLE = "VACATION_PAYABLE"
+    OVERTIME_EXPENSE = "OVERTIME_EXPENSE"
+    DOTACION_EXPENSE = "DOTACION_EXPENSE"
+    TERMINATION_EXPENSE = "TERMINATION_EXPENSE"
+    BANK_FEES_EXPENSE = "BANK_FEES_EXPENSE"
+    OTHER_INCOME = "OTHER_INCOME"
+
+
+PAYMENT_ROLE_BY_SLUG = {
+    "cash": AccountRole.CASH,
+    "transfer": AccountRole.BANK,
+    "check": AccountRole.BANK,
+    "digital": AccountRole.BANK,
+    "card": AccountRole.BANK,
+    "credit_card": AccountRole.BANK,
+    "debit_card": AccountRole.BANK,
+    "other": AccountRole.BANK,
+    "credit": AccountRole.ACCOUNTS_RECEIVABLE,
+    "customer_wallet": AccountRole.CUSTOMER_ADVANCES,
+    "table_session_advance": AccountRole.CUSTOMER_ADVANCES,
+}
+
+_TAX_BINDINGS = {
+    "inc": ("inc_gl_account_id", "inc_gl_account_code", AccountRole.INC_PAYABLE),
+    "iva": ("iva_gl_account_id", "iva_gl_account_code", AccountRole.IVA_PAYABLE),
+    "liquor": (
+        "liquor_tax_gl_account_id",
+        "liquor_tax_gl_account_code",
+        AccountRole.LIQUOR_TAX_PAYABLE,
+    ),
+}
+
+
+@dataclass(frozen=True)
+class AccountRef:
+    id: UUID
+    code: str
+    name: str
+    role: Optional[str]
+    source: str
+
+
+class MissingAccountRoleError(APIError):
+    def __init__(self, tenant_id: UUID, role: str, source: Optional[str] = None):
+        self.tenant_id = tenant_id
+        self.role = role
+        self.source = source
+        suffix = " for {}".format(source) if source else ""
+        super().__init__(
+            "Required account role {} is not configured for tenant {}{}".format(
+                role, tenant_id, suffix
+            ),
+            status_code=409,
+            details={"code": "ACCOUNT_ROLE_MISSING", "role": role, "source": source},
+        )
+
+
+def _account_ref(row: Any, role: Optional[str], source: str) -> AccountRef:
+    return AccountRef(
+        id=row["id"],
+        code=str(row["code"]),
+        name=str(row["name"]),
+        role=role,
+        source=source,
+    )
+
+
+async def resolve_account(
+    conn,
+    tenant_id: UUID,
+    role: str,
+    required: bool = True,
+    source: Optional[str] = None,
+) -> Optional[AccountRef]:
+    row = await conn.fetchrow(
+        """
+        SELECT
+            COALESCE(override_account.id, default_account.id) AS id,
+            COALESCE(override_account.code, default_account.code) AS code,
+            COALESCE(override_account.name, default_account.name) AS name,
+            CASE WHEN override_account.id IS NOT NULL THEN 'tenant_override'
+                 ELSE 'localization_default' END AS binding_source
+        FROM tenant_financial_profiles profile
+        LEFT JOIN tenant_account_role_overrides binding
+          ON binding.tenant_id = profile.tenant_id
+         AND binding.role = $2
+        LEFT JOIN tenant_accounts override_account
+          ON override_account.id = binding.tenant_account_id
+         AND override_account.tenant_id = profile.tenant_id
+         AND override_account.is_active = TRUE
+        LEFT JOIN account_template_role_defaults defaults
+          ON defaults.localization_id = profile.accounting_localization
+         AND defaults.role = $2
+        LEFT JOIN tenant_accounts default_account
+          ON default_account.tenant_id = profile.tenant_id
+         AND default_account.template_id = defaults.account_template_id
+         AND default_account.is_active = TRUE
+        WHERE profile.tenant_id = $1
+          AND COALESCE(override_account.id, default_account.id) IS NOT NULL
+        """,
+        tenant_id,
+        role,
+    )
+    if row:
+        return _account_ref(row, role, str(row["binding_source"]))
+    if required:
+        raise MissingAccountRoleError(tenant_id, role, source)
+    return None
+
+
+async def resolve_account_by_id(
+    conn, tenant_id: UUID, account_id: Optional[UUID]
+) -> Optional[AccountRef]:
+    if not account_id:
+        return None
+    row = await conn.fetchrow(
+        """
+        SELECT id, code, name
+        FROM tenant_accounts
+        WHERE id = $1 AND tenant_id = $2 AND is_active = TRUE
+        """,
+        account_id,
+        tenant_id,
+    )
+    return _account_ref(row, None, "explicit_account_id") if row else None
+
+
+async def resolve_legacy_account(
+    conn, tenant_id: UUID, code: Optional[str]
+) -> Optional[AccountRef]:
+    """Compatibility-only lookup for a stored tenant customization."""
+    if not code:
+        return None
+    row = await conn.fetchrow(
+        """
+        SELECT id, code, name
+        FROM tenant_accounts
+        WHERE tenant_id = $1 AND code = $2 AND is_active = TRUE
+        """,
+        tenant_id,
+        str(code),
+    )
+    return _account_ref(row, None, "legacy_binding") if row else None
+
+
+async def resolve_configured_account(
+    conn,
+    tenant_id: UUID,
+    account_id: Optional[UUID],
+    legacy_code: Optional[str],
+    fallback_role: str,
+    source: Optional[str] = None,
+) -> AccountRef:
+    explicit = await resolve_account_by_id(conn, tenant_id, account_id)
+    if explicit:
+        return explicit
+    legacy = await resolve_legacy_account(conn, tenant_id, legacy_code)
+    if legacy:
+        return legacy
+    account = await resolve_account(conn, tenant_id, fallback_role, source=source)
+    assert account is not None
+    return account
+
+
+def payment_role(payment_slug: Optional[str]) -> str:
+    return PAYMENT_ROLE_BY_SLUG.get(payment_slug or "", AccountRole.CASH)
+
+
+async def resolve_payment_account(
+    conn,
+    tenant_id: UUID,
+    payment_slug: Optional[str],
+    payment_method_id: Optional[UUID] = None,
+    payment_group_id: Optional[UUID] = None,
+    source: Optional[str] = None,
+) -> AccountRef:
+    resolved_slug = payment_slug
+    if payment_method_id:
+        row = await conn.fetchrow(
+            """
+            SELECT pm.gl_account_id AS method_account_id,
+                   pm.gl_account_code AS method_legacy_code,
+                   pmg.gl_account_id AS group_account_id,
+                   pmg.gl_account_code AS group_legacy_code,
+                   pmg.tenant_id AS group_tenant_id,
+                   pmg.slug
+            FROM payment_methods pm
+            JOIN payment_method_groups pmg ON pmg.id = pm.group_id
+            WHERE pm.id = $1 AND pm.tenant_id = $2 AND pm.is_active = TRUE
+            """,
+            payment_method_id,
+            tenant_id,
+        )
+        if row:
+            resolved_slug = row["slug"] or resolved_slug
+            account = await resolve_account_by_id(
+                conn, tenant_id, row["method_account_id"] or row["group_account_id"]
+            )
+            if account:
+                return account
+            legacy_code = row["method_legacy_code"]
+            if not legacy_code and row["group_tenant_id"] is not None:
+                legacy_code = row["group_legacy_code"]
+            legacy = await resolve_legacy_account(conn, tenant_id, legacy_code)
+            if legacy:
+                return legacy
+
+    if payment_group_id:
+        row = await conn.fetchrow(
+            """
+            SELECT gl_account_id, gl_account_code, tenant_id, slug
+            FROM payment_method_groups
+            WHERE id = $1 AND (tenant_id = $2 OR tenant_id IS NULL) AND is_active = TRUE
+            """,
+            payment_group_id,
+            tenant_id,
+        )
+        if row:
+            resolved_slug = row["slug"] or resolved_slug
+            account = await resolve_account_by_id(conn, tenant_id, row["gl_account_id"])
+            if account:
+                return account
+            if row["tenant_id"] is not None:
+                legacy = await resolve_legacy_account(
+                    conn, tenant_id, row["gl_account_code"]
+                )
+                if legacy:
+                    return legacy
+
+    account = await resolve_account(
+        conn,
+        tenant_id,
+        payment_role(resolved_slug),
+        source=source or "payment_method",
+    )
+    assert account is not None
+    return account
+
+
+async def resolve_tax_account(
+    conn,
+    tenant_id: UUID,
+    tax_config: Dict[str, Any],
+    tax_kind: str,
+    required: bool = True,
+) -> Optional[AccountRef]:
+    if tax_kind not in _TAX_BINDINGS:
+        raise ValueError("Unsupported tax kind: {}".format(tax_kind))
+    id_field, code_field, role = _TAX_BINDINGS[tax_kind]
+    account_id = tax_config.get(id_field)
+    if account_id and not isinstance(account_id, UUID):
+        account_id = UUID(str(account_id))
+    try:
+        return await resolve_configured_account(
+            conn,
+            tenant_id,
+            account_id,
+            tax_config.get(code_field),
+            role,
+            source="{}_tax".format(tax_kind),
+        )
+    except MissingAccountRoleError:
+        if required:
+            raise
+        return None
+
+
+async def ensure_colombia_payroll(conn, tenant_id: UUID) -> None:
+    enabled = await conn.fetchval(
+        """
+        SELECT country_code = 'CO'
+           AND accounting_localization = 'WARO_CO_PUC_V1'
+        FROM tenant_financial_profiles
+        WHERE tenant_id = $1
+        """,
+        tenant_id,
+    )
+    if not enabled:
+        raise APIError(
+            "La nomina legal colombiana no esta disponible para este perfil financiero",
+            status_code=409,
+            details={"code": "COLOMBIA_PAYROLL_NOT_AVAILABLE"},
+        )
+
+
+async def require_colombia_payroll_capability(request) -> None:
+    session = require_valid_session(request)
+    if not session.tenant_id:
+        raise APIError("Tenant ID is required", status_code=401)
+    async with get_db_connection() as conn:
+        await ensure_colombia_payroll(conn, session.tenant_id)
+
+
+async def list_role_bindings(conn, tenant_id: UUID) -> List[Dict[str, Any]]:
+    rows = await conn.fetch(
+        """
+        SELECT roles.role,
+               roles.colombia_only,
+               COALESCE(override_account.id, default_account.id) AS account_id,
+               COALESCE(override_account.code, default_account.code) AS code,
+               COALESCE(override_account.name, default_account.name) AS name,
+               CASE WHEN override_account.id IS NOT NULL THEN 'tenant_override'
+                    WHEN default_account.id IS NOT NULL THEN 'localization_default'
+                    ELSE 'missing' END AS source
+        FROM tenant_financial_profiles profile
+        JOIN accounting_roles roles
+          ON NOT roles.colombia_only OR profile.country_code = 'CO'
+        LEFT JOIN tenant_account_role_overrides binding
+          ON binding.tenant_id = profile.tenant_id AND binding.role = roles.role
+        LEFT JOIN tenant_accounts override_account
+          ON override_account.id = binding.tenant_account_id
+         AND override_account.tenant_id = profile.tenant_id
+         AND override_account.is_active = TRUE
+        LEFT JOIN account_template_role_defaults defaults
+          ON defaults.localization_id = profile.accounting_localization
+         AND defaults.role = roles.role
+        LEFT JOIN tenant_accounts default_account
+          ON default_account.tenant_id = profile.tenant_id
+         AND default_account.template_id = defaults.account_template_id
+         AND default_account.is_active = TRUE
+        WHERE profile.tenant_id = $1
+        ORDER BY roles.role
+        """,
+        tenant_id,
+    )
+    return [dict(row) for row in rows]
+
+
+async def set_role_override(
+    conn, tenant_id: UUID, role: str, account_id: UUID
+) -> None:
+    valid_role = await conn.fetchval(
+        "SELECT 1 FROM accounting_roles WHERE role = $1", role
+    )
+    account = await resolve_account_by_id(conn, tenant_id, account_id)
+    if not valid_role or not account:
+        raise APIError(
+            "El rol o la cuenta contable no pertenece al tenant",
+            status_code=400,
+            details={"code": "ACCOUNT_ROLE_BINDING_INVALID"},
+        )
+    await conn.execute(
+        """
+        INSERT INTO tenant_account_role_overrides (tenant_id, role, tenant_account_id)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (tenant_id, role) DO UPDATE SET
+            tenant_account_id = EXCLUDED.tenant_account_id,
+            updated_at = NOW()
+        """,
+        tenant_id,
+        role,
+        account_id,
+    )
+
+
+async def delete_role_override(conn, tenant_id: UUID, role: str) -> None:
+    await conn.execute(
+        "DELETE FROM tenant_account_role_overrides WHERE tenant_id = $1 AND role = $2",
+        tenant_id,
+        role,
+    )

--- a/app/services/accounting_service.py
+++ b/app/services/accounting_service.py
@@ -6,13 +6,15 @@ from uuid import UUID
 from fastapi import Request
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
-from app.core.exceptions import AuthenticationError, AuthorizationError, ValidationError
+from app.core.exceptions import APIError, AuthenticationError, AuthorizationError, ValidationError
 from app.models.accounting import (
     TenantAccount,
     TenantAccountCreate,
     TenantAccountUpdate,
     TenantAccountResponse,
     TenantAccountsListResponse,
+    AccountRoleBinding,
+    AccountRoleBindingsResponse,
     JournalEntryCreate,
     JournalEntry,
     JournalEntryWithLines,
@@ -31,6 +33,14 @@ from app.models.accounting import (
     ProvisionsBreakdown,
     ProvisionsPreviewResponse,
     ProvisionsPostResponse,
+)
+from app.services.account_role_service import (
+    AccountRole,
+    delete_role_override,
+    ensure_colombia_payroll,
+    list_role_bindings,
+    resolve_account,
+    set_role_override,
 )
 
 logger = logging.getLogger(__name__)
@@ -137,6 +147,48 @@ async def get_accounts(
         raise ValidationError("Error al obtener cuentas")
 
 
+async def get_account_role_bindings(request: Request) -> AccountRoleBindingsResponse:
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("No hay un tenant seleccionado")
+    async with get_db_connection() as conn:
+        rows = await list_role_bindings(conn, tenant_id)
+    return AccountRoleBindingsResponse(
+        data=[AccountRoleBinding(**row) for row in rows]
+    )
+
+
+async def update_account_role_binding(
+    request: Request, role: str, account_id: UUID
+) -> AccountRoleBindingsResponse:
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("No hay un tenant seleccionado")
+    async with get_db_connection() as conn:
+        await set_role_override(conn, tenant_id, role.upper(), account_id)
+        rows = await list_role_bindings(conn, tenant_id)
+    return AccountRoleBindingsResponse(
+        data=[AccountRoleBinding(**row) for row in rows]
+    )
+
+
+async def remove_account_role_binding(
+    request: Request, role: str
+) -> AccountRoleBindingsResponse:
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("No hay un tenant seleccionado")
+    async with get_db_connection() as conn:
+        await delete_role_override(conn, tenant_id, role.upper())
+        rows = await list_role_bindings(conn, tenant_id)
+    return AccountRoleBindingsResponse(
+        data=[AccountRoleBinding(**row) for row in rows]
+    )
+
+
 async def create_account(request: Request, body: TenantAccountCreate) -> TenantAccountResponse:
     """
     Create a custom account for the tenant.
@@ -158,9 +210,15 @@ async def create_account(request: Request, body: TenantAccountCreate) -> TenantA
         if not code:
             raise ValidationError("El código de la cuenta es requerido")
 
-        level = _derive_level(code)
-
         async with get_db_connection() as conn:
+            localization = await conn.fetchval(
+                "SELECT accounting_localization FROM tenant_financial_profiles WHERE tenant_id = $1",
+                tenant_id,
+            )
+            level = _derive_level(code) if localization == "WARO_CO_PUC_V1" else body.level
+            if level not in (1, 2, 4, 6, 8):
+                raise ValidationError("Nivel contable invalido")
+
             # Ensure code is unique within tenant
             existing = await conn.fetchval(
                 "SELECT 1 FROM tenant_accounts WHERE tenant_id = $1 AND code = $2",
@@ -219,7 +277,7 @@ async def create_account(request: Request, body: TenantAccountCreate) -> TenantA
         logger.info(f"✅ Account created: {code} for tenant {tenant_id}")
         return TenantAccountResponse(data=account)
 
-    except (AuthenticationError, AuthorizationError, ValidationError):
+    except (APIError, AuthenticationError, AuthorizationError, ValidationError):
         raise
     except Exception as e:
         logger.error(f"❌ Error creating account: {e}", exc_info=True)
@@ -1118,6 +1176,7 @@ async def _compute_pl_for_period(
     tenant_id: UUID,
     year: int,
     month: int,
+    include_colombia_payroll: bool = True,
 ) -> PLPeriodData:
     """
     Compute the full P&L for a single calendar month.
@@ -1202,37 +1261,39 @@ async def _compute_pl_for_period(
         bucket = _OPEX_CATEGORY_MAP.get(row['category_code'], 'other')
         opex_buckets[bucket] += Decimal(str(row['total']))
 
-    # --- Payroll ---
-    payroll_row = await conn.fetchrow(
-        """
-        SELECT COALESCE(SUM(sp.payment_amount), 0) AS total
-        FROM salary_payments sp
-        JOIN tenant_members tm ON tm.id = sp.tenant_member_id
-        WHERE tm.tenant_id = $1
-          AND sp.period_month = $2
-          AND sp.status = 'paid'
-        """,
-        tenant_id, month_str,
-    )
-    payroll = Decimal(str(payroll_row['total']))
+    payroll = Decimal('0')
+    prov_base = Decimal('0')
+    if include_colombia_payroll:
+        payroll_row = await conn.fetchrow(
+            """
+            SELECT COALESCE(SUM(sp.payment_amount), 0) AS total
+            FROM salary_payments sp
+            JOIN tenant_members tm ON tm.id = sp.tenant_member_id
+            WHERE tm.tenant_id = $1
+              AND sp.period_month = $2
+              AND sp.status = 'paid'
+            """,
+            tenant_id, month_str,
+        )
+        payroll = Decimal(str(payroll_row['total']))
 
-    # --- Provisions base: latest salary config per employee ≤ target month ---
-    prov_base_row = await conn.fetchrow(
-        """
-        SELECT COALESCE(SUM(es.total_salary), 0) AS total
-        FROM employee_salaries es
-        JOIN tenant_members tm ON tm.id = es.tenant_member_id
-        WHERE tm.tenant_id = $1
-          AND es.period_month = (
-              SELECT MAX(es2.period_month)
-              FROM employee_salaries es2
-              WHERE es2.tenant_member_id = es.tenant_member_id
-                AND es2.period_month <= $2
-          )
-        """,
-        tenant_id, month_str,
-    )
-    prov_base = Decimal(str(prov_base_row['total']))
+        # Latest configured salary per employee at or before the target month.
+        prov_base_row = await conn.fetchrow(
+            """
+            SELECT COALESCE(SUM(es.total_salary), 0) AS total
+            FROM employee_salaries es
+            JOIN tenant_members tm ON tm.id = es.tenant_member_id
+            WHERE tm.tenant_id = $1
+              AND es.period_month = (
+                  SELECT MAX(es2.period_month)
+                  FROM employee_salaries es2
+                  WHERE es2.tenant_member_id = es.tenant_member_id
+                    AND es2.period_month <= $2
+              )
+            """,
+            tenant_id, month_str,
+        )
+        prov_base = Decimal(str(prov_base_row['total']))
 
     # --- Calculations ---
     cesantias     = (prov_base * _CESANTIAS_RATE).quantize(Decimal('1'))
@@ -1319,19 +1380,41 @@ async def get_pl_statement(
             raise ValidationError("El mes debe estar entre 1 y 12")
 
         async with get_db_connection() as conn:
-            current = await _compute_pl_for_period(conn, tenant_id, year, month)
+            profile = await conn.fetchrow(
+                """
+                SELECT country_code, base_currency_code, accounting_localization
+                FROM tenant_financial_profiles WHERE tenant_id = $1
+                """,
+                tenant_id,
+            )
+            if not profile:
+                raise ValidationError("Perfil financiero no configurado")
+            include_colombia_payroll = (
+                profile['country_code'] == 'CO'
+                and profile['accounting_localization'] == 'WARO_CO_PUC_V1'
+            )
+            current = await _compute_pl_for_period(
+                conn, tenant_id, year, month, include_colombia_payroll
+            )
 
             previous = None
             if compare_previous:
                 prev_month = month - 1 if month > 1 else 12
                 prev_year  = year if month > 1 else year - 1
-                previous = await _compute_pl_for_period(conn, tenant_id, prev_year, prev_month)
+                previous = await _compute_pl_for_period(
+                    conn, tenant_id, prev_year, prev_month, include_colombia_payroll
+                )
 
         logger.info(
             f"📊 P&L statement computed for tenant {tenant_id}: "
             f"{year}-{month:02d}, compare_previous={compare_previous}"
         )
-        return PLStatementResponse(current=current, previous=previous)
+        return PLStatementResponse(**{
+            'baseCurrencyCode': profile['base_currency_code'],
+            'accountingLocalization': profile['accounting_localization'],
+            'current': current,
+            'previous': previous,
+        })
 
     except (AuthenticationError, AuthorizationError, ValidationError):
         raise
@@ -1352,16 +1435,6 @@ _PROV_CESANTIAS   = Decimal('0.0833')
 _PROV_INTERESES   = Decimal('0.0100')
 _PROV_PRIMA       = Decimal('0.0833')
 _PROV_VACACIONES  = Decimal('0.0417')
-
-# PUC account codes for provisions
-_PROV_DEBIT_CODE  = '5105'  # Gastos de personal — sueldos
-_PROV_CREDIT_CODES = {
-    'cesantias':  '2610',
-    'intereses':  '2615',
-    'prima':      '2620',
-    'vacaciones': '2625',
-}
-
 
 async def _calculate_provisions(conn, tenant_id: UUID, year: int, month: int) -> dict:
     """
@@ -1442,6 +1515,7 @@ async def preview_provisions(
             raise ValidationError("El mes debe estar entre 1 y 12")
 
         async with get_db_connection() as conn:
+            await ensure_colombia_payroll(conn, tenant_id)
             p = await _calculate_provisions(conn, tenant_id, year, month)
 
         return ProvisionsPreviewResponse(**{
@@ -1459,7 +1533,7 @@ async def preview_provisions(
             }),
         })
 
-    except (AuthenticationError, AuthorizationError, ValidationError):
+    except (APIError, AuthenticationError, AuthorizationError, ValidationError):
         raise
     except Exception as e:
         logger.error(f"❌ Error previewing provisions: {e}", exc_info=True)
@@ -1489,109 +1563,76 @@ async def post_provisions(
         desc_prefix = f"Provisiones nómina {month_str}"
 
         async with get_db_connection() as conn:
-            # 1. Void any previously posted provision entries for this period
-            voided = await conn.fetchval(
-                """
-                UPDATE tenant_journal_entries
-                SET status = 'voided', voided_at = NOW()
-                WHERE tenant_id = $1
-                  AND source_module = 'nomina'
-                  AND description LIKE $2
-                  AND status = 'posted'
-                RETURNING id
-                """,
-                tenant_id, f"{desc_prefix}%",
-            )
-            voided_count = 1 if voided else 0
-            # Count all voided in this batch
-            voided_rows = await conn.fetch(
-                """
-                SELECT id FROM tenant_journal_entries
-                WHERE tenant_id = $1
-                  AND source_module = 'nomina'
-                  AND description LIKE $2
-                  AND status = 'voided'
-                  AND voided_at >= NOW() - INTERVAL '5 seconds'
-                """,
-                tenant_id, f"{desc_prefix}%",
-            )
-            voided_count = len(voided_rows)
-
-            # 2. Calculate provision amounts
+            await ensure_colombia_payroll(conn, tenant_id)
             p = await _calculate_provisions(conn, tenant_id, year, month)
-
-            # 3. Resolve debit account (5105)
-            debit_acct = await conn.fetchrow(
-                "SELECT id FROM tenant_accounts WHERE tenant_id=$1 AND code=$2 AND is_active=TRUE",
-                tenant_id, _PROV_DEBIT_CODE,
+            debit_acct = await resolve_account(
+                conn, tenant_id, AccountRole.PAYROLL_EXPENSE, source="accounting_provisions"
             )
-            if not debit_acct:
-                raise ValidationError(
-                    f"Cuenta {_PROV_DEBIT_CODE} no encontrada — configure el PUC del tenant"
-                )
-
-            # 4. Post one GL entry per provision type
-            provision_items = [
-                ('cesantias',  p['cesantias'],  '2610', f"{desc_prefix} — Cesantías"),
-                ('intereses',  p['intereses'],  '2615', f"{desc_prefix} — Intereses cesantías"),
-                ('prima',      p['prima'],      '2620', f"{desc_prefix} — Prima de servicios"),
-                ('vacaciones', p['vacaciones'], '2625', f"{desc_prefix} — Vacaciones"),
+            provision_specs = [
+                ('cesantias', p['cesantias'], AccountRole.CESANTIAS_PAYABLE, f"{desc_prefix} — Cesantías"),
+                ('intereses', p['intereses'], AccountRole.CESANTIAS_INTEREST_PAYABLE, f"{desc_prefix} — Intereses cesantías"),
+                ('prima', p['prima'], AccountRole.PRIMA_PAYABLE, f"{desc_prefix} — Prima de servicios"),
+                ('vacaciones', p['vacaciones'], AccountRole.VACATION_PAYABLE, f"{desc_prefix} — Vacaciones"),
             ]
+            provision_items = []
+            for key, amount, role, description in provision_specs:
+                if amount == 0:
+                    continue
+                credit_acct = await resolve_account(
+                    conn, tenant_id, role, source="accounting_provisions"
+                )
+                provision_items.append((key, amount, credit_acct, description))
 
             entry_ids: List[str] = []
             entry_date = f"{year}-{month:02d}-01"
-
-            for _key, amount, credit_code, description in provision_items:
-                if amount == 0:
-                    continue  # skip zero-amount entries
-
-                credit_acct = await conn.fetchrow(
-                    "SELECT id FROM tenant_accounts WHERE tenant_id=$1 AND code=$2 AND is_active=TRUE",
-                    tenant_id, credit_code,
-                )
-                if not credit_acct:
-                    logger.warning(
-                        f"[GL] Cuenta {credit_code} no encontrada para tenant {tenant_id} — "
-                        f"saltando provisión {_key}"
-                    )
-                    continue
-
-                amount_f = float(amount)
-
-                entry_row = await conn.fetchrow(
+            async with conn.transaction():
+                voided_rows = await conn.fetch(
                     """
-                    INSERT INTO tenant_journal_entries
+                    UPDATE tenant_journal_entries
+                    SET status = 'voided', voided_at = NOW()
+                    WHERE tenant_id = $1
+                      AND source_module = 'nomina'
+                      AND description LIKE $2
+                      AND status = 'posted'
+                    RETURNING id
+                    """,
+                    tenant_id,
+                    f"{desc_prefix}%",
+                )
+                voided_count = len(voided_rows)
+
+                for _key, amount, credit_acct, description in provision_items:
+                    amount_f = float(amount)
+                    entry_row = await conn.fetchrow(
+                        """
+                        INSERT INTO tenant_journal_entries
                         (tenant_id, entry_date, period_year, period_month,
                          description, source_module, status,
                          total_debit, total_credit)
                     VALUES ($1, $2, $3, $4, $5, 'nomina', 'posted', $6, $6)
                     RETURNING id
                     """,
-                    tenant_id, entry_date, year, month,
-                    description, amount_f,
-                )
-                entry_id = entry_row['id']
-
-                # Debit 5105
-                await conn.execute(
-                    """
-                    INSERT INTO tenant_journal_lines
+                        tenant_id, entry_date, year, month,
+                        description, amount_f,
+                    )
+                    entry_id = entry_row['id']
+                    await conn.execute(
+                        """
+                        INSERT INTO tenant_journal_lines
                         (journal_entry_id, account_id, debit, credit, description, line_order)
                     VALUES ($1, $2, $3, 0, $4, 1)
                     """,
-                    entry_id, debit_acct['id'], amount_f, description,
-                )
-                # Credit 261X
-                await conn.execute(
-                    """
-                    INSERT INTO tenant_journal_lines
+                        entry_id, debit_acct.id, amount_f, description,
+                    )
+                    await conn.execute(
+                        """
+                        INSERT INTO tenant_journal_lines
                         (journal_entry_id, account_id, debit, credit, description, line_order)
                     VALUES ($1, $2, 0, $3, $4, 2)
                     """,
-                    entry_id, credit_acct['id'], amount_f, description,
-                )
-
-                entry_ids.append(str(entry_id))
+                        entry_id, credit_acct.id, amount_f, description,
+                    )
+                    entry_ids.append(str(entry_id))
 
         logger.info(
             f"📋 Provisions posted for tenant {tenant_id}: {month_str} — "
@@ -1611,7 +1652,7 @@ async def post_provisions(
             'voidedCount':     voided_count,
         })
 
-    except (AuthenticationError, AuthorizationError, ValidationError):
+    except (APIError, AuthenticationError, AuthorizationError, ValidationError):
         raise
     except Exception as e:
         logger.error(f"❌ Error posting provisions: {e}", exc_info=True)

--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -29,6 +29,12 @@ from app.models.cierre import (
     OpenShiftCreate,
 )
 from app.services.tip_tax_service import tip_settlement_total
+from app.services.account_role_service import (
+    AccountRole,
+    resolve_account,
+    resolve_payment_account,
+    resolve_tax_account,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -37,19 +43,6 @@ logger = logging.getLogger(__name__)
 # GL helpers — Auto-posting ventas/arqueo → GL (#378)
 # ---------------------------------------------------------------------------
 
-# Payment slug → PUC debit account code
-_SLUG_DEBIT_CODE: Dict[str, str] = {
-    "cash":    "1105",   # Caja general
-    "digital": "1110",   # Bancos (Nequi, Daviplata)
-    "card":    "1110",   # Bancos
-    "credit":  "1305",   # Clientes (fiado — accounts receivable)
-    "customer_wallet": "2810",  # Anticipos clientes (api#369; tenant override in _post_order_gl_entry)
-    "table_session_advance": "2810",  # Anticipos recibidos aplicados a consumo minimo de mesa
-}
-
-INGRESOS_CODE   = "4175"   # Servicios de restaurante y similares
-COGS_CODE       = "6135"   # Costo de ventas
-INVENTARIO_CODE = "1435"   # Inventarios — materia prima y suministros
 NON_RECONCILABLE_PAYMENT_GROUPS = {"cash", "untracked"}
 RECONCILIATION_STATUSES = {"not_required", "pending", "matched", "needs_review", "resolved"}
 RECONCILIATION_REASONS = {
@@ -118,18 +111,17 @@ async def _resolve_standard_tax_account_id(
     tax_config: Dict[str, Any],
 ) -> Optional[UUID]:
     """Resolve INC/IVA credit account for standard (non-liquor) tax, including tip tax."""
-    tax_code = None
+    tax_kind = None
     if tax_config.get("inc_applicable"):
-        tax_code = str(tax_config["inc_gl_account_code"])
+        tax_kind = "inc"
     elif tax_config.get("iva_applicable"):
-        tax_code = str(tax_config["iva_gl_account_code"])
-    if not tax_code:
+        tax_kind = "iva"
+    if not tax_kind:
         return None
-    tax_row = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, tax_code,
+    account = await resolve_tax_account(
+        conn, tenant_id, tax_config, tax_kind, required=True
     )
-    return tax_row["id"] if tax_row else None
+    return account.id if account else None
 
 
 async def _get_tenant_tax_config(conn, tenant_id: UUID) -> Dict[str, Any]:
@@ -138,10 +130,11 @@ async def _get_tenant_tax_config(conn, tenant_id: UUID) -> Dict[str, Any]:
     if no row exists (safe for tenants created before migration 027).
     """
     row = await conn.fetchrow(
-        """SELECT inc_applicable, inc_rate,   inc_gl_account_code,
+        """SELECT inc_applicable, inc_rate, inc_gl_account_code, inc_gl_account_id,
                   inc_included_in_price,
-                  liquor_tax_applicable, liquor_tax_rate, liquor_tax_gl_account_code,
-                  iva_applicable, iva_rate, iva_gl_account_code,
+                  liquor_tax_applicable, liquor_tax_rate,
+                  liquor_tax_gl_account_code, liquor_tax_gl_account_id,
+                  iva_applicable, iva_rate, iva_gl_account_code, iva_gl_account_id,
                   iva_included_in_price
            FROM tenant_tax_config WHERE tenant_id = $1""",
         tenant_id,
@@ -151,14 +144,17 @@ async def _get_tenant_tax_config(conn, tenant_id: UUID) -> Dict[str, Any]:
     return {
         "inc_applicable":             False,
         "inc_rate":                   Decimal("0.0800"),
-        "inc_gl_account_code":        "2495",
+        "inc_gl_account_code":        None,
+        "inc_gl_account_id":          None,
         "inc_included_in_price":      True,
         "liquor_tax_applicable":      False,
         "liquor_tax_rate":            Decimal("0.0000"),
-        "liquor_tax_gl_account_code": "2408",
+        "liquor_tax_gl_account_code": None,
+        "liquor_tax_gl_account_id":   None,
         "iva_applicable":             False,
         "iva_rate":                   Decimal("0.1900"),
-        "iva_gl_account_code":        "2408",
+        "iva_gl_account_code":        None,
+        "iva_gl_account_id":          None,
         "iva_included_in_price":      False,
     }
 
@@ -209,36 +205,21 @@ async def _post_cierre_gl_entry(
         )
         return
 
-    # Resolve debit account UUIDs
+    # Resolve every account before creating the journal.
     debit_accounts: Dict[str, Any] = {}
     for slug, amount in slug_totals.items():
-        code = _SLUG_DEBIT_CODE.get(slug)
-        if not code:
-            logger.warning(f"[GL] Unknown payment slug '{slug}' — skip debit line")
-            continue
-        acct = await conn.fetchrow(
-            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-            tenant_id, code,
+        account = await resolve_payment_account(
+            conn, tenant_id, slug, source="cierre"
         )
-        if not acct:
-            logger.warning(
-                f"[GL] Debit account {code} not found for tenant {tenant_id} — "
-                f"skip GL post for cierre {summary_id}"
-            )
-            return
-        debit_accounts[slug] = {"id": acct["id"], "code": code, "amount": amount}
+        debit_accounts[slug] = {
+            "id": account.id,
+            "code": account.code,
+            "amount": amount,
+        }
 
-    # Resolve credit account(s)
-    ingresos_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, INGRESOS_CODE,
+    revenue_account = await resolve_account(
+        conn, tenant_id, AccountRole.SALES_REVENUE, source="cierre"
     )
-    if not ingresos_acct:
-        logger.warning(
-            f"[GL] Ingresos account {INGRESOS_CODE} not found for tenant {tenant_id} — "
-            f"skip GL post for cierre {summary_id}"
-        )
-        return
 
     # Determine tax split
     tax_amount = Decimal("0")
@@ -246,23 +227,13 @@ async def _post_cierre_gl_entry(
     if tax_config.get("inc_applicable"):
         rate = Decimal(str(tax_config["inc_rate"]))
         tax_amount = total_sales - (total_sales / (1 + rate))
-        tax_code = str(tax_config["inc_gl_account_code"])
-        tax_row = await conn.fetchrow(
-            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-            tenant_id, tax_code,
-        )
-        if tax_row:
-            tax_acct_id = tax_row["id"]
+        tax_account = await resolve_tax_account(conn, tenant_id, tax_config, "inc")
+        tax_acct_id = tax_account.id if tax_account else None
     elif tax_config.get("iva_applicable"):
         rate = Decimal(str(tax_config["iva_rate"]))
         tax_amount = total_sales - (total_sales / (1 + rate))
-        tax_code = str(tax_config["iva_gl_account_code"])
-        tax_row = await conn.fetchrow(
-            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-            tenant_id, tax_code,
-        )
-        if tax_row:
-            tax_acct_id = tax_row["id"]
+        tax_account = await resolve_tax_account(conn, tenant_id, tax_config, "iva")
+        tax_acct_id = tax_account.id if tax_account else None
 
     net_income = total_sales - tax_amount
     ts = float(total_sales)
@@ -299,7 +270,7 @@ async def _post_cierre_gl_entry(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, 0, $3, $4, $5)""",
-            entry_id, ingresos_acct["id"], float(net_income),
+            entry_id, revenue_account.id, float(net_income),
             f"{description} — ingreso neto", line_order,
         )
         line_order += 1
@@ -341,8 +312,8 @@ async def _post_order_gl_entry(
     source_module = 'orden' (distinguishable from cierre 'ventas' entries)
     source_id     = order_id
 
-    DR  [payment account]    debit_total   (1105 Caja / 1110 Bancos / 1305 Clientes)
-    CR  4175 Ingresos        product net + dedicated tip line when tip > 0
+    DR  [payment account]    debit_total
+    CR  SALES_REVENUE        product net + dedicated tip line when tip > 0
     CR  2495/2408 Impuesto   tax_amount    (product + tip tax when applicable)
 
     Tax modes (per tenant_tax_config):
@@ -369,49 +340,13 @@ async def _post_order_gl_entry(
         logger.info(f"[GL] Order {order_id}: zero amount — skip GL post")
         return
 
-    async def resolve_debit_code(method: str, method_id: Optional[UUID]) -> str:
-        debit_code = None
-        if method_id:
-            pm_row = await conn.fetchrow(
-                """SELECT COALESCE(pm.gl_account_code, pmg.gl_account_code) AS code
-                   FROM payment_methods pm
-                   JOIN payment_method_groups pmg ON pm.group_id = pmg.id
-                   WHERE pm.id = $1""",
-                method_id,
-            )
-            if pm_row and pm_row["code"]:
-                debit_code = pm_row["code"]
-        if not debit_code:
-            debit_code = _SLUG_DEBIT_CODE.get(method or "", "1105")
-        if method == "customer_wallet":
-            liability_row = await conn.fetchrow(
-                """
-                SELECT customer_wallet_liability_gl_code
-                FROM tenant_public_profiles
-                WHERE tenant_id = $1
-                """,
-                tenant_id,
-            )
-            if liability_row and liability_row["customer_wallet_liability_gl_code"]:
-                debit_code = str(liability_row["customer_wallet_liability_gl_code"])
-        return str(debit_code)
-
-    async def resolve_debit_account(code: str):
-        debit_acct = await conn.fetchrow(
-            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-            tenant_id,
-            code,
-        )
-        if not debit_acct:
-            logger.warning(
-                f"[GL] Debit account {code} not found for tenant {tenant_id} — "
-                f"skip GL post for order {order_id}"
-            )
-            return None
-        return debit_acct
-
-    # ── Resolve debit account: specific method → group → slug fallback ────
-    debit_code = await resolve_debit_code(payment_method, payment_method_id)
+    debit_account = await resolve_payment_account(
+        conn,
+        tenant_id,
+        payment_method,
+        payment_method_id=payment_method_id,
+        source="order",
+    )
     split_debits: List[Dict[str, Any]] = []
     if payment_splits:
         split_total = sum(Decimal(str(split.get("amount") or 0)) for split in payment_splits)
@@ -424,24 +359,19 @@ async def _post_order_gl_entry(
                     {
                         "amount": Decimal(str(split.get("amount") or 0)),
                         "payment_method": split.get("payment_method") or "",
-                        "code": await resolve_debit_code(
+                        "account": await resolve_payment_account(
+                            conn,
+                            tenant_id,
                             split.get("payment_method") or "",
-                            split_method_id,
+                            payment_method_id=split_method_id,
+                            source="order_split",
                         ),
                     }
                 )
 
-    # ── Resolve 4135 Ingresos ──────────────────────────────────────────────
-    ingresos_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, INGRESOS_CODE,
+    revenue_account = await resolve_account(
+        conn, tenant_id, AccountRole.SALES_REVENUE, source="order"
     )
-    if not ingresos_acct:
-        logger.warning(
-            f"[GL] Ingresos account {INGRESOS_CODE} not found for tenant {tenant_id} — "
-            f"skip GL post for order {order_id}"
-        )
-        return
 
     # ── Fetch order items with per-product tax_category ──────────────────
     # Use net_total (post-discount) when available, falling back to subtotal.
@@ -485,7 +415,6 @@ async def _post_order_gl_entry(
 
     if tax_config.get("inc_applicable") and standard_subtotal > 0:
         rate = Decimal(str(tax_config["inc_rate"]))
-        tax_code = str(tax_config["inc_gl_account_code"])
         if tax_config.get("inc_included_in_price", True):
             # Extractive: price already includes INC
             standard_tax = standard_subtotal - (standard_subtotal / (1 + rate))
@@ -493,38 +422,24 @@ async def _post_order_gl_entry(
             # Additive: INC charged on top of base price
             standard_tax = standard_subtotal * rate
             standard_is_additive = True
-        tax_row = await conn.fetchrow(
-            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-            tenant_id, tax_code,
-        )
-        if tax_row:
-            standard_acct_id = tax_row["id"]
+        tax_account = await resolve_tax_account(conn, tenant_id, tax_config, "inc")
+        standard_acct_id = tax_account.id if tax_account else None
 
     elif tax_config.get("iva_applicable") and standard_subtotal > 0:
         rate = Decimal(str(tax_config["iva_rate"]))
-        tax_code = str(tax_config["iva_gl_account_code"])
         if tax_config.get("iva_included_in_price", False):
             standard_tax = standard_subtotal - (standard_subtotal / (1 + rate))
         else:
             standard_tax = standard_subtotal * rate
             standard_is_additive = True
-        tax_row = await conn.fetchrow(
-            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-            tenant_id, tax_code,
-        )
-        if tax_row:
-            standard_acct_id = tax_row["id"]
+        tax_account = await resolve_tax_account(conn, tenant_id, tax_config, "iva")
+        standard_acct_id = tax_account.id if tax_account else None
 
     if tax_config.get("liquor_tax_applicable") and liquor_subtotal > 0:
         rate = Decimal(str(tax_config["liquor_tax_rate"]))
-        tax_code = str(tax_config["liquor_tax_gl_account_code"])
         liquor_tax = liquor_subtotal * rate  # IVA licores — always additive (external VAT)
-        tax_row = await conn.fetchrow(
-            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-            tenant_id, tax_code,
-        )
-        if tax_row:
-            liquor_acct_id = tax_row["id"]
+        tax_account = await resolve_tax_account(conn, tenant_id, tax_config, "liquor")
+        liquor_acct_id = tax_account.id if tax_account else None
 
     # ── Compute debit_total and net_revenue ───────────────────────────────
     # Additive taxes (non-included INC/IVA, liquor) increase what the customer pays.
@@ -565,32 +480,21 @@ async def _post_order_gl_entry(
                     remaining_debit -= debit_amount
                 if debit_amount <= 0:
                     continue
-                split_acct = await resolve_debit_account(split["code"])
-                if not split_acct:
-                    return
+                split_acct = split["account"]
                 split_debit_lines.append(
                     {
-                        "account_id": split_acct["id"],
+                        "account_id": split_acct.id,
                         "amount": debit_amount,
                         "payment_method": split["payment_method"],
                     }
                 )
         else:
-            debit_acct = await resolve_debit_account(debit_code)
-            if not debit_acct:
-                return
+            debit_acct = debit_account
     advance_acct = None
     if advance_debit > 0:
-        advance_acct = await conn.fetchrow(
-            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-            tenant_id, _SLUG_DEBIT_CODE["table_session_advance"],
+        advance_acct = await resolve_account(
+            conn, tenant_id, AccountRole.CUSTOMER_ADVANCES, source="order_advance"
         )
-        if not advance_acct:
-            logger.warning(
-                f"[GL] Advance account 2810 not found for tenant {tenant_id} — "
-                f"skip GL post for order {order_id}"
-            )
-            return
 
     dt = float(debit_total)
     description = f"#{order_number}" if order_number else f"Venta {order_date.isoformat()} — orden {order_id}"
@@ -617,7 +521,7 @@ async def _post_order_gl_entry(
                        (journal_entry_id, account_id, debit, credit, description, line_order)
                    VALUES ($1, $2, $3, 0, $4, $5)""",
                 entry_id,
-                advance_acct["id"],
+                advance_acct.id,
                 float(advance_debit),
                 f"{description} — aplicación anticipo mesa",
                 line_order,
@@ -642,19 +546,19 @@ async def _post_order_gl_entry(
                        (journal_entry_id, account_id, debit, credit, description, line_order)
                    VALUES ($1, $2, $3, 0, $4, $5)""",
                 entry_id,
-                debit_acct["id"],
+                debit_acct.id,
                 float(payment_debit),
                 description,
                 line_order,
             )
             line_order += 1
 
-        # Credit line — product net revenue to 4175
+        # Credit line — product net revenue
         await conn.execute(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, 0, $3, $4, $5)""",
-            entry_id, ingresos_acct["id"], float(product_net_revenue),
+            entry_id, revenue_account.id, float(product_net_revenue),
             f"{description} — ingreso neto",
             line_order,
         )
@@ -686,7 +590,7 @@ async def _post_order_gl_entry(
                 """INSERT INTO tenant_journal_lines
                        (journal_entry_id, account_id, debit, credit, description, line_order)
                    VALUES ($1, $2, 0, $3, $4, $5)""",
-                entry_id, ingresos_acct["id"], float(tip_net_revenue),
+                entry_id, revenue_account.id, float(tip_net_revenue),
                 tip_description,
                 line_order,
             )
@@ -761,33 +665,16 @@ async def _post_deferred_order_tip_gl(
         )
         return
 
-    debit_code = None
-    if payment_method_id:
-        pm_row = await conn.fetchrow(
-            """SELECT COALESCE(pm.gl_account_code, pmg.gl_account_code) AS code
-               FROM payment_methods pm
-               JOIN payment_method_groups pmg ON pm.group_id = pmg.id
-               WHERE pm.id = $1""",
-            payment_method_id,
-        )
-        if pm_row and pm_row["code"]:
-            debit_code = pm_row["code"]
-    if not debit_code:
-        debit_code = _SLUG_DEBIT_CODE.get(payment_method or "", "1105")
-
-    debit_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, debit_code,
+    debit_acct = await resolve_payment_account(
+        conn,
+        tenant_id,
+        payment_method,
+        payment_method_id=payment_method_id,
+        source="deferred_tip",
     )
-    ingresos_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, INGRESOS_CODE,
+    revenue_account = await resolve_account(
+        conn, tenant_id, AccountRole.SALES_REVENUE, source="deferred_tip"
     )
-    if not debit_acct or not ingresos_acct:
-        logger.warning(
-            f"[GL] Deferred tip for order {order_id}: missing debit/ingresos account — skip"
-        )
-        return
 
     tip_tax_acct_id = None
     if tip_tax_credit > 0:
@@ -819,14 +706,14 @@ async def _post_deferred_order_tip_gl(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, $3, 0, $4, $5)""",
-            entry_id, debit_acct["id"], settlement_f, tip_description, line_order,
+            entry_id, debit_acct.id, settlement_f, tip_description, line_order,
         )
         line_order += 1
         await conn.execute(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, 0, $3, $4, $5)""",
-            entry_id, ingresos_acct["id"], float(tip_net_revenue),
+            entry_id, revenue_account.id, float(tip_net_revenue),
             f"{tip_description} — ingreso neto", line_order,
         )
         if tip_tax_credit > 0 and tip_tax_acct_id:
@@ -855,8 +742,8 @@ async def _post_order_cogs_gl_entry(
     """
     Post a COGS GL journal entry for a completed order.
 
-    DR  6135 Costo de ventas      total_ingredient_cost
-    CR  1435 Inventarios          total_ingredient_cost
+    DR  COGS                       total_ingredient_cost
+    CR  INVENTORY                  total_ingredient_cost
 
     Cost basis: sum of order_item_ingredients.total_cost (captured at sale time
     using last purchase unit_cost × quantity consumed).
@@ -864,8 +751,8 @@ async def _post_order_cogs_gl_entry(
     Rules:
     - Only posts if total ingredient cost > 0 (skip if no purchase history)
     - Idempotent: skips if source_module='orden_cogs' entry already exists
-    - Missing 6135 or 1435 account → warning logged, no exception raised
-    - Failure must never block order completion — caller wraps in try/except
+    - Missing COGS or INVENTORY role fails explicitly before journal insertion
+    - The caller decides whether non-configuration failures block completion
     """
     # ── Idempotency guard ──────────────────────────────────────────────────
     existing = await conn.fetchval(
@@ -891,29 +778,12 @@ async def _post_order_cogs_gl_entry(
         logger.info(f"[GL] Order {order_id}: no ingredient cost data — skip COGS entry")
         return
 
-    # ── Resolve 6135 Costo de ventas ───────────────────────────────────────
-    cogs_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, COGS_CODE,
+    cogs_acct = await resolve_account(
+        conn, tenant_id, AccountRole.COGS, source="order_cogs"
     )
-    if not cogs_acct:
-        logger.warning(
-            f"[GL] COGS account {COGS_CODE} not found for tenant {tenant_id} — "
-            f"skip COGS entry for order {order_id}"
-        )
-        return
-
-    # ── Resolve 1435 Inventarios ───────────────────────────────────────────
-    inv_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, INVENTARIO_CODE,
+    inv_acct = await resolve_account(
+        conn, tenant_id, AccountRole.INVENTORY, source="order_cogs"
     )
-    if not inv_acct:
-        logger.warning(
-            f"[GL] Inventory account {INVENTARIO_CODE} not found for tenant {tenant_id} — "
-            f"skip COGS entry for order {order_id}"
-        )
-        return
 
     # ── Insert entry + 2 lines ─────────────────────────────────────────────
     amount = float(total_cogs)
@@ -932,20 +802,20 @@ async def _post_order_cogs_gl_entry(
         )
         entry_id = entry_row["id"]
 
-        # Debit — 6135 Costo de ventas
+        # Debit — cost of goods sold
         await conn.execute(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, $3, 0, $4, 0)""",
-            entry_id, cogs_acct["id"], amount, description,
+            entry_id, cogs_acct.id, amount, description,
         )
 
-        # Credit — 1435 Inventarios
+        # Credit — inventory
         await conn.execute(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, 0, $3, $4, 1)""",
-            entry_id, inv_acct["id"], amount, description,
+            entry_id, inv_acct.id, amount, description,
         )
 
     logger.info(
@@ -2805,7 +2675,7 @@ async def create_cierre(request: Request, body: CierreCreate) -> dict:
             # Revenue is already recorded per-order via _post_order_gl_entry()
             # (source_module='orden') when each POS/table/online order completes.
             # Posting again here (source_module='ventas') would double-count
-            # income in account 4175. The cierre serves as a cash reconciliation
+            # income in the SALES_REVENUE role. The cierre is a cash reconciliation
             # report, not as the GL trigger for revenue recognition.
 
         return {
@@ -3052,17 +2922,6 @@ async def update_reconciliation_reported(
         raise APIError(f"Error in update_reconciliation_reported: {exc}", status_code=500)
 
 
-async def _account_id_for_code(conn, tenant_id: UUID, code: str):
-    return await conn.fetchval(
-        """
-        SELECT id
-        FROM tenant_accounts
-        WHERE tenant_id = $1 AND code = $2 AND is_active = true
-        """,
-        tenant_id, code,
-    )
-
-
 async def _create_reconciliation_journal_entry(
     conn,
     tenant_id: UUID,
@@ -3080,46 +2939,48 @@ async def _create_reconciliation_journal_entry(
         return None
 
     amount = abs(diff)
-    payment_code = _SLUG_DEBIT_CODE.get(row["group_slug"], "1110")
-    payment_account_id = await _account_id_for_code(conn, tenant_id, payment_code)
-    if not payment_account_id:
-        logger.warning("[reconciliation] Missing payment account %s for tenant %s", payment_code, tenant_id)
-        return None
-
-    debit_code = None
-    credit_code = None
+    payment_account = await resolve_payment_account(
+        conn, tenant_id, row["group_slug"], source="reconciliation"
+    )
+    debit_account = None
+    credit_account = None
     if reason == "commission":
-        debit_code = "5305"
-        credit_code = payment_code
+        debit_account = await resolve_account(
+            conn, tenant_id, AccountRole.BANK_FEES_EXPENSE, source="reconciliation"
+        )
+        credit_account = payment_account
     elif reason == "missing_sale":
-        debit_code = payment_code
-        credit_code = INGRESOS_CODE
+        debit_account = payment_account
+        credit_account = await resolve_account(
+            conn, tenant_id, AccountRole.SALES_REVENUE, source="reconciliation"
+        )
     elif reason == "client_balance":
-        debit_code = payment_code
-        credit_code = "2810"
+        debit_account = payment_account
+        credit_account = await resolve_account(
+            conn, tenant_id, AccountRole.CUSTOMER_ADVANCES, source="reconciliation"
+        )
     elif reason == "real_surplus":
-        debit_code = payment_code
-        credit_code = "4295"
+        debit_account = payment_account
+        credit_account = await resolve_account(
+            conn, tenant_id, AccountRole.OTHER_INCOME, source="reconciliation"
+        )
     elif reason == "real_shortage":
-        debit_code = "1305"
-        credit_code = payment_code
+        debit_account = await resolve_account(
+            conn, tenant_id, AccountRole.ACCOUNTS_RECEIVABLE, source="reconciliation"
+        )
+        credit_account = payment_account
     elif reason == "other":
         if diff > 0:
-            debit_code = payment_code
-            credit_code = "4295"
+            debit_account = payment_account
+            credit_account = await resolve_account(
+                conn, tenant_id, AccountRole.OTHER_INCOME, source="reconciliation"
+            )
         else:
-            debit_code = "5305"
-            credit_code = payment_code
+            debit_account = await resolve_account(
+                conn, tenant_id, AccountRole.BANK_FEES_EXPENSE, source="reconciliation"
+            )
+            credit_account = payment_account
     else:
-        return None
-
-    debit_account_id = await _account_id_for_code(conn, tenant_id, debit_code)
-    credit_account_id = await _account_id_for_code(conn, tenant_id, credit_code)
-    if not debit_account_id or not credit_account_id:
-        logger.warning(
-            "[reconciliation] Missing accounts debit=%s credit=%s tenant=%s",
-            debit_code, credit_code, tenant_id,
-        )
         return None
 
     entry_date = row["period_end"]
@@ -3159,9 +3020,9 @@ async def _create_reconciliation_journal_entry(
             ($1, $4, 0, $3, $5, 1)
         """,
         entry_id,
-        debit_account_id,
+        debit_account.id,
         float(amount),
-        credit_account_id,
+        credit_account.id,
         description,
     )
     return entry_id

--- a/app/services/credit_service.py
+++ b/app/services/credit_service.py
@@ -12,70 +12,30 @@ from fastapi import Request
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError
+from app.services.account_role_service import (
+    AccountRole,
+    resolve_account,
+    resolve_payment_account,
+)
 import logging
 
 logger = logging.getLogger(__name__)
 
-_PAYMENT_DEBIT_FALLBACKS = {
-    "cash": "1105",
-    "digital": "1110",
-    "card": "1110",
-    "credit": "1305",
-}
-_CARTERA_RECEIVABLE_CODE = "1305"
-
-
-async def _resolve_account_id(conn, tenant_id: UUID, code: str) -> Optional[UUID]:
-    return await conn.fetchval(
-        """
-        SELECT id
-        FROM tenant_accounts
-        WHERE tenant_id = $1 AND code = $2 AND is_active = true
-        """,
-        tenant_id,
-        code,
-    )
-
-
-async def _resolve_credit_payment_debit_code(
+async def _resolve_credit_payment_debit_account(
     conn,
     tenant_id: UUID,
     payment_method: str,
     group_id: UUID,
     payment_method_id: Optional[UUID],
-) -> str:
-    if payment_method_id:
-        method_code = await conn.fetchval(
-            """
-            SELECT COALESCE(pm.gl_account_code, pmg.gl_account_code)
-            FROM payment_methods pm
-            JOIN payment_method_groups pmg ON pm.group_id = pmg.id
-            WHERE pm.id = $1
-              AND pm.tenant_id = $2
-              AND pm.group_id = $3
-            """,
-            payment_method_id,
-            tenant_id,
-            group_id,
-        )
-        if method_code:
-            return str(method_code)
-
-    group_code = await conn.fetchval(
-        """
-        SELECT gl_account_code
-        FROM payment_method_groups
-        WHERE id = $1
-          AND is_active = true
-          AND (tenant_id IS NULL OR tenant_id = $2)
-        """,
-        group_id,
+):
+    return await resolve_payment_account(
+        conn,
         tenant_id,
+        payment_method,
+        payment_method_id=payment_method_id,
+        payment_group_id=group_id,
+        source="credit_payment",
     )
-    if group_code:
-        return str(group_code)
-
-    return _PAYMENT_DEBIT_FALLBACKS.get(payment_method or "", "1105")
 
 
 async def _post_credit_payment_gl(
@@ -105,29 +65,19 @@ async def _post_credit_payment_gl(
         logger.info("[credit GL] Payment %s already posted as journal %s", payment_id, existing)
         return existing
 
-    debit_code = await _resolve_credit_payment_debit_code(
+    debit_account = await _resolve_credit_payment_debit_account(
         conn,
         tenant_id,
         payment_method,
         group_id,
         payment_method_id,
     )
-    credit_code = _CARTERA_RECEIVABLE_CODE
-    debit_account_id = await _resolve_account_id(conn, tenant_id, debit_code)
-    credit_account_id = await _resolve_account_id(conn, tenant_id, credit_code)
-    if not debit_account_id or not credit_account_id:
-        logger.warning(
-            "[credit GL] Missing accounts debit=%s credit=%s tenant=%s payment=%s",
-            debit_code,
-            credit_code,
-            tenant_id,
-            payment_id,
-        )
-        raise APIError(
-            "No se pudo registrar el asiento contable del abono de cartera.",
-            status_code=500,
-            details={"code": "credit_payment_gl_account_missing"},
-        )
+    receivable_account = await resolve_account(
+        conn,
+        tenant_id,
+        AccountRole.ACCOUNTS_RECEIVABLE,
+        source="credit_payment",
+    )
 
     entry_date = (
         payment_date_value.date()
@@ -164,9 +114,9 @@ async def _post_credit_payment_gl(
         VALUES ($1, $2, $3, 0, $4, 0)
         """,
         entry_id,
-        debit_account_id,
+        debit_account.id,
         amt,
-        f"Dr {debit_code} - abono cartera",
+        f"Dr {debit_account.code} - abono cartera",
     )
     await conn.execute(
         """
@@ -175,9 +125,9 @@ async def _post_credit_payment_gl(
         VALUES ($1, $2, 0, $3, $4, 1)
         """,
         entry_id,
-        credit_account_id,
+        receivable_account.id,
         amt,
-        f"Cr {credit_code} - clientes por cobrar",
+        f"Cr {receivable_account.code} - clientes por cobrar",
     )
     return entry_id
 

--- a/app/services/customer_wallet_service.py
+++ b/app/services/customer_wallet_service.py
@@ -16,61 +16,39 @@ from fastapi import Request
 from app.core.exceptions import APIError, AuthenticationError
 from app.core.middleware import require_valid_session
 from app.database import get_db_connection
-from app.services.cierre_service import _SLUG_DEBIT_CODE
+from app.services.account_role_service import (
+    AccountRole,
+    resolve_account,
+    resolve_payment_account,
+)
 from app.services.customer_relationship_service import is_tenant_customer
 
 logger = logging.getLogger(__name__)
 
 WALLET_PAYMENT_SLUG = "customer_wallet"
 ANONYMOUS_PHONE = "0000000000"
-DEFAULT_LIABILITY_CODE = "2810"
 RECENT_MOVEMENTS_DEFAULT = 20
 
 
-async def _resolve_liability_code(conn, tenant_id: UUID) -> str:
-    row = await conn.fetchrow(
-        """
-        SELECT customer_wallet_liability_gl_code
-        FROM tenant_public_profiles
-        WHERE tenant_id = $1
-        """,
-        tenant_id,
+async def _resolve_liability_account(conn, tenant_id: UUID):
+    return await resolve_account(
+        conn, tenant_id, AccountRole.CUSTOMER_ADVANCES, source="customer_wallet"
     )
-    if row and row["customer_wallet_liability_gl_code"]:
-        return str(row["customer_wallet_liability_gl_code"])
-    return DEFAULT_LIABILITY_CODE
 
 
-async def _resolve_account_id(conn, tenant_id: UUID, code: str) -> Optional[UUID]:
-    row = await conn.fetchrow(
-        """
-        SELECT id FROM tenant_accounts
-        WHERE tenant_id = $1 AND code = $2 AND is_active = true
-        """,
-        tenant_id,
-        code,
-    )
-    return row["id"] if row else None
-
-
-async def _resolve_payment_debit_code(
+async def _resolve_payment_debit_account(
     conn,
+    tenant_id: UUID,
     payment_method: str,
     payment_method_id: Optional[UUID],
-) -> str:
-    if payment_method_id:
-        pm_row = await conn.fetchrow(
-            """
-            SELECT COALESCE(pm.gl_account_code, pmg.gl_account_code) AS code
-            FROM payment_methods pm
-            JOIN payment_method_groups pmg ON pm.group_id = pmg.id
-            WHERE pm.id = $1
-            """,
-            payment_method_id,
-        )
-        if pm_row and pm_row["code"]:
-            return str(pm_row["code"])
-    return _SLUG_DEBIT_CODE.get(payment_method or "", "1105")
+):
+    return await resolve_payment_account(
+        conn,
+        tenant_id,
+        payment_method,
+        payment_method_id=payment_method_id,
+        source="customer_wallet",
+    )
 
 
 async def assert_wallet_customer_identified(conn, profile_id: UUID) -> None:
@@ -292,18 +270,10 @@ async def _post_recharge_gl(
     entry_date: date,
     created_by: Optional[UUID],
 ) -> Optional[UUID]:
-    liability_code = await _resolve_liability_code(conn, tenant_id)
-    debit_code = await _resolve_payment_debit_code(conn, payment_method, payment_method_id)
-    debit_acct = await _resolve_account_id(conn, tenant_id, debit_code)
-    credit_acct = await _resolve_account_id(conn, tenant_id, liability_code)
-    if not debit_acct or not credit_acct:
-        logger.warning(
-            "[wallet GL] Missing accounts debit=%s credit=%s tenant=%s — skip",
-            debit_code,
-            liability_code,
-            tenant_id,
-        )
-        return None
+    credit_acct = await _resolve_liability_account(conn, tenant_id)
+    debit_acct = await _resolve_payment_debit_account(
+        conn, tenant_id, payment_method, payment_method_id
+    )
     return await _post_two_line_gl(
         conn,
         tenant_id,
@@ -312,11 +282,11 @@ async def _post_recharge_gl(
         f"wallet-recharge-{movement_id}",
         "customer_wallet_recharge",
         movement_id,
-        debit_acct,
-        credit_acct,
+        debit_acct.id,
+        credit_acct.id,
         amount,
-        f"Dr {debit_code} — recarga billetera",
-        f"Cr {liability_code} — anticipo cliente",
+        f"Dr {debit_acct.code} — recarga billetera",
+        f"Cr {credit_acct.code} — anticipo cliente",
         created_by,
     )
 
@@ -331,16 +301,10 @@ async def _post_refund_gl(
     entry_date: date,
     created_by: Optional[UUID],
 ) -> Optional[UUID]:
-    liability_code = await _resolve_liability_code(conn, tenant_id)
-    credit_code = await _resolve_payment_debit_code(conn, payment_method, payment_method_id)
-    debit_acct = await _resolve_account_id(conn, tenant_id, liability_code)
-    credit_acct = await _resolve_account_id(conn, tenant_id, credit_code)
-    if not debit_acct or not credit_acct:
-        logger.warning(
-            "[wallet GL] Missing accounts for refund tenant=%s — skip",
-            tenant_id,
-        )
-        return None
+    debit_acct = await _resolve_liability_account(conn, tenant_id)
+    credit_acct = await _resolve_payment_debit_account(
+        conn, tenant_id, payment_method, payment_method_id
+    )
     return await _post_two_line_gl(
         conn,
         tenant_id,
@@ -349,11 +313,11 @@ async def _post_refund_gl(
         f"wallet-refund-{movement_id}",
         "customer_wallet_refund",
         movement_id,
-        debit_acct,
-        credit_acct,
+        debit_acct.id,
+        credit_acct.id,
         amount,
-        f"Dr {liability_code} — devolución anticipo",
-        f"Cr {credit_code} — salida de caja/banco",
+        f"Dr {debit_acct.code} — devolución anticipo",
+        f"Cr {credit_acct.code} — salida de caja/banco",
         created_by,
     )
 

--- a/app/services/direct_purchase_service.py
+++ b/app/services/direct_purchase_service.py
@@ -131,6 +131,12 @@ from app.services.purchase_tracking_service import (
     create_status_history_entry,
     upload_purchase_attachments
 )
+from app.services.account_role_service import (
+    AccountRole,
+    MissingAccountRoleError,
+    resolve_account,
+    resolve_payment_account,
+)
 import logging
 import json
 from uuid import uuid4
@@ -191,17 +197,16 @@ async def _post_purchase_gl_entry(
 ) -> None:
     """
     Post GL entry for a received purchase:
-        Déb 1435 Inventarios   ←  total_amount
+        Déb INVENTORY          ←  total_amount
         Cré <payment account>  →  total_amount
 
     Credit account resolution (two-level, migration 028):
         1. payment_methods.gl_account_code       (individual override)
         2. payment_method_groups.gl_account_code  (group default)
         3. payment_method group slug default      (cash/card/digital without sub-method)
-        4. Hardcoded fallback: 2205 Proveedores   (no payment method set)
+        4. ACCOUNTS_PAYABLE role when no payment method is set
 
-    Silently skips if: total_amount <= 0, account missing, period closed.
-    Caller MUST wrap in try/except for graceful degrade.
+    Skips zero amounts and closed periods. Missing roles fail explicitly.
     """
     amount = Decimal(str(total_amount))
     if amount <= 0:
@@ -224,55 +229,21 @@ async def _post_purchase_gl_entry(
         )
         return
 
-    debit_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, "1435",
+    debit_acct = await resolve_account(
+        conn, tenant_id, AccountRole.INVENTORY, source="direct_purchase"
     )
-    if not debit_acct:
-        logger.warning(f"[GL] Account 1435 not found for tenant {tenant_id} — skip GL post")
-        return
-
-    # Two-level credit account lookup (migration 028)
-    credit_code = None
-    if payment_method_id:
-        row = await conn.fetchrow(
-            """SELECT pm.gl_account_code AS method_code,
-                      pmg.gl_account_code AS group_code
-               FROM payment_methods pm
-               JOIN payment_method_groups pmg ON pmg.id = pm.group_id
-               WHERE pm.id = $1""",
-            payment_method_id,
-        )
-        if row:
-            credit_code = row["method_code"] or row["group_code"]
-
-    if not credit_code and payment_method:
-        row = await conn.fetchrow(
-            """SELECT gl_account_code
-                 FROM payment_method_groups
-                WHERE slug = $1
-                  AND (tenant_id = $2 OR tenant_id IS NULL)
-                  AND is_active = TRUE
-                ORDER BY (tenant_id IS NULL) ASC
-                LIMIT 1""",
-            payment_method,
+    if payment_method or payment_method_id:
+        credit_acct = await resolve_payment_account(
+            conn,
             tenant_id,
+            payment_method,
+            payment_method_id=payment_method_id,
+            source="direct_purchase",
         )
-        if row:
-            credit_code = row["gl_account_code"]
-
-    if not credit_code:
-        credit_code = "2205"  # Fallback: Proveedores nacionales
-
-    credit_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, credit_code,
-    )
-    if not credit_acct:
-        logger.warning(
-            f"[GL] Credit account {credit_code} not found for tenant {tenant_id} — skip GL post"
+    else:
+        credit_acct = await resolve_account(
+            conn, tenant_id, AccountRole.ACCOUNTS_PAYABLE, source="direct_purchase"
         )
-        return
 
     amt = float(amount)
     async with conn.transaction():
@@ -291,18 +262,18 @@ async def _post_purchase_gl_entry(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, $3, 0, $4, 0)""",
-            entry_id, debit_acct["id"], amt, description,
+            entry_id, debit_acct.id, amt, description,
         )
         await conn.execute(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, 0, $3, $4, 1)""",
-            entry_id, credit_acct["id"], amt, description,
+            entry_id, credit_acct.id, amt, description,
         )
 
     logger.info(
         f"[GL] ✅ Posted purchase entry {entry_id} for purchase {purchase_id} "
-        f"(debit=1435, credit={credit_code}, amount={amt})"
+        f"(debit={debit_acct.code}, credit={credit_acct.code}, amount={amt})"
     )
 
 
@@ -721,7 +692,7 @@ async def create_direct_purchase(
                         None
                     )
 
-                # 6. GL auto-post — Déb 1435 / Cré <payment account> (#106)
+                # 6. GL auto-post — Déb INVENTORY / Cré <payment account> (#106)
                 #    SAVEPOINT: GL failure never rolls back the purchase save.
                 try:
                     async with conn.transaction():
@@ -734,6 +705,8 @@ async def create_direct_purchase(
                             UUID(payment_method_id) if payment_method_id else None,
                             timezone_name,
                         )
+                except MissingAccountRoleError:
+                    raise
                 except Exception as _gl_err:
                     logger.warning(
                         f"[GL] purchase GL post failed for {purchase_id}: {_gl_err}"
@@ -755,6 +728,8 @@ async def create_direct_purchase(
                     }
                 }
 
+    except MissingAccountRoleError:
+        raise
     except AuthenticationError:
         raise
     except HTTPException:

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -25,6 +25,11 @@ from app.services.cierre_service import (
     _post_order_cogs_gl_entry,
     _post_order_gl_entry,
 )
+from app.services.account_role_service import (
+    AccountRole,
+    MissingAccountRoleError,
+    resolve_account,
+)
 from app.services.email_helpers import send_pos_receipt_email
 from app.services.email_sender import resolve_sender_email_for_tenant
 from app.services.invoicing_presentation import (
@@ -902,23 +907,32 @@ async def get_order_by_id(
 
             _promo_summary = await _get_order_promo_summary(conn, order_id)
             _waro_summary = await _get_order_waro_redemption_summary(conn, order_id)
-            advance_gl_row = await conn.fetchrow(
-                """
-                SELECT COALESCE(SUM(jl.debit), 0) AS advance_applied
-                FROM tenant_journal_entries je
-                JOIN tenant_journal_lines jl ON jl.journal_entry_id = je.id
-                JOIN tenant_accounts ta ON ta.id = jl.account_id
-                WHERE je.tenant_id = $1
-                  AND je.source_module = 'orden'
-                  AND je.source_id = $2
-                  AND je.status = 'posted'
-                  AND ta.code = '2810'
-                  AND jl.debit > 0
-                  AND jl.description ILIKE '%anticipo mesa%'
-                """,
+            advance_account = await resolve_account(
+                conn,
                 tenant_id,
-                order_id,
+                AccountRole.CUSTOMER_ADVANCES,
+                required=False,
+                source="order_detail",
             )
+            advance_gl_row = None
+            if advance_account:
+                advance_gl_row = await conn.fetchrow(
+                    """
+                    SELECT COALESCE(SUM(jl.debit), 0) AS advance_applied
+                    FROM tenant_journal_entries je
+                    JOIN tenant_journal_lines jl ON jl.journal_entry_id = je.id
+                    WHERE je.tenant_id = $1
+                      AND je.source_module = 'orden'
+                      AND je.source_id = $2
+                      AND je.status = 'posted'
+                      AND jl.account_id = $3
+                      AND jl.debit > 0
+                      AND jl.description ILIKE '%anticipo mesa%'
+                    """,
+                    tenant_id,
+                    order_id,
+                    advance_account.id,
+                )
             _tip_amount = float(order_row['tip_amount']) if order_row['tip_amount'] is not None else 0.0
             _tip_tax_amount = float(order_row['tip_tax_amount']) if order_row['tip_tax_amount'] is not None else 0.0
             _settlement_amount = float(order_row['total_amount']) + _tip_amount + _tip_tax_amount
@@ -1241,6 +1255,8 @@ async def bulk_update_order_status(
                             order_date=gl_order_date,
                             order_number=int(ord_row["order_number"]),
                         )
+                except MissingAccountRoleError:
+                    raise
                 except Exception as gl_exc:
                     logger.error(f"GL entries failed for bulk status update: {gl_exc}")
 
@@ -1461,6 +1477,8 @@ async def update_order_status(
                                 order_date=gl_order_date,
                                 order_number=int(completed_order["order_number"]),
                             )
+                    except MissingAccountRoleError:
+                        raise
                     except Exception as gl_exc:
                         logger.error(f"GL entries failed for order status update: {gl_exc}")
                 elif old_status == 'completed' and status in ('cancelled', 'pending'):
@@ -3979,6 +3997,8 @@ async def create_manual_order(
                         order_number=int(order_row["order_number"]),
                         payment_splits=split_payments or None,
                     )
+                except MissingAccountRoleError:
+                    raise
                 except Exception as e:
                     logger.error(f"GL entry failed for manual order {order_id}: {e}")
 
@@ -3990,6 +4010,8 @@ async def create_manual_order(
                         order_date=gl_order_date,
                         order_number=int(order_row["order_number"]),
                     )
+                except MissingAccountRoleError:
+                    raise
                 except Exception as e:
                     logger.error(f"COGS GL entry failed for manual order {order_id}: {e}")
 

--- a/app/services/payment_method_service.py
+++ b/app/services/payment_method_service.py
@@ -43,6 +43,7 @@ async def list_groups(request: Request) -> dict:
                 pmg.is_active,
                 pmg.sort_order,
                 pmg.gl_account_code,
+                pmg.gl_account_id,
                 COUNT(pm.id) FILTER (
                     WHERE pm.is_active = true AND pm.tenant_id = $1
                 ) AS method_count
@@ -65,6 +66,7 @@ async def list_groups(request: Request) -> dict:
             "isActive": row["is_active"],
             "sortOrder": row["sort_order"],
             "glAccountCode": row["gl_account_code"],
+            "glAccountId": str(row["gl_account_id"]) if row["gl_account_id"] else None,
             "methodCount": row["method_count"],
         }
         for row in rows
@@ -155,12 +157,16 @@ async def patch_group(request: Request, group_id: UUID, body: PatchGroupRequest)
             updates.append(f"gl_account_code = ${idx}")
             params.append(body.glAccountCode if body.glAccountCode != "" else None)
             idx += 1
+        if body.glAccountId is not None:
+            updates.append(f"gl_account_id = ${idx}")
+            params.append(body.glAccountId)
+            idx += 1
 
         if not updates:
             # Nothing to update — return current state
             row = await conn.fetchrow(
                 """
-                SELECT id, tenant_id, name, slug, triggers_cartera, is_active, sort_order, gl_account_code
+                SELECT id, tenant_id, name, slug, triggers_cartera, is_active, sort_order, gl_account_code, gl_account_id
                 FROM payment_method_groups WHERE id = $1
                 """,
                 group_id,
@@ -172,7 +178,7 @@ async def patch_group(request: Request, group_id: UUID, body: PatchGroupRequest)
                 UPDATE payment_method_groups
                 SET {', '.join(updates)}
                 WHERE id = ${idx}
-                RETURNING id, tenant_id, name, slug, triggers_cartera, is_active, sort_order, gl_account_code
+                RETURNING id, tenant_id, name, slug, triggers_cartera, is_active, sort_order, gl_account_code, gl_account_id
                 """,
                 *params,
             )
@@ -188,6 +194,7 @@ async def patch_group(request: Request, group_id: UUID, body: PatchGroupRequest)
             "isActive": row["is_active"],
             "sortOrder": row["sort_order"],
             "glAccountCode": row["gl_account_code"],
+            "glAccountId": str(row["gl_account_id"]) if row["gl_account_id"] else None,
         },
     }
 
@@ -202,7 +209,7 @@ async def list_methods(request: Request) -> dict:
     async with get_db_connection(use_transaction=False) as conn:
         rows = await conn.fetch(
             """
-            SELECT pm.id, pm.tenant_id, pm.group_id, pm.name, pm.is_active, pm.sort_order, pm.gl_account_code
+            SELECT pm.id, pm.tenant_id, pm.group_id, pm.name, pm.is_active, pm.sort_order, pm.gl_account_code, pm.gl_account_id
             FROM payment_methods pm
             WHERE pm.tenant_id = $1
             ORDER BY pm.sort_order, pm.name
@@ -219,6 +226,7 @@ async def list_methods(request: Request) -> dict:
             "isActive": row["is_active"],
             "sortOrder": row["sort_order"],
             "glAccountCode": row["gl_account_code"],
+            "glAccountId": str(row["gl_account_id"]) if row["gl_account_id"] else None,
         }
         for row in rows
     ]
@@ -257,15 +265,16 @@ async def create_method(request: Request, body: CreateMethodRequest) -> dict:
             # to its sub-account in a single round-trip (instead of POST + PATCH).
             row = await conn.fetchrow(
                 """
-                INSERT INTO payment_methods (tenant_id, group_id, name, sort_order, gl_account_code)
-                VALUES ($1, $2, $3, $4, $5)
-                RETURNING id, tenant_id, group_id, name, is_active, sort_order, gl_account_code
+                INSERT INTO payment_methods (tenant_id, group_id, name, sort_order, gl_account_code, gl_account_id)
+                VALUES ($1, $2, $3, $4, $5, $6)
+                RETURNING id, tenant_id, group_id, name, is_active, sort_order, gl_account_code, gl_account_id
                 """,
                 tenant_id,
                 group_id,
                 body.name,
                 body.sortOrder,
                 body.glAccountCode if body.glAccountCode else None,
+                body.glAccountId,
             )
         except UniqueViolationError:
             raise ValidationError(
@@ -282,6 +291,7 @@ async def create_method(request: Request, body: CreateMethodRequest) -> dict:
             "isActive": row["is_active"],
             "sortOrder": row["sort_order"],
             "glAccountCode": row["gl_account_code"],
+            "glAccountId": str(row["gl_account_id"]) if row["gl_account_id"] else None,
         },
     }
 
@@ -336,10 +346,14 @@ async def patch_method(request: Request, method_id: UUID, body: PatchMethodReque
             updates.append(f"gl_account_code = ${idx}")
             params.append(body.glAccountCode if body.glAccountCode != "" else None)
             idx += 1
+        if body.glAccountId is not None:
+            updates.append(f"gl_account_id = ${idx}")
+            params.append(body.glAccountId)
+            idx += 1
 
         if not updates:
             row = await conn.fetchrow(
-                "SELECT id, tenant_id, group_id, name, is_active, sort_order, gl_account_code FROM payment_methods WHERE id = $1",
+                "SELECT id, tenant_id, group_id, name, is_active, sort_order, gl_account_code, gl_account_id FROM payment_methods WHERE id = $1",
                 method_id,
             )
         else:
@@ -349,7 +363,7 @@ async def patch_method(request: Request, method_id: UUID, body: PatchMethodReque
                 UPDATE payment_methods
                 SET {', '.join(updates)}
                 WHERE id = ${idx}
-                RETURNING id, tenant_id, group_id, name, is_active, sort_order, gl_account_code
+                RETURNING id, tenant_id, group_id, name, is_active, sort_order, gl_account_code, gl_account_id
                 """,
                 *params,
             )
@@ -364,6 +378,7 @@ async def patch_method(request: Request, method_id: UUID, body: PatchMethodReque
             "isActive": row["is_active"],
             "sortOrder": row["sort_order"],
             "glAccountCode": row["gl_account_code"],
+            "glAccountId": str(row["gl_account_id"]) if row["gl_account_id"] else None,
         },
     }
 
@@ -409,7 +424,7 @@ async def _list_payment_methods_by_tenant_id(
     async with get_db_connection(use_transaction=False) as conn:
         groups = await conn.fetch(
             """
-            SELECT id, name, slug, triggers_cartera, gl_account_code
+            SELECT id, name, slug, triggers_cartera, gl_account_code, gl_account_id
             FROM payment_method_groups
             WHERE (tenant_id IS NULL OR tenant_id = $1) AND is_active = true
             ORDER BY sort_order, name
@@ -419,7 +434,7 @@ async def _list_payment_methods_by_tenant_id(
 
         methods = await conn.fetch(
             """
-            SELECT id, group_id, name, gl_account_code
+            SELECT id, group_id, name, gl_account_code, gl_account_id
             FROM payment_methods
             WHERE tenant_id = $1 AND is_active = true
             ORDER BY sort_order, name
@@ -436,6 +451,7 @@ async def _list_payment_methods_by_tenant_id(
             "id": str(m["id"]),
             "name": m["name"],
             "glAccountCode": m["gl_account_code"],
+            "glAccountId": str(m["gl_account_id"]) if m["gl_account_id"] else None,
         })
 
     data = [
@@ -445,6 +461,7 @@ async def _list_payment_methods_by_tenant_id(
             "slug": g["slug"],
             "triggersCartera": g["triggers_cartera"],
             "glAccountCode": g["gl_account_code"],
+            "glAccountId": str(g["gl_account_id"]) if g["gl_account_id"] else None,
             "methods": methods_by_group.get(str(g["id"]), []),
         }
         for g in groups

--- a/app/services/purchase_tracking_service.py
+++ b/app/services/purchase_tracking_service.py
@@ -13,6 +13,12 @@ from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError
 from app.services.aws_s3_service import AWSS3Service
 from app.core.timezones import local_date_for_tenant, resolve_tenant_timezone
+from app.services.account_role_service import (
+    AccountRole,
+    MissingAccountRoleError,
+    resolve_account,
+    resolve_payment_account,
+)
 import logging
 
 logger = logging.getLogger(__name__)
@@ -57,19 +63,17 @@ def validate_state_transition(from_status: str, to_status: str) -> bool:
     return to_status in allowed_transitions
 
 
-async def _resolve_purchase_payment_account_code(
+async def _resolve_purchase_payment_account(
     conn,
     tenant_id: UUID,
     payment_method: Optional[str],
     payment_method_id: Optional[UUID],
-) -> tuple[Optional[str], Optional[str]]:
-    """Resolve stored method slug and GL credit account for supplier payments."""
+) -> tuple:
+    """Resolve stored method slug and semantic GL account for supplier payments."""
     method_slug = payment_method
-    credit_code = None
-
     if payment_method_id:
         row = await conn.fetchrow(
-            """SELECT pmg.slug, pm.gl_account_code AS method_code, pmg.gl_account_code AS group_code
+            """SELECT pmg.slug
                FROM payment_methods pm
                JOIN payment_method_groups pmg ON pmg.id = pm.group_id
                WHERE pm.id = $1
@@ -80,35 +84,14 @@ async def _resolve_purchase_payment_account_code(
         )
         if row:
             method_slug = row["slug"]
-            credit_code = row["method_code"] or row["group_code"]
-
-    if not credit_code and method_slug:
-        row = await conn.fetchrow(
-            """SELECT gl_account_code
-                 FROM payment_method_groups
-                WHERE slug = $1
-                  AND (tenant_id = $2 OR tenant_id IS NULL)
-                  AND is_active = TRUE
-                ORDER BY (tenant_id IS NULL) ASC
-                LIMIT 1""",
-            method_slug,
-            tenant_id,
-        )
-        if row:
-            credit_code = row["gl_account_code"]
-
-    if not credit_code:
-        credit_code = {
-            "cash": "1105",
-            "transfer": "1110",
-            "check": "1110",
-            "card": "1110",
-            "credit_card": "1110",
-            "debit_card": "1110",
-            "digital": "1110",
-        }.get(method_slug or "", "1105")
-
-    return method_slug, credit_code
+    account = await resolve_payment_account(
+        conn,
+        tenant_id,
+        method_slug,
+        payment_method_id=payment_method_id,
+        source="supplier_payment",
+    )
+    return method_slug, account
 
 
 async def _post_supplier_payment_gl_entry(
@@ -121,7 +104,7 @@ async def _post_supplier_payment_gl_entry(
     payment_method: Optional[str],
     payment_method_id: Optional[UUID],
 ) -> None:
-    """Post payment of supplier debt: Deb 2205 / Cred payment method account."""
+    """Post supplier payment: debit ACCOUNTS_PAYABLE, credit settlement role."""
     amount_decimal = Decimal(str(amount))
     if amount_decimal <= 0:
         return
@@ -160,64 +143,52 @@ async def _post_supplier_payment_gl_entry(
         )
         return
 
-    debit_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id,
-        "2205",
+    debit_acct = await resolve_account(
+        conn, tenant_id, AccountRole.ACCOUNTS_PAYABLE, source="supplier_payment"
     )
-    method_slug, credit_code = await _resolve_purchase_payment_account_code(
+    method_slug, credit_acct = await _resolve_purchase_payment_account(
         conn,
         tenant_id,
         payment_method,
         payment_method_id,
     )
-    credit_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id,
-        credit_code,
-    )
-    if not debit_acct or not credit_acct:
-        logger.warning(
-            f"[GL] Supplier payment account missing (debit=2205, credit={credit_code}, method={method_slug})"
-        )
-        return
-
     amount_value = float(amount_decimal)
-    entry_row = await conn.fetchrow(
-        """INSERT INTO tenant_journal_entries
+    async with conn.transaction():
+        entry_row = await conn.fetchrow(
+            """INSERT INTO tenant_journal_entries
                (tenant_id, entry_date, period_year, period_month,
                 description, source_module, source_id, status,
                 total_debit, total_credit, posted_at)
            VALUES ($1, $2, $3, $4, $5, 'system', $6, 'posted', $7, $8, NOW())
            RETURNING id""",
-        tenant_id,
-        entry_date,
-        period_year,
-        period_month,
-        description,
-        purchase_id,
-        amount_value,
-        amount_value,
-    )
-    entry_id = entry_row["id"]
-    await conn.execute(
-        """INSERT INTO tenant_journal_lines
+            tenant_id,
+            entry_date,
+            period_year,
+            period_month,
+            description,
+            purchase_id,
+            amount_value,
+            amount_value,
+        )
+        entry_id = entry_row["id"]
+        await conn.execute(
+            """INSERT INTO tenant_journal_lines
                (journal_entry_id, account_id, debit, credit, description, line_order)
            VALUES ($1, $2, $3, 0, $4, 0)""",
-        entry_id,
-        debit_acct["id"],
-        amount_value,
-        description,
-    )
-    await conn.execute(
-        """INSERT INTO tenant_journal_lines
+            entry_id,
+            debit_acct.id,
+            amount_value,
+            description,
+        )
+        await conn.execute(
+            """INSERT INTO tenant_journal_lines
                (journal_entry_id, account_id, debit, credit, description, line_order)
            VALUES ($1, $2, 0, $3, $4, 1)""",
-        entry_id,
-        credit_acct["id"],
-        amount_value,
-        description,
-    )
+            entry_id,
+            credit_acct.id,
+            amount_value,
+            description,
+        )
 
 # =============================================================================
 # ATTACHMENT UPLOAD HELPER
@@ -361,6 +332,8 @@ async def get_purchase_status_history(
 
             return StatusHistoryResponse(data=history)
 
+    except MissingAccountRoleError:
+        raise
     except AuthenticationError:
         raise
     except HTTPException:
@@ -514,6 +487,8 @@ async def get_transition_detail(
             }
         }
 
+    except MissingAccountRoleError:
+        raise
     except AuthenticationError:
         raise
     except HTTPException:
@@ -1194,24 +1169,30 @@ async def transition_to_received(
                     except Exception as discord_error:
                         logger.error(f"Failed to send Discord notification for purchase reception: {discord_error}")
 
-                # GL auto-post — Déb 1435 / Cré <payment account> (#106)
+                # GL auto-post — Déb INVENTORY / Cré <payment account> (#106)
                 # SAVEPOINT: GL failure never rolls back the purchase transition.
                 try:
                     from app.services.direct_purchase_service import _post_purchase_gl_entry
                     gl_row = await conn.fetchrow(
-                        """SELECT total_amount, purchase_date, purchase_number, payment_method_id
+                        """SELECT total_amount, purchase_date, purchase_number,
+                                  payment_method, payment_method_id
                            FROM tenant_purchases WHERE id = $1""",
                         purchase_id,
                     )
                     if gl_row and gl_row["total_amount"]:
+                        timezone_name = await resolve_tenant_timezone(conn, tenant_id)
                         async with conn.transaction():
                             await _post_purchase_gl_entry(
                                 conn, tenant_id, purchase_id,
                                 float(gl_row["total_amount"]),
                                 gl_row["purchase_date"],
                                 f"Compra recibida {gl_row['purchase_number'] or purchase_id}",
+                                gl_row["payment_method"],
                                 gl_row["payment_method_id"],
+                                timezone_name,
                             )
+                except MissingAccountRoleError:
+                    raise
                 except Exception as _gl_err:
                     logger.warning(
                         f"[GL] purchase GL post failed for {purchase_id}: {_gl_err}"
@@ -1219,6 +1200,8 @@ async def transition_to_received(
 
                 return {"success": True, "message": f"Purchase {target_status}"}
 
+    except MissingAccountRoleError:
+        raise
     except AuthenticationError:
         raise
     except HTTPException:
@@ -1435,7 +1418,7 @@ async def transition_to_paid(
                         detail=f"Cannot transition from {purchase['status']} to paid"
                     )
 
-                payment_method, _credit_code = await _resolve_purchase_payment_account_code(
+                payment_method, _credit_account = await _resolve_purchase_payment_account(
                     conn,
                     tenant_id,
                     payment_method,
@@ -1509,6 +1492,8 @@ async def transition_to_paid(
                         payment_method=payment_method,
                         payment_method_id=payment_method_id,
                     )
+                except MissingAccountRoleError:
+                    raise
                 except Exception as gl_error:
                     logger.warning(f"[GL] supplier payment GL post failed for {purchase_id}: {gl_error}")
 
@@ -1531,6 +1516,8 @@ async def transition_to_paid(
 
                 return {"success": True, "message": "Payment registered successfully"}
 
+    except MissingAccountRoleError:
+        raise
     except AuthenticationError:
         raise
     except HTTPException:

--- a/app/services/salary_service.py
+++ b/app/services/salary_service.py
@@ -13,6 +13,12 @@ from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import ValidationError, NotFoundError
 from app.services.aws_s3_service import AWSS3Service
+from app.services.account_role_service import (
+    AccountRole,
+    MissingAccountRoleError,
+    resolve_account,
+    resolve_payment_account,
+)
 import asyncpg
 from app.models.salary import (
     EmployeesWithSalaryResponse,
@@ -49,26 +55,6 @@ logger = logging.getLogger(__name__)
 
 # SMMLV 2026 - Should be fetched from database
 DEFAULT_SMMLV = Decimal('1423500')
-
-# GL account codes for salary/payroll — debit side (expense)
-_SALARY_DEBIT_CODE = {
-    "employee":   "5105",  # Sueldos de personal
-    "contractor": "5199",  # Otros gastos y honorarios
-    "daily":      "5105",  # Sueldos de personal (jornalero)
-}
-
-# Slug fallback for credit side (cash/bank) — used when payment_method is not a UUID
-# or when payment_methods.gl_account_code is null in DB
-_SALARY_CREDIT_SLUG_FALLBACK = {
-    "cash":     "1105",  # Caja general
-    "transfer": "1110",  # Bancos
-    "check":    "1110",  # Bancos
-    "other":    "1110",  # Bancos
-    "card":     "1110",  # Bancos (datáfono)
-    "digital":  "1110",  # Bancos (Nequi, Daviplata, PSE)
-    "credit":   "1305",  # Clientes (fiado)
-}
-
 
 def get_color_for_name(name: str) -> str:
     """Generate a consistent color based on name"""
@@ -117,38 +103,35 @@ async def get_current_smmlv(conn, tenant_id: UUID) -> Decimal:
     return Decimal(str(result)) if result else DEFAULT_SMMLV
 
 
-async def _resolve_salary_credit_gl_code(conn, payment_method: Optional[str]) -> str:
-    """
-    Resolve the GL account code for the credit side of a salary payment.
-    Mirrors the same cascade used by _post_order_gl_entry in cierre_service.py:
-      1. If payment_method is a UUID → query payment_methods JOIN payment_method_groups
-         for COALESCE(pm.gl_account_code, pmg.gl_account_code)
-      2. Fall back to slug-based dict (_SALARY_CREDIT_SLUG_FALLBACK)
-      3. Ultimate fallback: "1110" (Bancos)
-    """
+async def _resolve_salary_credit_account(conn, tenant_id: UUID, payment_method: Optional[str]):
+    """Resolve a salary settlement account by explicit method or semantic role."""
     if payment_method:
         try:
-            UUID(payment_method)
-            is_uuid = True
+            method_id = UUID(payment_method)
         except (ValueError, AttributeError):
-            is_uuid = False
-
-        if is_uuid:
-            row = await conn.fetchrow(
-                """SELECT COALESCE(pm.gl_account_code, pmg.gl_account_code) AS code
-                   FROM payment_methods pm
-                   JOIN payment_method_groups pmg ON pm.group_id = pmg.id
-                   WHERE pm.id = $1""",
-                UUID(payment_method),
+            method_id = None
+        if method_id:
+            return await resolve_payment_account(
+                conn,
+                tenant_id,
+                "transfer",
+                payment_method_id=method_id,
+                source="salary",
             )
-            if row and row["code"]:
-                return row["code"]
+        return await resolve_payment_account(
+            conn, tenant_id, payment_method, source="salary"
+        )
+    return await resolve_account(conn, tenant_id, AccountRole.BANK, source="salary")
 
-        slug_code = _SALARY_CREDIT_SLUG_FALLBACK.get(payment_method)
-        if slug_code:
-            return slug_code
 
-    return "1110"
+async def _resolve_salary_disbursement_accounts(
+    conn, tenant_id: UUID, debit_role: str, payment_method: Optional[str], source: str
+):
+    debit_account = await resolve_account(conn, tenant_id, debit_role, source=source)
+    credit_account = await _resolve_salary_credit_account(
+        conn, tenant_id, payment_method
+    )
+    return debit_account, credit_account
 
 
 async def _post_salary_gl_entry(
@@ -169,19 +152,19 @@ async def _post_salary_gl_entry(
 
     Without withholding or SS (2 lines):
       DR: 5105 (employee/daily) or 5199 (contractor)  — gross
-      CR: 1105/1110 (cash/bank)                        — gross
+      CR: settlement account role                      — gross
 
     With withholding (3 lines, contractors only):
       DR: 5199 Honorarios                              — gross
-      CR: 1110 Bancos                                  — net (gross − withholding)
+      CR: settlement account role                      — net (gross − withholding)
       CR: 2367 Retención en la fuente por pagar        — withholding
 
     With SS deductions (3 lines, employees/daily):
       DR: 5105 Sueldos                                 — gross
-      CR: 1110 Bancos                                  — net_pay (gross − employee_ss)
+      CR: settlement account role                      — net_pay (gross − employee_ss)
       CR: 237005 Aportes SS empleado (EPS + AFP)       — employee_ss
 
-    Silently skips if accounts missing, period closed, or already posted.
+    Skips closed/already-posted periods; missing roles fail explicitly.
     Caller MUST wrap in try/except.
     """
     if payment_amount <= 0:
@@ -208,25 +191,15 @@ async def _post_salary_gl_entry(
         logger.warning(f"[GL] Period {entry_date.year}-{entry_date.month:02d} closed — skip GL for salary payment {payment_id}")
         return
 
-    # Resolve debit account (expense)
-    debit_code = _SALARY_DEBIT_CODE.get(employment_type or "employee", "5105")
-    debit_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, debit_code,
+    debit_role = (
+        AccountRole.CONTRACTOR_EXPENSE
+        if employment_type == "contractor"
+        else AccountRole.PAYROLL_EXPENSE
     )
-    if not debit_acct:
-        logger.warning(f"[GL] Debit account {debit_code} not found for tenant {tenant_id} — skip salary GL")
-        return
-
-    # Resolve credit account (cash/bank) — dynamic UUID-aware lookup
-    credit_code = await _resolve_salary_credit_gl_code(conn, payment_method)
-    credit_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, credit_code,
+    debit_acct = await resolve_account(
+        conn, tenant_id, debit_role, source="salary"
     )
-    if not credit_acct:
-        logger.warning(f"[GL] Credit account {credit_code} not found for tenant {tenant_id} — skip salary GL")
-        return
+    credit_acct = await _resolve_salary_credit_account(conn, tenant_id, payment_method)
 
     gross_amt = float(payment_amount)
     use_withholding = withholding_amount and withholding_amount > 0
@@ -236,23 +209,14 @@ async def _post_salary_gl_entry(
         wh_amt = float(withholding_amount or 0)
         net_amt = gross_amt - wh_amt
 
-        # Resolve account 2367 — Retención en la fuente por pagar
-        wh_acct = await conn.fetchrow(
-            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = '2367' AND is_active = true",
-            tenant_id,
+        wh_acct = await resolve_account(
+            conn, tenant_id, AccountRole.WITHHOLDING_PAYABLE, source="salary"
         )
-        if not wh_acct:
-            logger.warning(f"[GL] Withholding account 2367 not found for tenant {tenant_id} — posting without withholding split")
-            use_withholding = False
 
     if use_ss:
-        ss_acct = await conn.fetchrow(
-            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = '237005' AND is_active = true",
-            tenant_id,
+        ss_acct = await resolve_account(
+            conn, tenant_id, AccountRole.EMPLOYEE_SS_PAYABLE, source="salary"
         )
-        if not ss_acct:
-            logger.warning(f"[GL] SS account 237005 not found for tenant {tenant_id} — posting gross without SS split")
-            use_ss = False
 
     async with conn.transaction():
         entry_row = await conn.fetchrow(
@@ -272,7 +236,7 @@ async def _post_salary_gl_entry(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, $3, 0, $4, 0)""",
-            entry_id, debit_acct["id"], gross_amt, description,
+            entry_id, debit_acct.id, gross_amt, description,
         )
 
         if use_withholding:
@@ -281,16 +245,16 @@ async def _post_salary_gl_entry(
                 """INSERT INTO tenant_journal_lines
                        (journal_entry_id, account_id, debit, credit, description, line_order)
                    VALUES ($1, $2, 0, $3, $4, 1)""",
-                entry_id, credit_acct["id"], net_amt, description,
+                entry_id, credit_acct.id, net_amt, description,
             )
             # Credit line 2 — 2367 Retención en la fuente por pagar
             await conn.execute(
                 """INSERT INTO tenant_journal_lines
                        (journal_entry_id, account_id, debit, credit, description, line_order)
                    VALUES ($1, $2, 0, $3, $4, 2)""",
-                entry_id, wh_acct["id"], wh_amt, f"Retefuente — {description}",
+                entry_id, wh_acct.id, wh_amt, f"Retefuente — {description}",
             )
-            logger.info(f"[GL] Posted salary entry {entry_id} for payment {payment_id} (gross={gross_amt}, net={net_amt}, wh={wh_amt}, debit={debit_code}, credit={credit_code}, wh_acct=2367)")
+            logger.info(f"[GL] Posted salary entry {entry_id} for payment {payment_id} (gross={gross_amt}, net={net_amt}, wh={wh_amt}, debit={debit_acct.code}, credit={credit_acct.code})")
         elif use_ss:
             net_amt_ss = float(net_pay)
             ss_emp_amt = float(employee_ss)
@@ -299,25 +263,25 @@ async def _post_salary_gl_entry(
                 """INSERT INTO tenant_journal_lines
                        (journal_entry_id, account_id, debit, credit, description, line_order)
                    VALUES ($1, $2, 0, $3, $4, 1)""",
-                entry_id, credit_acct["id"], net_amt_ss, description,
+                entry_id, credit_acct.id, net_amt_ss, description,
             )
             # Credit line 2 — 2370 employee SS deduction
             await conn.execute(
                 """INSERT INTO tenant_journal_lines
                        (journal_entry_id, account_id, debit, credit, description, line_order)
                    VALUES ($1, $2, 0, $3, $4, 2)""",
-                entry_id, ss_acct["id"], ss_emp_amt, f"SS empleado — {description}",
+                entry_id, ss_acct.id, ss_emp_amt, f"SS empleado — {description}",
             )
-            logger.info(f"[GL] Posted salary entry {entry_id} for payment {payment_id} (gross={gross_amt}, net={net_amt_ss}, ss_emp={ss_emp_amt}, debit={debit_code}, credit={credit_code})")
+            logger.info(f"[GL] Posted salary entry {entry_id} for payment {payment_id} (gross={gross_amt}, net={net_amt_ss}, ss_emp={ss_emp_amt}, debit={debit_acct.code}, credit={credit_acct.code})")
         else:
             # Credit line — cash/bank (full amount)
             await conn.execute(
                 """INSERT INTO tenant_journal_lines
                        (journal_entry_id, account_id, debit, credit, description, line_order)
                    VALUES ($1, $2, 0, $3, $4, 1)""",
-                entry_id, credit_acct["id"], gross_amt, description,
+                entry_id, credit_acct.id, gross_amt, description,
             )
-            logger.info(f"[GL] Posted salary entry {entry_id} for payment {payment_id} (amount={gross_amt}, debit={debit_code}, credit={credit_code})")
+            logger.info(f"[GL] Posted salary entry {entry_id} for payment {payment_id} (amount={gross_amt}, debit={debit_acct.code}, credit={credit_acct.code})")
 
 
 async def _post_provision_gl_entries(
@@ -331,14 +295,9 @@ async def _post_provision_gl_entries(
     """
     Post monthly social benefit provision GL entries after a salary payment.
 
-    DR 5106 Gasto prima de servicios         CR 2620 Prima de servicios
-    DR 5107 Gasto cesantías                  CR 2610 Cesantías consolidadas
-    DR 5108 Gasto intereses sobre cesantías  CR 2615 Intereses sobre cesantías
-    DR 5109 Gasto vacaciones                 CR 2625 Vacaciones consolidadas
-
-    Graceful degrade — never raises, never blocks the payment flow.
+    Debit and credit accounts are resolved from the four benefit role pairs.
+    A missing required role fails before any journal row is inserted.
     Skips for 'contractor' employment type.
-    Caller MUST wrap in try/except.
     """
     if employment_type == "contractor":
         return
@@ -373,7 +332,44 @@ async def _post_provision_gl_entries(
         Decimal("0.01"), rounding=ROUND_HALF_UP
     )
 
-    # Upsert salary_provisions row (persists even if GL fails)
+    # Check accounting period is open
+    today = date.today()
+    closed = await conn.fetchval(
+        """SELECT 1 FROM tenant_monthly_periods
+           WHERE tenant_id = $1 AND year = $2 AND month = $3 AND status = 'closed'""",
+        tenant_id, today.year, today.month,
+    )
+    if closed:
+        logger.warning(
+            f"[provision_gl] Period {today.year}-{today.month:02d} closed — skip GL for provision on payment {payment_id}"
+        )
+        return
+
+    # Resolve the complete journal before inserting its header.
+    provision_pairs = [
+        (AccountRole.PRIMA_EXPENSE, AccountRole.PRIMA_PAYABLE, prima, "Provisión prima de servicios"),
+        (AccountRole.CESANTIAS_EXPENSE, AccountRole.CESANTIAS_PAYABLE, cesantias, "Provisión cesantías"),
+        (AccountRole.CESANTIAS_INTEREST_EXPENSE, AccountRole.CESANTIAS_INTEREST_PAYABLE, int_cesantias, "Provisión intereses sobre cesantías"),
+        (AccountRole.VACATION_EXPENSE, AccountRole.VACATION_PAYABLE, vacaciones, "Provisión vacaciones"),
+    ]
+
+    lines = []
+    for debit_role, credit_role, amount, description in provision_pairs:
+        if amount <= 0:
+            continue
+        dr_acct = await resolve_account(
+            conn, tenant_id, debit_role, source="salary_provision"
+        )
+        cr_acct = await resolve_account(
+            conn, tenant_id, credit_role, source="salary_provision"
+        )
+        lines.append((dr_acct, cr_acct, float(amount), description))
+
+    if not lines:
+        return
+
+    total_debit = sum(line[2] for line in lines)
+
     existing_prov = await conn.fetchval(
         "SELECT 1 FROM salary_provisions WHERE payment_id = $1",
         payment_id,
@@ -389,52 +385,6 @@ async def _post_provision_gl_entries(
             employment_type or "employee",
             gross_salary, prima, cesantias, int_cesantias, vacaciones,
         )
-
-    # Check accounting period is open
-    today = date.today()
-    closed = await conn.fetchval(
-        """SELECT 1 FROM tenant_monthly_periods
-           WHERE tenant_id = $1 AND year = $2 AND month = $3 AND status = 'closed'""",
-        tenant_id, today.year, today.month,
-    )
-    if closed:
-        logger.warning(
-            f"[provision_gl] Period {today.year}-{today.month:02d} closed — skip GL for provision on payment {payment_id}"
-        )
-        return
-
-    # Resolve GL accounts — expense (DR) and provision (CR)
-    # pairs: (dr_code, cr_code, amount, description)
-    provision_pairs = [
-        ("5106", "2620", prima,         "Provisión prima de servicios"),
-        ("5107", "2610", cesantias,     "Provisión cesantías"),
-        ("5108", "2615", int_cesantias, "Provisión intereses sobre cesantías"),
-        ("5109", "2625", vacaciones,    "Provisión vacaciones"),
-    ]
-
-    lines = []
-    for dr_code, cr_code, amount, description in provision_pairs:
-        if amount <= 0:
-            continue
-        dr_acct = await conn.fetchval(
-            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-            tenant_id, dr_code,
-        )
-        cr_acct = await conn.fetchval(
-            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-            tenant_id, cr_code,
-        )
-        if not dr_acct or not cr_acct:
-            logger.warning(
-                f"[provision_gl] Missing account {dr_code} or {cr_code} for tenant {tenant_id} — skip {description}"
-            )
-            continue
-        lines.append((dr_acct, cr_acct, float(amount), description))
-
-    if not lines:
-        return
-
-    total_debit = sum(l[2] for l in lines)
 
     async with conn.transaction():
         entry_row = await conn.fetchrow(
@@ -456,14 +406,14 @@ async def _post_provision_gl_entries(
                 """INSERT INTO tenant_journal_lines
                        (journal_entry_id, account_id, debit, credit, description, line_order)
                    VALUES ($1, $2, $3, 0, $4, $5)""",
-                entry_id, dr_acct, amount, description, line_order,
+                entry_id, dr_acct.id, amount, description, line_order,
             )
             line_order += 1
             await conn.execute(
                 """INSERT INTO tenant_journal_lines
                        (journal_entry_id, account_id, debit, credit, description, line_order)
                    VALUES ($1, $2, 0, $3, $4, $5)""",
-                entry_id, cr_acct, amount, description, line_order,
+                entry_id, cr_acct.id, amount, description, line_order,
             )
             line_order += 1
 
@@ -523,18 +473,12 @@ async def _post_ss_gl_entry(
         logger.warning(f"[ss_gl] Period closed — skip SS GL for payment {payment_id}")
         return
 
-    # Resolve accounts
-    debit_acct = await conn.fetchval(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = '5120' AND is_active = true",
-        tenant_id,
+    debit_acct = await resolve_account(
+        conn, tenant_id, AccountRole.EMPLOYER_SS_EXPENSE, source="salary_ss"
     )
-    credit_acct = await conn.fetchval(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = '237010' AND is_active = true",
-        tenant_id,
+    credit_acct = await resolve_account(
+        conn, tenant_id, AccountRole.EMPLOYER_SS_PAYABLE, source="salary_ss"
     )
-    if not debit_acct or not credit_acct:
-        logger.warning(f"[ss_gl] Missing account 5120 or 237010 for tenant {tenant_id} — skip SS GL")
-        return
 
     emp_total = float(employer_total)
     ss_description = f"Aportes SS empleador — {description}"
@@ -556,13 +500,13 @@ async def _post_ss_gl_entry(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, $3, 0, $4, 0)""",
-            entry_id, debit_acct, emp_total, ss_description,
+            entry_id, debit_acct.id, emp_total, ss_description,
         )
         await conn.execute(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, 0, $3, $4, 1)""",
-            entry_id, credit_acct, emp_total, ss_description,
+            entry_id, credit_acct.id, emp_total, ss_description,
         )
 
     logger.info(
@@ -1051,6 +995,8 @@ async def record_salary_payment_json(
                 net_pay=net_pay,
                 employee_ss=employee_ss,
             )
+        except MissingAccountRoleError:
+            raise
         except Exception as gl_err:
             logger.warning(f"[GL] Salary GL posting failed for payment {payment_id}: {gl_err}")
 
@@ -1064,6 +1010,8 @@ async def record_salary_payment_json(
                 employment_type=employment_type,
                 gross_salary=payment_amount,
             )
+        except MissingAccountRoleError:
+            raise
         except Exception as prov_err:
             logger.warning(f"[provision_gl] Provision GL posting failed for payment {payment_id}: {prov_err}")
 
@@ -1095,6 +1043,8 @@ async def record_salary_payment_json(
                     employer_arl, employer_caja, net_pay,
                     payment_id,
                 )
+            except MissingAccountRoleError:
+                raise
             except Exception as ss_err:
                 logger.warning(f"[ss_gl] SS GL posting failed for payment {payment_id}: {ss_err}")
 
@@ -1285,6 +1235,8 @@ async def record_salary_payment(
                 description=mp_gl_description,
                 withholding_amount=mp_withholding_amount,
             )
+        except MissingAccountRoleError:
+            raise
         except Exception as gl_err:
             logger.warning(f"[GL] Salary GL posting failed for payment {payment_id}: {gl_err}")
 
@@ -1298,6 +1250,8 @@ async def record_salary_payment(
                 employment_type=mp_employment_type,
                 gross_salary=actual_payment_amount,
             )
+        except MissingAccountRoleError:
+            raise
         except Exception as prov_err:
             logger.warning(f"[provision_gl] Provision GL posting failed for payment {payment_id}: {prov_err}")
 
@@ -1942,26 +1896,9 @@ async def _post_prima_payment_gl_entry(
         )
         return
 
-    # Resolve DR account: 2620 (Provisión prima de servicios) — debit liquidates liability
-    dr_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = '2620' AND is_active = true",
-        tenant_id,
+    dr_acct, cr_acct = await _resolve_salary_disbursement_accounts(
+        conn, tenant_id, AccountRole.PRIMA_PAYABLE, payment_method, "prima_payment"
     )
-    if not dr_acct:
-        logger.warning(f"[prima_gl] DR account 2620 not found for tenant {tenant_id} — skip prima GL")
-        return
-
-    # Resolve CR account: bank/cash (dynamic, same as salary credit resolution)
-    credit_code = await _resolve_salary_credit_gl_code(conn, payment_method)
-    cr_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, credit_code,
-    )
-    if not cr_acct:
-        logger.warning(
-            f"[prima_gl] CR account {credit_code} not found for tenant {tenant_id} — skip prima GL"
-        )
-        return
 
     amount_float = float(prima_amount)
 
@@ -1984,19 +1921,19 @@ async def _post_prima_payment_gl_entry(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, $3, 0, $4, 0)""",
-            entry_id, dr_acct["id"], amount_float, f"Prima de servicios {semestre}",
+            entry_id, dr_acct.id, amount_float, f"Prima de servicios {semestre}",
         )
         # CR line — bank/cash
         await conn.execute(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, 0, $3, $4, 1)""",
-            entry_id, cr_acct["id"], amount_float, f"Prima de servicios {semestre}",
+            entry_id, cr_acct.id, amount_float, f"Prima de servicios {semestre}",
         )
 
     logger.info(
         f"[prima_gl] Posted prima entry {entry_id} for payment {prima_payment_id} "
-        f"(amount={amount_float}, DR=2620, CR={credit_code}, semestre={semestre})"
+        f"(amount={amount_float}, DR={dr_acct.code}, CR={cr_acct.code}, semestre={semestre})"
     )
 
 
@@ -2075,6 +2012,8 @@ async def record_prima_payment(
                 payment_date=payment_date,
                 semestre=data.semestre,
             )
+        except MissingAccountRoleError:
+            raise
         except Exception as gl_err:
             logger.warning(f"[prima_gl] GL post failed for prima payment {payment_id}: {gl_err}")
 
@@ -2225,26 +2164,9 @@ async def _post_cesantias_payment_gl_entry(
         )
         return
 
-    # Resolve DR account: 2610 (Cesantías consolidadas) — debit liquidates liability
-    dr_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = '2610' AND is_active = true",
-        tenant_id,
+    dr_acct, cr_acct = await _resolve_salary_disbursement_accounts(
+        conn, tenant_id, AccountRole.CESANTIAS_PAYABLE, payment_method, "cesantias_payment"
     )
-    if not dr_acct:
-        logger.warning(f"[cesantias_gl] DR account 2610 not found for tenant {tenant_id} — skip cesantias GL")
-        return
-
-    # Resolve CR account: bank/cash
-    credit_code = await _resolve_salary_credit_gl_code(conn, payment_method)
-    cr_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, credit_code,
-    )
-    if not cr_acct:
-        logger.warning(
-            f"[cesantias_gl] CR account {credit_code} not found for tenant {tenant_id} — skip cesantias GL"
-        )
-        return
 
     amount_float = float(cesantias_amount)
 
@@ -2267,19 +2189,19 @@ async def _post_cesantias_payment_gl_entry(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, $3, 0, $4, 0)""",
-            entry_id, dr_acct["id"], amount_float, (f"Cesantías {anio} — {fondo_name}" if fondo_name else f"Cesantías {anio}"),
+            entry_id, dr_acct.id, amount_float, (f"Cesantías {anio} — {fondo_name}" if fondo_name else f"Cesantías {anio}"),
         )
         # CR line — bank/cash
         await conn.execute(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, 0, $3, $4, 1)""",
-            entry_id, cr_acct["id"], amount_float, (f"Cesantías {anio} — {fondo_name}" if fondo_name else f"Cesantías {anio}"),
+            entry_id, cr_acct.id, amount_float, (f"Cesantías {anio} — {fondo_name}" if fondo_name else f"Cesantías {anio}"),
         )
 
     logger.info(
         f"[cesantias_gl] Posted cesantias entry {entry_id} for payment {cesantias_payment_id} "
-        f"(amount={amount_float}, DR=2610, CR={credit_code}, anio={anio})"
+        f"(amount={amount_float}, DR={dr_acct.code}, CR={cr_acct.code}, anio={anio})"
     )
 
 
@@ -2331,26 +2253,13 @@ async def _post_int_cesantias_payment_gl_entry(
         )
         return
 
-    # Resolve DR account: 2615 (Intereses sobre cesantías) — debit liquidates liability
-    dr_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = '2615' AND is_active = true",
+    dr_acct, cr_acct = await _resolve_salary_disbursement_accounts(
+        conn,
         tenant_id,
+        AccountRole.CESANTIAS_INTEREST_PAYABLE,
+        payment_method,
+        "cesantias_interest_payment",
     )
-    if not dr_acct:
-        logger.warning(f"[int_cesantias_gl] DR account 2615 not found for tenant {tenant_id} — skip int_cesantias GL")
-        return
-
-    # Resolve CR account: bank/cash
-    credit_code = await _resolve_salary_credit_gl_code(conn, payment_method)
-    cr_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, credit_code,
-    )
-    if not cr_acct:
-        logger.warning(
-            f"[int_cesantias_gl] CR account {credit_code} not found for tenant {tenant_id} — skip int_cesantias GL"
-        )
-        return
 
     amount_float = float(int_cesantias_amount)
 
@@ -2373,19 +2282,19 @@ async def _post_int_cesantias_payment_gl_entry(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, $3, 0, $4, 0)""",
-            entry_id, dr_acct["id"], amount_float, f"Intereses sobre cesantías {anio}",
+            entry_id, dr_acct.id, amount_float, f"Intereses sobre cesantías {anio}",
         )
         # CR line — bank/cash
         await conn.execute(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, 0, $3, $4, 1)""",
-            entry_id, cr_acct["id"], amount_float, f"Intereses sobre cesantías {anio}",
+            entry_id, cr_acct.id, amount_float, f"Intereses sobre cesantías {anio}",
         )
 
     logger.info(
         f"[int_cesantias_gl] Posted int_cesantias entry {entry_id} for payment {int_cesantias_payment_id} "
-        f"(amount={amount_float}, DR=2615, CR={credit_code}, anio={anio})"
+        f"(amount={amount_float}, DR={dr_acct.code}, CR={cr_acct.code}, anio={anio})"
     )
 
 
@@ -2467,6 +2376,8 @@ async def record_cesantias_payment(
                 anio=data.anio,
                 fondo_name=data.fondo_name,
             )
+        except MissingAccountRoleError:
+            raise
         except Exception as gl_err:
             logger.warning(f"[cesantias_gl] GL post failed for cesantias payment {payment_id}: {gl_err}")
 
@@ -2611,6 +2522,8 @@ async def record_int_cesantias_payment(
                 payment_date=payment_date,
                 anio=data.anio,
             )
+        except MissingAccountRoleError:
+            raise
         except Exception as gl_err:
             logger.warning(f"[int_cesantias_gl] GL post failed for int_cesantias payment {payment_id}: {gl_err}")
 
@@ -2718,26 +2631,9 @@ async def _post_vacaciones_payment_gl_entry(
         )
         return
 
-    # Resolve DR account: 2625 (Vacaciones consolidadas) — debit liquidates liability
-    dr_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = '2625' AND is_active = true",
-        tenant_id,
+    dr_acct, cr_acct = await _resolve_salary_disbursement_accounts(
+        conn, tenant_id, AccountRole.VACATION_PAYABLE, payment_method, "vacation_payment"
     )
-    if not dr_acct:
-        logger.warning(f"[vacaciones_gl] DR account 2625 not found for tenant {tenant_id} — skip GL")
-        return
-
-    # Resolve CR account: bank/cash
-    credit_code = await _resolve_salary_credit_gl_code(conn, payment_method)
-    cr_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, credit_code,
-    )
-    if not cr_acct:
-        logger.warning(
-            f"[vacaciones_gl] CR account {credit_code} not found for tenant {tenant_id} — skip GL"
-        )
-        return
 
     amount_float = float(vacaciones_amount)
 
@@ -2760,19 +2656,19 @@ async def _post_vacaciones_payment_gl_entry(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, $3, 0, $4, 0)""",
-            entry_id, dr_acct["id"], amount_float, f"Vacaciones {anio}",
+            entry_id, dr_acct.id, amount_float, f"Vacaciones {anio}",
         )
         # CR line — bank/cash
         await conn.execute(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, 0, $3, $4, 1)""",
-            entry_id, cr_acct["id"], amount_float, f"Vacaciones {anio}",
+            entry_id, cr_acct.id, amount_float, f"Vacaciones {anio}",
         )
 
     logger.info(
         f"[vacaciones_gl] Posted entry {entry_id} for payment {vacaciones_payment_id} "
-        f"(amount={amount_float}, DR=2625, CR={credit_code}, anio={anio})"
+        f"(amount={amount_float}, DR={dr_acct.code}, CR={cr_acct.code}, anio={anio})"
     )
 
 
@@ -2851,6 +2747,8 @@ async def record_vacaciones_payment(
                 payment_date=payment_date,
                 anio=data.anio,
             )
+        except MissingAccountRoleError:
+            raise
         except Exception as e:
             logger.error(f"[vacaciones_gl] GL post failed for payment {payment_id}: {e}")
 
@@ -2957,26 +2855,9 @@ async def _post_dotacion_gl_entry(
         )
         return
 
-    # Resolve DR account: 5115 (Dotación al personal)
-    dr_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = '5115' AND is_active = true",
-        tenant_id,
+    dr_acct, cr_acct = await _resolve_salary_disbursement_accounts(
+        conn, tenant_id, AccountRole.DOTACION_EXPENSE, payment_method, "dotacion_payment"
     )
-    if not dr_acct:
-        logger.warning(f"[dotacion_gl] DR account 5115 not found for tenant {tenant_id} — skip dotacion GL")
-        return
-
-    # Resolve CR account: bank/cash
-    credit_code = await _resolve_salary_credit_gl_code(conn, payment_method)
-    cr_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, credit_code,
-    )
-    if not cr_acct:
-        logger.warning(
-            f"[dotacion_gl] CR account {credit_code} not found for tenant {tenant_id} — skip dotacion GL"
-        )
-        return
 
     amount_float = float(total_amount)
     period_label = {'APR': 'Apr', 'AUG': 'Ago', 'DEC': 'Dic'}.get(period, period)
@@ -3000,19 +2881,19 @@ async def _post_dotacion_gl_entry(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, $3, 0, $4, 0)""",
-            entry_id, dr_acct["id"], amount_float, f"Dotación {period_label} {year}",
+            entry_id, dr_acct.id, amount_float, f"Dotación {period_label} {year}",
         )
         # CR line — bank/cash
         await conn.execute(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, 0, $3, $4, 1)""",
-            entry_id, cr_acct["id"], amount_float, f"Dotación {period_label} {year}",
+            entry_id, cr_acct.id, amount_float, f"Dotación {period_label} {year}",
         )
 
     logger.info(
         f"[dotacion_gl] Posted dotacion entry {entry_id} for payment {dotacion_payment_id} "
-        f"(amount={amount_float}, DR=5115, CR={credit_code}, {period} {year})"
+        f"(amount={amount_float}, DR={dr_acct.code}, CR={cr_acct.code}, {period} {year})"
     )
 
 
@@ -3091,6 +2972,8 @@ async def record_dotacion_payment(
                 period=data.period,
                 year=data.year,
             )
+        except MissingAccountRoleError:
+            raise
         except Exception as e:
             logger.error(f"[dotacion_gl] GL post failed for payment {payment_id}: {e}")
 
@@ -3200,28 +3083,13 @@ async def _post_pila_gl_entry(
         )
         return
 
-    # Resolve DR accounts: 237005 (employee SS) and 237010 (employer SS)
-    dr_237005 = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = '237005' AND is_active = true",
-        tenant_id,
+    dr_employee = await resolve_account(
+        conn, tenant_id, AccountRole.EMPLOYEE_SS_PAYABLE, source="pila_payment"
     )
-    dr_237010 = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = '237010' AND is_active = true",
-        tenant_id,
+    dr_employer = await resolve_account(
+        conn, tenant_id, AccountRole.EMPLOYER_SS_PAYABLE, source="pila_payment"
     )
-    if not dr_237005 or not dr_237010:
-        logger.warning(f"[pila_gl] DR accounts 237005/237010 not found for tenant {tenant_id} — skip PILA GL")
-        return
-
-    # Resolve CR account: bank/cash
-    credit_code = await _resolve_salary_credit_gl_code(conn, payment_method)
-    cr_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, credit_code,
-    )
-    if not cr_acct:
-        logger.warning(f"[pila_gl] CR account {credit_code} not found for tenant {tenant_id} — skip PILA GL")
-        return
+    cr_acct = await _resolve_salary_credit_account(conn, tenant_id, payment_method)
 
     emp_float = float(employee_ss_amount)
     emp_er_float = float(employer_ss_amount)
@@ -3247,7 +3115,7 @@ async def _post_pila_gl_entry(
                 """INSERT INTO tenant_journal_lines
                        (journal_entry_id, account_id, debit, credit, description, line_order)
                    VALUES ($1, $2, $3, 0, $4, 0)""",
-                entry_id, dr_237005["id"], emp_float, f"PILA empleado {period_month}",
+                entry_id, dr_employee.id, emp_float, f"PILA empleado {period_month}",
             )
 
         # DR line 2 — 237010 Aportes SS empleador (clears liability)
@@ -3256,7 +3124,7 @@ async def _post_pila_gl_entry(
                 """INSERT INTO tenant_journal_lines
                        (journal_entry_id, account_id, debit, credit, description, line_order)
                    VALUES ($1, $2, $3, 0, $4, 1)""",
-                entry_id, dr_237010["id"], emp_er_float, f"PILA empleador {period_month}",
+                entry_id, dr_employer.id, emp_er_float, f"PILA empleador {period_month}",
             )
 
         # CR line — bank/cash
@@ -3264,12 +3132,12 @@ async def _post_pila_gl_entry(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, 0, $3, $4, 2)""",
-            entry_id, cr_acct["id"], total_float, f"PILA {period_month}",
+            entry_id, cr_acct.id, total_float, f"PILA {period_month}",
         )
 
     logger.info(
         f"[pila_gl] Posted PILA entry {entry_id} for payment {pila_payment_id} "
-        f"(total={total_float}, DR237005={emp_float}, DR237010={emp_er_float}, CR={credit_code}, {period_month})"
+        f"(total={total_float}, employee={emp_float}, employer={emp_er_float}, CR={cr_acct.code}, {period_month})"
     )
 
 
@@ -3311,6 +3179,8 @@ async def record_pila_payment(
                 payment_date=payment_date,
                 period_month=data.period_month,
             )
+        except MissingAccountRoleError:
+            raise
         except Exception as e:
             logger.error(f"[pila_gl] GL post failed for PILA payment {payment_id}: {e}")
 
@@ -3380,39 +3250,48 @@ async def get_pila_pending(
     tenant_id = session.tenant_id
 
     async with get_db_connection() as conn:
+        employee_account = await resolve_account(
+            conn, tenant_id, AccountRole.EMPLOYEE_SS_PAYABLE, source="pila_pending"
+        )
+        employer_account = await resolve_account(
+            conn, tenant_id, AccountRole.EMPLOYER_SS_PAYABLE, source="pila_pending"
+        )
         rows = await conn.fetch(
             """SELECT
                  LPAD(tje.period_year::text, 4, '0') || '-' ||
                  LPAD(tje.period_month::text, 2, '0') AS period_month,
-                 ta.code,
+                 tjl.account_id,
                  SUM(tjl.credit) - COALESCE(SUM(tjl.debit), 0) AS net_liability
                FROM tenant_journal_lines tjl
                JOIN tenant_journal_entries tje ON tje.id = tjl.journal_entry_id
-               JOIN tenant_accounts ta ON ta.id = tjl.account_id
-               WHERE ta.tenant_id = $1
-                 AND ta.code IN ('237005', '237010')
-               GROUP BY tje.period_year, tje.period_month, ta.code
+               WHERE tje.tenant_id = $1
+                 AND tjl.account_id IN ($2, $3)
+               GROUP BY tje.period_year, tje.period_month, tjl.account_id
                HAVING SUM(tjl.credit) - COALESCE(SUM(tjl.debit), 0) > 0
-               ORDER BY tje.period_year, tje.period_month, ta.code""",
+               ORDER BY tje.period_year, tje.period_month, tjl.account_id""",
             tenant_id,
+            employee_account.id,
+            employer_account.id,
         )
 
         # Pivot: group by period_month, split by code
         period_map: Dict[str, Dict[str, Decimal]] = {}
         for r in rows:
             pm = r["period_month"]
-            code = r["code"]
+            account_key = (
+                "employee" if r["account_id"] == employee_account.id else "employer"
+            )
             net = Decimal(str(r["net_liability"]))
             if pm not in period_map:
-                period_map[pm] = {"237005": Decimal("0"), "237010": Decimal("0")}
-            period_map[pm][code] = net
+                period_map[pm] = {"employee": Decimal("0"), "employer": Decimal("0")}
+            period_map[pm][account_key] = net
 
         pending: List[PilaPendingByPeriod] = [
             PilaPendingByPeriod(
                 period_month=pm,
-                employee_ss_pending=vals["237005"],
-                employer_ss_pending=vals["237010"],
-                total_pending=vals["237005"] + vals["237010"],
+                employee_ss_pending=vals["employee"],
+                employer_ss_pending=vals["employer"],
+                total_pending=vals["employee"] + vals["employer"],
             )
             for pm, vals in sorted(period_map.items())
         ]
@@ -3463,82 +3342,45 @@ async def _post_overtime_gl_entry(
             )
             return
 
-        # Resolve DR account: 5110 (Gastos de personal — horas extras)
-        dr_account_id = await conn.fetchval(
-            "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = '5110' AND is_active = true",
-            tenant_id,
+        debit_account, credit_account = await _resolve_salary_disbursement_accounts(
+            conn, tenant_id, AccountRole.OVERTIME_EXPENSE, payment_method, "overtime_payment"
         )
-        if not dr_account_id:
-            logger.warning(f"[overtime_gl] DR account 5110 not found for tenant {tenant_id} — skip overtime GL")
-            return
-
-        # Resolve CR account (bank) — same pattern as dotación
-        cr_account_id = None
-        credit_code = "1110"
-        if payment_method:
-            pm_row = await conn.fetchrow(
-                """SELECT gl_account_id FROM payment_method_gl_accounts
-                   WHERE tenant_id = $1 AND (payment_method_id::text = $2 OR slug = $2)
-                   LIMIT 1""",
-                tenant_id, str(payment_method),
-            )
-            if pm_row and pm_row['gl_account_id']:
-                cr_account_id = pm_row['gl_account_id']
-                acc_code = await conn.fetchval(
-                    "SELECT code FROM tenant_accounts WHERE id = $1", cr_account_id
-                )
-                if acc_code:
-                    credit_code = acc_code
-
-        if not cr_account_id:
-            cr_account_id = await conn.fetchval(
-                "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = '1110' AND is_active = true",
-                tenant_id,
-            )
-        if not cr_account_id:
-            logger.warning(f"[overtime_gl] CR account not found for tenant {tenant_id} — skip overtime GL")
-            return
 
         amount_float = float(total_amount)
 
-        # Create journal entry
-        entry_id = await conn.fetchval(
-            """INSERT INTO tenant_journal_entries
-               (tenant_id, entry_date, description, total_debit, total_credit,
-                source_module, source_id, status, created_by, created_at)
-               VALUES ($1, $2, $3, $4, $5, 'nomina_horas_extras', $6, 'posted', NULL, NOW())
-               RETURNING id""",
-            tenant_id,
-            entry_date,
-            f"Horas extras — {entry_date.strftime('%Y-%m')}",
-            amount_float,
-            amount_float,
-            overtime_payment_id,
-        )
-
-        # DR line — 5110 Gastos de personal — horas extras
-        await conn.execute(
-            """INSERT INTO tenant_journal_entry_lines
-               (entry_id, account_id, debit, credit, description)
-               VALUES ($1, $2, $3, 0, 'Gasto horas extras')""",
-            entry_id, dr_account_id, amount_float,
-        )
-
-        # CR line — bank account
-        await conn.execute(
-            """INSERT INTO tenant_journal_entry_lines
-               (entry_id, account_id, debit, credit, description)
-               VALUES ($1, $2, 0, $3, 'Pago horas extras')""",
-            entry_id, cr_account_id, amount_float,
-        )
+        async with conn.transaction():
+            entry_id = await conn.fetchval(
+                """INSERT INTO tenant_journal_entries
+                   (tenant_id, entry_date, period_year, period_month, description,
+                    total_debit, total_credit, source_module, source_id, status, posted_at)
+                   VALUES ($1, $2, $3, $4, $5, $6, $6,
+                           'nomina_horas_extras', $7, 'posted', NOW())
+                   RETURNING id""",
+                tenant_id, entry_date, entry_date.year, entry_date.month,
+                f"Horas extras — {entry_date.strftime('%Y-%m')}",
+                amount_float, overtime_payment_id,
+            )
+            await conn.execute(
+                """INSERT INTO tenant_journal_lines
+                   (journal_entry_id, account_id, debit, credit, description, line_order)
+                   VALUES ($1, $2, $3, 0, 'Gasto horas extras', 0)""",
+                entry_id, debit_account.id, amount_float,
+            )
+            await conn.execute(
+                """INSERT INTO tenant_journal_lines
+                   (journal_entry_id, account_id, debit, credit, description, line_order)
+                   VALUES ($1, $2, 0, $3, 'Pago horas extras', 1)""",
+                entry_id, credit_account.id, amount_float,
+            )
 
         logger.info(
             f"[overtime_gl] Posted entry {entry_id} for payment {overtime_payment_id} "
-            f"(amount={amount_float}, DR=5110, CR={credit_code})"
+            f"(amount={amount_float}, DR={debit_account.code}, CR={credit_account.code})"
         )
 
     except Exception as exc:
         logger.error(f"[overtime_gl] GL entry failed for payment {overtime_payment_id}: {exc}", exc_info=True)
+        raise
 
 
 async def record_overtime_payment(request: Request, member_id: UUID, data) -> 'OvertimePaymentResponse':
@@ -3752,31 +3594,34 @@ async def _post_liquidacion_gl_entry(
     DR 2625 Vacaciones consolidadas    (vacaciones_amount)
     DR 2615 Intereses sobre cesantías  (int_cesantias_amount)
     DR 5198 Indemnizaciones al personal (indemnizacion_amount, if > 0)
-    CR 1110 Banco / Caja               (total_amount)
+    CR settlement account role         (total_amount)
     """
     try:
         entry_date = payment_date.date() if hasattr(payment_date, 'date') else payment_date
         description = f"Liquidación contrato — {member_name}"
         total_debit = float(breakdown['total_amount'])
 
-        # Resolve account IDs
-        acct_2610 = await conn.fetchrow("SELECT id FROM tenant_accounts WHERE tenant_id=$1 AND code='2610'", tenant_id)
-        acct_2620 = await conn.fetchrow("SELECT id FROM tenant_accounts WHERE tenant_id=$1 AND code='2620'", tenant_id)
-        acct_2625 = await conn.fetchrow("SELECT id FROM tenant_accounts WHERE tenant_id=$1 AND code='2625'", tenant_id)
-        acct_2615 = await conn.fetchrow("SELECT id FROM tenant_accounts WHERE tenant_id=$1 AND code='2615'", tenant_id)
-        acct_5198 = await conn.fetchrow("SELECT id FROM tenant_accounts WHERE tenant_id=$1 AND code='5198'", tenant_id)
-
-        # Resolve bank account from payment_method (same logic as other GL helpers)
-        bank_codes = ['1110', '1120', '1105']
-        credit_acct = None
-        for code in bank_codes:
-            credit_acct = await conn.fetchrow("SELECT id FROM tenant_accounts WHERE tenant_id=$1 AND code=$2", tenant_id, code)
-            if credit_acct:
-                break
-
-        if not credit_acct:
-            logger.error(f"[GL] No bank account found for liquidación {liquidacion_id}")
-            return
+        role_amounts = [
+            (AccountRole.CESANTIAS_PAYABLE, breakdown['cesantias_amount'], 'Cesantías liquidación'),
+            (AccountRole.PRIMA_PAYABLE, breakdown['prima_amount'], 'Prima liquidación'),
+            (AccountRole.VACATION_PAYABLE, breakdown['vacaciones_amount'], 'Vacaciones liquidación'),
+            (AccountRole.CESANTIAS_INTEREST_PAYABLE, breakdown['int_cesantias_amount'], 'Intereses cesantías liquidación'),
+        ]
+        if breakdown['indemnizacion_amount'] > 0:
+            role_amounts.append(
+                (AccountRole.TERMINATION_EXPENSE, breakdown['indemnizacion_amount'], 'Indemnización sin justa causa')
+            )
+        debit_lines = []
+        for role, amount, line_description in role_amounts:
+            if float(amount) <= 0:
+                continue
+            account = await resolve_account(
+                conn, tenant_id, role, source="termination_payment"
+            )
+            debit_lines.append((account, amount, line_description))
+        credit_acct = await _resolve_salary_credit_account(
+            conn, tenant_id, payment_method
+        )
 
         idempotency_check = await conn.fetchrow(
             "SELECT id FROM tenant_journal_entries WHERE tenant_id=$1 AND source_module='nomina_liquidacion' AND source_id=$2",
@@ -3800,38 +3645,28 @@ async def _post_liquidacion_gl_entry(
             entry_id = entry_row['id']
             line_order = 0
 
-            # DR lines for liability settlements
-            dr_lines = [
-                (acct_2610, breakdown['cesantias_amount'], 'Cesantías liquidación'),
-                (acct_2620, breakdown['prima_amount'], 'Prima liquidación'),
-                (acct_2625, breakdown['vacaciones_amount'], 'Vacaciones liquidación'),
-                (acct_2615, breakdown['int_cesantias_amount'], 'Intereses cesantías liquidación'),
-            ]
-            if breakdown['indemnizacion_amount'] > 0 and acct_5198:
-                dr_lines.append((acct_5198, breakdown['indemnizacion_amount'], 'Indemnización sin justa causa'))
-
-            for acct, amount, desc in dr_lines:
-                if acct and float(amount) > 0:
-                    await conn.execute(
-                        """INSERT INTO tenant_journal_lines
-                               (journal_entry_id, account_id, debit, credit, description, line_order)
-                           VALUES ($1, $2, $3, 0, $4, $5)""",
-                        entry_id, acct['id'], float(amount), desc, line_order,
-                    )
-                    line_order += 1
+            for acct, amount, desc in debit_lines:
+                await conn.execute(
+                    """INSERT INTO tenant_journal_lines
+                           (journal_entry_id, account_id, debit, credit, description, line_order)
+                       VALUES ($1, $2, $3, 0, $4, $5)""",
+                    entry_id, acct.id, float(amount), desc, line_order,
+                )
+                line_order += 1
 
             # CR line — bank
             await conn.execute(
                 """INSERT INTO tenant_journal_lines
                        (journal_entry_id, account_id, debit, credit, description, line_order)
                    VALUES ($1, $2, 0, $3, $4, $5)""",
-                entry_id, credit_acct['id'], total_debit, description, line_order,
+                entry_id, credit_acct.id, total_debit, description, line_order,
             )
 
         logger.info(f"[GL] Posted liquidación entry {entry_id} for liquidacion_id={liquidacion_id}, total={total_debit}")
 
     except Exception as exc:
         logger.error(f"[GL] Failed to post liquidación entry for {liquidacion_id}: {exc}")
+        raise
 
 
 async def record_liquidacion(request: Request, member_id: UUID, data) -> 'LiquidacionResponse':

--- a/app/services/table_session_advances_service.py
+++ b/app/services/table_session_advances_service.py
@@ -17,11 +17,15 @@ from app.core.exceptions import APIError, AuthenticationError, NotFoundError
 from app.core.middleware import require_valid_session
 from app.database import get_db_connection
 from app.services.customer_wallet_service import (
-    DEFAULT_LIABILITY_CODE,
     WALLET_PAYMENT_SLUG,
     _post_two_line_gl,
-    _resolve_account_id,
-    _resolve_payment_debit_code,
+    _resolve_liability_account,
+    _resolve_payment_debit_account,
+)
+from app.services.account_role_service import (
+    AccountRole,
+    resolve_account,
+    resolve_tax_account,
 )
 
 logger = logging.getLogger(__name__)
@@ -31,7 +35,6 @@ TABLE_SESSION_ADVANCE_PAYMENT_SLUG = "table_session_advance"
 ADVANCE_RECEIVE_SOURCE = "table_session_advance_receive"
 ADVANCE_VOID_SOURCE = "table_session_advance_void"
 ADVANCE_COVER_SOURCE = "table_session_advance_cover"
-INGRESOS_CODE = "4175"
 
 
 def _amount_decimal(amount: Decimal | float | int | str) -> Decimal:
@@ -314,18 +317,18 @@ async def apply_session_advances_for_close(
 def _standard_cover_gl_amounts(amount: Decimal, tax_config: Dict[str, Any]) -> tuple:
     settlement = Decimal(str(amount or 0)).quantize(Decimal("0.01"))
     tax_amount = Decimal("0")
-    tax_code = None
+    tax_kind = None
     if settlement <= 0:
-        return settlement, settlement, tax_amount, tax_code
+        return settlement, settlement, tax_amount, tax_kind
     if tax_config.get("inc_applicable"):
         rate = Decimal(str(tax_config["inc_rate"]))
-        tax_code = str(tax_config["inc_gl_account_code"])
+        tax_kind = "inc"
         tax_amount = settlement - (settlement / (1 + rate))
     elif tax_config.get("iva_applicable"):
         rate = Decimal(str(tax_config["iva_rate"]))
-        tax_code = str(tax_config["iva_gl_account_code"])
+        tax_kind = "iva"
         tax_amount = settlement - (settlement / (1 + rate))
-    return settlement, settlement - tax_amount, tax_amount, tax_code
+    return settlement, settlement - tax_amount, tax_amount, tax_kind
 
 
 async def recognize_unconsumed_advance_cover_for_close(
@@ -359,6 +362,19 @@ async def recognize_unconsumed_advance_cover_for_close(
         logger.info("[table advance GL] Cover for session %s already posted", table_session_id)
         return Decimal("0")
 
+    liability_acct = await _resolve_liability_account(conn, tenant_id)
+    revenue_acct = await resolve_account(
+        conn, tenant_id, AccountRole.SALES_REVENUE, source="table_advance_cover"
+    )
+    _, _, preview_tax_amount, tax_kind = _standard_cover_gl_amounts(
+        cover_to_apply, tax_config
+    )
+    tax_acct = None
+    if tax_kind and preview_tax_amount > 0:
+        tax_acct = await resolve_tax_account(
+            conn, tenant_id, tax_config, tax_kind, required=True
+        )
+
     applied = await apply_session_advances_for_close(
         conn,
         tenant_id,
@@ -369,18 +385,7 @@ async def recognize_unconsumed_advance_cover_for_close(
     if applied <= 0:
         return Decimal("0")
 
-    settlement, net_revenue, tax_amount, tax_code = _standard_cover_gl_amounts(applied, tax_config)
-    liability_acct = await _resolve_account_id(conn, tenant_id, DEFAULT_LIABILITY_CODE)
-    revenue_acct = await _resolve_account_id(conn, tenant_id, INGRESOS_CODE)
-    tax_acct = await _resolve_account_id(conn, tenant_id, tax_code) if tax_code and tax_amount > 0 else None
-    if not liability_acct or not revenue_acct:
-        logger.warning(
-            "[table advance GL] Missing cover accounts liability=%s revenue=%s tenant=%s",
-            DEFAULT_LIABILITY_CODE,
-            INGRESOS_CODE,
-            tenant_id,
-        )
-        return applied
+    settlement, net_revenue, tax_amount, _ = _standard_cover_gl_amounts(applied, tax_config)
 
     async with conn.transaction():
         entry_row = await conn.fetchrow(
@@ -412,9 +417,9 @@ async def recognize_unconsumed_advance_cover_for_close(
             VALUES ($1, $2, $3, 0, $4, 0)
             """,
             entry_id,
-            liability_acct,
+            liability_acct.id,
             float(settlement),
-            "Dr 2810 - aplicación sobrante consumo mínimo",
+            f"Dr {liability_acct.code} - aplicación sobrante consumo mínimo",
         )
         await conn.execute(
             """
@@ -423,9 +428,9 @@ async def recognize_unconsumed_advance_cover_for_close(
             VALUES ($1, $2, 0, $3, $4, 1)
             """,
             entry_id,
-            revenue_acct,
+            revenue_acct.id,
             float(net_revenue),
-            "Cr 4175 - ingreso cover consumo mínimo",
+            f"Cr {revenue_acct.code} - ingreso cover consumo mínimo",
         )
         if tax_amount > 0 and tax_acct:
             await conn.execute(
@@ -435,7 +440,7 @@ async def recognize_unconsumed_advance_cover_for_close(
                 VALUES ($1, $2, 0, $3, $4, 2)
                 """,
                 entry_id,
-                tax_acct,
+                tax_acct.id,
                 float(tax_amount),
                 "Cr impuesto - cover consumo mínimo",
             )
@@ -572,17 +577,10 @@ async def _post_receive_gl(
     entry_date: date,
     created_by: Optional[UUID],
 ) -> Optional[UUID]:
-    debit_code = await _resolve_payment_debit_code(conn, payment_method, payment_method_id)
-    debit_acct = await _resolve_account_id(conn, tenant_id, debit_code)
-    credit_acct = await _resolve_account_id(conn, tenant_id, DEFAULT_LIABILITY_CODE)
-    if not debit_acct or not credit_acct:
-        logger.warning(
-            "[table advance GL] Missing accounts debit=%s credit=%s tenant=%s",
-            debit_code,
-            DEFAULT_LIABILITY_CODE,
-            tenant_id,
-        )
-        return None
+    debit_acct = await _resolve_payment_debit_account(
+        conn, tenant_id, payment_method, payment_method_id
+    )
+    credit_acct = await _resolve_liability_account(conn, tenant_id)
     return await _post_two_line_gl(
         conn,
         tenant_id,
@@ -591,11 +589,11 @@ async def _post_receive_gl(
         f"table-session-advance-{advance_id}",
         ADVANCE_RECEIVE_SOURCE,
         advance_id,
-        debit_acct,
-        credit_acct,
+        debit_acct.id,
+        credit_acct.id,
         amount,
-        f"Dr {debit_code} — anticipo mesa",
-        f"Cr {DEFAULT_LIABILITY_CODE} — anticipos recibidos",
+        f"Dr {debit_acct.code} — anticipo mesa",
+        f"Cr {credit_acct.code} — anticipos recibidos",
         created_by,
     )
 
@@ -610,17 +608,10 @@ async def _post_void_gl(
     entry_date: date,
     created_by: Optional[UUID],
 ) -> Optional[UUID]:
-    credit_code = await _resolve_payment_debit_code(conn, payment_method, payment_method_id)
-    debit_acct = await _resolve_account_id(conn, tenant_id, DEFAULT_LIABILITY_CODE)
-    credit_acct = await _resolve_account_id(conn, tenant_id, credit_code)
-    if not debit_acct or not credit_acct:
-        logger.warning(
-            "[table advance GL] Missing void accounts debit=%s credit=%s tenant=%s",
-            DEFAULT_LIABILITY_CODE,
-            credit_code,
-            tenant_id,
-        )
-        return None
+    debit_acct = await _resolve_liability_account(conn, tenant_id)
+    credit_acct = await _resolve_payment_debit_account(
+        conn, tenant_id, payment_method, payment_method_id
+    )
     return await _post_two_line_gl(
         conn,
         tenant_id,
@@ -629,11 +620,11 @@ async def _post_void_gl(
         f"table-session-advance-void-{advance_id}",
         ADVANCE_VOID_SOURCE,
         advance_id,
-        debit_acct,
-        credit_acct,
+        debit_acct.id,
+        credit_acct.id,
         amount,
-        f"Dr {DEFAULT_LIABILITY_CODE} — reverso anticipo mesa",
-        f"Cr {credit_code} — devolución anticipo mesa",
+        f"Dr {debit_acct.code} — reverso anticipo mesa",
+        f"Cr {credit_acct.code} — devolución anticipo mesa",
         created_by,
     )
 

--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -673,15 +673,19 @@ async def update_tax_config(request: Request, data) -> dict:
                     tenant_id,
                     inc_applicable, inc_included_in_price,
                     iva_applicable, iva_included_in_price,
-                    liquor_tax_applicable
+                    liquor_tax_applicable,
+                    inc_gl_account_id, iva_gl_account_id, liquor_tax_gl_account_id
                 )
-                VALUES ($1, $2, $3, $4, $5, $6)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
                 ON CONFLICT (tenant_id) DO UPDATE SET
                     inc_applicable        = EXCLUDED.inc_applicable,
                     inc_included_in_price = EXCLUDED.inc_included_in_price,
                     iva_applicable        = EXCLUDED.iva_applicable,
                     iva_included_in_price = EXCLUDED.iva_included_in_price,
                     liquor_tax_applicable = EXCLUDED.liquor_tax_applicable,
+                    inc_gl_account_id = COALESCE(EXCLUDED.inc_gl_account_id, tenant_tax_config.inc_gl_account_id),
+                    iva_gl_account_id = COALESCE(EXCLUDED.iva_gl_account_id, tenant_tax_config.iva_gl_account_id),
+                    liquor_tax_gl_account_id = COALESCE(EXCLUDED.liquor_tax_gl_account_id, tenant_tax_config.liquor_tax_gl_account_id),
                     updated_at            = NOW()
                 RETURNING *
                 """,
@@ -691,6 +695,9 @@ async def update_tax_config(request: Request, data) -> dict:
                 data.iva_applicable,
                 data.iva_included_in_price,
                 data.liquor_tax_applicable,
+                data.inc_gl_account_id,
+                data.iva_gl_account_id,
+                data.liquor_tax_gl_account_id,
             )
 
             return {"success": True, "data": dict(row)}

--- a/migrations/105_account_role_bindings.sql
+++ b/migrations/105_account_role_bindings.sql
@@ -1,0 +1,221 @@
+-- Issue #623: semantic account roles and tenant-scoped account bindings.
+-- Codes remain during the compatibility window, but automatic producers resolve
+-- account UUIDs from roles or explicit tenant-owned bindings.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS accounting_roles (
+    role VARCHAR(60) PRIMARY KEY,
+    colombia_only BOOLEAN NOT NULL DEFAULT false,
+    description VARCHAR(240) NOT NULL
+);
+
+INSERT INTO accounting_roles (role, colombia_only, description) VALUES
+    ('CASH', false, 'Cash settlement account'),
+    ('BANK', false, 'Bank settlement account'),
+    ('ACCOUNTS_RECEIVABLE', false, 'Customer receivable account'),
+    ('INVENTORY', false, 'Inventory asset account'),
+    ('ACCOUNTS_PAYABLE', false, 'Supplier payable account'),
+    ('SALES_REVENUE', false, 'Sales revenue account'),
+    ('TAX_PAYABLE', false, 'Generic tax payable account'),
+    ('COGS', false, 'Cost of goods sold account'),
+    ('PAYROLL_EXPENSE', false, 'Generic payroll expense account'),
+    ('CUSTOMER_ADVANCES', false, 'Customer advances liability'),
+    ('INC_PAYABLE', true, 'Colombia consumption tax payable'),
+    ('IVA_PAYABLE', true, 'Colombia VAT payable'),
+    ('LIQUOR_TAX_PAYABLE', true, 'Colombia liquor tax payable'),
+    ('CONTRACTOR_EXPENSE', true, 'Colombia contractor expense'),
+    ('WITHHOLDING_PAYABLE', true, 'Colombia withholding payable'),
+    ('EMPLOYEE_SS_PAYABLE', true, 'Colombia employee social-security payable'),
+    ('EMPLOYER_SS_PAYABLE', true, 'Colombia employer social-security payable'),
+    ('EMPLOYER_SS_EXPENSE', true, 'Colombia employer social-security expense'),
+    ('PRIMA_EXPENSE', true, 'Colombia service bonus provision expense'),
+    ('PRIMA_PAYABLE', true, 'Colombia service bonus payable'),
+    ('CESANTIAS_EXPENSE', true, 'Colombia severance provision expense'),
+    ('CESANTIAS_PAYABLE', true, 'Colombia severance payable'),
+    ('CESANTIAS_INTEREST_EXPENSE', true, 'Colombia severance interest expense'),
+    ('CESANTIAS_INTEREST_PAYABLE', true, 'Colombia severance interest payable'),
+    ('VACATION_EXPENSE', true, 'Colombia vacation provision expense'),
+    ('VACATION_PAYABLE', true, 'Colombia vacation payable'),
+    ('OVERTIME_EXPENSE', true, 'Colombia overtime expense'),
+    ('DOTACION_EXPENSE', true, 'Colombia work-clothing expense'),
+    ('TERMINATION_EXPENSE', true, 'Colombia termination expense'),
+    ('BANK_FEES_EXPENSE', false, 'Bank fees and settlement differences'),
+    ('OTHER_INCOME', false, 'Other operating or non-operating income')
+ON CONFLICT (role) DO UPDATE SET
+    colombia_only = EXCLUDED.colombia_only,
+    description = EXCLUDED.description;
+
+ALTER TABLE account_template_role_defaults
+    DROP CONSTRAINT IF EXISTS account_template_role_defaults_role_check;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'account_template_role_defaults'::regclass
+          AND conname = 'fk_account_template_role_catalog'
+    ) THEN
+        ALTER TABLE account_template_role_defaults
+            ADD CONSTRAINT fk_account_template_role_catalog
+            FOREIGN KEY (role) REFERENCES accounting_roles(role);
+    END IF;
+END $$;
+
+-- Historical payroll migrations created some tenant rows without template_id.
+-- Link only CO rows whose code matches the localized template; IDs and names stay intact.
+UPDATE tenant_accounts accounts
+SET template_id = templates.id
+FROM tenant_financial_profiles profiles
+JOIN account_templates templates
+  ON templates.localization_id = profiles.accounting_localization
+WHERE profiles.tenant_id = accounts.tenant_id
+  AND profiles.accounting_localization = 'WARO_CO_PUC_V1'
+  AND templates.code = accounts.code
+  AND accounts.template_id IS NULL;
+
+WITH role_codes(role, code) AS (
+    VALUES
+        ('INC_PAYABLE', '2495'),
+        ('IVA_PAYABLE', '2408'),
+        ('LIQUOR_TAX_PAYABLE', '2408'),
+        ('CONTRACTOR_EXPENSE', '5199'),
+        ('WITHHOLDING_PAYABLE', '2367'),
+        ('EMPLOYEE_SS_PAYABLE', '237005'),
+        ('EMPLOYER_SS_PAYABLE', '237010'),
+        ('EMPLOYER_SS_EXPENSE', '5120'),
+        ('PRIMA_EXPENSE', '5106'),
+        ('PRIMA_PAYABLE', '2620'),
+        ('CESANTIAS_EXPENSE', '5107'),
+        ('CESANTIAS_PAYABLE', '2610'),
+        ('CESANTIAS_INTEREST_EXPENSE', '5108'),
+        ('CESANTIAS_INTEREST_PAYABLE', '2615'),
+        ('VACATION_EXPENSE', '5109'),
+        ('VACATION_PAYABLE', '2625'),
+        ('OVERTIME_EXPENSE', '5110'),
+        ('DOTACION_EXPENSE', '5115'),
+        ('TERMINATION_EXPENSE', '5198'),
+        ('BANK_FEES_EXPENSE', '5305'),
+        ('OTHER_INCOME', '4295')
+)
+INSERT INTO account_template_role_defaults (localization_id, role, account_template_id)
+SELECT 'WARO_CO_PUC_V1', role_codes.role, templates.id
+FROM role_codes
+JOIN account_templates templates
+  ON templates.localization_id = 'WARO_CO_PUC_V1'
+ AND templates.code = role_codes.code
+ON CONFLICT (localization_id, role) DO UPDATE
+SET account_template_id = EXCLUDED.account_template_id;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'tenant_accounts'::regclass
+          AND conname = 'uq_tenant_accounts_tenant_id_id'
+    ) THEN
+        ALTER TABLE tenant_accounts
+            ADD CONSTRAINT uq_tenant_accounts_tenant_id_id UNIQUE (tenant_id, id);
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS tenant_account_role_overrides (
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    role VARCHAR(60) NOT NULL REFERENCES accounting_roles(role),
+    tenant_account_id UUID NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, role),
+    CONSTRAINT fk_role_override_tenant_account
+        FOREIGN KEY (tenant_id, tenant_account_id)
+        REFERENCES tenant_accounts(tenant_id, id)
+);
+
+ALTER TABLE payment_methods ADD COLUMN IF NOT EXISTS gl_account_id UUID;
+ALTER TABLE payment_method_groups ADD COLUMN IF NOT EXISTS gl_account_id UUID;
+ALTER TABLE tenant_tax_config
+    ADD COLUMN IF NOT EXISTS inc_gl_account_id UUID,
+    ADD COLUMN IF NOT EXISTS iva_gl_account_id UUID,
+    ADD COLUMN IF NOT EXISTS liquor_tax_gl_account_id UUID;
+
+UPDATE payment_methods methods
+SET gl_account_id = accounts.id
+FROM tenant_accounts accounts
+WHERE accounts.tenant_id = methods.tenant_id
+  AND accounts.code = methods.gl_account_code
+  AND methods.gl_account_id IS NULL;
+
+UPDATE payment_method_groups groups
+SET gl_account_id = accounts.id
+FROM tenant_accounts accounts
+WHERE groups.tenant_id IS NOT NULL
+  AND accounts.tenant_id = groups.tenant_id
+  AND accounts.code = groups.gl_account_code
+  AND groups.gl_account_id IS NULL;
+
+UPDATE tenant_tax_config config
+SET inc_gl_account_id = accounts.id
+FROM tenant_accounts accounts
+WHERE accounts.tenant_id = config.tenant_id
+  AND accounts.code = config.inc_gl_account_code
+  AND config.inc_gl_account_id IS NULL;
+
+UPDATE tenant_tax_config config
+SET iva_gl_account_id = accounts.id
+FROM tenant_accounts accounts
+WHERE accounts.tenant_id = config.tenant_id
+  AND accounts.code = config.iva_gl_account_code
+  AND config.iva_gl_account_id IS NULL;
+
+UPDATE tenant_tax_config config
+SET liquor_tax_gl_account_id = accounts.id
+FROM tenant_accounts accounts
+WHERE accounts.tenant_id = config.tenant_id
+  AND accounts.code = config.liquor_tax_gl_account_code
+  AND config.liquor_tax_gl_account_id IS NULL;
+
+INSERT INTO tenant_account_role_overrides (tenant_id, role, tenant_account_id)
+SELECT profiles.tenant_id, 'CUSTOMER_ADVANCES', accounts.id
+FROM tenant_public_profiles profiles
+JOIN tenant_accounts accounts
+  ON accounts.tenant_id = profiles.tenant_id
+ AND accounts.code = profiles.customer_wallet_liability_gl_code
+ON CONFLICT (tenant_id, role) DO NOTHING;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_payment_method_tenant_account') THEN
+        ALTER TABLE payment_methods ADD CONSTRAINT fk_payment_method_tenant_account
+            FOREIGN KEY (tenant_id, gl_account_id) REFERENCES tenant_accounts(tenant_id, id);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_payment_group_tenant_account') THEN
+        ALTER TABLE payment_method_groups ADD CONSTRAINT fk_payment_group_tenant_account
+            FOREIGN KEY (tenant_id, gl_account_id) REFERENCES tenant_accounts(tenant_id, id);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_tax_inc_tenant_account') THEN
+        ALTER TABLE tenant_tax_config ADD CONSTRAINT fk_tax_inc_tenant_account
+            FOREIGN KEY (tenant_id, inc_gl_account_id) REFERENCES tenant_accounts(tenant_id, id);
+        ALTER TABLE tenant_tax_config ADD CONSTRAINT fk_tax_iva_tenant_account
+            FOREIGN KEY (tenant_id, iva_gl_account_id) REFERENCES tenant_accounts(tenant_id, id);
+        ALTER TABLE tenant_tax_config ADD CONSTRAINT fk_tax_liquor_tenant_account
+            FOREIGN KEY (tenant_id, liquor_tax_gl_account_id) REFERENCES tenant_accounts(tenant_id, id);
+    END IF;
+END $$;
+
+ALTER TABLE payment_method_groups
+    DROP CONSTRAINT IF EXISTS chk_payment_group_tenant_account_scope;
+ALTER TABLE payment_method_groups
+    ADD CONSTRAINT chk_payment_group_tenant_account_scope
+    CHECK (gl_account_id IS NULL OR tenant_id IS NOT NULL);
+
+CREATE INDEX IF NOT EXISTS idx_role_overrides_account
+    ON tenant_account_role_overrides(tenant_account_id);
+
+COMMENT ON TABLE tenant_account_role_overrides IS
+    'Tenant-owned semantic account overrides. Localization template defaults are the fallback.';
+COMMENT ON COLUMN payment_methods.gl_account_code IS
+    'Deprecated compatibility field; automatic posting uses gl_account_id.';
+COMMENT ON COLUMN payment_method_groups.gl_account_code IS
+    'Deprecated compatibility field; automatic posting uses gl_account_id or semantic group role.';
+
+COMMIT;

--- a/tests/sql/account_role_bindings.sql
+++ b/tests/sql/account_role_bindings.sql
@@ -1,0 +1,35 @@
+-- Run after migrations with: psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f tests/sql/account_role_bindings.sql
+BEGIN;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_name = 'tenant_account_role_overrides'
+    ) THEN
+        RAISE EXCEPTION 'tenant_account_role_overrides is missing';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'payment_methods' AND column_name = 'gl_account_id'
+    ) THEN
+        RAISE EXCEPTION 'payment_methods.gl_account_id is missing';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM accounting_roles
+        WHERE role = 'BANK' AND colombia_only = false
+    ) THEN
+        RAISE EXCEPTION 'generic BANK role is missing';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM accounting_roles
+        WHERE role = 'CESANTIAS_PAYABLE' AND colombia_only = true
+    ) THEN
+        RAISE EXCEPTION 'Colombia payroll roles are missing';
+    END IF;
+END $$;
+
+ROLLBACK;

--- a/tests/test_account_role_resolution.py
+++ b/tests/test_account_role_resolution.py
@@ -1,0 +1,162 @@
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.exceptions import APIError
+from app.services import credit_service
+from app.services.accounting_service import _compute_pl_for_period
+from app.services.account_role_service import (
+    AccountRef,
+    AccountRole,
+    MissingAccountRoleError,
+    ensure_colombia_payroll,
+    resolve_account,
+    resolve_payment_account,
+)
+
+
+@pytest.mark.asyncio
+async def test_resolver_prefers_tenant_override_and_is_code_independent():
+    tenant_id = uuid4()
+    account_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "id": account_id,
+        "code": "LOCAL-BANK-RENAMED",
+        "name": "Operating account renamed",
+        "binding_source": "tenant_override",
+    })
+
+    account = await resolve_account(conn, tenant_id, AccountRole.BANK, source="test")
+
+    assert account == AccountRef(
+        account_id,
+        "LOCAL-BANK-RENAMED",
+        "Operating account renamed",
+        AccountRole.BANK,
+        "tenant_override",
+    )
+    query = conn.fetchrow.await_args.args[0]
+    assert "binding.role = $2" in query
+    assert "accounts.code" not in query
+
+
+@pytest.mark.asyncio
+async def test_missing_required_role_is_explicit():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+
+    with pytest.raises(MissingAccountRoleError) as exc:
+        await resolve_account(conn, tenant_id, AccountRole.COGS, source="order_cogs")
+
+    assert exc.value.role == AccountRole.COGS
+    assert exc.value.source == "order_cogs"
+
+
+@pytest.mark.asyncio
+async def test_payment_account_prefers_explicit_uuid_binding():
+    tenant_id = uuid4()
+    method_id = uuid4()
+    account = AccountRef(uuid4(), "BANK-01", "Bank", None, "explicit_account_id")
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "method_account_id": account.id,
+        "method_legacy_code": "legacy",
+        "group_account_id": None,
+        "group_legacy_code": None,
+        "group_tenant_id": None,
+        "slug": "digital",
+    })
+
+    with patch(
+        "app.services.account_role_service.resolve_account_by_id",
+        new=AsyncMock(return_value=account),
+    ) as by_id, patch(
+        "app.services.account_role_service.resolve_legacy_account",
+        new=AsyncMock(),
+    ) as legacy:
+        resolved = await resolve_payment_account(
+            conn, tenant_id, "digital", payment_method_id=method_id
+        )
+
+    assert resolved == account
+    by_id.assert_awaited_once_with(conn, tenant_id, account.id)
+    legacy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_role_aborts_credit_journal_before_header_insert():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=None)
+    conn.fetchrow = AsyncMock()
+
+    with patch(
+        "app.services.credit_service._resolve_credit_payment_debit_account",
+        new=AsyncMock(side_effect=MissingAccountRoleError(tenant_id, AccountRole.BANK)),
+    ):
+        with pytest.raises(MissingAccountRoleError):
+            await credit_service._post_credit_payment_gl(
+                conn,
+                tenant_id,
+                uuid4(),
+                uuid4(),
+                Decimal("10"),
+                "digital",
+                uuid4(),
+                None,
+                date(2026, 7, 14),
+                uuid4(),
+            )
+
+    conn.fetchrow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_colombia_payroll_gate_rejects_global_profile():
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=False)
+
+    with pytest.raises(APIError) as exc:
+        await ensure_colombia_payroll(conn, uuid4())
+
+    assert exc.value.status_code == 409
+    assert exc.value.details["code"] == "COLOMBIA_PAYROLL_NOT_AVAILABLE"
+
+
+@pytest.mark.asyncio
+async def test_global_pl_does_not_query_or_include_colombia_payroll():
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        {"total_sales": 0},
+        {"total": 0},
+        {"total": 0},
+    ])
+    conn.fetch = AsyncMock(return_value=[])
+
+    result = await _compute_pl_for_period(
+        conn, uuid4(), 2026, 7, include_colombia_payroll=False
+    )
+
+    assert result.operating_expenses.payroll == 0
+    assert result.provisions.total == 0
+    assert conn.fetchrow.await_count == 3
+    queries = "\n".join(call.args[0] for call in conn.fetchrow.await_args_list)
+    assert "salary_payments" not in queries
+    assert "employee_salaries" not in queries
+
+
+def test_migration_defines_scoped_uuid_bindings_and_compatibility_backfill():
+    migration = Path("migrations/105_account_role_bindings.sql").read_text()
+
+    assert "CREATE TABLE IF NOT EXISTS accounting_roles" in migration
+    assert "CREATE TABLE IF NOT EXISTS tenant_account_role_overrides" in migration
+    assert "FOREIGN KEY (tenant_id, tenant_account_id)" in migration
+    assert "ADD COLUMN IF NOT EXISTS gl_account_id UUID" in migration
+    assert "methods.gl_account_id IS NULL" in migration
+    assert "config.inc_gl_account_id IS NULL" in migration

--- a/tests/test_credit_payment_methods.py
+++ b/tests/test_credit_payment_methods.py
@@ -8,6 +8,7 @@ import pytest
 
 from app.core.exceptions import APIError
 from app.services import credit_service
+from app.services.account_role_service import AccountRef, AccountRole
 
 
 class _AsyncContext:
@@ -41,24 +42,29 @@ def _credit_order(tenant_id, customer_id):
 
 
 @pytest.mark.asyncio
-async def test_credit_payment_debit_code_uses_group_puc_when_method_has_no_puc():
+async def test_credit_payment_debit_account_uses_semantic_payment_resolver():
     tenant_id = uuid4()
     group_id = uuid4()
     method_id = uuid4()
-    conn = MagicMock()
-    conn.fetchval = AsyncMock(side_effect=["112010"])
+    expected = AccountRef(uuid4(), "BANK-01", "Settlement", AccountRole.BANK, "tenant_override")
 
-    code = await credit_service._resolve_credit_payment_debit_code(
-        conn,
+    with patch(
+        "app.services.credit_service.resolve_payment_account",
+        new=AsyncMock(return_value=expected),
+    ) as resolver:
+        account = await credit_service._resolve_credit_payment_debit_account(
+            MagicMock(), tenant_id, "digital", group_id, method_id
+        )
+
+    assert account == expected
+    resolver.assert_awaited_once_with(
+        resolver.await_args.args[0],
         tenant_id,
         "digital",
-        group_id,
-        method_id,
+        payment_method_id=method_id,
+        payment_group_id=group_id,
+        source="credit_payment",
     )
-
-    assert code == "112010"
-    lookup_args = conn.fetchval.await_args.args
-    assert lookup_args[1:] == (method_id, tenant_id, group_id)
 
 
 @pytest.mark.asyncio
@@ -88,6 +94,12 @@ async def test_register_credit_payment_base_method_persists_null_method_id():
     ), patch(
         "app.services.credit_service.get_db_connection",
         return_value=_AsyncContext(conn),
+    ), patch(
+        "app.services.credit_service.resolve_payment_account",
+        new=AsyncMock(return_value=AccountRef(uuid4(), "CASH", "Cash", AccountRole.CASH, "localization_default")),
+    ), patch(
+        "app.services.credit_service.resolve_account",
+        new=AsyncMock(return_value=AccountRef(uuid4(), "AR", "Receivable", AccountRole.ACCOUNTS_RECEIVABLE, "localization_default")),
     ):
         result = await credit_service.register_credit_payment(
             _request(),
@@ -133,6 +145,12 @@ async def test_register_credit_payment_custom_method_validates_and_persists_id()
     ), patch(
         "app.services.credit_service.get_db_connection",
         return_value=_AsyncContext(conn),
+    ), patch(
+        "app.services.credit_service.resolve_payment_account",
+        new=AsyncMock(return_value=AccountRef(uuid4(), "BANK", "Bank", AccountRole.BANK, "tenant_override")),
+    ), patch(
+        "app.services.credit_service.resolve_account",
+        new=AsyncMock(return_value=AccountRef(uuid4(), "AR", "Receivable", AccountRole.ACCOUNTS_RECEIVABLE, "localization_default")),
     ):
         result = await credit_service.register_credit_payment(
             _request(),
@@ -188,6 +206,12 @@ async def test_register_credit_payment_posts_gl_with_custom_method_puc():
     ), patch(
         "app.services.credit_service.get_db_connection",
         return_value=_AsyncContext(conn),
+    ), patch(
+        "app.services.credit_service.resolve_payment_account",
+        new=AsyncMock(return_value=AccountRef(debit_account_id, "112005", "Bank", AccountRole.BANK, "tenant_override")),
+    ), patch(
+        "app.services.credit_service.resolve_account",
+        new=AsyncMock(return_value=AccountRef(credit_account_id, "1305", "Receivable", AccountRole.ACCOUNTS_RECEIVABLE, "localization_default")),
     ):
         result = await credit_service.register_credit_payment(
             _request(),
@@ -253,6 +277,12 @@ async def test_register_credit_payment_gl_uses_slug_fallback_without_puc():
     ), patch(
         "app.services.credit_service.get_db_connection",
         return_value=_AsyncContext(conn),
+    ), patch(
+        "app.services.credit_service.resolve_payment_account",
+        new=AsyncMock(return_value=AccountRef(debit_account_id, "BANK", "Bank", AccountRole.BANK, "localization_default")),
+    ), patch(
+        "app.services.credit_service.resolve_account",
+        new=AsyncMock(return_value=AccountRef(credit_account_id, "AR", "Receivable", AccountRole.ACCOUNTS_RECEIVABLE, "localization_default")),
     ):
         await credit_service.register_credit_payment(
             _request(),
@@ -261,12 +291,10 @@ async def test_register_credit_payment_gl_uses_slug_fallback_without_puc():
             "digital",
         )
 
-    debit_account_lookup_args = conn.fetchval.await_args_list[2].args
-    credit_account_lookup_args = conn.fetchval.await_args_list[3].args
-    assert debit_account_lookup_args[1:] == (tenant_id, "1110")
-    assert credit_account_lookup_args[1:] == (tenant_id, "1305")
     debit_args = conn.execute.await_args_list[1].args
     credit_args = conn.execute.await_args_list[2].args
+    assert debit_args[2] == debit_account_id
+    assert credit_args[2] == credit_account_id
     assert debit_args[3] == 20.0
     assert credit_args[3] == 20.0
 

--- a/tests/test_manual_order_gl_cogs.py
+++ b/tests/test_manual_order_gl_cogs.py
@@ -11,6 +11,7 @@ from fastapi import Request
 from app.core.exceptions import APIError
 from app.routers.orders import ManualOrderModifier
 from app.services import cierre_service, orders_service
+from app.services.account_role_service import AccountRef, AccountRole
 
 
 class _AsyncContext:
@@ -675,26 +676,29 @@ async def test_post_order_gl_entry_uses_selected_method_account_before_slug_fall
     conn.execute = AsyncMock()
     conn.transaction = MagicMock(return_value=_AsyncContext())
 
-    await cierre_service._post_order_gl_entry(
-        conn=conn,
-        tenant_id=tenant_id,
-        order_id=order_id,
-        order_date=date(2026, 6, 16),
-        total_amount=Decimal("42000"),
-        payment_method="cash",
-        payment_method_id=method_id,
-        tax_config={},
-        order_number=8521,
-    )
+    payment_resolver = AsyncMock(return_value=AccountRef(
+        debit_account_id, "BANK-CARD", "Selected bank", AccountRole.BANK, "explicit_account_id"
+    ))
+    role_resolver = AsyncMock(return_value=AccountRef(
+        ingresos_account_id, "REVENUE", "Revenue", AccountRole.SALES_REVENUE, "localization_default"
+    ))
+    with patch("app.services.cierre_service.resolve_payment_account", new=payment_resolver), patch(
+        "app.services.cierre_service.resolve_account", new=role_resolver
+    ):
+        await cierre_service._post_order_gl_entry(
+            conn=conn,
+            tenant_id=tenant_id,
+            order_id=order_id,
+            order_date=date(2026, 6, 16),
+            total_amount=Decimal("42000"),
+            payment_method="cash",
+            payment_method_id=method_id,
+            tax_config={},
+            order_number=8521,
+        )
 
-    method_lookup_args = conn.fetchrow.await_args_list[0].args
-    debit_lookup_args = next(
-        call.args for call in conn.fetchrow.await_args_list
-        if len(call.args) >= 3 and call.args[1:] == (tenant_id, "1120")
-    )
     debit_line_args = conn.execute.await_args_list[0].args
-    assert method_lookup_args[1] == method_id
-    assert debit_lookup_args[1:] == (tenant_id, "1120")
+    assert payment_resolver.await_args.kwargs["payment_method_id"] == method_id
     assert debit_line_args[2] == debit_account_id
 
 
@@ -723,25 +727,32 @@ async def test_post_order_gl_entry_splits_table_advance_to_2810():
     conn.execute = AsyncMock()
     conn.transaction = MagicMock(return_value=_AsyncContext())
 
-    await cierre_service._post_order_gl_entry(
-        conn=conn,
-        tenant_id=tenant_id,
-        order_id=order_id,
-        order_date=date(2026, 6, 16),
-        total_amount=Decimal("70000"),
-        payment_method="table_session_advance",
-        payment_method_id=None,
-        tax_config={},
-        order_number=8522,
-        advance_amount=Decimal("70000"),
+    advance_ref = AccountRef(
+        advance_account_id, "ADVANCE", "Customer advances", AccountRole.CUSTOMER_ADVANCES, "localization_default"
     )
+    revenue_ref = AccountRef(
+        ingresos_account_id, "REVENUE", "Revenue", AccountRole.SALES_REVENUE, "localization_default"
+    )
+    async def resolve_role(_conn, _tenant_id, role, **_kwargs):
+        return advance_ref if role == AccountRole.CUSTOMER_ADVANCES else revenue_ref
 
-    advance_lookup_args = next(
-        call.args for call in conn.fetchrow.await_args_list
-        if len(call.args) >= 3 and call.args[1:] == (tenant_id, "2810")
-    )
+    with patch("app.services.cierre_service.resolve_payment_account", new=AsyncMock(return_value=advance_ref)), patch(
+        "app.services.cierre_service.resolve_account", new=AsyncMock(side_effect=resolve_role)
+    ):
+        await cierre_service._post_order_gl_entry(
+            conn=conn,
+            tenant_id=tenant_id,
+            order_id=order_id,
+            order_date=date(2026, 6, 16),
+            total_amount=Decimal("70000"),
+            payment_method="table_session_advance",
+            payment_method_id=None,
+            tax_config={},
+            order_number=8522,
+            advance_amount=Decimal("70000"),
+        )
+
     advance_line_args = conn.execute.await_args_list[0].args
-    assert advance_lookup_args[1:] == (tenant_id, "2810")
     assert advance_line_args[2] == advance_account_id
     assert advance_line_args[3] == 70000.0
     assert "aplicación anticipo mesa" in advance_line_args[4]
@@ -781,29 +792,29 @@ async def test_post_order_gl_entry_splits_debits_by_payment_puc():
     conn.execute = AsyncMock()
     conn.transaction = MagicMock(return_value=_AsyncContext())
 
-    await cierre_service._post_order_gl_entry(
-        conn=conn,
-        tenant_id=tenant_id,
-        order_id=order_id,
-        order_date=date(2026, 6, 19),
-        total_amount=Decimal("45000"),
-        payment_method="card",
-        payment_method_id=card_method_id,
-        tax_config={},
-        order_number=15342,
-        payment_splits=[
-            {
-                "amount": Decimal("42000"),
-                "payment_method": "digital",
-                "payment_method_id": digital_method_id,
-            },
-            {
-                "amount": Decimal("3000"),
-                "payment_method": "card",
-                "payment_method_id": card_method_id,
-            },
-        ],
-    )
+    async def resolve_payment(_conn, _tenant_id, _slug, payment_method_id=None, **_kwargs):
+        account_id = digital_account_id if payment_method_id == digital_method_id else card_account_id
+        return AccountRef(account_id, "BANK", "Bank", AccountRole.BANK, "explicit_account_id")
+
+    with patch("app.services.cierre_service.resolve_payment_account", new=AsyncMock(side_effect=resolve_payment)), patch(
+        "app.services.cierre_service.resolve_account",
+        new=AsyncMock(return_value=AccountRef(ingresos_account_id, "REVENUE", "Revenue", AccountRole.SALES_REVENUE, "localization_default")),
+    ):
+        await cierre_service._post_order_gl_entry(
+            conn=conn,
+            tenant_id=tenant_id,
+            order_id=order_id,
+            order_date=date(2026, 6, 19),
+            total_amount=Decimal("45000"),
+            payment_method="card",
+            payment_method_id=card_method_id,
+            tax_config={},
+            order_number=15342,
+            payment_splits=[
+                {"amount": Decimal("42000"), "payment_method": "digital", "payment_method_id": digital_method_id},
+                {"amount": Decimal("3000"), "payment_method": "card", "payment_method_id": card_method_id},
+            ],
+        )
 
     debit_lines = [
         call.args for call in conn.execute.await_args_list

--- a/tests/test_order_modifier_cogs.py
+++ b/tests/test_order_modifier_cogs.py
@@ -1,12 +1,13 @@
 """Sale edit + COGS paths for composite modifier options (#1124)."""
 from datetime import date
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 
 from app.services import pos_cart_service
 from app.services.cierre_service import _post_order_cogs_gl_entry
+from app.services.account_role_service import AccountRef
 
 ORDER_ITEM_ID = uuid4()
 MODIFIER_ID = uuid4()
@@ -100,17 +101,32 @@ async def test_return_modifier_inventory_reverses_composite_lines():
 
 @pytest.mark.asyncio
 async def test_cogs_gl_query_sums_order_item_ingredients():
+    class _Transaction:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
     mock_conn = AsyncMock()
     mock_conn.fetchval = AsyncMock(side_effect=[None, 2500.0])
-    mock_conn.fetchrow = AsyncMock(return_value=None)
+    mock_conn.fetchrow = AsyncMock(return_value={"id": uuid4()})
+    mock_conn.transaction = MagicMock(return_value=_Transaction())
 
-    await _post_order_cogs_gl_entry(
-        mock_conn,
-        TENANT_ID,
-        ORDER_ID,
-        date(2026, 6, 2),
-        order_number=99,
-    )
+    async def resolve_role(_conn, _tenant_id, role, **_kwargs):
+        return AccountRef(uuid4(), role, role, role, "localization_default")
+
+    with patch(
+        "app.services.cierre_service.resolve_account",
+        new=AsyncMock(side_effect=resolve_role),
+    ):
+        await _post_order_cogs_gl_entry(
+            mock_conn,
+            TENANT_ID,
+            ORDER_ID,
+            date(2026, 6, 2),
+            order_number=99,
+        )
 
     cogs_query = mock_conn.fetchval.await_args_list[1].args[0]
     assert "order_item_ingredients" in cogs_query

--- a/tests/test_salary_account_roles.py
+++ b/tests/test_salary_account_roles.py
@@ -1,0 +1,100 @@
+from datetime import date
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services.account_role_service import (
+    AccountRef,
+    AccountRole,
+    MissingAccountRoleError,
+)
+from app.services.salary_service import (
+    _post_provision_gl_entries,
+    _post_salary_gl_entry,
+    _resolve_salary_credit_account,
+)
+
+
+@pytest.mark.asyncio
+async def test_salary_uuid_payment_uses_semantic_payment_resolver():
+    tenant_id = uuid4()
+    method_id = uuid4()
+    expected = AccountRef(uuid4(), "BANK", "Bank", AccountRole.BANK, "explicit_account_id")
+    conn = MagicMock()
+
+    with patch(
+        "app.services.salary_service.resolve_payment_account",
+        new=AsyncMock(return_value=expected),
+    ) as resolver:
+        account = await _resolve_salary_credit_account(conn, tenant_id, str(method_id))
+
+    assert account == expected
+    resolver.assert_awaited_once_with(
+        conn,
+        tenant_id,
+        "transfer",
+        payment_method_id=method_id,
+        source="salary",
+    )
+
+
+@pytest.mark.asyncio
+async def test_salary_missing_expense_role_does_not_insert_journal_header():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(side_effect=[None, None])
+    conn.fetchrow = AsyncMock()
+
+    with patch(
+        "app.services.salary_service.resolve_account",
+        new=AsyncMock(
+            side_effect=MissingAccountRoleError(
+                tenant_id, AccountRole.PAYROLL_EXPENSE, "salary"
+            )
+        ),
+    ):
+        with pytest.raises(MissingAccountRoleError):
+            await _post_salary_gl_entry(
+                conn,
+                tenant_id,
+                uuid4(),
+                date(2026, 7, 14),
+                Decimal("100"),
+                "employee",
+                "cash",
+                "Salary",
+            )
+
+    conn.fetchrow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_provision_missing_role_resolves_before_mutation_or_header():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(side_effect=[None, 0, None])
+    conn.fetchrow = AsyncMock()
+    conn.execute = AsyncMock()
+
+    with patch(
+        "app.services.salary_service.resolve_account",
+        new=AsyncMock(
+            side_effect=MissingAccountRoleError(
+                tenant_id, AccountRole.PRIMA_EXPENSE, "salary_provision"
+            )
+        ),
+    ):
+        with pytest.raises(MissingAccountRoleError):
+            await _post_provision_gl_entries(
+                conn,
+                tenant_id,
+                uuid4(),
+                "2026-07",
+                "employee",
+                Decimal("1200"),
+            )
+
+    conn.execute.assert_not_awaited()
+    conn.fetchrow.assert_not_awaited()

--- a/tests/test_table_session_advances.py
+++ b/tests/test_table_session_advances.py
@@ -154,7 +154,7 @@ class TestAdvanceValidation:
         assert settlement == Decimal("108000.00")
         assert net.quantize(Decimal("0.01")) == Decimal("100000.00")
         assert tax.quantize(Decimal("0.01")) == Decimal("8000.00")
-        assert tax_code == "2495"
+        assert tax_code == "inc"
 
 
 class TestCreateSessionAdvance:


### PR DESCRIPTION
## Summary
- add tenant-scoped semantic account role bindings with localization defaults and UUID backfills
- migrate automatic journals for sales, COGS, purchases, credit, wallet/advances, payroll and provisions away from PUC-code decisions
- expose role-binding APIs and gate Colombian payroll for Global profiles
- keep legacy account-code fields only as a compatibility bridge

## Validation
- `111 passed` focused regression matrix
- Python compilation and Python 3.9 syntax validation passed
- Ruff passed on the issue-clean surface
- `git diff --check` passed
- full suite: 1313 passed, 11 skipped, 22 unrelated baseline failures (legacy mocks/database event-loop tests)
- SQL runtime script added; not executed locally because `TEST_DATABASE_URL` is unset
- build intentionally not run per request

Closes #623