### PR TITLE
fix(billing): reconcile approved payment return

### DIFF
--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -27,6 +27,7 @@ from app.database import get_db_connection
 from app.services import (
     billing_service,
     billing_email_service,
+    billing_webhook_service,
     legal_service,
     onboarding_service,
     wompi_service,
@@ -188,11 +189,17 @@ async def get_my_remaining_usage(request: Request):
     "/verify-payment",
     dependencies=[Depends(require_module(Module.MI_PLAN))],
 )
-async def verify_payment(request: Request, transaction_id: str = Query(...)):
+async def verify_payment(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    transaction_id: str = Query(...),
+):
     """
-    Consulta el estado de una transacción al regresar del checkout de Wompi.
+    Consulta el estado de una transacción al regresar del checkout de Wompi
+    y reconcilia una aprobación si el webhook todavía no fue procesado.
 
-    Este endpoint nunca activa acceso; solo el webhook firmado puede hacerlo.
+    La activación usa exclusivamente el resultado consultado por el servidor
+    en Wompi y exige que la referencia pertenezca al tenant autenticado.
     """
     session = require_valid_session(request)
     tenant_id = session.tenant_id
@@ -215,6 +222,44 @@ async def verify_payment(request: Request, transaction_id: str = Query(...)):
     if not belongs_to_tenant:
         from fastapi import HTTPException
         raise HTTPException(status_code=404, detail="Payment transaction not found")
+
+    if wompi_status == "APPROVED":
+        amount_in_cents = billing_service._webhook_amount_in_cents(
+            transaction.get("amount_in_cents")
+        )
+        currency = str(transaction.get("currency") or "").strip().upper()
+        period_anchor = billing_service.parse_wompi_period_anchor(transaction)
+        async with get_db_connection() as conn:
+            tenant_info = await billing_service.activate_tenant_subscription(
+                conn,
+                gateway_reference=payment_link_id,
+                payment_id=transaction_id,
+                amount=amount_in_cents / 100,
+                currency=currency,
+                period_anchor=period_anchor,
+                expected_tenant_id=tenant_id,
+                amount_in_cents=amount_in_cents,
+            )
+        if tenant_info:
+            background_tasks.add_task(
+                billing_email_service.send_payment_renewed_email,
+                tenant_name=tenant_info["tenant_name"],
+                tenant_email=tenant_info["tenant_email"],
+                next_period_end=tenant_info["next_period_end"],
+            )
+            background_tasks.add_task(
+                billing_webhook_service.send_payment_approved_webhook,
+                tenant_id=tenant_info["tenant_id"],
+                subscription_id=tenant_info["subscription_id"],
+                tenant_name=tenant_info["tenant_name"],
+                tenant_email=tenant_info["tenant_email"],
+                plan_name=tenant_info["plan_name"],
+                amount=amount_in_cents / 100,
+                currency=currency,
+                next_period_end=tenant_info["next_period_end"],
+                gateway_reference=payment_link_id,
+                transaction_id=transaction_id,
+            )
 
     return {
         "status": internal_status,

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -1822,6 +1822,8 @@ async def activate_tenant_subscription(
     amount: float = 0,
     currency: str = "COP",
     period_anchor: Optional[datetime] = None,
+    expected_tenant_id: Optional[UUID] = None,
+    amount_in_cents: Optional[int] = None,
 ):
     """
     Llamado desde el webhook de Wompi cuando la transacción es APPROVED.
@@ -1831,13 +1833,14 @@ async def activate_tenant_subscription(
     row = await conn.fetchrow("""
         SELECT ts.id, ts.tenant_id, ts.billing_cycle,
                t.name AS tenant_name, t.email AS tenant_email,
-               sp.name AS plan_name
+               sp.name AS plan_name, sp.price_annual
         FROM tenant_subscriptions ts
         JOIN tenants t ON t.id = ts.tenant_id
         JOIN subscription_plans sp ON sp.id = ts.plan_id
         WHERE ts.gateway_reference = $1
           AND ts.status IN ('pending', 'past_due')
-    """, gateway_reference)
+          AND ($2::uuid IS NULL OR ts.tenant_id = $2)
+    """, gateway_reference, expected_tenant_id)
 
     if row is None:
         logger.warning(
@@ -1845,6 +1848,17 @@ async def activate_tenant_subscription(
             gateway_reference,
         )
         return None
+
+    if amount_in_cents is not None:
+        expected_amount_in_cents = annual_price_in_cents(row["price_annual"])
+        if (
+            currency.upper() != "COP"
+            or amount_in_cents != expected_amount_in_cents
+        ):
+            raise HTTPException(
+                status_code=409,
+                detail="La transacción no coincide con el valor de la suscripción",
+            )
 
     if await payment_approved_exists(conn, row["id"], payment_id):
         logger.info(

--- a/tests/test_billing_activation.py
+++ b/tests/test_billing_activation.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
+from fastapi import HTTPException
 
 from app.services import billing_service
 
@@ -205,6 +206,34 @@ async def test_activate_tenant_subscription_duplicate_returns_none():
     )
 
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_activate_tenant_subscription_rejects_return_amount_mismatch():
+    tenant_id = uuid4()
+    sub_row = {
+        "id": uuid4(),
+        "tenant_id": tenant_id,
+        "billing_cycle": "annual",
+        "tenant_name": "Test tenant",
+        "tenant_email": "test@example.com",
+        "plan_name": "Pro",
+        "price_annual": 95900,
+    }
+    conn, _ = _conn_with_activation(sub_row=sub_row)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await billing_service.activate_tenant_subscription(
+            conn,
+            gateway_reference="test-link",
+            payment_id="tx-mismatch",
+            amount=1,
+            currency="COP",
+            expected_tenant_id=tenant_id,
+            amount_in_cents=100,
+        )
+
+    assert exc_info.value.status_code == 409
     conn.execute.assert_not_called()
 
 

--- a/tests/test_onboarding_billing.py
+++ b/tests/test_onboarding_billing.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
-from fastapi import HTTPException
+from fastapi import BackgroundTasks, HTTPException
 
 from app.routers import billing
 from app.services import billing_service, wompi_service
@@ -468,14 +468,25 @@ async def test_unmatched_sandbox_event_never_calls_legacy_subscription_handlers(
 
 
 @pytest.mark.asyncio
-async def test_browser_verify_payment_is_read_only():
+async def test_browser_verify_payment_reconciles_owned_approved_subscription():
     tenant_id = uuid4()
     session = SimpleNamespace(tenant_id=tenant_id)
+    background_tasks = BackgroundTasks()
     transaction = {
         "id": "tx-approved",
         "status": "APPROVED",
         "payment_link_id": "link-onboarding",
         "amount_in_cents": 9590000,
+        "currency": "COP",
+        "finalized_at": "2026-07-16T18:32:25.077Z",
+    }
+    tenant_info = {
+        "tenant_id": str(tenant_id),
+        "subscription_id": str(uuid4()),
+        "tenant_name": "Test tenant",
+        "tenant_email": "test@example.com",
+        "plan_name": "Pro",
+        "next_period_end": "2027-07-16T18:32:25.077+00:00",
     }
 
     @asynccontextmanager
@@ -490,10 +501,58 @@ async def test_browser_verify_payment_is_read_only():
         new=AsyncMock(return_value=True),
     ), patch.object(
         billing.billing_service,
-        "activate_subscription_by_gateway_ref",
-        new=AsyncMock(),
+        "activate_tenant_subscription",
+        new=AsyncMock(return_value=tenant_info),
     ) as activate:
-        result = await billing.verify_payment(object(), transaction_id="tx-approved")
+        result = await billing.verify_payment(
+            object(),
+            background_tasks,
+            transaction_id="tx-approved",
+        )
 
     assert result["status"] == "active"
+    activate.assert_awaited_once()
+    kwargs = activate.await_args.kwargs
+    assert kwargs["gateway_reference"] == "link-onboarding"
+    assert kwargs["payment_id"] == "tx-approved"
+    assert kwargs["expected_tenant_id"] == tenant_id
+    assert kwargs["amount_in_cents"] == 9590000
+    assert kwargs["currency"] == "COP"
+    assert len(background_tasks.tasks) == 2
+
+
+@pytest.mark.asyncio
+async def test_browser_verify_payment_does_not_activate_pending_transaction():
+    tenant_id = uuid4()
+    session = SimpleNamespace(tenant_id=tenant_id)
+    transaction = {
+        "id": "tx-pending",
+        "status": "PENDING",
+        "payment_link_id": "link-pending",
+        "amount_in_cents": 9590000,
+        "currency": "COP",
+    }
+
+    @asynccontextmanager
+    async def db_context(*args, **kwargs):
+        yield AsyncMock()
+
+    with patch.object(billing, "require_valid_session", return_value=session), patch.object(
+        billing.wompi_service, "get_transaction", new=AsyncMock(return_value=transaction)
+    ), patch.object(billing, "get_db_connection", side_effect=db_context), patch.object(
+        billing.billing_service,
+        "payment_reference_belongs_to_tenant",
+        new=AsyncMock(return_value=True),
+    ), patch.object(
+        billing.billing_service,
+        "activate_tenant_subscription",
+        new=AsyncMock(),
+    ) as activate:
+        result = await billing.verify_payment(
+            object(),
+            BackgroundTasks(),
+            transaction_id="tx-pending",
+        )
+
+    assert result["status"] == "pending"
     activate.assert_not_awaited()


### PR DESCRIPTION
## Qué cambió

-  reconcilia una transacción  cuando el webhook aún no fue procesado.
- La activación se limita al tenant autenticado y valida referencia, moneda COP y monto exacto del plan.
- Conserva idempotencia y programa las notificaciones normales solo en la primera activación.

## Causa

El retorno de Wompi consultaba el estado pero era deliberadamente de solo lectura. Si el webhook no llegaba, la interfaz mostraba el pago como aprobado mientras la suscripción permanecía .

## Validación

- 65 pruebas de billing, onboarding y webhooks aprobadas.
- Transacción sandbox  verificada como  y reconciliada localmente.
- Sin migraciones, build ni despliegue.