### PR TITLE
fix(migration): allow pending onboarding owner transition

### DIFF
--- a/migrations/110_repair_pending_onboarding_activation.sql
+++ b/migrations/110_repair_pending_onboarding_activation.sql
@@ -1,30 +1,70 @@
 -- Issue #1655: keep self-service identities pending until payment is approved
 -- and repair rows activated by the previous terms-acceptance transition.
 
--- Revoke premature membership access only when there is no trusted payment or
--- active subscription evidence. Every statement is predicate-guarded so a
--- partial execution can be rerun safely.
-UPDATE tenant_members tm
-SET is_active = false
-FROM tenant_onboarding o, tenants t
-WHERE o.tenant_id = t.id
-  AND tm.tenant_id = t.id
-  AND tm.user_id = o.owner_user_id
-  AND tm.role = 'owner'
-  AND tm.is_active = true
-  AND t.lifecycle_status = 'active'
-  AND o.state = 'payment_pending'
-  AND NOT EXISTS (
-      SELECT 1
-      FROM billing_payment_attempts a
-      WHERE a.tenant_id = t.id AND a.status = 'approved'
-  )
-  AND NOT EXISTS (
-      SELECT 1
-      FROM tenant_subscriptions s
-      WHERE s.tenant_id = t.id AND s.status = 'active'
-  );
+-- Migration 062 protects the last active owner. Self-service onboarding is the
+-- narrow exception: its bound owner may be inactive while the tenant is pending,
+-- and payment activation may replace that temporary role with canonical admin.
+CREATE OR REPLACE FUNCTION enforce_tenant_owner_minimum()
+RETURNS TRIGGER AS $$
+DECLARE
+    remaining_owners INT;
+BEGIN
+    IF NOT (OLD.role IN ('owner', 'superuser') AND OLD.is_active = true) THEN
+        RETURN COALESCE(NEW, OLD);
+    END IF;
 
+    IF TG_OP = 'UPDATE'
+       AND NEW.tenant_id = OLD.tenant_id
+       AND NEW.user_id = OLD.user_id
+       AND (
+           (NEW.role = 'owner' AND NEW.is_active = false)
+           OR (NEW.role = 'admin' AND NEW.is_active = true)
+       )
+       AND EXISTS (
+           SELECT 1
+           FROM tenants t
+           JOIN tenant_onboarding o
+             ON o.tenant_id = t.id
+            AND o.owner_user_id = OLD.user_id
+           WHERE t.id = OLD.tenant_id
+             AND t.lifecycle_status = 'pending'
+             AND o.state NOT IN ('setup_complete', 'cancelled')
+       )
+    THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT COUNT(*) INTO remaining_owners
+      FROM tenant_members
+     WHERE tenant_id = OLD.tenant_id
+       AND role IN ('owner', 'superuser')
+       AND is_active = true
+       AND id <> OLD.id;
+
+    IF TG_OP = 'UPDATE'
+       AND NEW.role IN ('owner', 'superuser')
+       AND NEW.is_active = true
+       AND NEW.tenant_id = OLD.tenant_id
+    THEN
+        remaining_owners := remaining_owners + 1;
+    END IF;
+
+    IF remaining_owners < 1 THEN
+        RAISE EXCEPTION
+            'tenant % must retain at least one active owner',
+            OLD.tenant_id
+            USING ERRCODE = 'check_violation';
+    END IF;
+
+    RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION enforce_tenant_owner_minimum() IS
+    'Protects the last active owner, except the bound owner transitions of a pending self-service onboarding.';
+
+-- Return the tenant to pending before deactivating its temporary owner so the
+-- trigger exception is explicit and limited to the onboarding state machine.
 UPDATE tenants t
 SET lifecycle_status = 'pending'
 FROM tenant_onboarding o
@@ -37,8 +77,32 @@ WHERE o.tenant_id = t.id
       WHERE tm.tenant_id = t.id
         AND tm.user_id = o.owner_user_id
         AND tm.role = 'owner'
-        AND tm.is_active = false
+        AND tm.is_active = true
   )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM billing_payment_attempts a
+      WHERE a.tenant_id = t.id AND a.status = 'approved'
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM tenant_subscriptions s
+      WHERE s.tenant_id = t.id AND s.status = 'active'
+  );
+
+-- Revoke premature membership access only when there is no trusted payment or
+-- active subscription evidence. Every statement is predicate-guarded so a
+-- partial execution can be rerun safely.
+UPDATE tenant_members tm
+SET is_active = false
+FROM tenant_onboarding o, tenants t
+WHERE o.tenant_id = t.id
+  AND tm.tenant_id = t.id
+  AND tm.user_id = o.owner_user_id
+  AND tm.role = 'owner'
+  AND tm.is_active = true
+  AND t.lifecycle_status = 'pending'
+  AND o.state = 'payment_pending'
   AND NOT EXISTS (
       SELECT 1
       FROM billing_payment_attempts a

--- a/tests/test_onboarding_resume_migration.py
+++ b/tests/test_onboarding_resume_migration.py
@@ -11,6 +11,13 @@ MIGRATION_SQL = (
 def test_resume_migration_is_payment_guarded_and_idempotent():
     sql = MIGRATION_SQL.read_text()
 
+    assert "CREATE OR REPLACE FUNCTION enforce_tenant_owner_minimum()" in sql
+    assert "t.lifecycle_status = 'pending'" in sql
+    assert "NEW.role = 'owner' AND NEW.is_active = false" in sql
+    assert "NEW.role = 'admin' AND NEW.is_active = true" in sql
+    assert sql.index("SET lifecycle_status = 'pending'") < sql.index("SET is_active = false")
+    tenant_repair = sql[sql.index("UPDATE tenants t"):sql.index("-- Revoke premature membership access")]
+    assert "tm.is_active = true" in tenant_repair
     assert "o.state = 'payment_pending'" in sql
     assert "SET lifecycle_status = 'pending'" in sql
     assert "SET is_active = false" in sql


### PR DESCRIPTION
## Resumen
- conserva el safeguard del último owner para tenants activos
- permite únicamente las transiciones del owner vinculado a un onboarding pendiente
- reordena la reparación para devolver primero el tenant a `pending`

## Validación
- 39 pruebas enfocadas aprobadas
- dry-run transaccional contra la base configurada: `premature=0`, `resumable=1`
- rollback verificado: la base permaneció sin cambios durante el ensayo

Refs uno0uno/warocol.com#1655