### PR TITLE
Batch 1: registro por correo y tenant pendiente reanudable

### DIFF
--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -6,6 +6,7 @@ from fastapi import Request, Response
 from fastapi.responses import JSONResponse
 from app.database import get_db_connection
 from app.config import settings
+from app.core.onboarding_access import is_pending_session_route_allowed
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +80,9 @@ class SessionContext:
             self.expires_at = session_data['expires_at']
             self.is_active = session_data['is_active']
             self.role: Optional[str] = session_data.get('role')
+            self.lifecycle_status = session_data.get('lifecycle_status') or 'active'
+            self.onboarding_state = session_data.get('onboarding_state')
+            self.next_step = session_data.get('next_step')
             self.is_valid = True
         else:
             self.user_id = None
@@ -88,6 +92,9 @@ class SessionContext:
             self.expires_at = None
             self.is_active = False
             self.role: Optional[str] = None
+            self.lifecycle_status = 'active'
+            self.onboarding_state = None
+            self.next_step = None
             self.is_valid = False
 
     def to_dict(self) -> Dict[str, Any]:
@@ -99,6 +106,9 @@ class SessionContext:
             'expires_at': self.expires_at,
             'is_active': self.is_active,
             'role': self.role,
+            'lifecycle_status': self.lifecycle_status,
+            'onboarding_state': self.onboarding_state,
+            'next_step': self.next_step,
             'is_valid': self.is_valid
         }
 
@@ -582,6 +592,32 @@ async def session_validation_middleware(request: Request, call_next):
         except Exception as e:
             logger.error("Unexpected session validation error for path %s: %s", path, e, exc_info=True)
             request.state.session_context = SessionContext()
+
+        session_context = request.state.session_context
+        if (
+            session_context.is_valid
+            and session_context.lifecycle_status == 'pending'
+            and not is_pending_session_route_allowed(request.method, path)
+        ):
+            logger.warning(
+                "Denied pending tenant session: method=%s path=%s tenant=%s user=%s",
+                request.method,
+                path,
+                session_context.tenant_id,
+                session_context.user_id,
+            )
+            return JSONResponse(
+                status_code=403,
+                content={
+                    "error": True,
+                    "message": "Tenant onboarding is not active",
+                    "details": {
+                        "lifecycleStatus": session_context.lifecycle_status,
+                        "onboardingState": session_context.onboarding_state,
+                        "nextStep": session_context.next_step,
+                    },
+                },
+            )
 
         return await call_next(request)
 

--- a/app/core/onboarding_access.py
+++ b/app/core/onboarding_access.py
@@ -1,0 +1,38 @@
+from typing import FrozenSet, Optional, Tuple
+
+
+_NEXT_STEP_BY_STATE = {
+    "email_verified": "business_profile",
+    "business_profile_pending": "business_profile",
+    "terms_pending": "terms",
+    "payment_pending": "payment",
+    "paid": "activation",
+    "active": "setup",
+    "setup_complete": None,
+    "cancelled": None,
+}
+
+
+# Pending sessions are denied by default. Keep this list exact so adding a new
+# route under /billing or /legal never grants it pre-payment by accident.
+PENDING_SESSION_ROUTE_ALLOWLIST: FrozenSet[Tuple[str, str]] = frozenset({
+    ("GET", "/auth/session"),
+    ("POST", "/auth/signout"),
+    ("GET", "/onboarding/status"),
+    ("GET", "/legal/terms/current"),
+    ("GET", "/legal/terms/status"),
+    ("POST", "/legal/terms/accept"),
+    ("GET", "/billing/plans"),
+    ("POST", "/billing/subscribe"),
+    ("GET", "/billing/subscription"),
+    ("GET", "/billing/verify-payment"),
+    ("GET", "/billing/access-status"),
+})
+
+
+def is_pending_session_route_allowed(method: str, path: str) -> bool:
+    return (method.upper(), path.rstrip("/") or "/") in PENDING_SESSION_ROUTE_ALLOWLIST
+
+
+def next_step_for_state(state: Optional[str]) -> Optional[str]:
+    return _NEXT_STEP_BY_STATE.get(state)

--- a/app/core/onboarding_access.py
+++ b/app/core/onboarding_access.py
@@ -22,11 +22,6 @@ PENDING_SESSION_ROUTE_ALLOWLIST: FrozenSet[Tuple[str, str]] = frozenset({
     ("GET", "/legal/terms/current"),
     ("GET", "/legal/terms/status"),
     ("POST", "/legal/terms/accept"),
-    ("GET", "/billing/plans"),
-    ("POST", "/billing/subscribe"),
-    ("GET", "/billing/subscription"),
-    ("GET", "/billing/verify-payment"),
-    ("GET", "/billing/access-status"),
 })
 
 

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from fastapi import Request, HTTPException, Response
 from app.config import settings
 from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES, is_legacy_internal_team_role
+from app.core.onboarding_access import next_step_for_state
 from typing import List, Optional
 
 logger = logging.getLogger(__name__)
@@ -374,9 +375,15 @@ async def get_session_from_request(request: Request) -> Optional[dict]:
             session_query = """
                 SELECT s.user_id, s.tenant_id, s.expires_at, s.is_active,
                        p.email, p.name,
-                       tm.role AS role
+                       tm.role AS role,
+                       COALESCE(t.lifecycle_status, 'active') AS lifecycle_status,
+                       o.state AS onboarding_state
                 FROM sessions s
                 JOIN profile p ON s.user_id = p.id
+                LEFT JOIN tenants t ON t.id = s.tenant_id
+                LEFT JOIN tenant_onboarding o
+                  ON o.tenant_id = s.tenant_id
+                 AND o.owner_user_id = s.user_id
                 LEFT JOIN LATERAL (
                     SELECT role
                     FROM tenant_members tm
@@ -424,6 +431,9 @@ async def get_session_from_request(request: Request) -> Optional[dict]:
                 'expires_at': session_result['expires_at'],
                 'is_active': session_result['is_active'],
                 'role': resolved_role,
+                'lifecycle_status': session_result.get('lifecycle_status') or 'active',
+                'onboarding_state': session_result.get('onboarding_state'),
+                'next_step': next_step_for_state(session_result.get('onboarding_state')),
             }
 
     except Exception as e:

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, pos_products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, ai_agents, customer_portal, leads, waros, billing, legal, payments_webhook, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
+from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, pos_products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, ai_agents, customer_portal, leads, waros, billing, legal, onboarding, payments_webhook, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
 from app.config import settings
 from app.core.logging import setup_logging
 from app.core.exceptions import api_exception_handler, general_exception_handler, APIError
@@ -154,6 +154,7 @@ app.middleware("http")(session_validation_middleware)
 
 # Include API routers
 app.include_router(auth.router, prefix="/auth", tags=["auth"])
+app.include_router(onboarding.router)
 app.include_router(me.router, prefix="/me", tags=["me"])
 app.include_router(tenants.router, prefix="/tenants", tags=["tenants"])
 app.include_router(financial.router, prefix="/finance", tags=["financial"])

--- a/app/models/auth.py
+++ b/app/models/auth.py
@@ -4,6 +4,7 @@ from typing import Literal, Optional, Dict, Any
 from uuid import UUID
 
 from app.core.email_utils import normalize_email
+from app.models.onboarding import OnboardingStatus, OnboardingState, TenantLifecycle
 
 PreferredLocale = Literal['es', 'en', 'pt', 'fr', 'de', 'ar', 'hi', 'zh']
 
@@ -48,6 +49,9 @@ class SessionResponse(BaseModel):
     session: Session
     has_internal_access: bool = False
     current_tenant: Optional[Tenant] = Field(alias='currentTenant', default=None)
+    lifecycle_status: TenantLifecycle = Field(alias='lifecycleStatus', default='active')
+    onboarding_state: Optional[OnboardingState] = Field(alias='onboardingState', default=None)
+    next_step: Optional[str] = Field(alias='nextStep', default=None)
     
     class Config:
         populate_by_name = True
@@ -89,11 +93,14 @@ class VerifyCodeResponse(BaseModel):
     message: str = "Verification successful"
     user: User
     tenant: Tenant
+    onboarding: Optional[OnboardingStatus] = None
 
 class VerifyTokenResponse(BaseModel):
     success: bool = True
     message: str = "Login successful"
     user: User
+    tenant: Optional[Tenant] = None
+    onboarding: Optional[OnboardingStatus] = None
 
 class UserTenantsResponse(BaseModel):
     success: bool = True

--- a/app/models/onboarding.py
+++ b/app/models/onboarding.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from typing import Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+TenantLifecycle = Literal["pending", "active", "suspended", "cancelled"]
+OnboardingState = Literal[
+    "email_verified",
+    "business_profile_pending",
+    "terms_pending",
+    "payment_pending",
+    "paid",
+    "active",
+    "setup_complete",
+    "cancelled",
+]
+
+
+class OnboardingStatus(BaseModel):
+    tenant_id: UUID = Field(alias="tenantId")
+    lifecycle_status: TenantLifecycle = Field(alias="lifecycleStatus")
+    state: Optional[OnboardingState] = None
+    next_step: Optional[str] = Field(alias="nextStep", default=None)
+    email_verified_at: Optional[datetime] = Field(alias="emailVerifiedAt", default=None)
+
+    class Config:
+        populate_by_name = True
+
+
+class OnboardingStatusResponse(BaseModel):
+    success: bool = True
+    data: OnboardingStatus

--- a/app/routers/onboarding.py
+++ b/app/routers/onboarding.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Request
+
+from app.core.middleware import require_valid_session
+from app.database import get_db_connection
+from app.models.onboarding import OnboardingStatusResponse
+from app.services.onboarding_service import get_status_for_tenant
+
+
+router = APIRouter(prefix="/onboarding", tags=["onboarding"])
+
+
+@router.get("/status", response_model=OnboardingStatusResponse)
+async def get_onboarding_status(request: Request):
+    session = require_valid_session(request)
+    async with get_db_connection(use_transaction=False) as conn:
+        return await get_status_for_tenant(conn, session.tenant_id)

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -8,6 +8,7 @@ from app.database import get_db_connection
 from app.core.security import collect_session_tokens, get_session_token, clear_session_cookie, set_session_cookie, get_client_ip
 from app.core.exceptions import AuthenticationError
 from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES, is_legacy_internal_team_role
+from app.core.onboarding_access import next_step_for_state
 from app.core.middleware import require_valid_session
 from app.models.auth import (
     ProfileAvatarResponse,
@@ -75,15 +76,31 @@ async def get_session_data(request: Request, response: Response) -> SessionRespo
             # Get tenant info if tenant_id exists (exact logic from warolabs.com)
             current_tenant = None
             user_role = None
+            lifecycle_status = 'active'
+            onboarding_state = None
             if session_result['tenant_id']:
-                tenant_query = "SELECT id, name, slug FROM tenants WHERE id = $1"
-                tenant_result = await conn.fetchrow(tenant_query, session_result['tenant_id'])
+                tenant_query = """
+                    SELECT t.id, t.name, t.slug, t.lifecycle_status,
+                           o.state AS onboarding_state
+                    FROM tenants t
+                    LEFT JOIN tenant_onboarding o
+                      ON o.tenant_id = t.id
+                     AND o.owner_user_id = $2
+                    WHERE t.id = $1
+                """
+                tenant_result = await conn.fetchrow(
+                    tenant_query,
+                    session_result['tenant_id'],
+                    session_result['user_id'],
+                )
                 if tenant_result:
                     current_tenant = Tenant(
                         id=tenant_result['id'],
                         name=tenant_result['name'],
                         slug=tenant_result['slug']
                     )
+                    lifecycle_status = tenant_result.get('lifecycle_status') or 'active'
+                    onboarding_state = tenant_result.get('onboarding_state')
                 # Only read role from ACTIVE memberships (#201). Customer rows
                 # are active memberships, but they are not internal team access.
                 role_result = await conn.fetchrow(
@@ -125,12 +142,12 @@ async def get_session_data(request: Request, response: Response) -> SessionRespo
             user = ProfileUser(
                 id=session_result['user_id'],
                 email=session_result['email'],
-                name=session_result['name'],
-                user_name=session_result['user_name'],
-                description=session_result['description'],
-                logo_avatar=session_result['logo_avatar'],
-                preferred_locale=session_result['preferred_locale'],
-                createdAt=session_result['user_created_at'],
+                name=session_result.get('name'),
+                user_name=session_result.get('user_name'),
+                description=session_result.get('description'),
+                logo_avatar=session_result.get('logo_avatar'),
+                preferred_locale=session_result.get('preferred_locale'),
+                createdAt=session_result.get('user_created_at') or datetime.utcnow(),
                 role=user_role
             )
             
@@ -146,7 +163,10 @@ async def get_session_data(request: Request, response: Response) -> SessionRespo
                 user=user,
                 session=session,
                 has_internal_access=is_legacy_internal_team_role(user_role),
-                currentTenant=current_tenant
+                currentTenant=current_tenant,
+                lifecycleStatus=lifecycle_status,
+                onboardingState=onboarding_state,
+                nextStep=next_step_for_state(onboarding_state),
             )
             
     except AuthenticationError:

--- a/app/services/magic_link_service.py
+++ b/app/services/magic_link_service.py
@@ -4,7 +4,7 @@ import random
 from datetime import datetime, timedelta
 from typing import Any, Optional
 from uuid import UUID
-from fastapi import Request, Response
+from fastapi import HTTPException, Request, Response
 from app.database import get_db_connection
 from app.core.security import set_session_cookie, get_client_ip
 from app.core.middleware import require_valid_tenant
@@ -12,7 +12,9 @@ from app.core.exceptions import AuthenticationError, ValidationError
 from app.core.email_utils import normalize_email
 from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
 from app.models.auth import User, Tenant, MagicLinkResponse, VerifyCodeResponse, VerifyTokenResponse
+from app.models.onboarding import OnboardingStatus
 from app.services.auth_service import replace_active_admin_sessions
+from app.services.onboarding_service import complete_registration, store_registration_challenge
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +58,70 @@ async def _tenant_email_branding(conn, tenant_id: UUID) -> dict[str, str]:
         return {"tenant_name": "WARO", "tenant_email": "", "brand_name": "WARO"}
     return dict(row)
 
+
+async def _complete_registration_login(
+    conn,
+    *,
+    request: Request,
+    response: Response,
+    tenant_context,
+    email: str,
+    credential: str,
+    kind: str,
+    login_method: str,
+) -> Optional[tuple[User, Tenant, Optional[OnboardingStatus]]]:
+    identity = await complete_registration(
+        conn,
+        email=email,
+        credential=credential,
+        kind=kind,
+    )
+    if not identity:
+        return None
+
+    session_id = secrets.token_hex(16)
+    expires_at = datetime.utcnow() + timedelta(days=7)
+    await conn.execute(
+        """
+        INSERT INTO sessions (
+          id, user_id, tenant_id, expires_at, created_at,
+          ip_address, user_agent, login_method, is_active
+        )
+        VALUES ($1, $2, $3, $4, NOW(), $5, $6, $7, true)
+        """,
+        session_id,
+        identity["user_id"],
+        identity["tenant_id"],
+        expires_at,
+        get_client_ip(request),
+        request.headers.get("user-agent"),
+        login_method,
+    )
+    await replace_active_admin_sessions(conn, identity["user_id"], session_id)
+    await set_session_cookie(response, session_id, tenant_context.site)
+
+    user = User(
+        id=identity["user_id"],
+        email=identity["email"],
+        name=identity.get("name"),
+        createdAt=identity.get("user_created_at") or datetime.utcnow(),
+    )
+    tenant = Tenant(
+        id=identity["tenant_id"],
+        name=identity["tenant_name"],
+        slug=identity["tenant_slug"],
+    )
+    onboarding = None
+    if identity.get("onboarding_state"):
+        onboarding = OnboardingStatus(
+            tenantId=identity["tenant_id"],
+            lifecycleStatus=identity["lifecycle_status"],
+            state=identity["onboarding_state"],
+            nextStep=identity.get("next_step"),
+            emailVerifiedAt=identity.get("email_verified_at"),
+        )
+    return user, tenant, onboarding
+
 async def send_magic_link(request: Request, email: str, redirect: Optional[str] = None) -> MagicLinkResponse:
     """
     Send magic link using tenant context from middleware
@@ -76,32 +142,40 @@ async def send_magic_link(request: Request, email: str, redirect: Optional[str] 
 
             user_result = await _lookup_internal_team_member(conn, email)
 
-            if not user_result:
-                logger.warning(
-                    "❌ User %s is not an active internal team member",
-                    email,
+            is_registration = user_result is None
+            if is_registration:
+                should_send = await store_registration_challenge(
+                    conn,
+                    email=email,
+                    token=token,
+                    code=verification_code,
+                    request_ip=get_client_ip(request),
+                    user_agent=request.headers.get("user-agent"),
                 )
-                raise AuthenticationError("User not found. Please contact an administrator.")
+                if not should_send:
+                    return MagicLinkResponse()
+                user_tenant_id = tenant_context.tenant_id
+                logger.info("Pre-registration verification challenge created")
+            else:
+                user_id = user_result['user_id']
+                user_tenant_id = user_result['tenant_id']
+                logger.info(f"✅ User found with ID: {user_id}, role: {user_result['role']}, tenant: {user_tenant_id}")
 
-            user_id = user_result['user_id']
-            user_tenant_id = user_result['tenant_id']
-            logger.info(f"✅ User found with ID: {user_id}, role: {user_result['role']}, tenant: {user_tenant_id}")
-            
-            # Mark old unused magic tokens as expired for this user
-            await conn.execute(
-                'UPDATE magic_tokens SET used = true, used_at = NOW() WHERE user_id = $1 AND used = false', 
-                user_id
-            )
-            
-            # Save new magic token to database with user's tenant_id
-            insert_token_query = """
-                INSERT INTO magic_tokens (user_id, token, verification_code, expires_at, tenant_id, used, created_at, used_at)
-                VALUES ($1, $2, $3, $4, $5, false, NOW(), NULL)
-            """
-            await conn.execute(insert_token_query,
-                user_id, token, verification_code, expires_at, user_tenant_id
-            )
-            logger.info(f"🔑 Magic token saved for user: {user_id}, tenant: {user_tenant_id}")
+                # Mark old unused magic tokens as expired for this user
+                await conn.execute(
+                    'UPDATE magic_tokens SET used = true, used_at = NOW() WHERE user_id = $1 AND used = false',
+                    user_id
+                )
+
+                # Save new magic token to database with user's tenant_id
+                insert_token_query = """
+                    INSERT INTO magic_tokens (user_id, token, verification_code, expires_at, tenant_id, used, created_at, used_at)
+                    VALUES ($1, $2, $3, $4, $5, false, NOW(), NULL)
+                """
+                await conn.execute(insert_token_query,
+                    user_id, token, verification_code, expires_at, user_tenant_id
+                )
+                logger.info(f"🔑 Magic token saved for user: {user_id}, tenant: {user_tenant_id}")
             
             # Send magic link email using AWS SES
             from app.services.aws_ses_service import ses_service
@@ -124,10 +198,15 @@ async def send_magic_link(request: Request, email: str, redirect: Optional[str] 
             if redirect:
                 magic_link_url += f"&redirect={redirect}"
             
-            member_branding = await _tenant_email_branding(conn, user_tenant_id)
-            brand_name = member_branding["brand_name"]
-            tenant_name = member_branding["tenant_name"]
-            tenant_email = member_branding["tenant_email"] or tenant_context.tenant_email
+            if is_registration:
+                brand_name = tenant_context.brand_name or "WARO"
+                tenant_name = tenant_context.tenant_name or "WARO"
+                tenant_email = tenant_context.tenant_email
+            else:
+                member_branding = await _tenant_email_branding(conn, user_tenant_id)
+                brand_name = member_branding["brand_name"]
+                tenant_name = member_branding["tenant_name"]
+                tenant_email = member_branding["tenant_email"] or tenant_context.tenant_email
 
             # Prepare tenant context for template (use the member's restaurant, not the site tenant)
             template_context = {
@@ -166,7 +245,7 @@ async def send_magic_link(request: Request, email: str, redirect: Optional[str] 
             
             return MagicLinkResponse()
             
-    except (ValidationError, AuthenticationError):
+    except (ValidationError, AuthenticationError, HTTPException):
         raise
     except Exception as e:
         logger.error(f"❌ Magic link handler error: {e}", exc_info=True)
@@ -207,8 +286,21 @@ async def verify_code(request: Request, response: Response, email: str, code: st
             )
             
             if not token_data:
-                logger.warning(f"❌ Invalid verification code for {email} on {tenant_context.site}")
-                raise AuthenticationError("Invalid or expired verification code")
+                registration = await _complete_registration_login(
+                    conn,
+                    request=request,
+                    response=response,
+                    tenant_context=tenant_context,
+                    email=email,
+                    credential=code,
+                    kind="code",
+                    login_method="onboarding_code",
+                )
+                if not registration:
+                    logger.warning(f"❌ Invalid verification code for {email} on {tenant_context.site}")
+                    raise AuthenticationError("Invalid or expired verification code")
+                user, tenant, onboarding = registration
+                return VerifyCodeResponse(user=user, tenant=tenant, onboarding=onboarding)
             
             logger.info(f"✅ Valid verification code for user: {token_data['user_id']}")
             
@@ -284,7 +376,7 @@ async def verify_code(request: Request, response: Response, email: str, code: st
 
             return VerifyCodeResponse(user=user, tenant=tenant)
             
-    except (ValidationError, AuthenticationError):
+    except (ValidationError, AuthenticationError, HTTPException):
         raise
     except Exception as e:
         logger.error(f"❌ Verification code handler error: {e}", exc_info=True)
@@ -325,8 +417,21 @@ async def verify_token(request: Request, response: Response, email: str, token: 
             )
             
             if not token_data:
-                logger.warning(f"❌ Invalid or expired token for {email} on {tenant_context.site}")
-                raise AuthenticationError("Invalid or expired token")
+                registration = await _complete_registration_login(
+                    conn,
+                    request=request,
+                    response=response,
+                    tenant_context=tenant_context,
+                    email=email,
+                    credential=token,
+                    kind="token",
+                    login_method="onboarding_magic_link",
+                )
+                if not registration:
+                    logger.warning(f"❌ Invalid or expired token for {email} on {tenant_context.site}")
+                    raise AuthenticationError("Invalid or expired token")
+                user, tenant, onboarding = registration
+                return VerifyTokenResponse(user=user, tenant=tenant, onboarding=onboarding)
             
             logger.info(f"✅ Valid token found for user: {token_data['user_id']}")
             
@@ -397,7 +502,7 @@ async def verify_token(request: Request, response: Response, email: str, token: 
             
             return VerifyTokenResponse(user=user)
             
-    except (ValidationError, AuthenticationError):
+    except (ValidationError, AuthenticationError, HTTPException):
         raise
     except Exception as e:
         logger.error(f"❌ Token verification handler error: {e}", exc_info=True)

--- a/app/services/onboarding_service.py
+++ b/app/services/onboarding_service.py
@@ -1,0 +1,300 @@
+import hashlib
+import hmac
+from typing import Any, Optional
+from uuid import UUID, uuid4
+
+from fastapi import HTTPException
+
+from app.config import settings
+from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
+from app.core.onboarding_access import next_step_for_state
+from app.models.onboarding import OnboardingStatus, OnboardingStatusResponse
+
+MAX_EMAIL_REQUESTS = 5
+MAX_IP_REQUESTS = 20
+MAX_VERIFY_ATTEMPTS = 5
+
+
+def _credential_hash(email: str, kind: str, value: str) -> str:
+    payload = f"onboarding:{kind}:{email}:{value}".encode("utf-8")
+    return hmac.new(settings.auth_secret.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+
+
+async def store_registration_challenge(
+    conn,
+    *,
+    email: str,
+    token: str,
+    code: str,
+    request_ip: Optional[str],
+    user_agent: Optional[str],
+) -> bool:
+    """Persist a pre-user challenge for an address without an active tenant."""
+    limits = await conn.fetchrow(
+        """
+        SELECT
+            COUNT(*) FILTER (WHERE normalized_email = $1) AS email_count,
+            COUNT(*) FILTER (WHERE request_ip = $2::inet) AS ip_count
+        FROM onboarding_email_challenges
+        WHERE created_at > NOW() - INTERVAL '15 minutes'
+          AND (normalized_email = $1 OR ($2::inet IS NOT NULL AND request_ip = $2::inet))
+        """,
+        email,
+        request_ip,
+    )
+    email_count = int((limits or {}).get("email_count") or 0)
+    ip_count = int((limits or {}).get("ip_count") or 0)
+    if email_count >= MAX_EMAIL_REQUESTS or ip_count >= MAX_IP_REQUESTS:
+        raise HTTPException(status_code=429, detail="Too many verification requests")
+
+    await conn.execute(
+        """
+        UPDATE onboarding_email_challenges
+        SET consumed_at = COALESCE(consumed_at, NOW())
+        WHERE normalized_email = $1
+          AND consumed_at IS NULL
+        """,
+        email,
+    )
+    await conn.execute(
+        """
+        INSERT INTO onboarding_email_challenges (
+            normalized_email, token_hash, code_hash, request_ip,
+            user_agent, expires_at
+        )
+        VALUES ($1, $2, $3, $4::inet, $5, NOW() + INTERVAL '15 minutes')
+        """,
+        email,
+        _credential_hash(email, "token", token),
+        _credential_hash(email, "code", code),
+        request_ip,
+        user_agent,
+    )
+    return True
+
+
+async def _identity_for_tenant(conn, user_id: UUID, tenant_id: UUID) -> Optional[dict[str, Any]]:
+    row = await conn.fetchrow(
+        """
+        SELECT p.id AS user_id, p.email, p.name,
+               p.created_at AS user_created_at,
+               t.id AS tenant_id, t.name AS tenant_name, t.slug AS tenant_slug,
+               t.lifecycle_status, o.state AS onboarding_state,
+               o.email_verified_at
+        FROM profile p
+        JOIN tenants t ON t.id = $2
+        LEFT JOIN tenant_onboarding o
+          ON o.tenant_id = t.id AND o.owner_user_id = p.id
+        WHERE p.id = $1
+        LIMIT 1
+        """,
+        user_id,
+        tenant_id,
+    )
+    if not row:
+        return None
+    result = dict(row)
+    result["next_step"] = next_step_for_state(result.get("onboarding_state"))
+    return result
+
+
+async def complete_registration(
+    conn,
+    *,
+    email: str,
+    credential: str,
+    kind: str,
+) -> Optional[dict[str, Any]]:
+    """Consume a challenge and atomically create or resume pending identity."""
+    if kind not in {"token", "code"}:
+        raise ValueError("Unsupported onboarding credential kind")
+
+    hash_column = "token_hash" if kind == "token" else "code_hash"
+    challenge = await conn.fetchrow(
+        f"""
+        SELECT id, consumed_at, completed_user_id, completed_tenant_id
+        FROM onboarding_email_challenges
+        WHERE normalized_email = $1
+          AND {hash_column} = $2
+          AND expires_at > NOW()
+          AND failed_attempts < $3
+        ORDER BY created_at DESC
+        LIMIT 1
+        FOR UPDATE
+        """,
+        email,
+        _credential_hash(email, kind, credential),
+        MAX_VERIFY_ATTEMPTS,
+    )
+    if not challenge:
+        await conn.execute(
+            """
+            UPDATE onboarding_email_challenges
+            SET failed_attempts = LEAST(failed_attempts + 1, $2)
+            WHERE id = (
+                SELECT id
+                FROM onboarding_email_challenges
+                WHERE normalized_email = $1
+                  AND consumed_at IS NULL
+                  AND expires_at > NOW()
+                ORDER BY created_at DESC
+                LIMIT 1
+            )
+            """,
+            email,
+            MAX_VERIFY_ATTEMPTS,
+        )
+        return None
+
+    if challenge.get("completed_user_id") and challenge.get("completed_tenant_id"):
+        return await _identity_for_tenant(
+            conn,
+            challenge["completed_user_id"],
+            challenge["completed_tenant_id"],
+        )
+    if challenge.get("consumed_at"):
+        return None
+
+    # Serialize all provisioning decisions for one normalized address. The DB
+    # constraints remain the final protection if callers bypass this service.
+    await conn.execute("SELECT pg_advisory_xact_lock(hashtext($1))", email)
+
+    active = await conn.fetchrow(
+        """
+        SELECT p.id AS user_id, p.email, p.name,
+               p.created_at AS user_created_at,
+               t.id AS tenant_id, t.name AS tenant_name, t.slug AS tenant_slug,
+               t.lifecycle_status, NULL::text AS onboarding_state,
+               NULL::timestamptz AS email_verified_at
+        FROM profile p
+        JOIN tenant_members tm ON tm.user_id = p.id
+        JOIN tenants t ON t.id = tm.tenant_id
+        WHERE lower(trim(p.email)) = $1
+          AND tm.is_active = true
+          AND tm.role = ANY($2::text[])
+          AND t.lifecycle_status = 'active'
+        ORDER BY tm.id
+        LIMIT 1
+        """,
+        email,
+        list(LEGACY_INTERNAL_TEAM_ROLES),
+    )
+    if active:
+        identity = dict(active)
+        identity["next_step"] = None
+    else:
+        pending = await conn.fetchrow(
+            """
+            SELECT p.id AS user_id, p.email, p.name,
+                   p.created_at AS user_created_at,
+                   t.id AS tenant_id, t.name AS tenant_name, t.slug AS tenant_slug,
+                   t.lifecycle_status, o.state AS onboarding_state,
+                   o.email_verified_at
+            FROM profile p
+            JOIN tenant_onboarding o ON o.owner_user_id = p.id
+            JOIN tenants t ON t.id = o.tenant_id
+            WHERE lower(trim(p.email)) = $1
+              AND t.lifecycle_status = 'pending'
+              AND o.state NOT IN ('setup_complete', 'cancelled')
+            LIMIT 1
+            """,
+            email,
+        )
+        if pending:
+            identity = dict(pending)
+            identity["next_step"] = next_step_for_state(identity.get("onboarding_state"))
+        else:
+            profile = await conn.fetchrow(
+                """
+                INSERT INTO profile (email, created_at, updated_at)
+                VALUES ($1, NOW(), NOW())
+                ON CONFLICT ((lower(trim(email)))) DO UPDATE
+                    SET email = EXCLUDED.email,
+                        updated_at = NOW()
+                RETURNING id, email, name, created_at
+                """,
+                email,
+            )
+            tenant_id = uuid4()
+            slug = f"onboarding-{tenant_id.hex[:16]}"
+            await conn.execute(
+                """
+                INSERT INTO tenants (id, name, slug, email, lifecycle_status, created_at)
+                VALUES ($1, 'Negocio pendiente', $2, $3, 'pending', NOW())
+                """,
+                tenant_id,
+                slug,
+                email,
+            )
+            onboarding = await conn.fetchrow(
+                """
+                INSERT INTO tenant_onboarding (
+                    tenant_id, owner_user_id, verified_email, state,
+                    email_verified_at, created_at, updated_at
+                )
+                VALUES ($1, $2, $3, 'business_profile_pending', NOW(), NOW(), NOW())
+                RETURNING state, email_verified_at
+                """,
+                tenant_id,
+                profile["id"],
+                email,
+            )
+            await conn.execute(
+                """
+                INSERT INTO tenant_members (id, tenant_id, user_id, role, is_active)
+                VALUES (gen_random_uuid(), $1, $2, 'owner', false)
+                """,
+                tenant_id,
+                profile["id"],
+            )
+            identity = {
+                "user_id": profile["id"],
+                "email": profile["email"],
+                "name": profile.get("name"),
+                "user_created_at": profile["created_at"],
+                "tenant_id": tenant_id,
+                "tenant_name": "Negocio pendiente",
+                "tenant_slug": slug,
+                "lifecycle_status": "pending",
+                "onboarding_state": onboarding["state"],
+                "email_verified_at": onboarding["email_verified_at"],
+                "next_step": next_step_for_state(onboarding["state"]),
+            }
+
+    await conn.execute(
+        """
+        UPDATE onboarding_email_challenges
+        SET consumed_at = COALESCE(consumed_at, NOW()),
+            completed_user_id = $2,
+            completed_tenant_id = $3
+        WHERE id = $1
+        """,
+        challenge["id"],
+        identity["user_id"],
+        identity["tenant_id"],
+    )
+    return identity
+
+
+async def get_status_for_tenant(conn, tenant_id: UUID) -> OnboardingStatusResponse:
+    row = await conn.fetchrow(
+        """
+        SELECT t.id AS tenant_id, t.lifecycle_status,
+               o.state, o.email_verified_at
+        FROM tenants t
+        LEFT JOIN tenant_onboarding o ON o.tenant_id = t.id
+        WHERE t.id = $1
+        """,
+        tenant_id,
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Onboarding not found")
+    return OnboardingStatusResponse(
+        data=OnboardingStatus(
+            tenantId=row["tenant_id"],
+            lifecycleStatus=row["lifecycle_status"],
+            state=row.get("state"),
+            nextStep=next_step_for_state(row.get("state")),
+            emailVerifiedAt=row.get("email_verified_at"),
+        )
+    )

--- a/app/services/onboarding_service.py
+++ b/app/services/onboarding_service.py
@@ -30,6 +30,17 @@ async def store_registration_challenge(
     user_agent: Optional[str],
 ) -> bool:
     """Persist a pre-user challenge for an address without an active tenant."""
+    # Serialize the read/check/write sequence for every affected rate-limit
+    # bucket. Sorting avoids deadlocks when requests share only one bucket.
+    lock_keys = [f"onboarding-email:{email}"]
+    if request_ip:
+        lock_keys.append(f"onboarding-ip:{request_ip}")
+    for lock_key in sorted(lock_keys):
+        await conn.execute(
+            "SELECT pg_advisory_xact_lock(hashtext($1))",
+            lock_key,
+        )
+
     limits = await conn.fetchrow(
         """
         SELECT

--- a/migrations/106_onboarding_registration.sql
+++ b/migrations/106_onboarding_registration.sql
@@ -1,5 +1,29 @@
 -- Issue #630: resumable self-service registration without operational access.
 
+-- Fail before changing the schema when historical identities collide under the
+-- normalized comparison used by onboarding. These rows require an explicit
+-- identity merge; silently choosing or deleting one would be destructive.
+DO $$
+DECLARE
+    duplicate_groups integer;
+BEGIN
+    SELECT COUNT(*)
+    INTO duplicate_groups
+    FROM (
+        SELECT lower(trim(email))
+        FROM profile
+        WHERE email IS NOT NULL AND trim(email) <> ''
+        GROUP BY lower(trim(email))
+        HAVING COUNT(*) > 1
+    ) duplicates;
+
+    IF duplicate_groups > 0 THEN
+        RAISE EXCEPTION
+            'Cannot enforce normalized profile email uniqueness: % duplicate group(s) require identity reconciliation',
+            duplicate_groups;
+    END IF;
+END $$;
+
 CREATE UNIQUE INDEX IF NOT EXISTS profile_email_lower_unique
     ON profile (lower(trim(email)));
 

--- a/migrations/106_onboarding_registration.sql
+++ b/migrations/106_onboarding_registration.sql
@@ -1,0 +1,86 @@
+-- Issue #630: resumable self-service registration without operational access.
+
+CREATE UNIQUE INDEX IF NOT EXISTS profile_email_lower_unique
+    ON profile (lower(trim(email)));
+
+ALTER TABLE tenants
+    ADD COLUMN IF NOT EXISTS lifecycle_status text NOT NULL DEFAULT 'active';
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'tenants_lifecycle_status_check'
+    ) THEN
+        ALTER TABLE tenants
+            ADD CONSTRAINT tenants_lifecycle_status_check
+            CHECK (lifecycle_status IN ('pending', 'active', 'suspended', 'cancelled'));
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS onboarding_email_challenges (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    normalized_email text NOT NULL,
+    token_hash text NOT NULL UNIQUE,
+    code_hash text NOT NULL,
+    request_ip inet,
+    user_agent text,
+    failed_attempts integer NOT NULL DEFAULT 0,
+    expires_at timestamptz NOT NULL,
+    consumed_at timestamptz,
+    completed_user_id uuid REFERENCES profile(id),
+    completed_tenant_id uuid REFERENCES tenants(id),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT onboarding_email_normalized_check
+        CHECK (normalized_email = lower(trim(normalized_email))),
+    CONSTRAINT onboarding_email_attempts_check
+        CHECK (failed_attempts BETWEEN 0 AND 5)
+);
+
+CREATE INDEX IF NOT EXISTS idx_onboarding_challenge_email_created
+    ON onboarding_email_challenges (normalized_email, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_onboarding_challenge_ip_created
+    ON onboarding_email_challenges (request_ip, created_at DESC)
+    WHERE request_ip IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS tenant_onboarding (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id uuid NOT NULL UNIQUE REFERENCES tenants(id),
+    owner_user_id uuid NOT NULL REFERENCES profile(id),
+    verified_email text NOT NULL,
+    state text NOT NULL DEFAULT 'business_profile_pending',
+    email_verified_at timestamptz NOT NULL DEFAULT now(),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT tenant_onboarding_email_normalized_check
+        CHECK (verified_email = lower(trim(verified_email))),
+    CONSTRAINT tenant_onboarding_state_check CHECK (state IN (
+        'email_verified',
+        'business_profile_pending',
+        'terms_pending',
+        'payment_pending',
+        'paid',
+        'active',
+        'setup_complete',
+        'cancelled'
+    ))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS tenant_onboarding_owner_in_progress_unique
+    ON tenant_onboarding (owner_user_id)
+    WHERE state NOT IN ('setup_complete', 'cancelled');
+
+CREATE UNIQUE INDEX IF NOT EXISTS tenant_members_pending_owner_unique
+    ON tenant_members (tenant_id, user_id)
+    WHERE role = 'owner';
+
+COMMENT ON COLUMN tenants.lifecycle_status IS
+    'Server-owned tenant lifecycle. Public onboarding creates pending; trusted payment activation promotes to active.';
+
+COMMENT ON TABLE onboarding_email_challenges IS
+    'Hashed, rate-limited pre-registration challenges. No profile or tenant is required before verification.';
+
+COMMENT ON TABLE tenant_onboarding IS
+    'Server-side onboarding state machine and owner binding for a tenant.';

--- a/tests/test_customer_internal_access.py
+++ b/tests/test_customer_internal_access.py
@@ -54,18 +54,22 @@ def _session_row(session_token, tenant_id, user_id, expires_at, role_email):
 
 
 @pytest.mark.asyncio
-async def test_send_magic_link_denies_customer_only_membership():
-    """A customer-only row is filtered out before an internal magic token is created."""
+async def test_send_magic_link_routes_customer_only_email_to_verified_onboarding():
+    """A customer row cannot log in internally but may start a separate verified onboarding."""
     from app.services.magic_link_service import send_magic_link
 
     tenant_id = uuid4()
     db_ctx, conn = _build_db_mock(fetchrow_side_effect=[None])
 
+    registration_store = AsyncMock(return_value=False)
     with patch("app.services.magic_link_service.get_db_connection", side_effect=db_ctx), \
-         patch("app.services.magic_link_service.require_valid_tenant", return_value=_tenant_context(tenant_id)):
-        with pytest.raises(AuthenticationError):
-            await send_magic_link(_request(), "customer@example.com")
+         patch("app.services.magic_link_service.require_valid_tenant", return_value=_tenant_context(tenant_id)), \
+         patch("app.services.magic_link_service.store_registration_challenge", new=registration_store):
+        result = await send_magic_link(_request(), "customer@example.com")
 
+    assert result.success is True
+    registration_store.assert_awaited_once()
+    assert registration_store.await_args.kwargs["email"] == "customer@example.com"
     conn.execute.assert_not_awaited()
     assert conn.fetchrow.await_args.args[1] == "customer@example.com"
     assert conn.fetchrow.await_args.args[2] == ["superuser", "admin", "employee", "member", "promotor"]
@@ -81,7 +85,8 @@ async def test_verify_token_denies_customer_only_membership_before_session_creat
     db_ctx, conn = _build_db_mock(fetchrow_side_effect=[None])
 
     with patch("app.services.magic_link_service.get_db_connection", side_effect=db_ctx), \
-         patch("app.services.magic_link_service.require_valid_tenant", return_value=_tenant_context(tenant_id)):
+         patch("app.services.magic_link_service.require_valid_tenant", return_value=_tenant_context(tenant_id)), \
+         patch("app.services.magic_link_service._complete_registration_login", new=AsyncMock(return_value=None)):
         with pytest.raises(AuthenticationError):
             await verify_token(_request(), response, "customer@example.com", "token")
 

--- a/tests/test_onboarding_access.py
+++ b/tests/test_onboarding_access.py
@@ -1,0 +1,86 @@
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from app.core.middleware import SessionContext, session_validation_middleware
+from app.core.onboarding_access import is_pending_session_route_allowed
+
+
+def _request(method: str, path: str) -> Request:
+    return Request({
+        "type": "http",
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "https",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": [(b"host", b"test")],
+        "client": ("127.0.0.1", 1234),
+        "server": ("test", 443),
+    })
+
+
+def _pending_session() -> dict:
+    return {
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "new@example.com",
+        "name": None,
+        "expires_at": None,
+        "is_active": True,
+        "role": None,
+        "lifecycle_status": "pending",
+        "onboarding_state": "business_profile_pending",
+        "next_step": "business_profile",
+    }
+
+
+def test_pending_allowlist_is_exact():
+    assert is_pending_session_route_allowed("GET", "/auth/session")
+    assert is_pending_session_route_allowed("GET", "/legal/terms/current")
+    assert is_pending_session_route_allowed("POST", "/billing/subscribe")
+    assert not is_pending_session_route_allowed("GET", "/legal/terms/audit")
+    assert not is_pending_session_route_allowed("DELETE", "/billing/subscription")
+    assert not is_pending_session_route_allowed("GET", "/orders")
+
+
+def test_session_context_exposes_server_owned_onboarding_state():
+    session = SessionContext(_pending_session())
+    assert session.lifecycle_status == "pending"
+    assert session.onboarding_state == "business_profile_pending"
+    assert session.next_step == "business_profile"
+    assert session.role is None
+
+
+@pytest.mark.asyncio
+async def test_pending_session_is_denied_before_operational_handler():
+    request = _request("GET", "/orders")
+    call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
+
+    with patch(
+        "app.core.security.get_session_from_request",
+        new=AsyncMock(return_value=_pending_session()),
+    ):
+        response = await session_validation_middleware(request, call_next)
+
+    assert response.status_code == 403
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pending_session_can_reach_onboarding_status():
+    request = _request("GET", "/onboarding/status")
+    call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
+
+    with patch(
+        "app.core.security.get_session_from_request",
+        new=AsyncMock(return_value=_pending_session()),
+    ):
+        response = await session_validation_middleware(request, call_next)
+
+    assert response.status_code == 200
+    call_next.assert_awaited_once()

--- a/tests/test_onboarding_access.py
+++ b/tests/test_onboarding_access.py
@@ -42,7 +42,8 @@ def _pending_session() -> dict:
 def test_pending_allowlist_is_exact():
     assert is_pending_session_route_allowed("GET", "/auth/session")
     assert is_pending_session_route_allowed("GET", "/legal/terms/current")
-    assert is_pending_session_route_allowed("POST", "/billing/subscribe")
+    assert not is_pending_session_route_allowed("POST", "/billing/subscribe")
+    assert not is_pending_session_route_allowed("GET", "/billing/verify-payment")
     assert not is_pending_session_route_allowed("GET", "/legal/terms/audit")
     assert not is_pending_session_route_allowed("DELETE", "/billing/subscription")
     assert not is_pending_session_route_allowed("GET", "/orders")

--- a/tests/test_onboarding_registration.py
+++ b/tests/test_onboarding_registration.py
@@ -31,7 +31,10 @@ async def test_new_email_challenge_is_hashed_and_does_not_create_identity():
         )
 
     assert created is True
-    insert = conn.execute.await_args_list[1]
+    insert = next(
+        call for call in conn.execute.await_args_list
+        if "INSERT INTO onboarding_email_challenges" in call.args[0]
+    )
     assert "onboarding_email_challenges" in insert.args[0]
     assert "raw-token" not in insert.args
     assert "123456" not in insert.args
@@ -58,7 +61,7 @@ async def test_profile_without_active_tenant_can_start_verified_onboarding():
     )
 
     assert created is True
-    assert conn.execute.await_count == 2
+    assert conn.execute.await_count == 3
 
 
 @pytest.mark.asyncio
@@ -77,7 +80,11 @@ async def test_registration_challenge_enforces_persisted_rate_limit():
         )
 
     assert exc.value.status_code == 429
-    conn.execute.assert_not_awaited()
+    assert conn.execute.await_count == 2
+    assert all(
+        "pg_advisory_xact_lock" in call.args[0]
+        for call in conn.execute.await_args_list
+    )
 
 
 @pytest.mark.asyncio
@@ -255,6 +262,7 @@ async def test_magic_token_verification_returns_pending_session_contract():
 def test_migration_has_database_idempotency_and_lifecycle_guards():
     sql = Path("migrations/106_onboarding_registration.sql").read_text()
     assert "profile_email_lower_unique" in sql
+    assert "duplicate group(s) require identity reconciliation" in sql
     assert "tenants_lifecycle_status_check" in sql
     assert "tenant_onboarding_owner_in_progress_unique" in sql
     assert "tenant_members_pending_owner_unique" in sql

--- a/tests/test_onboarding_registration.py
+++ b/tests/test_onboarding_registration.py
@@ -1,0 +1,262 @@
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.onboarding_service import (
+    complete_registration,
+    store_registration_challenge,
+)
+
+
+@pytest.mark.asyncio
+async def test_new_email_challenge_is_hashed_and_does_not_create_identity():
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"email_count": 0, "ip_count": 0})
+    conn.execute = AsyncMock(return_value="OK")
+
+    with patch("app.services.onboarding_service.settings.auth_secret", "test-secret"):
+        created = await store_registration_challenge(
+            conn,
+            email="new@example.com",
+            token="raw-token",
+            code="123456",
+            request_ip="127.0.0.1",
+            user_agent="pytest",
+        )
+
+    assert created is True
+    insert = conn.execute.await_args_list[1]
+    assert "onboarding_email_challenges" in insert.args[0]
+    assert "raw-token" not in insert.args
+    assert "123456" not in insert.args
+    assert len(insert.args[2]) == 64
+    assert len(insert.args[3]) == 64
+    sql = " ".join(call.args[0] for call in conn.execute.await_args_list)
+    assert "INSERT INTO profile" not in sql
+    assert "INSERT INTO tenants" not in sql
+
+
+@pytest.mark.asyncio
+async def test_profile_without_active_tenant_can_start_verified_onboarding():
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"email_count": 0, "ip_count": 0})
+    conn.execute = AsyncMock(return_value="OK")
+
+    created = await store_registration_challenge(
+        conn,
+        email="customer@example.com",
+        token="token",
+        code="123456",
+        request_ip=None,
+        user_agent="pytest",
+    )
+
+    assert created is True
+    assert conn.execute.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_registration_challenge_enforces_persisted_rate_limit():
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"email_count": 5, "ip_count": 1})
+
+    with pytest.raises(HTTPException) as exc:
+        await store_registration_challenge(
+            conn,
+            email="new@example.com",
+            token="token",
+            code="123456",
+            request_ip="127.0.0.1",
+            user_agent="pytest",
+        )
+
+    assert exc.value.status_code == 429
+    conn.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_verified_challenge_atomically_creates_pending_owner():
+    challenge_id = uuid4()
+    user_id = uuid4()
+    tenant_id = uuid4()
+    created_at = datetime.now(timezone.utc)
+    verified_at = datetime.now(timezone.utc)
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        {
+            "id": challenge_id,
+            "consumed_at": None,
+            "completed_user_id": None,
+            "completed_tenant_id": None,
+        },
+        None,
+        None,
+        {
+            "id": user_id,
+            "email": "new@example.com",
+            "name": None,
+            "created_at": created_at,
+        },
+        {"state": "business_profile_pending", "email_verified_at": verified_at},
+    ])
+    conn.execute = AsyncMock(return_value="OK")
+
+    with patch("app.services.onboarding_service.settings.auth_secret", "test-secret"), patch(
+        "app.services.onboarding_service.uuid4", return_value=tenant_id
+    ):
+        identity = await complete_registration(
+            conn,
+            email="new@example.com",
+            credential="raw-token",
+            kind="token",
+        )
+
+    assert identity["user_id"] == user_id
+    assert identity["tenant_id"] == tenant_id
+    assert identity["lifecycle_status"] == "pending"
+    assert identity["onboarding_state"] == "business_profile_pending"
+    assert identity["next_step"] == "business_profile"
+    writes = "\n".join(call.args[0] for call in conn.execute.await_args_list)
+    assert "pg_advisory_xact_lock" in writes
+    assert "INSERT INTO tenants" in writes
+    assert "'pending'" in writes
+    assert "INSERT INTO tenant_members" in writes
+    assert "'owner', false" in writes
+    assert "tenant_public_profiles" not in writes
+    assert "seed_tenant_accounts" not in writes
+
+
+@pytest.mark.asyncio
+async def test_completed_challenge_retry_returns_same_identity_without_writes():
+    challenge_id = uuid4()
+    user_id = uuid4()
+    tenant_id = uuid4()
+    identity_row = {
+        "user_id": user_id,
+        "email": "new@example.com",
+        "name": None,
+        "user_created_at": datetime.now(timezone.utc),
+        "tenant_id": tenant_id,
+        "tenant_name": "Negocio pendiente",
+        "tenant_slug": "onboarding-stable",
+        "lifecycle_status": "pending",
+        "onboarding_state": "business_profile_pending",
+        "email_verified_at": datetime.now(timezone.utc),
+    }
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        {
+            "id": challenge_id,
+            "consumed_at": datetime.now(timezone.utc),
+            "completed_user_id": user_id,
+            "completed_tenant_id": tenant_id,
+        },
+        identity_row,
+    ])
+
+    with patch("app.services.onboarding_service.settings.auth_secret", "test-secret"):
+        identity = await complete_registration(
+            conn,
+            email="new@example.com",
+            credential="raw-token",
+            kind="token",
+        )
+
+    assert identity["user_id"] == user_id
+    assert identity["tenant_id"] == tenant_id
+    conn.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_superseded_challenge_cannot_provision_identity():
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "id": uuid4(),
+        "consumed_at": datetime.now(timezone.utc),
+        "completed_user_id": None,
+        "completed_tenant_id": None,
+    })
+
+    with patch("app.services.onboarding_service.settings.auth_secret", "test-secret"):
+        identity = await complete_registration(
+            conn,
+            email="new@example.com",
+            credential="old-token",
+            kind="token",
+        )
+
+    assert identity is None
+    conn.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_magic_token_verification_returns_pending_session_contract():
+    from app.services.magic_link_service import verify_token
+
+    user_id = uuid4()
+    tenant_id = uuid4()
+    now = datetime.now(timezone.utc)
+    identity = {
+        "user_id": user_id,
+        "email": "new@example.com",
+        "name": None,
+        "user_created_at": now,
+        "tenant_id": tenant_id,
+        "tenant_name": "Negocio pendiente",
+        "tenant_slug": "onboarding-stable",
+        "lifecycle_status": "pending",
+        "onboarding_state": "business_profile_pending",
+        "email_verified_at": now,
+        "next_step": "business_profile",
+    }
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+    conn.execute = AsyncMock(return_value="OK")
+
+    @asynccontextmanager
+    async def db_ctx():
+        yield conn
+
+    request = MagicMock()
+    request.headers = {"user-agent": "pytest"}
+    request.client = SimpleNamespace(host="127.0.0.1")
+    response = MagicMock()
+    tenant_context = SimpleNamespace(site="warocol.com")
+
+    with patch("app.services.magic_link_service.get_db_connection", side_effect=db_ctx), patch(
+        "app.services.magic_link_service.require_valid_tenant", return_value=tenant_context
+    ), patch(
+        "app.services.magic_link_service.complete_registration",
+        new=AsyncMock(return_value=identity),
+    ), patch(
+        "app.services.magic_link_service.replace_active_admin_sessions",
+        new=AsyncMock(return_value=0),
+    ), patch(
+        "app.services.magic_link_service.set_session_cookie", new=AsyncMock()
+    ):
+        result = await verify_token(request, response, "new@example.com", "token")
+
+    assert result.tenant.id == tenant_id
+    assert result.onboarding.lifecycle_status == "pending"
+    assert result.onboarding.next_step == "business_profile"
+    session_write = next(
+        call for call in conn.execute.await_args_list if "INSERT INTO sessions" in call.args[0]
+    )
+    assert session_write.args[2] == user_id
+    assert session_write.args[3] == tenant_id
+
+
+def test_migration_has_database_idempotency_and_lifecycle_guards():
+    sql = Path("migrations/106_onboarding_registration.sql").read_text()
+    assert "profile_email_lower_unique" in sql
+    assert "tenants_lifecycle_status_check" in sql
+    assert "tenant_onboarding_owner_in_progress_unique" in sql
+    assert "tenant_members_pending_owner_unique" in sql
+    assert "onboarding_email_challenges" in sql
+    assert "DEFAULT 'active'" in sql


### PR DESCRIPTION
## Summary
- add hashed, rate-limited pre-registration challenges and atomic resumable provisioning
- persist tenant lifecycle/onboarding state and expose it in auth/session APIs
- deny pending sessions by default with an exact pre-activation route allowlist

## Tests
- 36 passed: onboarding, auth, and customer-access tests
- 24 passed: tenant and EQUIPO permission regressions
- 45 passed: magic-link, tenant-switch, profile, legal, and billing targeted regressions
- `python -m compileall -q app`
- `git diff --check`
- build not run (requested)

Closes #630
