### PR TITLE
Resolve ingredients by warehouse categories

### DIFF
--- a/app/models/ingredient.py
+++ b/app/models/ingredient.py
@@ -123,6 +123,29 @@ class IngredientCategoriesResponse(BaseModel):
     data: List[IngredientCategoryOption]
 
 
+class IngredientCategoryResolutionRequest(BaseModel):
+    category_ids: List[UUID] = Field(..., min_length=1, max_length=100)
+    exclude_ingredient_ids: List[UUID] = Field(default_factory=list, max_length=10000)
+
+
+class IngredientCategoryCandidate(BaseModel):
+    ingredient_id: UUID
+    name: str
+    unit: str
+    warehouse_category_id: UUID
+
+
+class IngredientCategoryResolutionData(BaseModel):
+    ingredients: List[IngredientCategoryCandidate]
+    empty_category_ids: List[UUID]
+    unavailable_category_ids: List[UUID]
+
+
+class IngredientCategoryResolutionResponse(BaseModel):
+    success: bool = True
+    data: IngredientCategoryResolutionData
+
+
 # =============================================================================
 # INGREDIENT PURCHASE UNITS MODELS
 # =============================================================================

--- a/app/routers/ingredients.py
+++ b/app/routers/ingredients.py
@@ -3,8 +3,8 @@ from typing import Any, Dict, Optional
 from uuid import UUID
 from app.core.middleware import require_valid_session
 from app.core.permissions import Module, require_module
-from app.services.ingredients_service import get_ingredient_categories, get_ingredients_list, update_ingredient_unit_weight, match_ingredient_by_name, create_tenant_ingredient, update_tenant_ingredient, archive_tenant_ingredient, restore_tenant_ingredient, hard_delete_tenant_ingredient
-from app.models.ingredient import IngredientCategoriesResponse, IngredientsListResponse, TenantIngredientCreate, TenantIngredientUpdate
+from app.services.ingredients_service import get_ingredient_categories, get_ingredients_list, resolve_ingredients_by_warehouse_categories, update_ingredient_unit_weight, match_ingredient_by_name, create_tenant_ingredient, update_tenant_ingredient, archive_tenant_ingredient, restore_tenant_ingredient, hard_delete_tenant_ingredient
+from app.models.ingredient import IngredientCategoriesResponse, IngredientCategoryResolutionRequest, IngredientCategoryResolutionResponse, IngredientsListResponse, TenantIngredientCreate, TenantIngredientUpdate
 from app.database import get_db_connection
 
 router = APIRouter()
@@ -99,6 +99,33 @@ async def get_ingredient_categories_endpoint(
         "total": len(categories),
         "data": categories,
     }
+
+
+@router.post(
+    "/resolve-by-warehouse-categories",
+    response_model=IngredientCategoryResolutionResponse,
+    dependencies=[Depends(require_module(Module.ABASTECIMIENTO))],
+)
+async def resolve_ingredients_by_warehouse_categories_endpoint(
+    body: IngredientCategoryResolutionRequest,
+    request: Request,
+):
+    """Prepare ingredient candidates for one or more warehouse categories."""
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+
+    if not tenant_id:
+        raise HTTPException(status_code=401, detail="Tenant context required")
+
+    async with get_db_connection() as conn:
+        data = await resolve_ingredients_by_warehouse_categories(
+            conn,
+            tenant_id,
+            body.category_ids,
+            body.exclude_ingredient_ids,
+        )
+
+    return {"success": True, "data": data}
 
 
 @router.get("/{ingredient_id}", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])

--- a/app/services/ingredients_service.py
+++ b/app/services/ingredients_service.py
@@ -79,6 +79,84 @@ async def get_ingredient_categories(
     return await list_warehouse_categories(conn, tenant_id, search, limit)
 
 
+async def resolve_ingredients_by_warehouse_categories(
+    conn,
+    tenant_id: UUID,
+    category_ids: List[UUID],
+    exclude_ingredient_ids: Optional[List[UUID]] = None,
+) -> Dict[str, Any]:
+    """Resolve visible active ingredients for ordered warehouse categories."""
+    ordered_category_ids = list(dict.fromkeys(category_ids))
+    excluded_ids = list(dict.fromkeys(exclude_ingredient_ids or []))
+
+    rows = await conn.fetch(
+        """
+        WITH requested_categories AS (
+            SELECT category_id, MIN(position)::int AS position
+            FROM unnest($2::uuid[]) WITH ORDINALITY AS requested(category_id, position)
+            GROUP BY category_id
+        ),
+        visible_categories AS (
+            SELECT requested.category_id, requested.position, wc.id IS NOT NULL AS is_available
+            FROM requested_categories requested
+            LEFT JOIN warehouse_categories wc
+              ON wc.id = requested.category_id
+             AND wc.is_active = TRUE
+             AND (wc.tenant_id IS NULL OR wc.tenant_id = $1)
+        )
+        SELECT
+            category.category_id,
+            category.position,
+            category.is_available,
+            ingredient.id AS ingredient_id,
+            ingredient.name,
+            ingredient.unit,
+            ingredient.warehouse_category_id
+        FROM visible_categories category
+        LEFT JOIN ingredients ingredient
+          ON ingredient.warehouse_category_id = category.category_id
+         AND category.is_available
+         AND ingredient.is_active = TRUE
+         AND (ingredient.tenant_id IS NULL OR ingredient.tenant_id = $1)
+         AND NOT (ingredient.id = ANY($3::uuid[]))
+        ORDER BY category.position, LOWER(ingredient.name) NULLS LAST,
+                 ingredient.name NULLS LAST, ingredient.id
+        """,
+        tenant_id,
+        ordered_category_ids,
+        excluded_ids,
+    )
+
+    ingredients: List[Dict[str, Any]] = []
+    empty_category_ids: List[UUID] = []
+    unavailable_category_ids: List[UUID] = []
+    seen_ingredient_ids = set()
+
+    for row in rows:
+        category_id = row["category_id"]
+        if not row["is_available"]:
+            unavailable_category_ids.append(category_id)
+            continue
+        if row["ingredient_id"] is None:
+            empty_category_ids.append(category_id)
+            continue
+        if row["ingredient_id"] in seen_ingredient_ids:
+            continue
+        seen_ingredient_ids.add(row["ingredient_id"])
+        ingredients.append({
+            "ingredient_id": row["ingredient_id"],
+            "name": row["name"],
+            "unit": row["unit"],
+            "warehouse_category_id": row["warehouse_category_id"],
+        })
+
+    return {
+        "ingredients": ingredients,
+        "empty_category_ids": empty_category_ids,
+        "unavailable_category_ids": unavailable_category_ids,
+    }
+
+
 def resolve_purchase_units(purchase_units: list, base_unit: str) -> list:
     """
     Validate each purchase_unit key against the catalog and resolve

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -17,6 +17,7 @@ from app.services.ingredients_service import (
     _validate_unit_for_type,
     create_tenant_ingredient,
     get_ingredient_categories,
+    resolve_ingredients_by_warehouse_categories,
     update_tenant_ingredient,
 )
 from app.models.ingredient import TenantIngredientUpdate
@@ -218,6 +219,120 @@ class TestIngredientCategorySearch:
         assert "(wc.tenant_id IS NULL OR wc.tenant_id = $1)" in query
         assert "wc.normalized_name LIKE $2" in query
         assert params == [tenant_id, "%categoria%", 50]
+
+
+class TestIngredientCategoryResolution:
+    @pytest.mark.asyncio
+    async def test_resolves_unique_candidates_in_requested_category_order(self):
+        tenant_id = uuid4()
+        first_category_id = uuid4()
+        second_category_id = uuid4()
+        first_ingredient_id = uuid4()
+        second_ingredient_id = uuid4()
+        excluded_ingredient_id = uuid4()
+        conn = AsyncMock()
+        conn.fetch = AsyncMock(return_value=[
+            {
+                "category_id": first_category_id,
+                "position": 1,
+                "is_available": True,
+                "ingredient_id": first_ingredient_id,
+                "name": "Aguacate",
+                "unit": "gr",
+                "warehouse_category_id": first_category_id,
+            },
+            {
+                "category_id": second_category_id,
+                "position": 2,
+                "is_available": True,
+                "ingredient_id": second_ingredient_id,
+                "name": "Yogur",
+                "unit": "ml",
+                "warehouse_category_id": second_category_id,
+            },
+            {
+                "category_id": second_category_id,
+                "position": 2,
+                "is_available": True,
+                "ingredient_id": second_ingredient_id,
+                "name": "Yogur",
+                "unit": "ml",
+                "warehouse_category_id": second_category_id,
+            },
+        ])
+
+        result = await resolve_ingredients_by_warehouse_categories(
+            conn,
+            tenant_id,
+            [first_category_id, first_category_id, second_category_id],
+            [excluded_ingredient_id, excluded_ingredient_id],
+        )
+
+        assert [row["ingredient_id"] for row in result["ingredients"]] == [
+            first_ingredient_id,
+            second_ingredient_id,
+        ]
+        assert result["empty_category_ids"] == []
+        assert result["unavailable_category_ids"] == []
+        query, *params = conn.fetch.await_args.args
+        assert "WITH ORDINALITY" in query
+        assert "wc.tenant_id IS NULL OR wc.tenant_id = $1" in query
+        assert "ingredient.tenant_id IS NULL OR ingredient.tenant_id = $1" in query
+        assert "ingredient.id = ANY($3::uuid[])" in query
+        assert params == [
+            tenant_id,
+            [first_category_id, second_category_id],
+            [excluded_ingredient_id],
+        ]
+        conn.fetch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reports_empty_and_unavailable_categories_without_failing_candidates(self):
+        tenant_id = uuid4()
+        populated_category_id = uuid4()
+        empty_category_id = uuid4()
+        unavailable_category_id = uuid4()
+        ingredient_id = uuid4()
+        conn = AsyncMock()
+        conn.fetch = AsyncMock(return_value=[
+            {
+                "category_id": populated_category_id,
+                "position": 1,
+                "is_available": True,
+                "ingredient_id": ingredient_id,
+                "name": "Arroz",
+                "unit": "gr",
+                "warehouse_category_id": populated_category_id,
+            },
+            {
+                "category_id": empty_category_id,
+                "position": 2,
+                "is_available": True,
+                "ingredient_id": None,
+                "name": None,
+                "unit": None,
+                "warehouse_category_id": None,
+            },
+            {
+                "category_id": unavailable_category_id,
+                "position": 3,
+                "is_available": False,
+                "ingredient_id": None,
+                "name": None,
+                "unit": None,
+                "warehouse_category_id": None,
+            },
+        ])
+
+        result = await resolve_ingredients_by_warehouse_categories(
+            conn,
+            tenant_id,
+            [populated_category_id, empty_category_id, unavailable_category_id],
+        )
+
+        assert [row["ingredient_id"] for row in result["ingredients"]] == [ingredient_id]
+        assert result["empty_category_ids"] == [empty_category_id]
+        assert result["unavailable_category_ids"] == [unavailable_category_id]
 
 
 class TestIngredientsEndpoint:


### PR DESCRIPTION
## Summary
- add one ordered multi-category ingredient resolution endpoint
- enforce active global/current-tenant visibility and exclusions
- report empty and unavailable categories without losing partial results

## Tests
- `pytest tests/test_ingredients.py` (26 passed)
- `git diff --check`

Refs uno0uno/warocol.com#1670
