### PR TITLE
feat(onboarding): delegar suscripción a Mi Plan

### DIFF
--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -1909,7 +1909,10 @@ async def get_subscription_access(tenant_id: UUID, conn) -> SubscriptionAccess:
                 grace_days_remaining=0,
                 subscription_status="payment_pending",
                 next_payment_date=None,
-                message="Elige un plan y completa el pago para activar los módulos de WARO.",
+                message=(
+                    "Ve a Mi Plan, elige una suscripción y completa el pago "
+                    "para activar los módulos de WARO."
+                ),
             )
         return SubscriptionAccess(
             level="free",

--- a/app/services/onboarding_service.py
+++ b/app/services/onboarding_service.py
@@ -415,6 +415,7 @@ async def complete_registration(
                 "next_step": next_step_for_state(onboarding["state"]),
             }
 
+    is_self_service_onboarding = identity.get("onboarding_state") is not None
     if identity["lifecycle_status"] == "pending" and all((
         challenge.get("business_name"),
         challenge.get("country_code"),
@@ -432,9 +433,10 @@ async def complete_registration(
         identity["tenant_name"] = financial.data.business_name
         identity["onboarding_state"] = financial.data.state
         identity["next_step"] = financial.data.next_step
+        identity["lifecycle_status"] = "active"
 
     notification = None
-    if identity["lifecycle_status"] == "pending":
+    if is_self_service_onboarding:
         phone_number = challenge.get("phone_number")
         phone_country_code = challenge.get("phone_country_code")
         if phone_number and phone_country_code:
@@ -557,7 +559,12 @@ def _profile_from_row(row: Any) -> Optional[TenantFinancialProfile]:
 def _ensure_pending_financial_state(row: Any) -> None:
     if not row:
         raise HTTPException(status_code=404, detail="Onboarding not found")
-    if row["lifecycle_status"] != "pending":
+    is_pending = row["lifecycle_status"] == "pending"
+    is_promoted = (
+        row["lifecycle_status"] == "active"
+        and row["state"] == "payment_pending"
+    )
+    if not is_pending and not is_promoted:
         raise HTTPException(
             status_code=409,
             detail={"code": "ONBOARDING_NOT_PENDING"},
@@ -608,6 +615,55 @@ async def get_onboarding_financial_profile(
     )
     _ensure_pending_financial_state(row)
     return _financial_response(row)
+
+
+async def _promote_onboarding_identity(conn, tenant_id: UUID) -> str:
+    state_row = await conn.fetchrow(
+        """
+        UPDATE tenant_onboarding
+        SET state = 'payment_pending',
+            updated_at = CASE
+                WHEN state IS DISTINCT FROM 'payment_pending' THEN NOW()
+                ELSE updated_at
+            END
+        WHERE tenant_id = $1
+          AND state IN ('business_profile_pending', 'terms_pending', 'payment_pending')
+        RETURNING state
+        """,
+        tenant_id,
+    )
+    if state_row is None:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "ONBOARDING_ACTIVATION_CONFLICT"},
+        )
+
+    member_update = await conn.execute(
+        """
+        UPDATE tenant_members tm
+        SET role = 'admin', is_active = true
+        FROM tenant_onboarding o
+        WHERE o.tenant_id = $1
+          AND tm.tenant_id = o.tenant_id
+          AND tm.user_id = o.owner_user_id
+          AND tm.role IN ('owner', 'admin')
+        """,
+        tenant_id,
+    )
+    tenant_update = await conn.execute(
+        """
+        UPDATE tenants
+        SET lifecycle_status = 'active'
+        WHERE id = $1 AND lifecycle_status IN ('pending', 'active')
+        """,
+        tenant_id,
+    )
+    if member_update != "UPDATE 1" or tenant_update != "UPDATE 1":
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "ONBOARDING_ACTIVATION_CONFLICT"},
+        )
+    return state_row["state"]
 
 
 async def update_onboarding_financial_profile(
@@ -661,8 +717,8 @@ async def update_onboarding_financial_profile(
             )
         result = dict(profile)
         result["business_name"] = context["business_name"]
-        result["lifecycle_status"] = context["lifecycle_status"]
-        result["state"] = context["state"]
+        result["lifecycle_status"] = "active"
+        result["state"] = await _promote_onboarding_identity(conn, tenant_id)
         return _financial_response(result)
 
     await conn.execute(
@@ -718,26 +774,11 @@ async def update_onboarding_financial_profile(
         document_mode,
         fiscal_provider,
     )
-    state_row = await conn.fetchrow(
-        """
-        UPDATE tenant_onboarding
-        SET state = CASE
-                WHEN state = 'business_profile_pending' THEN 'terms_pending'
-                ELSE state
-            END,
-            updated_at = CASE
-                WHEN state = 'business_profile_pending' THEN NOW()
-                ELSE updated_at
-            END
-        WHERE tenant_id = $1
-        RETURNING state
-        """,
-        tenant_id,
-    )
+    state = await _promote_onboarding_identity(conn, tenant_id)
     result = dict(profile)
     result["business_name"] = data.business_name
-    result["lifecycle_status"] = "pending"
-    result["state"] = state_row["state"]
+    result["lifecycle_status"] = "active"
+    result["state"] = state
     return _financial_response(result)
 
 
@@ -856,7 +897,7 @@ async def activate_paid_onboarding_identity(conn, tenant_id: UUID) -> Optional[d
         JOIN tenant_members tm
           ON tm.tenant_id = t.id
          AND tm.user_id = o.owner_user_id
-         AND tm.role = 'owner'
+         AND tm.role IN ('owner', 'admin')
         WHERE t.id = $1
         FOR UPDATE OF t, o, tm
         """,
@@ -872,7 +913,7 @@ async def activate_paid_onboarding_identity(conn, tenant_id: UUID) -> Optional[d
         """
         UPDATE tenant_members
         SET is_active = true, role = 'admin'
-        WHERE id = $1 AND role = 'owner'
+        WHERE id = $1 AND role IN ('owner', 'admin')
         """,
         context["owner_member_id"],
     )

--- a/migrations/112_promote_completed_onboarding.sql
+++ b/migrations/112_promote_completed_onboarding.sql
@@ -1,0 +1,97 @@
+-- Issue #645: business profile completion enables an internal tenant session
+-- while billing remains blocked until the tenant subscribes from Mi Plan.
+
+-- Move eligible legacy rows to the new billing boundary first. Keeping the
+-- tenant pending during the membership transition is required by the narrow
+-- trigger exception defined in migration 110.
+UPDATE tenant_onboarding o
+SET state = 'payment_pending',
+    updated_at = CASE
+        WHEN o.state IS DISTINCT FROM 'payment_pending' THEN NOW()
+        ELSE o.updated_at
+    END
+FROM tenants t
+WHERE t.id = o.tenant_id
+  AND t.lifecycle_status IN ('pending', 'active')
+  AND o.state IN ('terms_pending', 'payment_pending')
+  AND EXISTS (
+      SELECT 1
+      FROM tenant_financial_profiles fp
+      WHERE fp.tenant_id = o.tenant_id
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM billing_payment_attempts a
+      WHERE a.tenant_id = o.tenant_id
+        AND a.status = 'approved'
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM tenant_subscriptions s
+      WHERE s.tenant_id = o.tenant_id
+        AND s.status = 'active'
+  );
+
+-- Promote the bound self-service owner to the canonical internal admin role.
+-- Re-running this statement also repairs an inactive admin left by a partial
+-- deployment without touching unrelated tenant memberships.
+UPDATE tenant_members tm
+SET role = 'admin',
+    is_active = true
+FROM tenant_onboarding o, tenants t
+WHERE t.id = o.tenant_id
+  AND tm.tenant_id = o.tenant_id
+  AND tm.user_id = o.owner_user_id
+  AND tm.role IN ('owner', 'admin')
+  AND t.lifecycle_status IN ('pending', 'active')
+  AND o.state = 'payment_pending'
+  AND EXISTS (
+      SELECT 1
+      FROM tenant_financial_profiles fp
+      WHERE fp.tenant_id = o.tenant_id
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM billing_payment_attempts a
+      WHERE a.tenant_id = o.tenant_id
+        AND a.status = 'approved'
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM tenant_subscriptions s
+      WHERE s.tenant_id = o.tenant_id
+        AND s.status = 'active'
+  );
+
+-- Activate the tenant last, after its internal membership is usable.
+UPDATE tenants t
+SET lifecycle_status = 'active'
+FROM tenant_onboarding o
+WHERE o.tenant_id = t.id
+  AND t.lifecycle_status IN ('pending', 'active')
+  AND o.state = 'payment_pending'
+  AND EXISTS (
+      SELECT 1
+      FROM tenant_financial_profiles fp
+      WHERE fp.tenant_id = t.id
+  )
+  AND EXISTS (
+      SELECT 1
+      FROM tenant_members tm
+      WHERE tm.tenant_id = t.id
+        AND tm.user_id = o.owner_user_id
+        AND tm.role = 'admin'
+        AND tm.is_active = true
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM billing_payment_attempts a
+      WHERE a.tenant_id = t.id
+        AND a.status = 'approved'
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM tenant_subscriptions s
+      WHERE s.tenant_id = t.id
+        AND s.status = 'active'
+  );

--- a/tests/test_billing_subscribe_cycle.py
+++ b/tests/test_billing_subscribe_cycle.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 
 from app.core import permissions
 from app.core.middleware import SessionContext
+from app.routers import billing
 from app.routers.billing import tenant_router
 
 
@@ -76,9 +77,11 @@ def test_subscribe_requires_current_terms_before_wompi_link():
         conn.fetch = AsyncMock(return_value=[])
         yield conn
 
+    conn = MagicMock()
+
     @asynccontextmanager
     async def _billing_db():
-        yield MagicMock()
+        yield conn
 
     terms_error = HTTPException(
         status_code=409,
@@ -110,3 +113,71 @@ def test_subscribe_requires_current_terms_before_wompi_link():
     assert res.status_code == 409
     assert res.json()["detail"]["code"] == "terms_acceptance_required"
     wompi_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_active_promoted_tenant_uses_normal_subscription_flow():
+    tenant_id = uuid4()
+    plan_id = uuid4()
+    session = SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": tenant_id,
+        "email": "test@example.com",
+        "name": "Test User",
+        "expires_at": None,
+        "is_active": True,
+        "role": "admin",
+        "lifecycle_status": "active",
+        "onboarding_state": "payment_pending",
+    })
+
+    conn = MagicMock()
+
+    @asynccontextmanager
+    async def _billing_db():
+        yield conn
+
+    plan = {
+        "id": plan_id,
+        "name": "Plan Pro",
+        "price_annual": 1200000,
+        "amount_in_cents": 120000000,
+    }
+    checkout = {
+        "checkout_url": "https://checkout.example.test",
+        "wompi_link_id": "link-normal",
+    }
+    subscribed = {"status": "pending", "checkout_url": checkout["checkout_url"]}
+
+    with patch.object(billing, "require_valid_session", return_value=session), patch.object(
+        billing, "get_db_connection", side_effect=_billing_db
+    ), patch.object(
+        billing.billing_service,
+        "get_plan_for_subscribe",
+        new=AsyncMock(return_value=plan),
+    ), patch.object(
+        billing.legal_service,
+        "ensure_current_terms_accepted",
+        new=AsyncMock(),
+    ) as terms, patch.object(
+        billing.wompi_service,
+        "create_payment_link",
+        new=AsyncMock(return_value=checkout),
+    ), patch.object(
+        billing.billing_service,
+        "subscribe_tenant",
+        new=AsyncMock(return_value=subscribed),
+    ) as subscribe, patch.object(
+        billing.billing_service,
+        "create_onboarding_payment_attempt",
+        new=AsyncMock(),
+    ) as onboarding_attempt:
+        result = await billing.subscribe(
+            billing.SubscribeBody(plan_id=plan_id, billing_cycle="annual"),
+            MagicMock(),
+        )
+
+    assert result == subscribed
+    terms.assert_awaited_once_with(conn, tenant_id)
+    subscribe.assert_awaited_once()
+    onboarding_attempt.assert_not_awaited()

--- a/tests/test_billing_subscription_access.py
+++ b/tests/test_billing_subscription_access.py
@@ -132,4 +132,5 @@ async def test_payment_pending_onboarding_without_subscription_is_blocked():
 
     assert access.level == "blocked"
     assert access.subscription_status == "payment_pending"
+    assert "Mi Plan" in access.message
     assert "completa el pago" in access.message

--- a/tests/test_onboarding_billing.py
+++ b/tests/test_onboarding_billing.py
@@ -335,13 +335,13 @@ async def test_late_valid_attempt_after_activation_records_evidence_without_plan
 
 
 @pytest.mark.asyncio
-async def test_paid_identity_activation_updates_owner_onboarding_and_tenant_once():
+async def test_paid_identity_activation_accepts_promoted_admin_and_updates_once():
     tenant_id = uuid4()
     context = {
         "tenant_id": tenant_id,
         "tenant_name": "Restaurante",
         "tenant_email": "owner@example.com",
-        "lifecycle_status": "pending",
+        "lifecycle_status": "active",
         "onboarding_id": uuid4(),
         "state": "payment_pending",
         "owner_user_id": uuid4(),
@@ -356,10 +356,12 @@ async def test_paid_identity_activation_updates_owner_onboarding_and_tenant_once
     )
 
     assert activated["tenant_id"] == tenant_id
+    identity_query = " ".join(conn.fetchrow.await_args.args[0].split())
+    assert "tm.role IN ('owner', 'admin')" in identity_query
     assert conn.execute.await_count == 3
     statements = [" ".join(call.args[0].split()) for call in conn.execute.await_args_list]
     assert "SET is_active = true, role = 'admin'" in statements[0]
-    assert "role = 'owner'" in statements[0]
+    assert "role IN ('owner', 'admin')" in statements[0]
     assert "SET state = 'active'" in statements[1]
     assert "SET lifecycle_status = 'active'" in statements[2]
 

--- a/tests/test_onboarding_country_terms.py
+++ b/tests/test_onboarding_country_terms.py
@@ -65,14 +65,19 @@ async def test_catalog_read_has_no_default_profile_write():
 
 
 @pytest.mark.asyncio
-async def test_initial_selection_is_atomic_and_advances_to_terms():
+async def test_initial_selection_atomically_promotes_identity_to_billing_boundary():
     tenant_id = uuid4()
     profile = _profile_row(tenant_id)
     conn = AsyncMock()
     conn.fetchrow = AsyncMock(side_effect=[
         {"lifecycle_status": "pending", "state": "business_profile_pending"},
         profile,
-        {"state": "terms_pending"},
+        {"state": "payment_pending"},
+    ])
+    conn.execute = AsyncMock(side_effect=[
+        "UPDATE 1",
+        "UPDATE 1",
+        "UPDATE 1",
     ])
 
     result = await onboarding_service.update_onboarding_financial_profile(
@@ -88,16 +93,18 @@ async def test_initial_selection_is_atomic_and_advances_to_terms():
     assert result.data.profile.country_code == "US"
     assert result.data.business_name == "Cafe Central"
     assert result.data.profile.selection_revision == 1
-    assert result.data.state == "terms_pending"
-    assert result.data.next_step == "terms"
+    assert result.data.state == "payment_pending"
+    assert result.data.next_step == "payment"
     lock_query = conn.fetchrow.await_args_list[0].args[0]
     upsert_query = conn.fetchrow.await_args_list[1].args[0]
     assert "FOR UPDATE OF t, o" in lock_query
     assert "ON CONFLICT (tenant_id) DO UPDATE" in upsert_query
     assert "selection_revision + 1" in upsert_query
-    tenant_update = conn.execute.await_args.args[0]
-    assert "UPDATE tenants" in tenant_update
-    assert conn.execute.await_args.args[2] == "Cafe Central"
+    statements = [" ".join(call.args[0].split()) for call in conn.execute.await_args_list]
+    assert "UPDATE tenants SET name" in statements[0]
+    assert conn.execute.await_args_list[0].args[2] == "Cafe Central"
+    assert "SET role = 'admin', is_active = true" in statements[1]
+    assert "SET lifecycle_status = 'active'" in statements[2]
 
 
 @pytest.mark.asyncio
@@ -106,12 +113,14 @@ async def test_idempotent_selection_keeps_database_revision():
     conn = AsyncMock()
     conn.fetchrow = AsyncMock(side_effect=[
         {
-            "lifecycle_status": "pending",
+            "lifecycle_status": "active",
             "state": "payment_pending",
             "business_name": "Cafe Central",
         },
         _profile_row(tenant_id, revision=4),
+        {"state": "payment_pending"},
     ])
+    conn.execute = AsyncMock(side_effect=["UPDATE 1", "UPDATE 1"])
 
     result = await onboarding_service.update_onboarding_financial_profile(
         conn,
@@ -125,7 +134,7 @@ async def test_idempotent_selection_keeps_database_revision():
 
     assert result.data.profile.selection_revision == 4
     assert result.data.state == "payment_pending"
-    conn.execute.assert_not_awaited()
+    assert conn.execute.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_onboarding_registration.py
+++ b/tests/test_onboarding_registration.py
@@ -135,8 +135,8 @@ async def test_verified_challenge_atomically_creates_pending_owner():
 
     financial = AsyncMock(return_value=SimpleNamespace(data=SimpleNamespace(
         business_name="Restaurante Nuevo",
-        state="terms_pending",
-        next_step="terms",
+        state="payment_pending",
+        next_step="payment",
     )))
     with patch("app.services.onboarding_service.settings.auth_secret", "test-secret"), patch(
         "app.services.onboarding_service.uuid4", return_value=tenant_id
@@ -152,10 +152,10 @@ async def test_verified_challenge_atomically_creates_pending_owner():
 
     assert identity["user_id"] == user_id
     assert identity["tenant_id"] == tenant_id
-    assert identity["lifecycle_status"] == "pending"
+    assert identity["lifecycle_status"] == "active"
     assert identity["tenant_name"] == "Restaurante Nuevo"
-    assert identity["onboarding_state"] == "terms_pending"
-    assert identity["next_step"] == "terms"
+    assert identity["onboarding_state"] == "payment_pending"
+    assert identity["next_step"] == "payment"
     financial.assert_awaited_once()
     assert identity["registration_notification"]["source"] == "blog"
     assert identity["registration_notification"]["variant"] == "b"
@@ -166,6 +166,8 @@ async def test_verified_challenge_atomically_creates_pending_owner():
     assert "INSERT INTO tenant_members" in writes
     assert "'owner', false" in writes
     assert "UPDATE profile" in writes
+    assert "billing_payment_attempts" not in writes
+    assert "tenant_subscriptions" not in writes
     assert "tenant_public_profiles" not in writes
     assert "seed_tenant_accounts" not in writes
 

--- a/tests/test_onboarding_resume_migration.py
+++ b/tests/test_onboarding_resume_migration.py
@@ -6,6 +6,11 @@ MIGRATION_SQL = (
     / "migrations"
     / "110_repair_pending_onboarding_activation.sql"
 )
+PROMOTION_MIGRATION_SQL = (
+    Path(__file__).resolve().parents[1]
+    / "migrations"
+    / "112_promote_completed_onboarding.sql"
+)
 
 
 def test_resume_migration_is_payment_guarded_and_idempotent():
@@ -25,3 +30,20 @@ def test_resume_migration_is_payment_guarded_and_idempotent():
     assert sql.count("s.status = 'active'") >= 3
     assert "SET role = 'admin', is_active = true" in sql
     assert "o.state IN ('paid', 'active', 'setup_complete')" in sql
+
+
+def test_completed_profile_promotion_is_ordered_guarded_and_idempotent():
+    sql = PROMOTION_MIGRATION_SQL.read_text()
+
+    onboarding_update = sql.index("UPDATE tenant_onboarding o")
+    membership_update = sql.index("UPDATE tenant_members tm")
+    tenant_update = sql.index("UPDATE tenants t")
+    assert onboarding_update < membership_update < tenant_update
+    assert "o.state IN ('terms_pending', 'payment_pending')" in sql
+    assert "SET role = 'admin'," in sql
+    assert "is_active = true" in sql
+    assert "SET lifecycle_status = 'active'" in sql
+    assert sql.count("tenant_financial_profiles") >= 3
+    assert sql.count("a.status = 'approved'") >= 3
+    assert sql.count("s.status = 'active'") >= 3
+    assert "business_profile_pending" not in sql


### PR DESCRIPTION
## Summary
- promote completed business profiles to an active internal admin session while keeping billing at `payment_pending`
- keep new checkout and terms acceptance in the normal `/billing/subscribe` flow
- preserve historical onboarding payment webhook activation and add migration 112 for existing rows

## Tests
- `./venv/bin/pytest -q tests/test_onboarding_registration.py tests/test_magic_link_registration_contract.py tests/test_onboarding_country_terms.py tests/test_onboarding_billing.py tests/test_billing_subscription_access.py tests/test_billing_subscribe_cycle.py tests/test_onboarding_resume_migration.py` (71 passed)
- `git diff --check`
- no build requested

Stacked on #644.

Closes #645
