### PR TITLE
Redirect existing registrations to login

### DIFF
--- a/app/models/auth.py
+++ b/app/models/auth.py
@@ -78,6 +78,11 @@ class MagicLinkResponse(BaseModel):
     message: str = "Magic link sent successfully"
 
 
+class RegistrationMagicLinkResponse(BaseModel):
+    success: bool = True
+    action: Literal["verification_sent", "login_required"]
+
+
 _ATTRIBUTION_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$")
 
 

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -15,6 +15,7 @@ from app.models.auth import (
     MagicLinkRequest,
     MagicLinkResponse,
     RegistrationMagicLinkRequest,
+    RegistrationMagicLinkResponse,
     RegistrationOptionsResponse,
     RegistrationVerifyCodeRequest,
     RegistrationVerifyTokenRequest,
@@ -65,7 +66,7 @@ async def sign_in_magic_link(request: Request, payload: MagicLinkRequest):
     return await send_magic_link(request, payload.email, payload.redirect)
 
 
-@router.post("/register-magic-link", response_model=MagicLinkResponse)
+@router.post("/register-magic-link", response_model=RegistrationMagicLinkResponse)
 async def register_magic_link(request: Request, payload: RegistrationMagicLinkRequest):
     """Start an explicit self-service registration without provisioning identity."""
     return await send_registration_magic_link(request, payload)

--- a/app/services/magic_link_service.py
+++ b/app/services/magic_link_service.py
@@ -18,6 +18,7 @@ from app.models.auth import (
     MagicLinkResponse,
     RegistrationAttribution,
     RegistrationMagicLinkRequest,
+    RegistrationMagicLinkResponse,
     Tenant,
     User,
     VerifyCodeResponse,
@@ -324,15 +325,15 @@ async def send_magic_link(request: Request, email: str, redirect: Optional[str] 
 async def send_registration_magic_link(
     request: Request,
     payload: RegistrationMagicLinkRequest,
-) -> MagicLinkResponse:
-    """Start registration, or send login access when the identity already exists."""
+) -> RegistrationMagicLinkResponse:
+    """Start registration, or direct an existing identity to sign in."""
     try:
         email = normalize_email(str(payload.email))
         tenant_context = require_valid_tenant(request)
         async with get_db_connection() as conn:
             existing = await _lookup_internal_team_member(conn, email)
         if existing:
-            return await send_magic_link(request, email)
+            return RegistrationMagicLinkResponse(action="login_required")
 
         await _issue_registration_challenge(
             request,
@@ -350,7 +351,7 @@ async def send_registration_magic_link(
                 "last_variant": payload.variant,
             },
         )
-        return MagicLinkResponse()
+        return RegistrationMagicLinkResponse(action="verification_sent")
     except (ValidationError, AuthenticationError, HTTPException):
         raise
     except Exception as exc:

--- a/tests/test_magic_link_registration_contract.py
+++ b/tests/test_magic_link_registration_contract.py
@@ -139,7 +139,7 @@ async def test_registration_link_is_opaque_and_challenge_contains_no_raw_secret(
 
 
 @pytest.mark.asyncio
-async def test_existing_identity_registration_sends_login_instead_of_provisioning():
+async def test_existing_identity_registration_redirects_to_login_without_sending_code():
     conn = AsyncMock()
     conn.fetchrow = AsyncMock(return_value={
         "user_id": uuid4(),
@@ -151,13 +151,13 @@ async def test_existing_identity_registration_sends_login_instead_of_provisionin
     async def db_ctx(**_kwargs):
         yield conn
 
-    login = AsyncMock()
     with patch("app.services.magic_link_service.get_db_connection", side_effect=db_ctx), patch(
         "app.services.magic_link_service.require_valid_tenant", return_value=_tenant()
-    ), patch("app.services.magic_link_service.send_magic_link", login):
-        await send_registration_magic_link(_request(), _payload())
+    ), patch("app.services.magic_link_service.send_magic_link", new=AsyncMock()) as login:
+        result = await send_registration_magic_link(_request(), _payload())
 
-    login.assert_awaited_once()
+    assert result.action == "login_required"
+    login.assert_not_awaited()
     conn.execute.assert_not_awaited()
 
 


### PR DESCRIPTION
## What changed
- return a login_required action when registration finds an existing identity
- do not generate or send another verification code
- cover the existing-account contract with a regression test

## Why
Registration resend was issuing a login code that the registration verifier could not consume.

## Validation
- 21 focused auth and onboarding tests passed
- Python 3.9 compatibility scan passed