### PR TITLE
fix(auth): resume pending onboarding safely

### DIFF
--- a/app/services/magic_link_service.py
+++ b/app/services/magic_link_service.py
@@ -25,7 +25,11 @@ from app.models.auth import (
 )
 from app.models.onboarding import OnboardingStatus
 from app.services.auth_service import replace_active_admin_sessions
-from app.services.onboarding_service import complete_registration, store_registration_challenge
+from app.services.onboarding_service import (
+    complete_registration,
+    get_resumable_registration_draft,
+    store_registration_challenge,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +128,47 @@ async def _deliver_magic_link(
         logger.error("Magic link email delivery failed")
 
 
+async def _issue_registration_challenge(
+    request: Request,
+    tenant_context,
+    *,
+    email: str,
+    draft: dict[str, Any],
+) -> None:
+    """Replace a registration challenge while preserving its consented draft."""
+    token = secrets.token_hex(32)
+    verification_code = str(random.randint(100000, 999999))
+    async with get_db_connection() as conn:
+        await store_registration_challenge(
+            conn,
+            email=email,
+            token=token,
+            code=verification_code,
+            request_ip=get_client_ip(request),
+            user_agent=request.headers.get("user-agent"),
+            phone_country_code=draft.get("phone_country_code"),
+            phone_number=draft.get("phone_number"),
+            consent=True,
+            business_name=draft.get("business_name"),
+            country_code=draft.get("country_code"),
+            base_currency_code=draft.get("base_currency_code"),
+            source=draft.get("last_source") or draft.get("first_source"),
+            content=draft.get("last_content") or draft.get("first_content"),
+            campaign=draft.get("last_campaign") or draft.get("first_campaign"),
+            variant=draft.get("last_variant") or draft.get("first_variant"),
+        )
+
+    query = {"token": token, "purpose": "registration"}
+    await _deliver_magic_link(
+        email=email,
+        magic_link_url=f"{_magic_link_base_url(request, tenant_context)}/auth/verify?{urlencode(query)}",
+        verification_code=verification_code,
+        brand_name=tenant_context.brand_name or "WARO",
+        tenant_name=tenant_context.tenant_name or "WARO",
+        tenant_email=tenant_context.tenant_email,
+    )
+
+
 async def _complete_registration_login(
     conn,
     *,
@@ -197,7 +242,7 @@ async def _complete_registration_login(
     return user, tenant, onboarding
 
 async def send_magic_link(request: Request, email: str, redirect: Optional[str] = None) -> MagicLinkResponse:
-    """Send a login-only magic link for an existing identity."""
+    """Send access for an existing identity or a consented pending registration."""
     try:
         email = normalize_email(email)
         tenant_context = require_valid_tenant(request)
@@ -205,35 +250,56 @@ async def send_magic_link(request: Request, email: str, redirect: Optional[str] 
         async with get_db_connection() as conn:
             user_result = await _lookup_internal_team_member(conn, email)
             if not user_result:
+                registration_draft = await get_resumable_registration_draft(conn, email)
+            else:
+                registration_draft = None
+
+            if not user_result and not registration_draft:
                 return MagicLinkResponse()
 
-            token = secrets.token_hex(32)
-            verification_code = str(random.randint(100000, 999999))
-            expires_at = datetime.utcnow() + timedelta(minutes=15)
-            user_id = user_result["user_id"]
-            user_tenant_id = user_result["tenant_id"]
-            await conn.execute(
-                """
-                UPDATE magic_tokens SET used = true, used_at = NOW()
-                WHERE user_id = $1 AND used = false AND purpose = 'login'
-                """,
-                user_id,
-            )
-            await conn.execute(
-                """
-                INSERT INTO magic_tokens (
-                    user_id, token, verification_code, expires_at, tenant_id,
-                    used, created_at, used_at, purpose
+            if not registration_draft:
+                token = secrets.token_hex(32)
+                verification_code = str(random.randint(100000, 999999))
+                expires_at = datetime.utcnow() + timedelta(minutes=15)
+                user_id = user_result["user_id"]
+                user_tenant_id = user_result["tenant_id"]
+                await conn.execute(
+                    """
+                    UPDATE magic_tokens SET used = true, used_at = NOW()
+                    WHERE user_id = $1 AND used = false AND purpose = 'login'
+                    """,
+                    user_id,
                 )
-                VALUES ($1, $2, $3, $4, $5, false, NOW(), NULL, 'login')
-                """,
-                user_id,
-                token,
-                verification_code,
-                expires_at,
-                user_tenant_id,
-            )
-            branding = await _tenant_email_branding(conn, user_tenant_id)
+                await conn.execute(
+                    """
+                    INSERT INTO magic_tokens (
+                        user_id, token, verification_code, expires_at, tenant_id,
+                        used, created_at, used_at, purpose
+                    )
+                    VALUES ($1, $2, $3, $4, $5, false, NOW(), NULL, 'login')
+                    """,
+                    user_id,
+                    token,
+                    verification_code,
+                    expires_at,
+                    user_tenant_id,
+                )
+                branding = await _tenant_email_branding(conn, user_tenant_id)
+
+        if registration_draft:
+            # The public response stays generic. A fresh opaque registration
+            # challenge is issued only when consented draft data still exists.
+            try:
+                await _issue_registration_challenge(
+                    request,
+                    tenant_context,
+                    email=email,
+                    draft=registration_draft,
+                )
+            except HTTPException as exc:
+                if exc.status_code != 429:
+                    raise
+            return MagicLinkResponse()
 
         query = {"token": token, "email": email}
         if redirect:
@@ -268,36 +334,21 @@ async def send_registration_magic_link(
         if existing:
             return await send_magic_link(request, email)
 
-        token = secrets.token_hex(32)
-        verification_code = str(random.randint(100000, 999999))
-        async with get_db_connection() as conn:
-            await store_registration_challenge(
-                conn,
-                email=email,
-                token=token,
-                code=verification_code,
-                request_ip=get_client_ip(request),
-                user_agent=request.headers.get("user-agent"),
-                phone_country_code=payload.phone_country_code,
-                phone_number=payload.phone_number,
-                consent=payload.consent,
-                business_name=payload.business_name,
-                country_code=payload.country_code,
-                base_currency_code=payload.base_currency_code,
-                source=payload.source,
-                content=payload.content,
-                campaign=payload.campaign,
-                variant=payload.variant,
-            )
-
-        query = {"token": token, "purpose": "registration"}
-        await _deliver_magic_link(
+        await _issue_registration_challenge(
+            request,
+            tenant_context,
             email=email,
-            magic_link_url=f"{_magic_link_base_url(request, tenant_context)}/auth/verify?{urlencode(query)}",
-            verification_code=verification_code,
-            brand_name=tenant_context.brand_name or "WARO",
-            tenant_name=tenant_context.tenant_name or "WARO",
-            tenant_email=tenant_context.tenant_email,
+            draft={
+                "phone_country_code": payload.phone_country_code,
+                "phone_number": payload.phone_number,
+                "business_name": payload.business_name,
+                "country_code": payload.country_code,
+                "base_currency_code": payload.base_currency_code,
+                "last_source": payload.source,
+                "last_content": payload.content,
+                "last_campaign": payload.campaign,
+                "last_variant": payload.variant,
+            },
         )
         return MagicLinkResponse()
     except (ValidationError, AuthenticationError, HTTPException):

--- a/app/services/onboarding_service.py
+++ b/app/services/onboarding_service.py
@@ -163,6 +163,32 @@ async def store_registration_challenge(
     return True
 
 
+async def get_resumable_registration_draft(conn, email: str) -> Optional[dict[str, Any]]:
+    """Return the latest consented pre-verification draft without exposing secrets."""
+    row = await conn.fetchrow(
+        """
+        SELECT phone_country_code, phone_number,
+               business_name, country_code, base_currency_code,
+               first_source, first_content, first_campaign, first_variant,
+               last_source, last_content, last_campaign, last_variant
+        FROM onboarding_email_challenges
+        WHERE normalized_email = $1
+          AND purpose = 'registration'
+          AND consumed_at IS NULL
+          AND completed_user_id IS NULL
+          AND completed_tenant_id IS NULL
+          AND consent_at IS NOT NULL
+          AND created_at > NOW() - INTERVAL '24 hours'
+          AND failed_attempts < $2
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+        email,
+        MAX_VERIFY_ATTEMPTS,
+    )
+    return dict(row) if row else None
+
+
 async def _identity_for_tenant(conn, user_id: UUID, tenant_id: UUID) -> Optional[dict[str, Any]]:
     row = await conn.fetchrow(
         """
@@ -770,31 +796,6 @@ async def accept_onboarding_terms(
         """,
         tenant_id,
     )
-    owner_update = await conn.execute(
-        """
-        UPDATE tenant_members tm
-        SET is_active = true
-        FROM tenant_onboarding o
-        WHERE o.tenant_id = $1
-          AND tm.tenant_id = o.tenant_id
-          AND tm.user_id = o.owner_user_id
-          AND tm.role = 'owner'
-        """,
-        tenant_id,
-    )
-    tenant_update = await conn.execute(
-        """
-        UPDATE tenants
-        SET lifecycle_status = 'active'
-        WHERE id = $1 AND lifecycle_status = 'pending'
-        """,
-        tenant_id,
-    )
-    if owner_update != "UPDATE 1" or tenant_update not in {"UPDATE 0", "UPDATE 1"}:
-        raise HTTPException(
-            status_code=409,
-            detail={"code": "ONBOARDING_PROVISIONING_CONFLICT"},
-        )
     result["data"]["onboarding"] = {
         "state": state_row["state"],
         "nextStep": next_step_for_state(state_row["state"]),
@@ -868,7 +869,11 @@ async def activate_paid_onboarding_identity(conn, tenant_id: UUID) -> Optional[d
         return None
 
     owner_update = await conn.execute(
-        "UPDATE tenant_members SET is_active = true WHERE id = $1",
+        """
+        UPDATE tenant_members
+        SET is_active = true, role = 'admin'
+        WHERE id = $1 AND role = 'owner'
+        """,
         context["owner_member_id"],
     )
     onboarding_update = await conn.execute(

--- a/migrations/110_repair_pending_onboarding_activation.sql
+++ b/migrations/110_repair_pending_onboarding_activation.sql
@@ -1,0 +1,75 @@
+-- Issue #1655: keep self-service identities pending until payment is approved
+-- and repair rows activated by the previous terms-acceptance transition.
+
+-- Revoke premature membership access only when there is no trusted payment or
+-- active subscription evidence. Every statement is predicate-guarded so a
+-- partial execution can be rerun safely.
+UPDATE tenant_members tm
+SET is_active = false
+FROM tenant_onboarding o, tenants t
+WHERE o.tenant_id = t.id
+  AND tm.tenant_id = t.id
+  AND tm.user_id = o.owner_user_id
+  AND tm.role = 'owner'
+  AND tm.is_active = true
+  AND t.lifecycle_status = 'active'
+  AND o.state = 'payment_pending'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM billing_payment_attempts a
+      WHERE a.tenant_id = t.id AND a.status = 'approved'
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM tenant_subscriptions s
+      WHERE s.tenant_id = t.id AND s.status = 'active'
+  );
+
+UPDATE tenants t
+SET lifecycle_status = 'pending'
+FROM tenant_onboarding o
+WHERE o.tenant_id = t.id
+  AND t.lifecycle_status = 'active'
+  AND o.state = 'payment_pending'
+  AND EXISTS (
+      SELECT 1
+      FROM tenant_members tm
+      WHERE tm.tenant_id = t.id
+        AND tm.user_id = o.owner_user_id
+        AND tm.role = 'owner'
+        AND tm.is_active = false
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM billing_payment_attempts a
+      WHERE a.tenant_id = t.id AND a.status = 'approved'
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM tenant_subscriptions s
+      WHERE s.tenant_id = t.id AND s.status = 'active'
+  );
+
+-- Paid self-service owners use the established internal admin role after
+-- activation. This also repairs paid rows created before this migration.
+UPDATE tenant_members tm
+SET role = 'admin', is_active = true
+FROM tenant_onboarding o, tenants t
+WHERE o.tenant_id = t.id
+  AND tm.tenant_id = t.id
+  AND tm.user_id = o.owner_user_id
+  AND tm.role = 'owner'
+  AND t.lifecycle_status = 'active'
+  AND o.state IN ('paid', 'active', 'setup_complete')
+  AND (
+      EXISTS (
+          SELECT 1
+          FROM billing_payment_attempts a
+          WHERE a.tenant_id = t.id AND a.status = 'approved'
+      )
+      OR EXISTS (
+          SELECT 1
+          FROM tenant_subscriptions s
+          WHERE s.tenant_id = t.id AND s.status = 'active'
+      )
+  );

--- a/tests/test_customer_internal_access.py
+++ b/tests/test_customer_internal_access.py
@@ -54,25 +54,22 @@ def _session_row(session_token, tenant_id, user_id, expires_at, role_email):
 
 
 @pytest.mark.asyncio
-async def test_send_magic_link_routes_customer_only_email_to_verified_onboarding():
-    """A customer row cannot log in internally but may start a separate verified onboarding."""
+async def test_send_magic_link_keeps_customer_only_email_generic():
+    """Login never starts registration without a consented resumable challenge."""
     from app.services.magic_link_service import send_magic_link
 
     tenant_id = uuid4()
-    db_ctx, conn = _build_db_mock(fetchrow_side_effect=[None])
+    db_ctx, conn = _build_db_mock(fetchrow_side_effect=[None, None])
 
-    registration_store = AsyncMock(return_value=False)
     with patch("app.services.magic_link_service.get_db_connection", side_effect=db_ctx), \
-         patch("app.services.magic_link_service.require_valid_tenant", return_value=_tenant_context(tenant_id)), \
-         patch("app.services.magic_link_service.store_registration_challenge", new=registration_store):
+         patch("app.services.magic_link_service.require_valid_tenant", return_value=_tenant_context(tenant_id)):
         result = await send_magic_link(_request(), "customer@example.com")
 
     assert result.success is True
-    registration_store.assert_awaited_once()
-    assert registration_store.await_args.kwargs["email"] == "customer@example.com"
     conn.execute.assert_not_awaited()
-    assert conn.fetchrow.await_args.args[1] == "customer@example.com"
-    assert conn.fetchrow.await_args.args[2] == ["superuser", "admin", "employee", "member", "promotor"]
+    assert conn.fetchrow.await_count == 2
+    assert conn.fetchrow.await_args_list[0].args[1] == "customer@example.com"
+    assert conn.fetchrow.await_args_list[0].args[2] == ["superuser", "admin", "employee", "member", "promotor"]
 
 
 @pytest.mark.asyncio
@@ -114,7 +111,7 @@ async def test_verify_token_replaces_previous_active_admin_sessions():
                 "user_created_at": datetime(2024, 1, 1, tzinfo=timezone.utc),
                 "user_role": "admin",
             },
-            {"name": "Tenant"},
+            {"id": tenant_id, "name": "Tenant", "slug": "tenant"},
         ]
     )
     conn.fetch = AsyncMock(return_value=[])

--- a/tests/test_magic_link_registration_contract.py
+++ b/tests/test_magic_link_registration_contract.py
@@ -76,6 +76,37 @@ async def test_unknown_login_is_generic_and_has_no_side_effects():
 
 
 @pytest.mark.asyncio
+async def test_unverified_registration_login_reissues_consented_challenge():
+    draft = {
+        "phone_country_code": 57,
+        "phone_number": "3001234567",
+        "business_name": "Restaurante Prueba",
+        "country_code": "CO",
+        "base_currency_code": "COP",
+        "first_source": "home",
+        "last_source": "login",
+    }
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(side_effect=[None, draft])
+
+    @asynccontextmanager
+    async def db_ctx(**_kwargs):
+        yield conn
+
+    issue = AsyncMock()
+    with patch("app.services.magic_link_service.get_db_connection", side_effect=db_ctx), patch(
+        "app.services.magic_link_service.require_valid_tenant", return_value=_tenant()
+    ), patch("app.services.magic_link_service._issue_registration_challenge", issue):
+        result = await send_magic_link(_request(), "nuevo@example.com")
+
+    assert result.success is True
+    issue.assert_awaited_once()
+    assert issue.await_args.kwargs["email"] == "nuevo@example.com"
+    assert issue.await_args.kwargs["draft"] == draft
+    conn.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_registration_link_is_opaque_and_challenge_contains_no_raw_secret():
     conn = AsyncMock()
     conn.fetchrow = AsyncMock(side_effect=[None, {"email_count": 0, "ip_count": 0}])

--- a/tests/test_onboarding_billing.py
+++ b/tests/test_onboarding_billing.py
@@ -358,7 +358,8 @@ async def test_paid_identity_activation_updates_owner_onboarding_and_tenant_once
     assert activated["tenant_id"] == tenant_id
     assert conn.execute.await_count == 3
     statements = [" ".join(call.args[0].split()) for call in conn.execute.await_args_list]
-    assert "SET is_active = true" in statements[0]
+    assert "SET is_active = true, role = 'admin'" in statements[0]
+    assert "role = 'owner'" in statements[0]
     assert "SET state = 'active'" in statements[1]
     assert "SET lifecycle_status = 'active'" in statements[2]
 

--- a/tests/test_onboarding_country_terms.py
+++ b/tests/test_onboarding_country_terms.py
@@ -214,7 +214,7 @@ async def test_pending_acceptance_uses_canonical_source_and_advances_payment():
         },
         {"state": "payment_pending"},
     ])
-    conn.execute = AsyncMock(side_effect=["UPDATE 1", "UPDATE 1"])
+    conn.execute = AsyncMock()
     session = SimpleNamespace(tenant_id=tenant_id)
     accepted = {"success": True, "data": {"acceptance": {"id": "evidence"}}}
 
@@ -232,9 +232,7 @@ async def test_pending_acceptance_uses_canonical_source_and_advances_payment():
         "state": "payment_pending",
         "nextStep": "payment",
     }
-    statements = [" ".join(call.args[0].split()) for call in conn.execute.await_args_list]
-    assert "UPDATE tenant_members" in statements[0]
-    assert "SET lifecycle_status = 'active'" in statements[1]
+    conn.execute.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_onboarding_resume_migration.py
+++ b/tests/test_onboarding_resume_migration.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+MIGRATION_SQL = (
+    Path(__file__).resolve().parents[1]
+    / "migrations"
+    / "110_repair_pending_onboarding_activation.sql"
+)
+
+
+def test_resume_migration_is_payment_guarded_and_idempotent():
+    sql = MIGRATION_SQL.read_text()
+
+    assert "o.state = 'payment_pending'" in sql
+    assert "SET lifecycle_status = 'pending'" in sql
+    assert "SET is_active = false" in sql
+    assert sql.count("a.status = 'approved'") >= 3
+    assert sql.count("s.status = 'active'") >= 3
+    assert "SET role = 'admin', is_active = true" in sql
+    assert "o.state IN ('paid', 'active', 'setup_complete')" in sql


### PR DESCRIPTION
## Resumen
- reemite un challenge opaco de registro al iniciar sesión si existe un borrador consentido pendiente
- conserva genérica la respuesta para correos desconocidos
- mantiene tenant y owner pendientes hasta pago aprobado
- convierte el owner temporal al rol interno `admin` al activar el pago
- incluye migración idempotente para reparar activaciones prematuras

## Validación
- 55 pruebas enfocadas de auth/onboarding/billing/migración
- `compileall`
- `git diff --check`
- migración no aplicada a producción
- sin build, según solicitud

Refs uno0uno/warocol.com#1655