### PR TITLE
Add managed warehouse category catalog

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, pos_products, categories, recipe_bases, modifiers, ingredient_purchase_units, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, ai_agents, customer_portal, leads, waros, billing, legal, onboarding, payments_webhook, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
+from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, pos_products, categories, recipe_bases, modifiers, ingredient_purchase_units, warehouse_categories, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, ai_agents, customer_portal, leads, waros, billing, legal, onboarding, payments_webhook, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
 from app.config import settings
 from app.core.logging import setup_logging
 from app.core.exceptions import api_exception_handler, general_exception_handler, APIError
@@ -160,6 +160,7 @@ app.include_router(tenants.router, prefix="/tenants", tags=["tenants"])
 app.include_router(financial.router, prefix="/finance", tags=["financial"])
 app.include_router(ingredients.router, prefix="/suppliers/ingredients", tags=["ingredients"])
 app.include_router(ingredient_purchase_units.router, prefix="/suppliers/ingredient-purchase-units", tags=["ingredient-purchase-units"])
+app.include_router(warehouse_categories.router, prefix="/suppliers/warehouse-categories", tags=["warehouse-categories"])
 app.include_router(purchases.router, prefix="/suppliers/purchases", tags=["purchases"])
 app.include_router(suppliers.router, prefix="/suppliers/providers", tags=["suppliers"])
 app.include_router(supplier_portal.router, prefix="/supplier-portal", tags=["supplier-portal"])

--- a/app/models/ingredient.py
+++ b/app/models/ingredient.py
@@ -11,6 +11,7 @@ class IngredientBase(BaseModel):
     name: str = Field(..., min_length=1, max_length=255, description="Name of the ingredient")
     unit: str = Field(..., min_length=1, max_length=50, description="Unit of measure (e.g., kg, liter, unit)")
     category: Optional[str] = Field(None, max_length=255, description="Category of the ingredient")
+    warehouse_category_id: Optional[UUID] = Field(None, description="Stable warehouse category ID")
     type: Optional[str] = Field('food', max_length=20, description="Type of ingredient: 'food' (alimentos), 'service' (servicios), 'supply' (insumos)")
     description: Optional[str] = Field(None, max_length=1024, description="Detailed description of the ingredient")
     minimum_order_quantity: Optional[float] = Field(None, gt=0, description="Minimum order quantity for the ingredient")
@@ -40,6 +41,7 @@ class TenantIngredientCreate(BaseModel):
     unit: str = Field(..., description="food: gr/ml/kg/und/lt; service: hr or und; supply: und")
     type: Optional[str] = Field(default="food", description="food | service | supply")
     category: Optional[str] = Field(default=None, max_length=255)
+    warehouse_category_id: Optional[UUID] = None
     costo_unitario: Optional[float] = Field(default=None, ge=0)
     parent_id: Optional[str] = Field(default=None, description="UUID of a global base ingredient")
     is_resale: Optional[bool] = Field(default=False, description="Mark as resale product — will appear in /menu/reventa")
@@ -53,6 +55,7 @@ class TenantIngredientUpdate(BaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=255)
     unit: Optional[str] = Field(default=None, description="food: gr/ml/kg/und/lt; service: hr or und; supply: und")
     category: Optional[str] = Field(default=None, max_length=255)
+    warehouse_category_id: Optional[UUID] = None
     costo_unitario: Optional[float] = Field(default=None, ge=0)
     parent_id: Optional[str] = Field(default=None, description="UUID of a global base ingredient, or empty string to clear")
     is_resale: Optional[bool] = Field(default=None, description="Mark as resale product")
@@ -65,6 +68,7 @@ class IngredientUpdate(BaseModel):
     name: Optional[str] = Field(None, min_length=1, max_length=255)
     unit: Optional[str] = Field(None, min_length=1, max_length=50)
     category: Optional[str] = Field(None, max_length=255)
+    warehouse_category_id: Optional[UUID] = None
     type: Optional[str] = Field(None, max_length=20, description="Type: 'food', 'service', 'supply'")
     description: Optional[str] = Field(None, max_length=1024)
     minimum_order_quantity: Optional[float] = Field(None, gt=0)
@@ -101,7 +105,13 @@ class IngredientsListResponse(BaseModel):
 
 
 class IngredientCategoryOption(BaseModel):
+    id: UUID
+    tenant_id: Optional[UUID] = None
     name: str
+    normalized_name: str
+    is_active: bool
+    scope: str
+    can_manage: bool
     ingredient_count: int
     global_count: int
     tenant_count: int

--- a/app/models/warehouse_category.py
+++ b/app/models/warehouse_category.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class WarehouseCategoryCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+
+
+class WarehouseCategoryUpdate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+
+
+class WarehouseCategory(BaseModel):
+    id: UUID
+    tenant_id: Optional[UUID] = None
+    name: str
+    normalized_name: str
+    is_active: bool
+    scope: str
+    can_manage: bool
+    ingredient_count: int = 0
+    global_count: int = 0
+    tenant_count: int = 0
+    created_at: datetime
+    updated_at: datetime
+
+
+class WarehouseCategoryResponse(BaseModel):
+    success: bool = True
+    data: WarehouseCategory
+
+
+class WarehouseCategoriesResponse(BaseModel):
+    success: bool = True
+    total: int
+    data: List[WarehouseCategory]

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -12,6 +12,7 @@ from app.routers import (
     recipe_bases,
     modifiers,
     ingredient_purchase_units,
+    warehouse_categories,
     customers,
     pos_cart,
     pos_context,

--- a/app/routers/admin_ingredients.py
+++ b/app/routers/admin_ingredients.py
@@ -28,6 +28,7 @@ from pydantic import BaseModel
 from app.core.middleware import require_valid_session
 from app.core.permissions import Module, require_module
 from app.database import get_db_connection
+from app.services.warehouse_categories_service import resolve_global_warehouse_category
 
 logger = logging.getLogger(__name__)
 
@@ -316,15 +317,19 @@ async def create_global_ingredient(
                 )
 
         async with conn.transaction():
+            warehouse_category = await resolve_global_warehouse_category(conn, body.category)
             new_row = await conn.fetchrow(
                 """
-                INSERT INTO ingredients (name, unit, category, tenant_id)
-                VALUES ($1, $2, $3, NULL)
-                RETURNING id::text, name, unit, category
+                INSERT INTO ingredients (
+                    name, unit, category, warehouse_category_id, tenant_id
+                )
+                VALUES ($1, $2, $3, $4, NULL)
+                RETURNING id::text, name, unit, category, warehouse_category_id
                 """,
                 name,
                 unit_to_use,
-                body.category,
+                warehouse_category["name"] if warehouse_category else None,
+                warehouse_category["id"] if warehouse_category else None,
             )
 
             hierarchy_id = None

--- a/app/routers/ingredients.py
+++ b/app/routers/ingredients.py
@@ -28,7 +28,8 @@ async def create_custom_ingredient(
         raise HTTPException(status_code=401, detail="Tenant context required")
 
     async with get_db_connection() as conn:
-        data = await create_tenant_ingredient(conn, tenant_id, body)
+        async with conn.transaction():
+            data = await create_tenant_ingredient(conn, tenant_id, body)
 
     return {"success": True, "data": data}
 
@@ -189,7 +190,8 @@ async def update_custom_ingredient(
         raise HTTPException(status_code=401, detail="Tenant context required")
 
     async with get_db_connection() as conn:
-        data = await update_tenant_ingredient(conn, tenant_id, ingredient_id, body)
+        async with conn.transaction():
+            data = await update_tenant_ingredient(conn, tenant_id, ingredient_id, body)
 
     return {"success": True, "data": data}
 

--- a/app/routers/warehouse_categories.py
+++ b/app/routers/warehouse_categories.py
@@ -1,0 +1,102 @@
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from app.core.middleware import require_valid_session
+from app.core.permissions import Module, require_module
+from app.database import get_db_connection
+from app.models.warehouse_category import (
+    WarehouseCategoriesResponse,
+    WarehouseCategoryCreate,
+    WarehouseCategoryResponse,
+    WarehouseCategoryUpdate,
+)
+from app.services.warehouse_categories_service import (
+    archive_warehouse_category,
+    create_warehouse_category,
+    list_warehouse_categories,
+    rename_warehouse_category,
+)
+
+router = APIRouter()
+
+
+def _tenant_id(request: Request) -> UUID:
+    tenant_id = require_valid_session(request).tenant_id
+    if not tenant_id:
+        raise HTTPException(status_code=401, detail="Tenant context required")
+    return tenant_id
+
+
+@router.get(
+    "",
+    response_model=WarehouseCategoriesResponse,
+    dependencies=[Depends(require_module(Module.ABASTECIMIENTO))],
+)
+async def get_warehouse_categories(
+    request: Request,
+    search: Optional[str] = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=250),
+    include_archived: bool = Query(default=False),
+):
+    tenant_id = _tenant_id(request)
+    async with get_db_connection() as conn:
+        rows = await list_warehouse_categories(
+            conn,
+            tenant_id,
+            search=search,
+            limit=limit,
+            include_archived=include_archived,
+        )
+    return {"success": True, "total": len(rows), "data": rows}
+
+
+@router.post(
+    "",
+    response_model=WarehouseCategoryResponse,
+    status_code=201,
+    dependencies=[Depends(require_module(Module.ABASTECIMIENTO))],
+)
+async def post_warehouse_category(
+    request: Request,
+    body: WarehouseCategoryCreate,
+):
+    tenant_id = _tenant_id(request)
+    async with get_db_connection() as conn:
+        async with conn.transaction():
+            row = await create_warehouse_category(conn, tenant_id, body.name)
+    return {"success": True, "data": row}
+
+
+@router.patch(
+    "/{category_id}",
+    response_model=WarehouseCategoryResponse,
+    dependencies=[Depends(require_module(Module.ABASTECIMIENTO))],
+)
+async def patch_warehouse_category(
+    request: Request,
+    category_id: UUID,
+    body: WarehouseCategoryUpdate,
+):
+    tenant_id = _tenant_id(request)
+    async with get_db_connection() as conn:
+        async with conn.transaction():
+            row = await rename_warehouse_category(conn, tenant_id, category_id, body.name)
+    return {"success": True, "data": row}
+
+
+@router.patch(
+    "/{category_id}/archive",
+    response_model=WarehouseCategoryResponse,
+    dependencies=[Depends(require_module(Module.ABASTECIMIENTO))],
+)
+async def patch_archive_warehouse_category(
+    request: Request,
+    category_id: UUID,
+):
+    tenant_id = _tenant_id(request)
+    async with get_db_connection() as conn:
+        async with conn.transaction():
+            row = await archive_warehouse_category(conn, tenant_id, category_id)
+    return {"success": True, "data": row}

--- a/app/services/ingredients_service.py
+++ b/app/services/ingredients_service.py
@@ -7,6 +7,10 @@ import logging
 import asyncpg
 from app.core.exceptions import AuthenticationError
 from app.models.ingredient import Ingredient, IngredientsListResponse, TenantIngredientCreate, TenantIngredientUpdate
+from app.services.warehouse_categories_service import (
+    list_warehouse_categories,
+    resolve_assignable_warehouse_category,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -71,39 +75,8 @@ async def get_ingredient_categories(
     search: Optional[str] = None,
     limit: int = 100,
 ) -> List[Dict[str, Any]]:
-    """
-    Return distinct active ingredient categories visible to a tenant.
-
-    Categories remain textual until the managed warehouse-category catalog is
-    introduced, so this endpoint derives options from the data already stored
-    in `ingredients.category`.
-    """
-    query = """
-        SELECT
-            BTRIM(category) AS name,
-            COUNT(*)::int AS ingredient_count,
-            COUNT(*) FILTER (WHERE tenant_id IS NULL)::int AS global_count,
-            COUNT(*) FILTER (WHERE tenant_id = $1)::int AS tenant_count
-        FROM ingredients
-        WHERE (tenant_id IS NULL OR tenant_id = $1)
-          AND is_active = TRUE
-          AND NULLIF(BTRIM(category), '') IS NOT NULL
-    """
-    params: List[Any] = [tenant_id]
-
-    if search and search.strip():
-        query += " AND LOWER(unaccent(BTRIM(category))) LIKE LOWER(unaccent($2))"
-        params.append(f"%{search.strip()}%")
-
-    query += f"""
-        GROUP BY BTRIM(category)
-        ORDER BY LOWER(BTRIM(category)), BTRIM(category)
-        LIMIT ${len(params) + 1}
-    """
-    params.append(limit)
-
-    rows = await conn.fetch(query, *params)
-    return [dict(row) for row in rows]
+    """Compatibility alias backed by the managed warehouse category catalog."""
+    return await list_warehouse_categories(conn, tenant_id, search, limit)
 
 
 def resolve_purchase_units(purchase_units: list, base_unit: str) -> list:
@@ -168,6 +141,7 @@ async def get_ingredients_list(
                     i.name,
                     i.unit,
                     i.category,
+                    i.warehouse_category_id,
                     i.type,
                     i.description,
                     CAST(i.minimum_order_quantity AS float) as minimum_order_quantity,
@@ -427,18 +401,29 @@ async def create_tenant_ingredient(
             )
         parent_name = parent_row["name"]
 
+    category = await resolve_assignable_warehouse_category(
+        conn,
+        tenant_id,
+        data.warehouse_category_id,
+        data.category,
+    )
+
     try:
         row = await conn.fetchrow(
             """
-            INSERT INTO ingredients (name, unit, type, category, costo_unitario, parent_id, tenant_id, is_resale, unit_weight_gr, unit_weight_unit)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-            RETURNING id::text, name, unit, type, category, costo_unitario,
+            INSERT INTO ingredients (
+                name, unit, type, category, warehouse_category_id, costo_unitario,
+                parent_id, tenant_id, is_resale, unit_weight_gr, unit_weight_unit
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            RETURNING id::text, name, unit, type, category, warehouse_category_id, costo_unitario,
                       parent_id::text, tenant_id::text, is_resale, unit_weight_gr, unit_weight_unit, created_at
             """,
             name,
             data.unit,
             ingredient_type,
-            data.category,
+            category["name"] if category else None,
+            category["id"] if category else None,
             data.costo_unitario,
             parent_uuid,
             tenant_id,
@@ -492,7 +477,7 @@ async def update_tenant_ingredient(
     tenant_id guard ensures tenants can only edit their own ingredients.
     """
     row = await conn.fetchrow(
-        "SELECT id, name, unit, type, category, costo_unitario, parent_id::text FROM ingredients WHERE id = $1 AND tenant_id = $2",
+        "SELECT id, name, unit, type, category, warehouse_category_id, costo_unitario, parent_id::text FROM ingredients WHERE id = $1 AND tenant_id = $2",
         ingredient_id,
         tenant_id,
     )
@@ -512,8 +497,19 @@ async def update_tenant_ingredient(
         _validate_unit_for_type(data.unit, effective_type)
         updates["unit"] = data.unit
 
-    if data.category is not None:
-        updates["category"] = data.category or None
+    category_id_unchanged = (
+        data.warehouse_category_id is not None
+        and data.warehouse_category_id == row["warehouse_category_id"]
+    )
+    if (data.warehouse_category_id is not None or data.category is not None) and not category_id_unchanged:
+        category = await resolve_assignable_warehouse_category(
+            conn,
+            tenant_id,
+            data.warehouse_category_id,
+            data.category,
+        )
+        updates["category"] = category["name"] if category else None
+        updates["warehouse_category_id"] = category["id"] if category else None
 
     if data.costo_unitario is not None:
         updates["costo_unitario"] = data.costo_unitario
@@ -578,7 +574,8 @@ async def update_tenant_ingredient(
             f"""
             UPDATE ingredients SET {set_clauses}, updated_at = NOW()
             WHERE id = $1
-            RETURNING id::text, name, unit, category, costo_unitario, parent_id::text, tenant_id::text, updated_at
+            RETURNING id::text, name, unit, category, warehouse_category_id,
+                      costo_unitario, parent_id::text, tenant_id::text, updated_at
             """,
             ingredient_id,
             *values,

--- a/app/services/warehouse_categories_service.py
+++ b/app/services/warehouse_categories_service.py
@@ -1,0 +1,323 @@
+import re
+import unicodedata
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+import asyncpg
+from fastapi import HTTPException
+
+
+def clean_warehouse_category_name(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip())
+
+
+def normalize_warehouse_category_name(value: str) -> str:
+    cleaned = clean_warehouse_category_name(value)
+    decomposed = unicodedata.normalize("NFD", cleaned)
+    without_diacritics = "".join(
+        char for char in decomposed if unicodedata.category(char) != "Mn"
+    )
+    return without_diacritics.lower()
+
+
+def _category_dict(row, tenant_id: UUID) -> Dict[str, Any]:
+    data = dict(row)
+    owner_id = data.get("tenant_id")
+    data["scope"] = "global" if owner_id is None else "tenant"
+    data["can_manage"] = owner_id == tenant_id
+    for field in ("ingredient_count", "global_count", "tenant_count"):
+        data[field] = int(data.get(field) or 0)
+    return data
+
+
+async def list_warehouse_categories(
+    conn,
+    tenant_id: UUID,
+    search: Optional[str] = None,
+    limit: int = 100,
+    include_archived: bool = False,
+) -> List[Dict[str, Any]]:
+    params: List[Any] = [tenant_id]
+    query = """
+        SELECT
+            wc.id,
+            wc.tenant_id,
+            wc.name,
+            wc.normalized_name,
+            wc.is_active,
+            wc.created_at,
+            wc.updated_at,
+            COUNT(i.id)::int AS ingredient_count,
+            COUNT(i.id) FILTER (WHERE i.tenant_id IS NULL)::int AS global_count,
+            COUNT(i.id) FILTER (WHERE i.tenant_id = $1)::int AS tenant_count
+        FROM warehouse_categories wc
+        LEFT JOIN ingredients i
+          ON i.warehouse_category_id = wc.id
+         AND i.is_active = TRUE
+         AND (i.tenant_id IS NULL OR i.tenant_id = $1)
+        WHERE (wc.tenant_id IS NULL OR wc.tenant_id = $1)
+    """
+    if not include_archived:
+        query += " AND wc.is_active = TRUE"
+    if search and search.strip():
+        params.append(f"%{normalize_warehouse_category_name(search)}%")
+        query += f" AND wc.normalized_name LIKE ${len(params)}"
+    params.append(limit)
+    query += f"""
+        GROUP BY wc.id
+        ORDER BY wc.normalized_name, wc.name
+        LIMIT ${len(params)}
+    """
+    rows = await conn.fetch(query, *params)
+    return [_category_dict(row, tenant_id) for row in rows]
+
+
+async def _load_visible_category(conn, tenant_id: UUID, category_id: UUID):
+    row = await conn.fetchrow(
+        """
+        SELECT
+            wc.*,
+            COUNT(i.id)::int AS ingredient_count,
+            COUNT(i.id) FILTER (WHERE i.tenant_id IS NULL)::int AS global_count,
+            COUNT(i.id) FILTER (WHERE i.tenant_id = $1)::int AS tenant_count
+        FROM warehouse_categories wc
+        LEFT JOIN ingredients i
+          ON i.warehouse_category_id = wc.id
+         AND i.is_active = TRUE
+         AND (i.tenant_id IS NULL OR i.tenant_id = $1)
+        WHERE wc.id = $2
+          AND (wc.tenant_id IS NULL OR wc.tenant_id = $1)
+        GROUP BY wc.id
+        """,
+        tenant_id,
+        category_id,
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Warehouse category not found")
+    return row
+
+
+async def _load_owned_category(conn, tenant_id: UUID, category_id: UUID):
+    row = await _load_visible_category(conn, tenant_id, category_id)
+    if row["tenant_id"] != tenant_id:
+        raise HTTPException(status_code=404, detail="Warehouse category not found")
+    return row
+
+
+async def create_warehouse_category(
+    conn,
+    tenant_id: UUID,
+    name: str,
+) -> Dict[str, Any]:
+    display_name = clean_warehouse_category_name(name)
+    normalized_name = normalize_warehouse_category_name(display_name)
+    if not normalized_name:
+        raise HTTPException(status_code=422, detail="Warehouse category name cannot be empty")
+
+    duplicate = await conn.fetchrow(
+        """
+        SELECT id, is_active
+        FROM warehouse_categories
+        WHERE normalized_name = $2
+          AND (tenant_id IS NULL OR tenant_id = $1)
+        LIMIT 1
+        """,
+        tenant_id,
+        normalized_name,
+    )
+    if duplicate:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "warehouse_category_exists",
+                "is_archived": not duplicate["is_active"],
+                "message": "Ya existe una categoría de bodega con ese nombre.",
+            },
+        )
+
+    try:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO warehouse_categories (tenant_id, name, normalized_name)
+            VALUES ($1, $2, $3)
+            RETURNING *
+            """,
+            tenant_id,
+            display_name,
+            normalized_name,
+        )
+    except asyncpg.UniqueViolationError:
+        raise HTTPException(
+            status_code=409,
+            detail="Ya existe una categoría de bodega con ese nombre.",
+        )
+    return _category_dict(row, tenant_id)
+
+
+async def rename_warehouse_category(
+    conn,
+    tenant_id: UUID,
+    category_id: UUID,
+    name: str,
+) -> Dict[str, Any]:
+    await _load_owned_category(conn, tenant_id, category_id)
+    display_name = clean_warehouse_category_name(name)
+    normalized_name = normalize_warehouse_category_name(display_name)
+    if not normalized_name:
+        raise HTTPException(status_code=422, detail="Warehouse category name cannot be empty")
+
+    duplicate = await conn.fetchval(
+        """
+        SELECT EXISTS(
+            SELECT 1
+            FROM warehouse_categories
+            WHERE id <> $3
+              AND normalized_name = $2
+              AND (tenant_id IS NULL OR tenant_id = $1)
+        )
+        """,
+        tenant_id,
+        normalized_name,
+        category_id,
+    )
+    if duplicate:
+        raise HTTPException(
+            status_code=409,
+            detail="Ya existe una categoría de bodega con ese nombre.",
+        )
+
+    try:
+        await conn.execute(
+            """
+            UPDATE warehouse_categories
+            SET name = $3, normalized_name = $4, updated_at = NOW()
+            WHERE id = $2 AND tenant_id = $1
+            """,
+            tenant_id,
+            category_id,
+            display_name,
+            normalized_name,
+        )
+    except asyncpg.UniqueViolationError:
+        raise HTTPException(
+            status_code=409,
+            detail="Ya existe una categoría de bodega con ese nombre.",
+        )
+    return _category_dict(
+        await _load_visible_category(conn, tenant_id, category_id),
+        tenant_id,
+    )
+
+
+async def archive_warehouse_category(
+    conn,
+    tenant_id: UUID,
+    category_id: UUID,
+) -> Dict[str, Any]:
+    await _load_owned_category(conn, tenant_id, category_id)
+    await conn.execute(
+        """
+        UPDATE warehouse_categories
+        SET is_active = FALSE, updated_at = NOW()
+        WHERE id = $2 AND tenant_id = $1
+        """,
+        tenant_id,
+        category_id,
+    )
+    return _category_dict(
+        await _load_visible_category(conn, tenant_id, category_id),
+        tenant_id,
+    )
+
+
+async def resolve_assignable_warehouse_category(
+    conn,
+    tenant_id: UUID,
+    category_id: Optional[UUID] = None,
+    legacy_name: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    if category_id:
+        row = await conn.fetchrow(
+            """
+            SELECT id, name, tenant_id, is_active
+            FROM warehouse_categories
+            WHERE id = $2
+              AND (tenant_id IS NULL OR tenant_id = $1)
+            """,
+            tenant_id,
+            category_id,
+        )
+        if not row:
+            raise HTTPException(status_code=404, detail="Warehouse category not found")
+        if not row["is_active"]:
+            raise HTTPException(status_code=422, detail="Warehouse category is archived")
+        return dict(row)
+
+    if legacy_name is None or not legacy_name.strip():
+        return None
+
+    normalized_name = normalize_warehouse_category_name(legacy_name)
+    row = await conn.fetchrow(
+        """
+        SELECT id, name, tenant_id, is_active
+        FROM warehouse_categories
+        WHERE normalized_name = $2
+          AND (tenant_id IS NULL OR tenant_id = $1)
+        ORDER BY tenant_id NULLS FIRST
+        LIMIT 1
+        """,
+        tenant_id,
+        normalized_name,
+    )
+    if row:
+        if not row["is_active"]:
+            raise HTTPException(status_code=422, detail="Warehouse category is archived")
+        return dict(row)
+
+    created = await create_warehouse_category(conn, tenant_id, legacy_name)
+    return {
+        "id": created["id"],
+        "name": created["name"],
+        "tenant_id": created["tenant_id"],
+        "is_active": created["is_active"],
+    }
+
+
+async def resolve_global_warehouse_category(
+    conn,
+    name: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    if not name or not name.strip():
+        return None
+    display_name = clean_warehouse_category_name(name)
+    normalized_name = normalize_warehouse_category_name(display_name)
+    row = await conn.fetchrow(
+        """
+        SELECT id, name
+        FROM warehouse_categories
+        WHERE tenant_id IS NULL AND normalized_name = $1
+        """,
+        normalized_name,
+    )
+    if row:
+        return dict(row)
+    try:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO warehouse_categories (tenant_id, name, normalized_name)
+            VALUES (NULL, $1, $2)
+            RETURNING id, name
+            """,
+            display_name,
+            normalized_name,
+        )
+    except asyncpg.UniqueViolationError:
+        row = await conn.fetchrow(
+            """
+            SELECT id, name
+            FROM warehouse_categories
+            WHERE tenant_id IS NULL AND normalized_name = $1
+            """,
+            normalized_name,
+        )
+    return dict(row)

--- a/sql/20260716_warehouse_categories.sql
+++ b/sql/20260716_warehouse_categories.sql
@@ -1,0 +1,228 @@
+-- warocol.com#1668: managed, tenant-aware warehouse ingredient categories.
+CREATE EXTENSION IF NOT EXISTS unaccent;
+
+CREATE OR REPLACE FUNCTION normalize_warehouse_category_name(value TEXT)
+RETURNS TEXT
+LANGUAGE SQL
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+    SELECT LOWER(
+        REGEXP_REPLACE(
+            BTRIM(public.unaccent(COALESCE(value, ''))),
+            '\s+',
+            ' ',
+            'g'
+        )
+    )
+$$;
+
+CREATE TABLE IF NOT EXISTS warehouse_categories (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID REFERENCES tenants(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    normalized_name VARCHAR(255) NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT warehouse_categories_name_nonempty
+        CHECK (normalized_name <> '')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_warehouse_categories_global_name
+    ON warehouse_categories (normalized_name)
+    WHERE tenant_id IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_warehouse_categories_tenant_name
+    ON warehouse_categories (tenant_id, normalized_name)
+    WHERE tenant_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_warehouse_categories_tenant_active
+    ON warehouse_categories (tenant_id, is_active, normalized_name);
+
+ALTER TABLE ingredients
+    ADD COLUMN IF NOT EXISTS warehouse_category_id UUID;
+
+ALTER TABLE ingredients
+    DROP CONSTRAINT IF EXISTS ingredients_warehouse_category_id_fkey;
+ALTER TABLE ingredients
+    ADD CONSTRAINT ingredients_warehouse_category_id_fkey
+    FOREIGN KEY (warehouse_category_id)
+    REFERENCES warehouse_categories(id)
+    ON DELETE RESTRICT;
+
+CREATE INDEX IF NOT EXISTS idx_ingredients_warehouse_category_id
+    ON ingredients (warehouse_category_id);
+
+WITH grouped AS (
+    SELECT
+        normalize_warehouse_category_name(category) AS normalized_name,
+        REGEXP_REPLACE(BTRIM(category), '\s+', ' ', 'g') AS display_name,
+        COUNT(*) AS usage_count
+    FROM ingredients
+    WHERE tenant_id IS NULL
+      AND NULLIF(BTRIM(category), '') IS NOT NULL
+    GROUP BY 1, 2
+),
+ranked AS (
+    SELECT *,
+           ROW_NUMBER() OVER (
+               PARTITION BY normalized_name
+               ORDER BY usage_count DESC, LOWER(display_name), display_name
+           ) AS rank
+    FROM grouped
+)
+INSERT INTO warehouse_categories (tenant_id, name, normalized_name)
+SELECT NULL, display_name, normalized_name
+FROM ranked
+WHERE rank = 1
+ON CONFLICT (normalized_name) WHERE tenant_id IS NULL DO NOTHING;
+
+WITH grouped AS (
+    SELECT
+        tenant_id,
+        normalize_warehouse_category_name(category) AS normalized_name,
+        REGEXP_REPLACE(BTRIM(category), '\s+', ' ', 'g') AS display_name,
+        COUNT(*) AS usage_count
+    FROM ingredients
+    WHERE tenant_id IS NOT NULL
+      AND NULLIF(BTRIM(category), '') IS NOT NULL
+    GROUP BY 1, 2, 3
+),
+ranked AS (
+    SELECT *,
+           ROW_NUMBER() OVER (
+               PARTITION BY tenant_id, normalized_name
+               ORDER BY usage_count DESC, LOWER(display_name), display_name
+           ) AS rank
+    FROM grouped
+)
+INSERT INTO warehouse_categories (tenant_id, name, normalized_name)
+SELECT source.tenant_id, source.display_name, source.normalized_name
+FROM ranked source
+WHERE source.rank = 1
+  AND NOT EXISTS (
+      SELECT 1
+      FROM warehouse_categories global_category
+      WHERE global_category.tenant_id IS NULL
+        AND global_category.normalized_name = source.normalized_name
+  )
+ON CONFLICT (tenant_id, normalized_name)
+    WHERE tenant_id IS NOT NULL
+    DO NOTHING;
+
+UPDATE ingredients ingredient
+SET warehouse_category_id = (
+    SELECT category.id
+    FROM warehouse_categories category
+    WHERE category.normalized_name =
+              normalize_warehouse_category_name(ingredient.category)
+      AND (
+          category.tenant_id IS NULL
+          OR category.tenant_id = ingredient.tenant_id
+      )
+    ORDER BY category.tenant_id NULLS FIRST
+    LIMIT 1
+)
+WHERE NULLIF(BTRIM(ingredient.category), '') IS NOT NULL
+  AND ingredient.warehouse_category_id IS NULL;
+
+UPDATE ingredients ingredient
+SET category = category.name
+FROM warehouse_categories category
+WHERE ingredient.warehouse_category_id = category.id
+  AND ingredient.category IS DISTINCT FROM category.name;
+
+CREATE OR REPLACE FUNCTION set_warehouse_category_normalized_name()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.name := REGEXP_REPLACE(BTRIM(NEW.name), '\s+', ' ', 'g');
+    NEW.normalized_name := normalize_warehouse_category_name(NEW.name);
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS warehouse_categories_normalize_name ON warehouse_categories;
+CREATE TRIGGER warehouse_categories_normalize_name
+BEFORE INSERT OR UPDATE OF name ON warehouse_categories
+FOR EACH ROW
+EXECUTE FUNCTION set_warehouse_category_normalized_name();
+
+CREATE OR REPLACE FUNCTION mirror_warehouse_category_name()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    UPDATE ingredients
+    SET category = NEW.name,
+        updated_at = NOW()
+    WHERE warehouse_category_id = NEW.id
+      AND category IS DISTINCT FROM NEW.name;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS warehouse_categories_mirror_name ON warehouse_categories;
+CREATE TRIGGER warehouse_categories_mirror_name
+AFTER UPDATE OF name ON warehouse_categories
+FOR EACH ROW
+WHEN (OLD.name IS DISTINCT FROM NEW.name)
+EXECUTE FUNCTION mirror_warehouse_category_name();
+
+CREATE OR REPLACE FUNCTION derive_ingredient_warehouse_category()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    selected_category warehouse_categories%ROWTYPE;
+BEGIN
+    IF NEW.warehouse_category_id IS NULL THEN
+        IF TG_OP = 'UPDATE' THEN
+            IF OLD.warehouse_category_id IS NOT NULL THEN
+                NEW.category := NULL;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    SELECT *
+    INTO selected_category
+    FROM warehouse_categories
+    WHERE id = NEW.warehouse_category_id
+      AND (
+          tenant_id IS NULL
+          OR tenant_id = NEW.tenant_id
+      );
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Warehouse category is not visible to ingredient tenant'
+            USING ERRCODE = '23503';
+    END IF;
+
+    IF NOT selected_category.is_active THEN
+        IF TG_OP = 'INSERT' THEN
+            RAISE EXCEPTION 'Archived warehouse category cannot be assigned'
+                USING ERRCODE = '23514';
+        ELSIF NEW.warehouse_category_id IS DISTINCT FROM OLD.warehouse_category_id THEN
+            RAISE EXCEPTION 'Archived warehouse category cannot be assigned'
+                USING ERRCODE = '23514';
+        END IF;
+    END IF;
+
+    NEW.category := selected_category.name;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS ingredients_derive_warehouse_category ON ingredients;
+CREATE TRIGGER ingredients_derive_warehouse_category
+BEFORE INSERT OR UPDATE OF warehouse_category_id ON ingredients
+FOR EACH ROW
+EXECUTE FUNCTION derive_ingredient_warehouse_category();
+
+COMMENT ON TABLE warehouse_categories IS
+    'Warehouse ingredient categories. Separate from commercial menu categories.';
+COMMENT ON COLUMN ingredients.warehouse_category_id IS
+    'Stable warehouse category relation; ingredients.category is a compatibility mirror.';

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -80,22 +80,32 @@ class TestIngredientUnitTypeValidation:
     @pytest.mark.asyncio
     async def test_create_service_ingredient_und(self):
         tenant_id = uuid4()
+        warehouse_category_id = uuid4()
         conn = AsyncMock()
         conn.fetchrow = AsyncMock(
-            return_value={
-                "id": str(uuid4()),
-                "name": "Transporte domicilios",
-                "unit": "und",
-                "type": "service",
-                "category": "Logística",
-                "costo_unitario": None,
-                "parent_id": None,
-                "tenant_id": str(tenant_id),
-                "is_resale": False,
-                "unit_weight_gr": None,
-                "unit_weight_unit": "gr",
-                "created_at": None,
-            }
+            side_effect=[
+                {
+                    "id": warehouse_category_id,
+                    "name": "Logística",
+                    "tenant_id": tenant_id,
+                    "is_active": True,
+                },
+                {
+                    "id": str(uuid4()),
+                    "name": "Transporte domicilios",
+                    "unit": "und",
+                    "type": "service",
+                    "category": "Logística",
+                    "warehouse_category_id": warehouse_category_id,
+                    "costo_unitario": None,
+                    "parent_id": None,
+                    "tenant_id": str(tenant_id),
+                    "is_resale": False,
+                    "unit_weight_gr": None,
+                    "unit_weight_unit": "gr",
+                    "created_at": None,
+                },
+            ]
         )
         data = TenantIngredientCreate(
             name="Transporte domicilios",
@@ -106,6 +116,7 @@ class TestIngredientUnitTypeValidation:
         result = await create_tenant_ingredient(conn, tenant_id, data)
         assert result["unit"] == "und"
         assert result["type"] == "service"
+        assert result["warehouse_category_id"] == warehouse_category_id
 
     @pytest.mark.asyncio
     async def test_create_service_rejects_gr(self):
@@ -167,13 +178,25 @@ class TestIngredientCategorySearch:
         conn = AsyncMock()
         conn.fetch = AsyncMock(return_value=[
             {
+                "id": uuid4(),
+                "tenant_id": tenant_id,
                 "name": "categoria de prueba",
+                "normalized_name": "categoria de prueba",
+                "is_active": True,
+                "created_at": None,
+                "updated_at": None,
                 "ingredient_count": 2,
                 "global_count": 0,
                 "tenant_count": 2,
             },
             {
+                "id": uuid4(),
+                "tenant_id": tenant_id,
                 "name": "ingrediente categoria",
+                "normalized_name": "ingrediente categoria",
+                "is_active": True,
+                "created_at": None,
+                "updated_at": None,
                 "ingredient_count": 1,
                 "global_count": 0,
                 "tenant_count": 1,
@@ -192,8 +215,8 @@ class TestIngredientCategorySearch:
             "ingrediente categoria",
         ]
         query, *params = conn.fetch.await_args.args
-        assert "(tenant_id IS NULL OR tenant_id = $1)" in query
-        assert "LOWER(unaccent(BTRIM(category))) LIKE LOWER(unaccent($2))" in query
+        assert "(wc.tenant_id IS NULL OR wc.tenant_id = $1)" in query
+        assert "wc.normalized_name LIKE $2" in query
         assert params == [tenant_id, "%categoria%", 50]
 
 

--- a/tests/test_warehouse_categories.py
+++ b/tests/test_warehouse_categories.py
@@ -1,0 +1,188 @@
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.warehouse_categories_service import (
+    archive_warehouse_category,
+    create_warehouse_category,
+    list_warehouse_categories,
+    normalize_warehouse_category_name,
+    rename_warehouse_category,
+    resolve_assignable_warehouse_category,
+)
+
+
+def _category_row(tenant_id, name="Lácteos"):
+    return {
+        "id": uuid4(),
+        "tenant_id": tenant_id,
+        "name": name,
+        "normalized_name": "lacteos",
+        "is_active": True,
+        "created_at": datetime.now(timezone.utc),
+        "updated_at": datetime.now(timezone.utc),
+    }
+
+
+def test_normalizes_case_diacritics_and_repeated_spaces():
+    assert normalize_warehouse_category_name("  LÁCTEOS   Frescos  ") == "lacteos frescos"
+
+
+@pytest.mark.asyncio
+async def test_create_normalizes_and_scopes_to_tenant():
+    tenant_id = uuid4()
+    inserted = _category_row(tenant_id, "LÁCTEOS Frescos")
+    inserted["normalized_name"] = "lacteos frescos"
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(side_effect=[None, inserted])
+
+    result = await create_warehouse_category(conn, tenant_id, "  LÁCTEOS   Frescos ")
+
+    assert result["name"] == "LÁCTEOS Frescos"
+    assert result["normalized_name"] == "lacteos frescos"
+    assert result["scope"] == "tenant"
+    assert result["can_manage"] is True
+    insert_args = conn.fetchrow.await_args_list[1].args
+    assert insert_args[1:] == (tenant_id, "LÁCTEOS Frescos", "lacteos frescos")
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_visible_global_duplicate():
+    tenant_id = uuid4()
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"id": uuid4(), "is_active": True})
+
+    with pytest.raises(HTTPException) as exc:
+        await create_warehouse_category(conn, tenant_id, " lacteos ")
+
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_assignment_hides_cross_tenant_category():
+    tenant_id = uuid4()
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc:
+        await resolve_assignable_warehouse_category(
+            conn,
+            tenant_id,
+            category_id=uuid4(),
+        )
+
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_assignment_rejects_archived_visible_category():
+    tenant_id = uuid4()
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "id": uuid4(),
+        "name": "Salsas",
+        "tenant_id": tenant_id,
+        "is_active": False,
+    })
+
+    with pytest.raises(HTTPException) as exc:
+        await resolve_assignable_warehouse_category(
+            conn,
+            tenant_id,
+            category_id=uuid4(),
+        )
+
+    assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_list_is_scoped_to_global_or_current_tenant():
+    tenant_id = uuid4()
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=[])
+
+    await list_warehouse_categories(conn, tenant_id, search=" Lácteos ", limit=25)
+
+    query, *params = conn.fetch.await_args.args
+    assert "(wc.tenant_id IS NULL OR wc.tenant_id = $1)" in query
+    assert "wc.is_active = TRUE" in query
+    assert params == [tenant_id, "%lacteos%", 25]
+
+
+@pytest.mark.asyncio
+async def test_tenant_cannot_rename_global_category():
+    tenant_id = uuid4()
+    global_row = _category_row(None)
+    global_row.update({
+        "ingredient_count": 1,
+        "global_count": 1,
+        "tenant_count": 0,
+    })
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value=global_row)
+
+    with pytest.raises(HTTPException) as exc:
+        await rename_warehouse_category(
+            conn,
+            tenant_id,
+            global_row["id"],
+            "Nuevo nombre",
+        )
+
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_rename_keeps_category_identity():
+    tenant_id = uuid4()
+    category_id = uuid4()
+    owned = _category_row(tenant_id)
+    owned["id"] = category_id
+    owned.update({
+        "ingredient_count": 2,
+        "global_count": 0,
+        "tenant_count": 2,
+    })
+    renamed = dict(owned, name="Lácteos refrigerados", normalized_name="lacteos refrigerados")
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(side_effect=[owned, renamed])
+    conn.fetchval = AsyncMock(return_value=False)
+
+    result = await rename_warehouse_category(
+        conn,
+        tenant_id,
+        category_id,
+        " Lácteos   refrigerados ",
+    )
+
+    assert result["name"] == "Lácteos refrigerados"
+    update_query, *update_params = conn.execute.await_args.args
+    assert "UPDATE warehouse_categories" in update_query
+    assert update_params == [
+        tenant_id,
+        category_id,
+        "Lácteos refrigerados",
+        "lacteos refrigerados",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_archive_keeps_existing_association_counts():
+    tenant_id = uuid4()
+    active = _category_row(tenant_id)
+    active.update({
+        "ingredient_count": 3,
+        "global_count": 0,
+        "tenant_count": 3,
+    })
+    archived = dict(active, is_active=False)
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(side_effect=[active, archived])
+
+    result = await archive_warehouse_category(conn, tenant_id, active["id"])
+
+    assert result["is_active"] is False
+    assert result["ingredient_count"] == 3


### PR DESCRIPTION
## Summary
- add tenant-aware warehouse category schema, migration, normalization and backfill
- expose scoped create/search/rename/archive endpoints
- persist stable category IDs while keeping `ingredients.category` as a compatibility mirror

## Tests
- `pytest --noconftest tests/test_warehouse_categories.py tests/test_ingredients.py::TestIngredientUnitTypeValidation tests/test_ingredients.py::TestIngredientCategorySearch` (21 passed)
- `python3 -m py_compile ...`
- `git diff --check`

The full pytest bootstrap was not run locally because the environment is missing declared dependency `Babel`; no build was requested.

Refs uno0uno/warocol.com#1668
