### PR TITLE
Enforce authoritative financial readiness

### DIFF
--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from fastapi import Depends, Request, HTTPException
+from fastapi import Request, HTTPException
 from app.core.tenant import detect_and_validate_tenant
 from app.core.security import get_session_token
 # from app.services.auth_service import get_session_data  # Will implement in Day 3
@@ -44,6 +44,7 @@ async def require_invoicing_ready(request: Request) -> Dict[str, Any]:
             detail={
                 'error':   'tenant_not_ready_for_invoicing',
                 'checks':  payload['checks'],
+                'reason_codes': payload.get('reason_codes', []),
                 'missing': payload['missing'],
             },
         )

--- a/app/routers/tenant_config.py
+++ b/app/routers/tenant_config.py
@@ -31,10 +31,9 @@ router = APIRouter()
 @router.get(
     "/financial-profile",
     response_model=TenantFinancialProfileResponse,
-    dependencies=[Depends(require_module(Module.MI_NEGOCIO))],
 )
 async def get_financial_profile_endpoint(request: Request):
-    """Return authoritative base currency, capabilities and safe lock state."""
+    """Return tenant financial capabilities to any authenticated tenant member."""
     return await tenant_financial_profile_service.get_financial_profile(request)
 
 

--- a/app/services/invoicing_readiness_service.py
+++ b/app/services/invoicing_readiness_service.py
@@ -2,7 +2,7 @@
 Invoicing readiness service — issue #130
 
 Single source of truth for "can this tenant emit electronic invoices right now?"
-Six predicates must all be true:
+Nine predicates must all be true:
 
   1. customer_requested     — tenant_fiscal_data.electronic_invoicing_requested
                               = true (customer intent from /facturacion)
@@ -21,6 +21,10 @@ Six predicates must all be true:
                             — Matias Casa de Software emissions have
                               tenant_fiscal_data.matias_company_id configured
                               for the outbound Matias client_uuid.
+  7. country_is_colombia    — authoritative financial profile uses CO
+  8. document_mode_fiscal_integrated
+                            — authoritative document mode is fiscal_integrated
+  9. fiscal_provider_matias — authoritative fiscal provider is Matias
 
 About the no-responsable bypass that was here briefly:
 
@@ -47,7 +51,11 @@ and microservice gate uno0uno/api-facturacion#17 must consume the same JSON):
         "taxes_configured":     bool,  # compatibility: INC or IVA active
         "tax_requirement_satisfied": bool,
         "matias_company_id_configured": bool,
+        "country_is_colombia": bool,
+        "document_mode_fiscal_integrated": bool,
+        "fiscal_provider_matias": bool,
       },
+      "reason_codes": [str, ...],
       "missing": [str, ...],   # human-readable Spanish reasons
     }
 """
@@ -71,6 +79,9 @@ SELECT
     fd.type_organization_id         AS type_organization_id,
     fd.tax_regime_id                AS tax_regime_id,
     fd.tax_level_id                 AS tax_level_id,
+    tfp.country_code                AS country_code,
+    tfp.document_mode               AS document_mode,
+    tfp.fiscal_provider             AS fiscal_provider,
     COALESCE(ttc.inc_applicable, false) AS inc_applicable,
     COALESCE(ttc.iva_applicable, false) AS iva_applicable,
     EXISTS (
@@ -85,6 +96,7 @@ SELECT
 FROM tenants t
 LEFT JOIN tenant_fiscal_data fd ON fd.tenant_id = t.id
 LEFT JOIN tenant_tax_config  ttc ON ttc.tenant_id = t.id
+LEFT JOIN tenant_financial_profiles tfp ON tfp.tenant_id = t.id
 WHERE t.id = $1
 """
 
@@ -116,6 +128,9 @@ async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
     matias_company_id_configured = bool(
         matias_company_id and str(matias_company_id).strip()
     )
+    country_is_colombia = row['country_code'] == 'CO'
+    document_mode_fiscal_integrated = row['document_mode'] == 'fiscal_integrated'
+    fiscal_provider_matias = row['fiscal_provider'] == 'matias'
 
     missing_fiscal_fields: List[str] = []
     if row['nit'] is None:
@@ -147,6 +162,39 @@ async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
         missing.append(
             'Falta UUID cliente Matias (client_uuid) para emitir con Matias'
         )
+    if not country_is_colombia:
+        missing.append('El tenant no tiene localización fiscal colombiana')
+    if not document_mode_fiscal_integrated:
+        missing.append('El tenant no está configurado en modo fiscal_integrated')
+    if not fiscal_provider_matias:
+        missing.append('El proveedor fiscal del tenant no es Matias')
+
+    checks = {
+        'customer_requested': customer_requested,
+        'dev_flag_enabled': dev_flag_enabled,
+        'fiscal_data_complete': fiscal_data_complete,
+        'active_resolution': active_resolution,
+        'taxes_configured': taxes_configured,
+        'tax_requirement_satisfied': tax_requirement_satisfied,
+        'matias_company_id_configured': matias_company_id_configured,
+        'country_is_colombia': country_is_colombia,
+        'document_mode_fiscal_integrated': document_mode_fiscal_integrated,
+        'fiscal_provider_matias': fiscal_provider_matias,
+    }
+    reason_code_by_check = (
+        ('customer_requested', 'electronic_invoicing_not_requested'),
+        ('dev_flag_enabled', 'electronic_invoicing_disabled'),
+        ('fiscal_data_complete', 'fiscal_data_incomplete'),
+        ('active_resolution', 'dian_resolution_unavailable'),
+        ('tax_requirement_satisfied', 'tax_configuration_invalid'),
+        ('matias_company_id_configured', 'matias_company_id_missing'),
+        ('country_is_colombia', 'tenant_country_not_colombia'),
+        ('document_mode_fiscal_integrated', 'document_mode_not_fiscal_integrated'),
+        ('fiscal_provider_matias', 'fiscal_provider_not_matias'),
+    )
+    reason_codes = [
+        code for check, code in reason_code_by_check if not checks[check]
+    ]
 
     return {
         'ready': (
@@ -156,15 +204,11 @@ async def get_readiness(tenant_id: UUID) -> Optional[Dict[str, Any]]:
             and active_resolution
             and tax_requirement_satisfied
             and matias_company_id_configured
+            and country_is_colombia
+            and document_mode_fiscal_integrated
+            and fiscal_provider_matias
         ),
-        'checks': {
-            'customer_requested':   customer_requested,
-            'dev_flag_enabled':     dev_flag_enabled,
-            'fiscal_data_complete': fiscal_data_complete,
-            'active_resolution':    active_resolution,
-            'taxes_configured':     taxes_configured,
-            'tax_requirement_satisfied': tax_requirement_satisfied,
-            'matias_company_id_configured': matias_company_id_configured,
-        },
+        'checks': checks,
+        'reason_codes': reason_codes,
         'missing': missing,
     }

--- a/app/services/tenant_financial_profile_service.py
+++ b/app/services/tenant_financial_profile_service.py
@@ -1,5 +1,5 @@
 """Authoritative tenant financial profile and safe country/currency mutation."""
-from typing import Any
+from typing import Any, Optional, Tuple
 
 from fastapi import HTTPException, Request
 
@@ -71,7 +71,7 @@ _BLOCKERS_QUERY = """
 """
 
 
-def _financial_mode(country_code: str) -> tuple[str, str, str | None]:
+def _financial_mode(country_code: str) -> Tuple[str, str, Optional[str]]:
     if country_code == "CO":
         return "WARO_CO_PUC_V1", "fiscal_integrated", "matias"
     return "WARO_HOSPITALITY_GLOBAL_V1", "waro_commercial", None

--- a/tests/test_invoicing_readiness.py
+++ b/tests/test_invoicing_readiness.py
@@ -32,6 +32,9 @@ def _row(
     tax_level_id: int = 5,
     inc_applicable: bool = False,
     iva_applicable: bool = True,
+    country_code: str = 'CO',
+    document_mode: str = 'fiscal_integrated',
+    fiscal_provider='matias',
 ):
     return {
         'dev_flag_enabled':  dev_flag_enabled,
@@ -48,6 +51,9 @@ def _row(
         'active_resolution': active_resolution,
         'inc_applicable':    inc_applicable,
         'iva_applicable':    iva_applicable,
+        'country_code':      country_code,
+        'document_mode':     document_mode,
+        'fiscal_provider':   fiscal_provider,
     }
 
 
@@ -89,8 +95,36 @@ class TestReadinessService:
             'taxes_configured':     True,
             'tax_requirement_satisfied': True,
             'matias_company_id_configured': True,
+            'country_is_colombia': True,
+            'document_mode_fiscal_integrated': True,
+            'fiscal_provider_matias': True,
         }
+        assert payload['reason_codes'] == []
         assert payload['missing'] == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ('field', 'value', 'check', 'reason_code'),
+        (
+            ('country_code', 'US', 'country_is_colombia', 'tenant_country_not_colombia'),
+            (
+                'document_mode',
+                'waro_commercial',
+                'document_mode_fiscal_integrated',
+                'document_mode_not_fiscal_integrated',
+            ),
+            ('fiscal_provider', None, 'fiscal_provider_matias', 'fiscal_provider_not_matias'),
+        ),
+    )
+    async def test_authoritative_financial_profile_blocks_matias(
+        self, field, value, check, reason_code
+    ):
+        with _patch_db(_row(**{field: value})):
+            payload = await invoicing_readiness_service.get_readiness(_TENANT_ID)
+
+        assert payload['ready'] is False
+        assert payload['checks'][check] is False
+        assert reason_code in payload['reason_codes']
 
     @pytest.mark.asyncio
     async def test_customer_request_is_required_before_internal_enablement_can_be_ready(self):

--- a/tests/test_tenant_financial_profile.py
+++ b/tests/test_tenant_financial_profile.py
@@ -191,3 +191,15 @@ def test_migration_is_idempotent_and_does_not_rewrite_history():
 def test_blocker_query_is_tenant_scoped_and_ignores_null_legacy_rows():
     assert service._BLOCKERS_QUERY.count("tenant_id = $1") == 9
     assert "tenant_id IS NULL" not in service._BLOCKERS_QUERY
+
+
+def test_financial_profile_read_is_not_owner_module_gated():
+    from app.routers.tenant_config import router
+
+    routes = {
+        (next(iter(route.methods)), route.path): route
+        for route in router.routes
+        if getattr(route, "methods", None) and route.path == "/financial-profile"
+    }
+    assert routes[("GET", "/financial-profile")].dependant.dependencies == []
+    assert len(routes[("PUT", "/financial-profile")].dependant.dependencies) == 1


### PR DESCRIPTION
## Summary
- require CO + fiscal_integrated + Matias in API WARO readiness
- expose stable reason codes and preserve structured 403 responses
- allow authenticated tenant members to read financial capabilities while keeping updates owner-gated
- restore Python 3.9 compatibility for the financial profile service

Completes the companion defense required by #621 and uno0uno/api-facturacion#37.

## Verification
- `pytest -q tests/test_invoicing_readiness.py tests/test_tenant_financial_profile.py` (34 passed)
- `ruff check --target-version py39 ...`
- `git diff --check`