### PR TITLE
Add warehouse category search endpoint

### DIFF
--- a/app/models/ingredient.py
+++ b/app/models/ingredient.py
@@ -100,6 +100,19 @@ class IngredientsListResponse(BaseModel):
     data: List[Ingredient]
 
 
+class IngredientCategoryOption(BaseModel):
+    name: str
+    ingredient_count: int
+    global_count: int
+    tenant_count: int
+
+
+class IngredientCategoriesResponse(BaseModel):
+    success: bool = True
+    total: int
+    data: List[IngredientCategoryOption]
+
+
 # =============================================================================
 # INGREDIENT PURCHASE UNITS MODELS
 # =============================================================================

--- a/app/routers/ingredients.py
+++ b/app/routers/ingredients.py
@@ -3,8 +3,8 @@ from typing import Any, Dict, Optional
 from uuid import UUID
 from app.core.middleware import require_valid_session
 from app.core.permissions import Module, require_module
-from app.services.ingredients_service import get_ingredients_list, update_ingredient_unit_weight, match_ingredient_by_name, create_tenant_ingredient, update_tenant_ingredient, archive_tenant_ingredient, restore_tenant_ingredient, hard_delete_tenant_ingredient
-from app.models.ingredient import IngredientsListResponse, TenantIngredientCreate, TenantIngredientUpdate
+from app.services.ingredients_service import get_ingredient_categories, get_ingredients_list, update_ingredient_unit_weight, match_ingredient_by_name, create_tenant_ingredient, update_tenant_ingredient, archive_tenant_ingredient, restore_tenant_ingredient, hard_delete_tenant_ingredient
+from app.models.ingredient import IngredientCategoriesResponse, IngredientsListResponse, TenantIngredientCreate, TenantIngredientUpdate
 from app.database import get_db_connection
 
 router = APIRouter()
@@ -71,6 +71,33 @@ async def get_ingredients_endpoint(
     return await get_ingredients_list(
         request, response, page, limit, search, category, supplier_id, type, is_resale, base_only, tenant_only, show_archived
     )
+
+
+@router.get(
+    "/categories",
+    response_model=IngredientCategoriesResponse,
+    dependencies=[Depends(require_module(Module.ABASTECIMIENTO))],
+)
+async def get_ingredient_categories_endpoint(
+    request: Request,
+    search: Optional[str] = Query(default=None, description="Filter warehouse categories by name"),
+    limit: int = Query(default=100, ge=1, le=250),
+):
+    """List distinct ingredient categories visible to the current tenant."""
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+
+    if not tenant_id:
+        raise HTTPException(status_code=401, detail="Tenant context required")
+
+    async with get_db_connection() as conn:
+        categories = await get_ingredient_categories(conn, tenant_id, search, limit)
+
+    return {
+        "success": True,
+        "total": len(categories),
+        "data": categories,
+    }
 
 
 @router.get("/{ingredient_id}", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])

--- a/app/services/ingredients_service.py
+++ b/app/services/ingredients_service.py
@@ -65,6 +65,47 @@ PURCHASE_UNIT_CATALOG: Dict[str, Dict[str, Any]] = {
 }
 
 
+async def get_ingredient_categories(
+    conn,
+    tenant_id: UUID,
+    search: Optional[str] = None,
+    limit: int = 100,
+) -> List[Dict[str, Any]]:
+    """
+    Return distinct active ingredient categories visible to a tenant.
+
+    Categories remain textual until the managed warehouse-category catalog is
+    introduced, so this endpoint derives options from the data already stored
+    in `ingredients.category`.
+    """
+    query = """
+        SELECT
+            BTRIM(category) AS name,
+            COUNT(*)::int AS ingredient_count,
+            COUNT(*) FILTER (WHERE tenant_id IS NULL)::int AS global_count,
+            COUNT(*) FILTER (WHERE tenant_id = $1)::int AS tenant_count
+        FROM ingredients
+        WHERE (tenant_id IS NULL OR tenant_id = $1)
+          AND is_active = TRUE
+          AND NULLIF(BTRIM(category), '') IS NOT NULL
+    """
+    params: List[Any] = [tenant_id]
+
+    if search and search.strip():
+        query += " AND LOWER(unaccent(BTRIM(category))) LIKE LOWER(unaccent($2))"
+        params.append(f"%{search.strip()}%")
+
+    query += f"""
+        GROUP BY BTRIM(category)
+        ORDER BY LOWER(BTRIM(category)), BTRIM(category)
+        LIMIT ${len(params) + 1}
+    """
+    params.append(limit)
+
+    rows = await conn.fetch(query, *params)
+    return [dict(row) for row in rows]
+
+
 def resolve_purchase_units(purchase_units: list, base_unit: str) -> list:
     """
     Validate each purchase_unit key against the catalog and resolve

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -16,6 +16,7 @@ from app.models.ingredient import TenantIngredientCreate
 from app.services.ingredients_service import (
     _validate_unit_for_type,
     create_tenant_ingredient,
+    get_ingredient_categories,
     update_tenant_ingredient,
 )
 from app.models.ingredient import TenantIngredientUpdate
@@ -157,6 +158,43 @@ class TestIngredientUnitTypeValidation:
         data = TenantIngredientUpdate(unit="hr")
         result = await update_tenant_ingredient(conn, tenant_id, ingredient_id, data)
         assert result["unit"] == "hr"
+
+
+class TestIngredientCategorySearch:
+    @pytest.mark.asyncio
+    async def test_lists_tenant_visible_categories_with_partial_search(self):
+        tenant_id = uuid4()
+        conn = AsyncMock()
+        conn.fetch = AsyncMock(return_value=[
+            {
+                "name": "categoria de prueba",
+                "ingredient_count": 2,
+                "global_count": 0,
+                "tenant_count": 2,
+            },
+            {
+                "name": "ingrediente categoria",
+                "ingredient_count": 1,
+                "global_count": 0,
+                "tenant_count": 1,
+            },
+        ])
+
+        result = await get_ingredient_categories(
+            conn,
+            tenant_id,
+            search=" categoria ",
+            limit=50,
+        )
+
+        assert [category["name"] for category in result] == [
+            "categoria de prueba",
+            "ingrediente categoria",
+        ]
+        query, *params = conn.fetch.await_args.args
+        assert "(tenant_id IS NULL OR tenant_id = $1)" in query
+        assert "LOWER(unaccent(BTRIM(category))) LIKE LOWER(unaccent($2))" in query
+        assert params == [tenant_id, "%categoria%", 50]
 
 
 class TestIngredientsEndpoint:


### PR DESCRIPTION
## Qué cambió

- Agrega `GET /suppliers/ingredients/categories` antes de la ruta dinámica de ingrediente.
- Obtiene categorías reales desde `ingredients.category`, incluyendo globales y las del tenant actual.
- Soporta búsqueda parcial sin distinguir mayúsculas ni tildes.
- Devuelve conteos de ingredientes globales y del tenant.

## Causa raíz

El selector de categorías de bodega solo conocía una lista fija del frontend y no podía encontrar categorías ya guardadas en PostgreSQL.

## Validación

- Prueba focalizada de `get_ingredient_categories` aprobada.
- Compilación de los módulos Python modificados aprobada.
- Verificación por túnel PostgreSQL: 75 categorías visibles para el tenant.
- Verificación API directa y proxy Nuxt: `categoria` devuelve 2 coincidencias y `lacteos` encuentra también `Lácteos`.
- Sin build.