### PR TITLE
fix(billing): expose pending checkout URL

### DIFF
--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -1298,6 +1298,18 @@ async def get_tenant_subscription(conn, tenant_id: UUID) -> Dict[str, Any]:
             ts.cancelled_at,
             ts.created_at,
             ts.updated_at,
+            CASE
+                WHEN ts.status = 'pending' THEN (
+                    SELECT be.metadata->>'checkout_url'
+                    FROM billing_events be
+                    WHERE be.subscription_id = ts.id
+                      AND be.event_type = 'subscribe_initiated'
+                      AND NULLIF(be.metadata->>'checkout_url', '') IS NOT NULL
+                    ORDER BY be.created_at DESC
+                    LIMIT 1
+                )
+                ELSE NULL
+            END AS checkout_url,
             COALESCE(su.scans_used, 0) AS scans_used
         FROM tenant_subscriptions ts
         JOIN tenants t ON t.id = ts.tenant_id
@@ -1328,6 +1340,7 @@ async def get_tenant_subscription(conn, tenant_id: UUID) -> Dict[str, Any]:
         "cancelled_at": row["cancelled_at"].isoformat() if row["cancelled_at"] else None,
         "created_at": row["created_at"].isoformat(),
         "updated_at": row["updated_at"].isoformat(),
+        "checkout_url": row["checkout_url"],
         "scans_used": row["scans_used"],
     }
     return data

--- a/tests/test_billing_subscription_response.py
+++ b/tests/test_billing_subscription_response.py
@@ -1,0 +1,65 @@
+"""Tenant subscription response fields used by the Mi Plan recovery UI."""
+from datetime import datetime, timezone
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.services import billing_service
+
+
+def _subscription_row(*, status: str, checkout_url: Optional[str]):
+    now = datetime.now(timezone.utc)
+    return {
+        "id": uuid4(),
+        "tenant_id": uuid4(),
+        "tenant_name": "Test tenant",
+        "plan_id": uuid4(),
+        "plan_name": "Pro",
+        "plan_slug": "pro",
+        "scan_limit": 1000,
+        "plan_features": {},
+        "billing_cycle": "annual",
+        "status": status,
+        "current_period_start": now,
+        "current_period_end": now,
+        "gateway_reference": "wompi-link",
+        "cancelled_at": None,
+        "created_at": now,
+        "updated_at": now,
+        "checkout_url": checkout_url,
+        "scans_used": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_pending_subscription_exposes_latest_checkout_url():
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value=_subscription_row(
+            status="pending",
+            checkout_url="https://checkout.wompi.co/l/pending-link",
+        )
+    )
+
+    result = await billing_service.get_tenant_subscription(conn, uuid4())
+
+    assert result["checkout_url"] == "https://checkout.wompi.co/l/pending-link"
+    query = conn.fetchrow.await_args.args[0]
+    assert "FROM billing_events be" in query
+    assert "be.subscription_id = ts.id" in query
+    assert "be.event_type = 'subscribe_initiated'" in query
+    assert "WHEN ts.status = 'pending'" in query
+
+
+@pytest.mark.asyncio
+async def test_active_subscription_does_not_expose_checkout_url():
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value=_subscription_row(status="active", checkout_url=None)
+    )
+
+    result = await billing_service.get_tenant_subscription(conn, uuid4())
+
+    assert result["checkout_url"] is None


### PR DESCRIPTION
## Qué cambió

- Expone checkout_url en GET /billing/subscription únicamente para suscripciones pending.
- Lee el último enlace desde el evento subscribe_initiated asociado a la suscripción.
- No reutiliza intentos antiguos de onboarding.

## Por qué

Mi Plan necesitaba distinguir entre una suscripción pendiente recuperable y un onboarding payment_pending sin suscripción.

## Validación

- 68 pruebas focalizadas de billing/onboarding aprobadas.
- Consulta verificada contra PostgreSQL local.
- Sin migraciones ni cambios de datos.