### PR TITLE
feat: país, moneda y términos globales en onboarding

### DIFF
--- a/app/core/onboarding_access.py
+++ b/app/core/onboarding_access.py
@@ -19,6 +19,8 @@ PENDING_SESSION_ROUTE_ALLOWLIST: FrozenSet[Tuple[str, str]] = frozenset({
     ("GET", "/auth/session"),
     ("POST", "/auth/signout"),
     ("GET", "/onboarding/status"),
+    ("GET", "/onboarding/financial-profile"),
+    ("PUT", "/onboarding/financial-profile"),
     ("GET", "/legal/terms/current"),
     ("GET", "/legal/terms/status"),
     ("POST", "/legal/terms/accept"),

--- a/app/models/onboarding.py
+++ b/app/models/onboarding.py
@@ -4,6 +4,12 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
+from app.models.tenant_financial_profile import (
+    CountryCurrencyOption,
+    CurrencyMetadata,
+    TenantFinancialProfile,
+)
+
 
 TenantLifecycle = Literal["pending", "active", "suspended", "cancelled"]
 OnboardingState = Literal[
@@ -24,6 +30,11 @@ class OnboardingStatus(BaseModel):
     state: Optional[OnboardingState] = None
     next_step: Optional[str] = Field(alias="nextStep", default=None)
     email_verified_at: Optional[datetime] = Field(alias="emailVerifiedAt", default=None)
+    financial_profile: Optional[TenantFinancialProfile] = Field(
+        alias="financialProfile", default=None
+    )
+    terms_accepted: bool = Field(alias="termsAccepted", default=False)
+    terms_version: Optional[str] = Field(alias="termsVersion", default=None)
 
     class Config:
         populate_by_name = True
@@ -32,3 +43,19 @@ class OnboardingStatus(BaseModel):
 class OnboardingStatusResponse(BaseModel):
     success: bool = True
     data: OnboardingStatus
+
+
+class OnboardingFinancialData(BaseModel):
+    profile: Optional[TenantFinancialProfile] = None
+    catalog: list[CountryCurrencyOption]
+    currencies: list[CurrencyMetadata]
+    state: OnboardingState
+    next_step: Optional[str] = Field(alias="nextStep", default=None)
+
+    class Config:
+        populate_by_name = True
+
+
+class OnboardingFinancialResponse(BaseModel):
+    success: bool = True
+    data: OnboardingFinancialData

--- a/app/models/onboarding.py
+++ b/app/models/onboarding.py
@@ -2,12 +2,13 @@ from datetime import datetime
 from typing import Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from app.models.tenant_financial_profile import (
     CountryCurrencyOption,
     CurrencyMetadata,
     TenantFinancialProfile,
+    TenantFinancialProfileUpdate,
 )
 
 
@@ -30,6 +31,7 @@ class OnboardingStatus(BaseModel):
     state: Optional[OnboardingState] = None
     next_step: Optional[str] = Field(alias="nextStep", default=None)
     email_verified_at: Optional[datetime] = Field(alias="emailVerifiedAt", default=None)
+    business_name: str = Field(alias="businessName")
     financial_profile: Optional[TenantFinancialProfile] = Field(
         alias="financialProfile", default=None
     )
@@ -45,7 +47,20 @@ class OnboardingStatusResponse(BaseModel):
     data: OnboardingStatus
 
 
+class OnboardingBusinessProfileUpdate(TenantFinancialProfileUpdate):
+    business_name: str = Field(alias="businessName", min_length=2, max_length=120)
+
+    @field_validator("business_name", mode="before")
+    @classmethod
+    def _normalize_business_name(cls, value: str) -> str:
+        return " ".join(value.split()) if isinstance(value, str) else value
+
+    class Config:
+        populate_by_name = True
+
+
 class OnboardingFinancialData(BaseModel):
+    business_name: str = Field(alias="businessName")
     profile: Optional[TenantFinancialProfile] = None
     catalog: list[CountryCurrencyOption]
     currencies: list[CurrencyMetadata]

--- a/app/models/onboarding.py
+++ b/app/models/onboarding.py
@@ -53,7 +53,10 @@ class OnboardingBusinessProfileUpdate(TenantFinancialProfileUpdate):
     @field_validator("business_name", mode="before")
     @classmethod
     def _normalize_business_name(cls, value: str) -> str:
-        return " ".join(value.split()) if isinstance(value, str) else value
+        normalized = " ".join(value.split()) if isinstance(value, str) else value
+        if isinstance(normalized, str) and normalized.casefold() == "negocio pendiente":
+            raise ValueError("Business name is required")
+        return normalized
 
     class Config:
         populate_by_name = True

--- a/app/models/tenant_financial_profile.py
+++ b/app/models/tenant_financial_profile.py
@@ -32,6 +32,7 @@ class TenantFinancialProfile(BaseModel):
     accounting_localization: str
     document_mode: str
     fiscal_provider: Optional[str] = None
+    selection_revision: int = 1
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -29,6 +29,7 @@ from app.services import (
     billing_email_service,
     billing_webhook_service,
     legal_service,
+    onboarding_service,
     wompi_service,
     wompi_colombia_webhook_service,
 )
@@ -57,8 +58,10 @@ class SubscribeBody(BaseModel):
 )
 async def tenant_list_plans(request: Request):
     """List active subscription plans (tenant-facing, read-only)."""
-    require_valid_session(request)
+    session = require_valid_session(request)
     async with get_db_connection(use_transaction=False) as conn:
+        if session.lifecycle_status == "pending":
+            await onboarding_service.ensure_onboarding_payment_ready(conn, session)
         plans = await billing_service.list_plans(conn)
         return [p for p in plans if p["is_active"]]
 
@@ -90,8 +93,11 @@ async def subscribe(body: SubscribeBody, request: Request):
     tenant_id = session.tenant_id
 
     async with get_db_connection() as conn:
+        if session.lifecycle_status == "pending":
+            await onboarding_service.ensure_onboarding_payment_ready(conn, session)
         plan = await billing_service.get_plan_for_subscribe(conn, body.plan_id)
-        await legal_service.ensure_current_terms_accepted(conn, tenant_id)
+        if session.lifecycle_status != "pending":
+            await legal_service.ensure_current_terms_accepted(conn, tenant_id)
 
         amount = plan["price_annual"]
 

--- a/app/routers/legal.py
+++ b/app/routers/legal.py
@@ -9,7 +9,7 @@ from app.core.middleware import require_valid_session
 from app.core.permissions import Module, require_module
 from app.core.security import get_client_ip
 from app.database import get_db_connection
-from app.services import legal_service
+from app.services import legal_service, onboarding_service
 
 
 router = APIRouter(prefix="/legal", tags=["legal"])
@@ -79,6 +79,13 @@ async def get_terms_acceptance_audit(acceptance_id: UUID, request: Request):
 async def accept_terms(body: AcceptTermsBody, request: Request):
     session = require_valid_session(request)
     async with get_db_connection() as conn:
+        if session.lifecycle_status == "pending":
+            return await onboarding_service.accept_onboarding_terms(
+                conn,
+                session,
+                client_ip=get_client_ip(request),
+                user_agent=request.headers.get("user-agent"),
+            )
         return await legal_service.accept_current_terms(
             conn,
             session,

--- a/app/routers/onboarding.py
+++ b/app/routers/onboarding.py
@@ -2,8 +2,11 @@ from fastapi import APIRouter, Body, Request
 
 from app.core.middleware import require_valid_session
 from app.database import get_db_connection
-from app.models.onboarding import OnboardingFinancialResponse, OnboardingStatusResponse
-from app.models.tenant_financial_profile import TenantFinancialProfileUpdate
+from app.models.onboarding import (
+    OnboardingBusinessProfileUpdate,
+    OnboardingFinancialResponse,
+    OnboardingStatusResponse,
+)
 from app.services.onboarding_service import (
     get_onboarding_financial_profile,
     get_status_for_tenant,
@@ -31,7 +34,7 @@ async def get_financial_profile(request: Request):
 @router.put("/financial-profile", response_model=OnboardingFinancialResponse)
 async def update_financial_profile(
     request: Request,
-    profile_data: TenantFinancialProfileUpdate = Body(...),
+    profile_data: OnboardingBusinessProfileUpdate = Body(...),
 ):
     session = require_valid_session(request)
     async with get_db_connection() as conn:

--- a/app/routers/onboarding.py
+++ b/app/routers/onboarding.py
@@ -1,9 +1,14 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Body, Request
 
 from app.core.middleware import require_valid_session
 from app.database import get_db_connection
-from app.models.onboarding import OnboardingStatusResponse
-from app.services.onboarding_service import get_status_for_tenant
+from app.models.onboarding import OnboardingFinancialResponse, OnboardingStatusResponse
+from app.models.tenant_financial_profile import TenantFinancialProfileUpdate
+from app.services.onboarding_service import (
+    get_onboarding_financial_profile,
+    get_status_for_tenant,
+    update_onboarding_financial_profile,
+)
 
 
 router = APIRouter(prefix="/onboarding", tags=["onboarding"])
@@ -14,3 +19,22 @@ async def get_onboarding_status(request: Request):
     session = require_valid_session(request)
     async with get_db_connection(use_transaction=False) as conn:
         return await get_status_for_tenant(conn, session.tenant_id)
+
+
+@router.get("/financial-profile", response_model=OnboardingFinancialResponse)
+async def get_financial_profile(request: Request):
+    session = require_valid_session(request)
+    async with get_db_connection(use_transaction=False) as conn:
+        return await get_onboarding_financial_profile(conn, session.tenant_id)
+
+
+@router.put("/financial-profile", response_model=OnboardingFinancialResponse)
+async def update_financial_profile(
+    request: Request,
+    profile_data: TenantFinancialProfileUpdate = Body(...),
+):
+    session = require_valid_session(request)
+    async with get_db_connection() as conn:
+        return await update_onboarding_financial_profile(
+            conn, session.tenant_id, profile_data
+        )

--- a/app/services/legal_service.py
+++ b/app/services/legal_service.py
@@ -21,6 +21,12 @@ def _iso(value: Any) -> Optional[str]:
     return value.isoformat() if value else None
 
 
+def _document_metadata(value: Any) -> Dict[str, Any]:
+    metadata = dict(_json_value(value, {}))
+    metadata.setdefault("applicability", {"scope_type": "global"})
+    return metadata
+
+
 def _serialize_annex(row: Any) -> Dict[str, Any]:
     return {
         "id": str(row["id"]),
@@ -48,7 +54,7 @@ def _serialize_version(row: Any, annexes: list) -> Dict[str, Any]:
         "published_at": _iso(row["published_at"]),
         "content_url": row["content_url"],
         "content_sha256": row["content_sha256"],
-        "metadata": _json_value(row["metadata"], {}),
+        "metadata": _document_metadata(row["metadata"]),
         "annexes": annexes,
     }
 
@@ -63,6 +69,7 @@ def _serialize_acceptance(row: Any) -> Dict[str, Any]:
         "accepted_at": _iso(row["accepted_at"]),
         "client_ip": row["client_ip"],
         "user_agent": row["user_agent"],
+        "country_code": row.get("country_code_snapshot"),
         "tenant_name": row["tenant_name_snapshot"],
         "legal_name": row["legal_name_snapshot"],
         "document_type": row["document_type_snapshot"],
@@ -119,7 +126,18 @@ async def get_current_terms(conn, tenant_id: Optional[UUID] = None) -> Optional[
         FROM legal_document_annexes
         WHERE document_version_id = $1
           AND is_active = true
-          AND (tenant_id IS NULL OR tenant_id = $2)
+          AND (
+              scope_type = 'global'
+              OR (scope_type = 'tenant' AND tenant_id = $2)
+              OR (
+                  scope_type = 'country'
+                  AND country = (
+                      SELECT country_code::text
+                      FROM tenant_financial_profiles
+                      WHERE tenant_id = $2
+                  )
+              )
+          )
         ORDER BY sort_order ASC, code ASC
         """,
         row["version_id"],
@@ -213,7 +231,7 @@ async def publish_terms_version(
         effective_at,
         content_url,
         content_sha256,
-        json.dumps(metadata),
+        json.dumps(_document_metadata(metadata)),
     )
 
     # RETURNING cannot reference legal_documents columns directly in the upsert.
@@ -369,10 +387,12 @@ async def _snapshot_tenant(conn, tenant_id: UUID, fallback_email: Optional[str])
         SELECT
             t.name AS tenant_name,
             t.email AS tenant_email,
+            fp.country_code,
             COALESCE(tfd.business_name, li.legal_name, t.name) AS legal_name,
             COALESCE(tfd.nit, li.nit) AS document_number,
             COALESCE(tfd.email, li.email, t.email, $2) AS email
         FROM tenants t
+        LEFT JOIN tenant_financial_profiles fp ON fp.tenant_id = t.id
         LEFT JOIN tenant_fiscal_data tfd ON tfd.tenant_id = t.id
         LEFT JOIN legal_info li ON li.tenant_id = t.id
         WHERE t.id = $1
@@ -421,6 +441,7 @@ async def accept_current_terms(
             source,
             client_ip,
             user_agent,
+            country_code_snapshot,
             tenant_name_snapshot,
             legal_name_snapshot,
             document_type_snapshot,
@@ -435,7 +456,7 @@ async def accept_current_terms(
             evidence
         )
         VALUES (
-            $1, $2, $3, $4, $5, $6, $7, $8, 'NIT', $9, $10, $11, $12, $13, $14, $15,
+            $1, $2, $3, $4, $5, $6, $18, $7, $8, 'NIT', $9, $10, $11, $12, $13, $14, $15,
             $16::jsonb,
             jsonb_build_object('retention_years', $17::int, 'server_time_source', 'database_now')
         )
@@ -459,6 +480,7 @@ async def accept_current_terms(
         current["version"],
         json.dumps(annexes),
         current["retention_years"],
+        snapshot.get("country_code"),
     )
     if not row:
         acceptance = await get_acceptance_for_version(conn, tenant_id, UUID(current["version_id"]))

--- a/app/services/magic_link_service.py
+++ b/app/services/magic_link_service.py
@@ -116,6 +116,7 @@ async def _complete_registration_login(
         onboarding = OnboardingStatus(
             tenantId=identity["tenant_id"],
             lifecycleStatus=identity["lifecycle_status"],
+            businessName=identity["tenant_name"],
             state=identity["onboarding_state"],
             nextStep=identity.get("next_step"),
             emailVerifiedAt=identity.get("email_verified_at"),

--- a/app/services/onboarding_service.py
+++ b/app/services/onboarding_service.py
@@ -9,15 +9,13 @@ from app.config import settings
 from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
 from app.core.onboarding_access import next_step_for_state
 from app.models.onboarding import (
+    OnboardingBusinessProfileUpdate,
     OnboardingFinancialData,
     OnboardingFinancialResponse,
     OnboardingStatus,
     OnboardingStatusResponse,
 )
-from app.models.tenant_financial_profile import (
-    TenantFinancialProfile,
-    TenantFinancialProfileUpdate,
-)
+from app.models.tenant_financial_profile import TenantFinancialProfile
 from app.services import legal_service
 from app.services import tenant_financial_profile_service as financial_service
 
@@ -336,6 +334,7 @@ def _financial_response(row: Any) -> OnboardingFinancialResponse:
     state = row["state"]
     return OnboardingFinancialResponse(
         data=OnboardingFinancialData(
+            businessName=row["business_name"],
             profile=_profile_from_row(row),
             catalog=financial_service._catalog(),
             currencies=financial_service._currencies(),
@@ -351,7 +350,7 @@ async def get_onboarding_financial_profile(
     tenant_id = _require_tenant_id(tenant_id)
     row = await conn.fetchrow(
         """
-        SELECT t.lifecycle_status, o.state,
+        SELECT t.lifecycle_status, t.name AS business_name, o.state,
                fp.tenant_id AS profile_tenant_id,
                fp.country_code, fp.base_currency_code,
                fp.accounting_localization, fp.document_mode, fp.fiscal_provider,
@@ -372,7 +371,7 @@ async def get_onboarding_financial_profile(
 async def update_onboarding_financial_profile(
     conn,
     tenant_id: Optional[UUID],
-    data: TenantFinancialProfileUpdate,
+    data: OnboardingBusinessProfileUpdate,
 ) -> OnboardingFinancialResponse:
     tenant_id = _require_tenant_id(tenant_id)
     context = await conn.fetchrow(
@@ -389,6 +388,16 @@ async def update_onboarding_financial_profile(
 
     country_code, currency_code = financial_service.validate_country_currency_pair(
         data.country_code, data.base_currency_code
+    )
+    await conn.execute(
+        """
+        UPDATE tenants
+        SET name = $2
+        WHERE id = $1
+          AND name IS DISTINCT FROM $2
+        """,
+        tenant_id,
+        data.business_name,
     )
     accounting_localization, document_mode, fiscal_provider = (
         financial_service._financial_mode(country_code)
@@ -450,6 +459,7 @@ async def update_onboarding_financial_profile(
         tenant_id,
     )
     result = dict(profile)
+    result["business_name"] = data.business_name
     result["lifecycle_status"] = "pending"
     result["state"] = state_row["state"]
     return _financial_response(result)
@@ -562,7 +572,7 @@ async def get_status_for_tenant(conn, tenant_id: UUID) -> OnboardingStatusRespon
     tenant_id = _require_tenant_id(tenant_id)
     row = await conn.fetchrow(
         """
-        SELECT t.id AS tenant_id, t.lifecycle_status,
+        SELECT t.id AS tenant_id, t.name AS business_name, t.lifecycle_status,
                o.state, o.email_verified_at,
                fp.tenant_id AS profile_tenant_id,
                fp.country_code, fp.base_currency_code,
@@ -589,6 +599,7 @@ async def get_status_for_tenant(conn, tenant_id: UUID) -> OnboardingStatusRespon
         data=OnboardingStatus(
             tenantId=row["tenant_id"],
             lifecycleStatus=row["lifecycle_status"],
+            businessName=row["business_name"],
             state=row.get("state"),
             nextStep=next_step_for_state(row.get("state")),
             emailVerifiedAt=row.get("email_verified_at"),

--- a/app/services/onboarding_service.py
+++ b/app/services/onboarding_service.py
@@ -387,7 +387,7 @@ async def update_onboarding_financial_profile(
     tenant_id = _require_tenant_id(tenant_id)
     context = await conn.fetchrow(
         """
-        SELECT t.lifecycle_status, o.state
+        SELECT t.lifecycle_status, t.name AS business_name, o.state
         FROM tenants t
         JOIN tenant_onboarding o ON o.tenant_id = t.id
         WHERE t.id = $1
@@ -400,6 +400,40 @@ async def update_onboarding_financial_profile(
     country_code, currency_code = financial_service.validate_country_currency_pair(
         data.country_code, data.base_currency_code
     )
+    if context["state"] == "payment_pending":
+        profile = await conn.fetchrow(
+            """
+            SELECT tenant_id AS profile_tenant_id,
+                   country_code, base_currency_code,
+                   accounting_localization, document_mode, fiscal_provider,
+                   selection_revision,
+                   created_at AS profile_created_at,
+                   updated_at AS profile_updated_at
+            FROM tenant_financial_profiles
+            WHERE tenant_id = $1
+            FOR UPDATE
+            """,
+            tenant_id,
+        )
+        if (
+            not profile
+            or context["business_name"] != data.business_name
+            or profile["country_code"] != country_code
+            or profile["base_currency_code"] != currency_code
+        ):
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "ONBOARDING_FINANCIAL_PROFILE_LOCKED",
+                    "state": context["state"],
+                },
+            )
+        result = dict(profile)
+        result["business_name"] = context["business_name"]
+        result["lifecycle_status"] = context["lifecycle_status"]
+        result["state"] = context["state"]
+        return _financial_response(result)
+
     await conn.execute(
         """
         UPDATE tenants

--- a/app/services/onboarding_service.py
+++ b/app/services/onboarding_service.py
@@ -8,11 +8,27 @@ from fastapi import HTTPException
 from app.config import settings
 from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
 from app.core.onboarding_access import next_step_for_state
-from app.models.onboarding import OnboardingStatus, OnboardingStatusResponse
+from app.models.onboarding import (
+    OnboardingFinancialData,
+    OnboardingFinancialResponse,
+    OnboardingStatus,
+    OnboardingStatusResponse,
+)
+from app.models.tenant_financial_profile import (
+    TenantFinancialProfile,
+    TenantFinancialProfileUpdate,
+)
+from app.services import legal_service
+from app.services import tenant_financial_profile_service as financial_service
 
 MAX_EMAIL_REQUESTS = 5
 MAX_IP_REQUESTS = 20
 MAX_VERIFY_ATTEMPTS = 5
+PRE_PAYMENT_FINANCIAL_STATES = frozenset({
+    "business_profile_pending",
+    "terms_pending",
+    "payment_pending",
+})
 
 
 def _credential_hash(email: str, kind: str, value: str) -> str:
@@ -276,19 +292,299 @@ async def complete_registration(
     return identity
 
 
+def _require_tenant_id(tenant_id: Optional[UUID]) -> UUID:
+    if not tenant_id:
+        raise HTTPException(status_code=401, detail="Tenant ID is required")
+    return tenant_id
+
+
+def _profile_from_row(row: Any) -> Optional[TenantFinancialProfile]:
+    if not row or not row.get("profile_tenant_id"):
+        return None
+    return TenantFinancialProfile(
+        tenant_id=row["profile_tenant_id"],
+        country_code=row["country_code"],
+        base_currency_code=row["base_currency_code"],
+        accounting_localization=row["accounting_localization"],
+        document_mode=row["document_mode"],
+        fiscal_provider=row["fiscal_provider"],
+        selection_revision=row.get("selection_revision") or 1,
+        created_at=row.get("profile_created_at"),
+        updated_at=row.get("profile_updated_at"),
+    )
+
+
+def _ensure_pending_financial_state(row: Any) -> None:
+    if not row:
+        raise HTTPException(status_code=404, detail="Onboarding not found")
+    if row["lifecycle_status"] != "pending":
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "ONBOARDING_NOT_PENDING"},
+        )
+    if row["state"] not in PRE_PAYMENT_FINANCIAL_STATES:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "ONBOARDING_FINANCIAL_PROFILE_LOCKED",
+                "state": row["state"],
+            },
+        )
+
+
+def _financial_response(row: Any) -> OnboardingFinancialResponse:
+    state = row["state"]
+    return OnboardingFinancialResponse(
+        data=OnboardingFinancialData(
+            profile=_profile_from_row(row),
+            catalog=financial_service._catalog(),
+            currencies=financial_service._currencies(),
+            state=state,
+            nextStep=next_step_for_state(state),
+        )
+    )
+
+
+async def get_onboarding_financial_profile(
+    conn, tenant_id: Optional[UUID]
+) -> OnboardingFinancialResponse:
+    tenant_id = _require_tenant_id(tenant_id)
+    row = await conn.fetchrow(
+        """
+        SELECT t.lifecycle_status, o.state,
+               fp.tenant_id AS profile_tenant_id,
+               fp.country_code, fp.base_currency_code,
+               fp.accounting_localization, fp.document_mode, fp.fiscal_provider,
+               fp.selection_revision,
+               fp.created_at AS profile_created_at,
+               fp.updated_at AS profile_updated_at
+        FROM tenants t
+        JOIN tenant_onboarding o ON o.tenant_id = t.id
+        LEFT JOIN tenant_financial_profiles fp ON fp.tenant_id = t.id
+        WHERE t.id = $1
+        """,
+        tenant_id,
+    )
+    _ensure_pending_financial_state(row)
+    return _financial_response(row)
+
+
+async def update_onboarding_financial_profile(
+    conn,
+    tenant_id: Optional[UUID],
+    data: TenantFinancialProfileUpdate,
+) -> OnboardingFinancialResponse:
+    tenant_id = _require_tenant_id(tenant_id)
+    context = await conn.fetchrow(
+        """
+        SELECT t.lifecycle_status, o.state
+        FROM tenants t
+        JOIN tenant_onboarding o ON o.tenant_id = t.id
+        WHERE t.id = $1
+        FOR UPDATE OF t, o
+        """,
+        tenant_id,
+    )
+    _ensure_pending_financial_state(context)
+
+    country_code, currency_code = financial_service.validate_country_currency_pair(
+        data.country_code, data.base_currency_code
+    )
+    accounting_localization, document_mode, fiscal_provider = (
+        financial_service._financial_mode(country_code)
+    )
+    profile = await conn.fetchrow(
+        """
+        INSERT INTO tenant_financial_profiles (
+            tenant_id, country_code, base_currency_code,
+            accounting_localization, document_mode, fiscal_provider,
+            selection_revision
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, 1)
+        ON CONFLICT (tenant_id) DO UPDATE
+        SET selection_revision = CASE
+                WHEN tenant_financial_profiles.country_code IS DISTINCT FROM EXCLUDED.country_code
+                  OR tenant_financial_profiles.base_currency_code IS DISTINCT FROM EXCLUDED.base_currency_code
+                THEN tenant_financial_profiles.selection_revision + 1
+                ELSE tenant_financial_profiles.selection_revision
+            END,
+            country_code = EXCLUDED.country_code,
+            base_currency_code = EXCLUDED.base_currency_code,
+            accounting_localization = EXCLUDED.accounting_localization,
+            document_mode = EXCLUDED.document_mode,
+            fiscal_provider = EXCLUDED.fiscal_provider,
+            updated_at = CASE
+                WHEN tenant_financial_profiles.country_code IS DISTINCT FROM EXCLUDED.country_code
+                  OR tenant_financial_profiles.base_currency_code IS DISTINCT FROM EXCLUDED.base_currency_code
+                THEN NOW()
+                ELSE tenant_financial_profiles.updated_at
+            END
+        RETURNING tenant_id AS profile_tenant_id,
+                  country_code, base_currency_code,
+                  accounting_localization, document_mode, fiscal_provider,
+                  selection_revision,
+                  created_at AS profile_created_at,
+                  updated_at AS profile_updated_at
+        """,
+        tenant_id,
+        country_code,
+        currency_code,
+        accounting_localization,
+        document_mode,
+        fiscal_provider,
+    )
+    state_row = await conn.fetchrow(
+        """
+        UPDATE tenant_onboarding
+        SET state = CASE
+                WHEN state = 'business_profile_pending' THEN 'terms_pending'
+                ELSE state
+            END,
+            updated_at = CASE
+                WHEN state = 'business_profile_pending' THEN NOW()
+                ELSE updated_at
+            END
+        WHERE tenant_id = $1
+        RETURNING state
+        """,
+        tenant_id,
+    )
+    result = dict(profile)
+    result["lifecycle_status"] = "pending"
+    result["state"] = state_row["state"]
+    return _financial_response(result)
+
+
+async def accept_onboarding_terms(
+    conn,
+    session,
+    *,
+    client_ip: Optional[str],
+    user_agent: Optional[str],
+) -> dict[str, Any]:
+    tenant_id = _require_tenant_id(session.tenant_id)
+    context = await conn.fetchrow(
+        """
+        SELECT t.lifecycle_status, o.state, fp.country_code
+        FROM tenants t
+        JOIN tenant_onboarding o ON o.tenant_id = t.id
+        LEFT JOIN tenant_financial_profiles fp ON fp.tenant_id = t.id
+        WHERE t.id = $1
+        FOR UPDATE OF t, o
+        """,
+        tenant_id,
+    )
+    if not context or context["lifecycle_status"] != "pending":
+        raise HTTPException(status_code=409, detail={"code": "ONBOARDING_NOT_PENDING"})
+    if not context.get("country_code"):
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "ONBOARDING_FINANCIAL_PROFILE_REQUIRED"},
+        )
+    if context["state"] not in {"terms_pending", "payment_pending"}:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "ONBOARDING_TERMS_NOT_AVAILABLE", "state": context["state"]},
+        )
+
+    result = await legal_service.accept_current_terms(
+        conn,
+        session,
+        client_ip=client_ip,
+        user_agent=user_agent,
+        source="onboarding",
+    )
+    state_row = await conn.fetchrow(
+        """
+        UPDATE tenant_onboarding
+        SET state = CASE
+                WHEN state = 'terms_pending' THEN 'payment_pending'
+                ELSE state
+            END,
+            updated_at = CASE
+                WHEN state = 'terms_pending' THEN NOW()
+                ELSE updated_at
+            END
+        WHERE tenant_id = $1
+        RETURNING state
+        """,
+        tenant_id,
+    )
+    result["data"]["onboarding"] = {
+        "state": state_row["state"],
+        "nextStep": next_step_for_state(state_row["state"]),
+    }
+    return result
+
+
+async def ensure_onboarding_payment_ready(conn, session) -> None:
+    """Fail closed unless a pending tenant completed profile and current terms."""
+    tenant_id = _require_tenant_id(session.tenant_id)
+    context = await conn.fetchrow(
+        """
+        SELECT t.lifecycle_status, o.state,
+               fp.tenant_id AS profile_tenant_id
+        FROM tenants t
+        JOIN tenant_onboarding o ON o.tenant_id = t.id
+        LEFT JOIN tenant_financial_profiles fp ON fp.tenant_id = t.id
+        WHERE t.id = $1
+        """,
+        tenant_id,
+    )
+    if (
+        not context
+        or context["lifecycle_status"] != "pending"
+        or context["state"] != "payment_pending"
+        or not context.get("profile_tenant_id")
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "ONBOARDING_PAYMENT_NOT_READY"},
+        )
+
+    current = await legal_service.get_current_terms(conn, tenant_id)
+    if not current:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "ONBOARDING_CURRENT_TERMS_REQUIRED"},
+        )
+    acceptance = await legal_service.get_acceptance_for_version(
+        conn, tenant_id, UUID(current["version_id"])
+    )
+    if not acceptance:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "ONBOARDING_CURRENT_TERMS_REQUIRED"},
+        )
+
+
 async def get_status_for_tenant(conn, tenant_id: UUID) -> OnboardingStatusResponse:
+    tenant_id = _require_tenant_id(tenant_id)
     row = await conn.fetchrow(
         """
         SELECT t.id AS tenant_id, t.lifecycle_status,
-               o.state, o.email_verified_at
+               o.state, o.email_verified_at,
+               fp.tenant_id AS profile_tenant_id,
+               fp.country_code, fp.base_currency_code,
+               fp.accounting_localization, fp.document_mode, fp.fiscal_provider,
+               fp.selection_revision,
+               fp.created_at AS profile_created_at,
+               fp.updated_at AS profile_updated_at
         FROM tenants t
         LEFT JOIN tenant_onboarding o ON o.tenant_id = t.id
+        LEFT JOIN tenant_financial_profiles fp ON fp.tenant_id = t.id
         WHERE t.id = $1
         """,
         tenant_id,
     )
     if not row:
         raise HTTPException(status_code=404, detail="Onboarding not found")
+    current = await legal_service.get_current_terms(conn, tenant_id)
+    acceptance = None
+    if current:
+        acceptance = await legal_service.get_acceptance_for_version(
+            conn, tenant_id, UUID(current["version_id"])
+        )
     return OnboardingStatusResponse(
         data=OnboardingStatus(
             tenantId=row["tenant_id"],
@@ -296,5 +592,8 @@ async def get_status_for_tenant(conn, tenant_id: UUID) -> OnboardingStatusRespon
             state=row.get("state"),
             nextStep=next_step_for_state(row.get("state")),
             emailVerifiedAt=row.get("email_verified_at"),
+            financialProfile=_profile_from_row(row),
+            termsAccepted=acceptance is not None,
+            termsVersion=current["version"] if current else None,
         )
     )

--- a/app/services/tenant_financial_profile_service.py
+++ b/app/services/tenant_financial_profile_service.py
@@ -149,7 +149,7 @@ async def build_financial_response(
         """
         SELECT tenant_id, country_code, base_currency_code,
                accounting_localization, document_mode, fiscal_provider,
-               created_at, updated_at
+               selection_revision, created_at, updated_at
         FROM tenant_financial_profiles
         WHERE tenant_id = $1
         """ + suffix,
@@ -209,11 +209,12 @@ async def update_financial_profile(
                     accounting_localization = $4,
                     document_mode = $5,
                     fiscal_provider = $6,
+                    selection_revision = selection_revision + 1,
                     updated_at = NOW()
                 WHERE tenant_id = $1
                 RETURNING tenant_id, country_code, base_currency_code,
                           accounting_localization, document_mode, fiscal_provider,
-                          created_at, updated_at
+                          selection_revision, created_at, updated_at
                 """,
                 tenant_id,
                 country_code,

--- a/migrations/107_onboarding_country_terms.sql
+++ b/migrations/107_onboarding_country_terms.sql
@@ -1,0 +1,52 @@
+-- Issue #631: financial selection and global legal evidence during onboarding.
+
+ALTER TABLE tenant_financial_profiles
+    ADD COLUMN IF NOT EXISTS selection_revision BIGINT NOT NULL DEFAULT 1;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'tenant_financial_profiles_selection_revision_check'
+    ) THEN
+        ALTER TABLE tenant_financial_profiles
+            ADD CONSTRAINT tenant_financial_profiles_selection_revision_check
+            CHECK (selection_revision >= 1);
+    END IF;
+END $$;
+
+ALTER TABLE tenant_legal_acceptances
+    ADD COLUMN IF NOT EXISTS country_code_snapshot CHAR(2);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'tenant_legal_acceptances_country_snapshot_check'
+    ) THEN
+        ALTER TABLE tenant_legal_acceptances
+            ADD CONSTRAINT tenant_legal_acceptances_country_snapshot_check
+            CHECK (
+                country_code_snapshot IS NULL
+                OR country_code_snapshot ~ '^[A-Z]{2}$'
+            );
+    END IF;
+END $$;
+
+UPDATE legal_document_versions AS version
+SET metadata = jsonb_set(
+    COALESCE(version.metadata, '{}'::jsonb),
+    '{applicability}',
+    '{"scope_type":"global"}'::jsonb,
+    true
+)
+FROM legal_documents AS document
+WHERE version.document_id = document.id
+  AND document.code = 'terms_conditions'
+  AND NOT (COALESCE(version.metadata, '{}'::jsonb) ? 'applicability');
+
+COMMENT ON COLUMN tenant_financial_profiles.selection_revision IS
+    'Monotonic country/base-currency revision copied into future payment quotes.';
+
+COMMENT ON COLUMN tenant_legal_acceptances.country_code_snapshot IS
+    'Tenant financial country captured when this immutable acceptance was recorded.';

--- a/tests/test_legal_terms_acceptance.py
+++ b/tests/test_legal_terms_acceptance.py
@@ -43,6 +43,7 @@ def _acceptance_row(tenant_id, version_id):
         "accepted_at": now,
         "client_ip": "203.0.113.10",
         "user_agent": "pytest-agent",
+        "country_code_snapshot": "CO",
         "tenant_name_snapshot": "Waro Colombia",
         "legal_name_snapshot": "Waro Colombia SAS",
         "document_type_snapshot": "NIT",
@@ -137,6 +138,7 @@ async def test_accept_current_terms_captures_evidence_snapshot():
     snapshot = {
         "tenant_name": "Waro Colombia",
         "tenant_email": "tenant@warocol.com",
+        "country_code": "CO",
         "legal_name": "Waro Colombia SAS",
         "document_number": "900123456",
         "email": "legal@warocol.com",
@@ -156,11 +158,13 @@ async def test_accept_current_terms_captures_evidence_snapshot():
     assert result["data"]["already_accepted"] is False
     assert result["data"]["acceptance"]["client_ip"] == "203.0.113.10"
     assert result["data"]["acceptance"]["document_number"] == "900123456"
+    assert result["data"]["acceptance"]["country_code"] == "CO"
     insert_args = conn.fetchrow.await_args_list[-1].args
     assert insert_args[4] == "billing_checkout"
     assert insert_args[5] == "203.0.113.10"
     assert insert_args[6] == "pytest-agent"
     assert insert_args[9] == "900123456"
+    assert insert_args[18] == "CO"
 
 
 @pytest.mark.asyncio

--- a/tests/test_onboarding_access.py
+++ b/tests/test_onboarding_access.py
@@ -42,6 +42,8 @@ def _pending_session() -> dict:
 def test_pending_allowlist_is_exact():
     assert is_pending_session_route_allowed("GET", "/auth/session")
     assert is_pending_session_route_allowed("GET", "/legal/terms/current")
+    assert is_pending_session_route_allowed("GET", "/onboarding/financial-profile")
+    assert is_pending_session_route_allowed("PUT", "/onboarding/financial-profile")
     assert is_pending_session_route_allowed("POST", "/billing/subscribe")
     assert not is_pending_session_route_allowed("GET", "/legal/terms/audit")
     assert not is_pending_session_route_allowed("DELETE", "/billing/subscription")

--- a/tests/test_onboarding_country_terms.py
+++ b/tests/test_onboarding_country_terms.py
@@ -8,14 +8,17 @@ from uuid import uuid4
 import pytest
 from fastapi import HTTPException
 
-from app.models.tenant_financial_profile import TenantFinancialProfileUpdate
+from app.models.onboarding import OnboardingBusinessProfileUpdate
 from app.routers import billing
 from app.services import legal_service, onboarding_service
 
 
-def _profile_row(tenant_id, *, country="US", currency="USD", revision=1):
+def _profile_row(
+    tenant_id, *, business_name="Cafe Central", country="US", currency="USD", revision=1
+):
     colombia = country == "CO"
     return {
+        "business_name": business_name,
         "profile_tenant_id": tenant_id,
         "country_code": country,
         "base_currency_code": currency,
@@ -37,6 +40,7 @@ async def test_catalog_read_has_no_default_profile_write():
     conn.fetchrow = AsyncMock(return_value={
         "lifecycle_status": "pending",
         "state": "business_profile_pending",
+        "business_name": "Negocio pendiente",
         "profile_tenant_id": None,
     })
 
@@ -64,10 +68,15 @@ async def test_initial_selection_is_atomic_and_advances_to_terms():
     result = await onboarding_service.update_onboarding_financial_profile(
         conn,
         tenant_id,
-        TenantFinancialProfileUpdate(country_code="us", base_currency_code="usd"),
+        OnboardingBusinessProfileUpdate(
+            business_name="  Cafe   Central  ",
+            country_code="us",
+            base_currency_code="usd",
+        ),
     )
 
     assert result.data.profile.country_code == "US"
+    assert result.data.business_name == "Cafe Central"
     assert result.data.profile.selection_revision == 1
     assert result.data.state == "terms_pending"
     assert result.data.next_step == "terms"
@@ -76,6 +85,9 @@ async def test_initial_selection_is_atomic_and_advances_to_terms():
     assert "FOR UPDATE OF t, o" in lock_query
     assert "ON CONFLICT (tenant_id) DO UPDATE" in upsert_query
     assert "selection_revision + 1" in upsert_query
+    tenant_update = conn.execute.await_args.args[0]
+    assert "UPDATE tenants" in tenant_update
+    assert conn.execute.await_args.args[2] == "Cafe Central"
 
 
 @pytest.mark.asyncio
@@ -91,7 +103,11 @@ async def test_idempotent_selection_keeps_database_revision():
     result = await onboarding_service.update_onboarding_financial_profile(
         conn,
         tenant_id,
-        TenantFinancialProfileUpdate(country_code="US", base_currency_code="USD"),
+        OnboardingBusinessProfileUpdate(
+            business_name="Cafe Central",
+            country_code="US",
+            base_currency_code="USD",
+        ),
     )
 
     assert result.data.profile.selection_revision == 4
@@ -110,7 +126,11 @@ async def test_paid_onboarding_cannot_change_financial_selection():
         await onboarding_service.update_onboarding_financial_profile(
             conn,
             uuid4(),
-            TenantFinancialProfileUpdate(country_code="CO", base_currency_code="COP"),
+            OnboardingBusinessProfileUpdate(
+                business_name="Cafe Central",
+                country_code="CO",
+                base_currency_code="COP",
+            ),
         )
 
     assert exc.value.status_code == 409
@@ -259,6 +279,7 @@ async def test_resume_status_includes_profile_and_current_acceptance():
     version_id = uuid4()
     row = {
         "tenant_id": tenant_id,
+        "business_name": "Cafe Central",
         "lifecycle_status": "pending",
         "state": "payment_pending",
         "email_verified_at": datetime.now(timezone.utc),
@@ -279,6 +300,7 @@ async def test_resume_status_includes_profile_and_current_acceptance():
         result = await onboarding_service.get_status_for_tenant(conn, tenant_id)
 
     assert result.data.financial_profile.country_code == "CO"
+    assert result.data.business_name == "Cafe Central"
     assert result.data.financial_profile.selection_revision == 2
     assert result.data.terms_accepted is True
     assert result.data.terms_version == "1.1"

--- a/tests/test_onboarding_country_terms.py
+++ b/tests/test_onboarding_country_terms.py
@@ -105,9 +105,12 @@ async def test_idempotent_selection_keeps_database_revision():
     tenant_id = uuid4()
     conn = AsyncMock()
     conn.fetchrow = AsyncMock(side_effect=[
-        {"lifecycle_status": "pending", "state": "payment_pending"},
+        {
+            "lifecycle_status": "pending",
+            "state": "payment_pending",
+            "business_name": "Cafe Central",
+        },
         _profile_row(tenant_id, revision=4),
-        {"state": "payment_pending"},
     ])
 
     result = await onboarding_service.update_onboarding_financial_profile(
@@ -122,6 +125,39 @@ async def test_idempotent_selection_keeps_database_revision():
 
     assert result.data.profile.selection_revision == 4
     assert result.data.state == "payment_pending"
+    conn.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_payment_pending_rejects_changes_after_legal_acceptance():
+    tenant_id = uuid4()
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        {
+            "lifecycle_status": "pending",
+            "state": "payment_pending",
+            "business_name": "Cafe Central",
+        },
+        _profile_row(tenant_id, country="CO", currency="COP", revision=2),
+    ])
+
+    with pytest.raises(HTTPException) as exc:
+        await onboarding_service.update_onboarding_financial_profile(
+            conn,
+            tenant_id,
+            OnboardingBusinessProfileUpdate(
+                business_name="Cafe Central",
+                country_code="US",
+                base_currency_code="USD",
+            ),
+        )
+
+    assert exc.value.status_code == 409
+    assert exc.value.detail == {
+        "code": "ONBOARDING_FINANCIAL_PROFILE_LOCKED",
+        "state": "payment_pending",
+    }
+    conn.execute.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_onboarding_country_terms.py
+++ b/tests/test_onboarding_country_terms.py
@@ -1,0 +1,321 @@
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.tenant_financial_profile import TenantFinancialProfileUpdate
+from app.routers import billing
+from app.services import legal_service, onboarding_service
+
+
+def _profile_row(tenant_id, *, country="US", currency="USD", revision=1):
+    colombia = country == "CO"
+    return {
+        "profile_tenant_id": tenant_id,
+        "country_code": country,
+        "base_currency_code": currency,
+        "accounting_localization": (
+            "WARO_CO_PUC_V1" if colombia else "WARO_HOSPITALITY_GLOBAL_V1"
+        ),
+        "document_mode": "fiscal_integrated" if colombia else "waro_commercial",
+        "fiscal_provider": "matias" if colombia else None,
+        "selection_revision": revision,
+        "profile_created_at": None,
+        "profile_updated_at": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_catalog_read_has_no_default_profile_write():
+    tenant_id = uuid4()
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "lifecycle_status": "pending",
+        "state": "business_profile_pending",
+        "profile_tenant_id": None,
+    })
+
+    result = await onboarding_service.get_onboarding_financial_profile(conn, tenant_id)
+
+    assert result.data.profile is None
+    assert len(result.data.catalog) == 23
+    assert result.data.next_step == "business_profile"
+    query = conn.fetchrow.await_args.args[0]
+    assert "INSERT" not in query
+    assert "tenant_financial_profiles" in query
+
+
+@pytest.mark.asyncio
+async def test_initial_selection_is_atomic_and_advances_to_terms():
+    tenant_id = uuid4()
+    profile = _profile_row(tenant_id)
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        {"lifecycle_status": "pending", "state": "business_profile_pending"},
+        profile,
+        {"state": "terms_pending"},
+    ])
+
+    result = await onboarding_service.update_onboarding_financial_profile(
+        conn,
+        tenant_id,
+        TenantFinancialProfileUpdate(country_code="us", base_currency_code="usd"),
+    )
+
+    assert result.data.profile.country_code == "US"
+    assert result.data.profile.selection_revision == 1
+    assert result.data.state == "terms_pending"
+    assert result.data.next_step == "terms"
+    lock_query = conn.fetchrow.await_args_list[0].args[0]
+    upsert_query = conn.fetchrow.await_args_list[1].args[0]
+    assert "FOR UPDATE OF t, o" in lock_query
+    assert "ON CONFLICT (tenant_id) DO UPDATE" in upsert_query
+    assert "selection_revision + 1" in upsert_query
+
+
+@pytest.mark.asyncio
+async def test_idempotent_selection_keeps_database_revision():
+    tenant_id = uuid4()
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        {"lifecycle_status": "pending", "state": "payment_pending"},
+        _profile_row(tenant_id, revision=4),
+        {"state": "payment_pending"},
+    ])
+
+    result = await onboarding_service.update_onboarding_financial_profile(
+        conn,
+        tenant_id,
+        TenantFinancialProfileUpdate(country_code="US", base_currency_code="USD"),
+    )
+
+    assert result.data.profile.selection_revision == 4
+    assert result.data.state == "payment_pending"
+
+
+@pytest.mark.asyncio
+async def test_paid_onboarding_cannot_change_financial_selection():
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "lifecycle_status": "pending",
+        "state": "paid",
+    })
+
+    with pytest.raises(HTTPException) as exc:
+        await onboarding_service.update_onboarding_financial_profile(
+            conn,
+            uuid4(),
+            TenantFinancialProfileUpdate(country_code="CO", base_currency_code="COP"),
+        )
+
+    assert exc.value.status_code == 409
+    assert exc.value.detail["code"] == "ONBOARDING_FINANCIAL_PROFILE_LOCKED"
+    assert conn.fetchrow.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_pending_acceptance_requires_financial_profile():
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "lifecycle_status": "pending",
+        "state": "terms_pending",
+        "country_code": None,
+    })
+    session = SimpleNamespace(tenant_id=uuid4())
+
+    with pytest.raises(HTTPException) as exc:
+        await onboarding_service.accept_onboarding_terms(
+            conn, session, client_ip="203.0.113.10", user_agent="pytest"
+        )
+
+    assert exc.value.detail["code"] == "ONBOARDING_FINANCIAL_PROFILE_REQUIRED"
+
+
+@pytest.mark.asyncio
+async def test_pending_acceptance_uses_canonical_source_and_advances_payment():
+    tenant_id = uuid4()
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        {
+            "lifecycle_status": "pending",
+            "state": "terms_pending",
+            "country_code": "CO",
+        },
+        {"state": "payment_pending"},
+    ])
+    session = SimpleNamespace(tenant_id=tenant_id)
+    accepted = {"success": True, "data": {"acceptance": {"id": "evidence"}}}
+
+    with patch.object(
+        onboarding_service.legal_service,
+        "accept_current_terms",
+        new=AsyncMock(return_value=accepted),
+    ) as accept:
+        result = await onboarding_service.accept_onboarding_terms(
+            conn, session, client_ip="203.0.113.10", user_agent="pytest"
+        )
+
+    assert accept.await_args.kwargs["source"] == "onboarding"
+    assert result["data"]["onboarding"] == {
+        "state": "payment_pending",
+        "nextStep": "payment",
+    }
+
+
+@pytest.mark.asyncio
+async def test_payment_gate_requires_profile_state_and_current_acceptance():
+    tenant_id = uuid4()
+    version_id = uuid4()
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "lifecycle_status": "pending",
+        "state": "payment_pending",
+        "profile_tenant_id": tenant_id,
+    })
+    session = SimpleNamespace(tenant_id=tenant_id)
+
+    with patch.object(
+        onboarding_service.legal_service,
+        "get_current_terms",
+        new=AsyncMock(return_value={"version_id": str(version_id)}),
+    ), patch.object(
+        onboarding_service.legal_service,
+        "get_acceptance_for_version",
+        new=AsyncMock(return_value={"id": "accepted"}),
+    ):
+        await onboarding_service.ensure_onboarding_payment_ready(conn, session)
+
+
+@pytest.mark.asyncio
+async def test_payment_gate_fails_closed_without_published_terms():
+    tenant_id = uuid4()
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "lifecycle_status": "pending",
+        "state": "payment_pending",
+        "profile_tenant_id": tenant_id,
+    })
+    session = SimpleNamespace(tenant_id=tenant_id)
+
+    with patch.object(
+        onboarding_service.legal_service,
+        "get_current_terms",
+        new=AsyncMock(return_value=None),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await onboarding_service.ensure_onboarding_payment_ready(conn, session)
+
+    assert exc.value.detail["code"] == "ONBOARDING_CURRENT_TERMS_REQUIRED"
+
+
+@pytest.mark.asyncio
+async def test_pending_subscribe_checks_onboarding_before_wompi():
+    tenant_id = uuid4()
+    session = SimpleNamespace(tenant_id=tenant_id, lifecycle_status="pending")
+    conn = AsyncMock()
+
+    @asynccontextmanager
+    async def db_context():
+        yield conn
+
+    not_ready = HTTPException(
+        status_code=409,
+        detail={"code": "ONBOARDING_PAYMENT_NOT_READY"},
+    )
+    with patch.object(billing, "require_valid_session", return_value=session), patch.object(
+        billing, "get_db_connection", side_effect=db_context
+    ), patch.object(
+        billing.billing_service,
+        "get_plan_for_subscribe",
+        new=AsyncMock(return_value={"name": "Plan", "price_annual": 100}),
+    ) as get_plan, patch.object(
+        billing.onboarding_service,
+        "ensure_onboarding_payment_ready",
+        new=AsyncMock(side_effect=not_ready),
+    ), patch.object(
+        billing.wompi_service,
+        "create_payment_link",
+        new=AsyncMock(),
+    ) as wompi:
+        with pytest.raises(HTTPException) as exc:
+            await billing.subscribe(
+                billing.SubscribeBody(plan_id=uuid4(), billing_cycle="annual"),
+                object(),
+            )
+
+    assert exc.value.detail["code"] == "ONBOARDING_PAYMENT_NOT_READY"
+    get_plan.assert_not_awaited()
+    wompi.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resume_status_includes_profile_and_current_acceptance():
+    tenant_id = uuid4()
+    version_id = uuid4()
+    row = {
+        "tenant_id": tenant_id,
+        "lifecycle_status": "pending",
+        "state": "payment_pending",
+        "email_verified_at": datetime.now(timezone.utc),
+        **_profile_row(tenant_id, country="CO", currency="COP", revision=2),
+    }
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value=row)
+
+    with patch.object(
+        onboarding_service.legal_service,
+        "get_current_terms",
+        new=AsyncMock(return_value={"version_id": str(version_id), "version": "1.1"}),
+    ), patch.object(
+        onboarding_service.legal_service,
+        "get_acceptance_for_version",
+        new=AsyncMock(return_value={"id": "accepted"}),
+    ):
+        result = await onboarding_service.get_status_for_tenant(conn, tenant_id)
+
+    assert result.data.financial_profile.country_code == "CO"
+    assert result.data.financial_profile.selection_revision == 2
+    assert result.data.terms_accepted is True
+    assert result.data.terms_version == "1.1"
+    assert result.data.next_step == "payment"
+
+
+@pytest.mark.asyncio
+async def test_terms_metadata_is_global_and_annex_query_is_country_scoped():
+    version_id = uuid4()
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "document_id": uuid4(),
+        "document_code": "terms_conditions",
+        "document_title": "Terminos",
+        "retention_years": 10,
+        "version_id": version_id,
+        "version": "1.1",
+        "effective_at": datetime.now(timezone.utc),
+        "published_at": datetime.now(timezone.utc),
+        "content_url": "/terms",
+        "content_sha256": "hash",
+        "metadata": {},
+    })
+    conn.fetch = AsyncMock(return_value=[])
+
+    current = await legal_service.get_current_terms(conn, uuid4())
+
+    assert current["metadata"]["applicability"] == {"scope_type": "global"}
+    annex_query = conn.fetch.await_args.args[0]
+    assert "scope_type = 'global'" in annex_query
+    assert "scope_type = 'country'" in annex_query
+    assert "FROM tenant_financial_profiles" in annex_query
+
+
+def test_migration_adds_revision_country_snapshot_and_global_scope():
+    sql = Path("migrations/107_onboarding_country_terms.sql").read_text()
+    assert "selection_revision BIGINT NOT NULL DEFAULT 1" in sql
+    assert "country_code_snapshot CHAR(2)" in sql
+    assert "tenant_financial_profiles_selection_revision_check" in sql
+    assert "'{applicability}'" in sql

--- a/tests/test_onboarding_country_terms.py
+++ b/tests/test_onboarding_country_terms.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
+from pydantic import ValidationError
 
 from app.models.onboarding import OnboardingBusinessProfileUpdate
 from app.routers import billing
@@ -31,6 +32,15 @@ def _profile_row(
         "profile_created_at": None,
         "profile_updated_at": None,
     }
+
+
+def test_business_name_rejects_the_pending_placeholder():
+    with pytest.raises(ValidationError):
+        OnboardingBusinessProfileUpdate(
+            business_name="  Negocio pendiente  ",
+            country_code="CO",
+            base_currency_code="COP",
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- agrega catálogo y perfil financiero de onboarding sin default CO/COP por lectura
- registra revisión monotónica de país/moneda y evidencia legal con snapshot de país
- filtra anexos por aplicabilidad y bloquea planes/checkout hasta perfil + términos vigentes

## Tests
- 74 pruebas focalizadas aprobadas
- `git diff --check`
- Sin build, según solicitud

Closes #631