### PR TITLE
Buscar clientes por razón social

### DIFF
--- a/app/models/customer.py
+++ b/app/models/customer.py
@@ -94,6 +94,7 @@ class CustomerSummary(BaseModel):
     email: Optional[str] = None
     fiscal_id: Optional[str] = None
     fiscal_id_type: Optional[str] = None
+    fiscal_business_name: Optional[str] = None
 
 
 class CustomerUpdate(FiscalDataMixin):

--- a/app/services/customers_service.py
+++ b/app/services/customers_service.py
@@ -358,12 +358,12 @@ async def search_customers_by_query(
     limit: int = 20
 ) -> CustomerQuerySearchResponse:
     """
-    Search customers by partial name or phone number (ILIKE OR).
+    Search customers by name, phone number, fiscal ID, or business name.
     Results are scoped to the current tenant via tenant_customers.
 
     Args:
         request: FastAPI request object
-        q: Search query (partial name or phone)
+        q: Search query (exact, prefix, or partial match)
         limit: Maximum number of results (default 20)
 
     Returns:
@@ -377,32 +377,65 @@ async def search_customers_by_query(
             raise APIError("No tenant context found", status_code=400)
 
         async with get_db_connection() as conn:
-            # Match against name, phone, OR fiscal_id (NIT/cédula) so users
-            # can find a customer by typing the document number.
-            # Also return fiscal_id + fiscal_id_type so the UI can display
-            # the document that matched.
+            # Rank exact matches before prefixes and partial matches so the
+            # most relevant customers are not displaced by the result limit.
             query = """
-                SELECT DISTINCT
-                    p.id,
-                    p.name,
-                    p.phone_number,
-                    p.email,
-                    p.fiscal_id,
-                    p.fiscal_id_type
-                FROM profile p
-                JOIN tenant_customers tc ON tc.profile_id = p.id
-                WHERE tc.tenant_id = $1
-                  AND tc.is_active = true
-                  AND (
-                      p.name ILIKE $2
-                      OR p.phone_number ILIKE $2
-                      OR p.fiscal_id ILIKE $2
-                  )
-                ORDER BY p.name
-                LIMIT $3
+                WITH matching_customers AS (
+                    SELECT DISTINCT
+                        p.id,
+                        p.name,
+                        p.phone_number,
+                        p.email,
+                        p.fiscal_id,
+                        p.fiscal_id_type,
+                        p.fiscal_business_name,
+                        CASE
+                            WHEN (
+                                p.name ILIKE $2
+                                OR p.phone_number ILIKE $2
+                                OR p.fiscal_id ILIKE $2
+                                OR p.fiscal_business_name ILIKE $2
+                            ) THEN 0
+                            WHEN (
+                                p.name ILIKE $3
+                                OR p.phone_number ILIKE $3
+                                OR p.fiscal_id ILIKE $3
+                                OR p.fiscal_business_name ILIKE $3
+                            ) THEN 1
+                            ELSE 2
+                        END AS match_rank
+                    FROM profile p
+                    JOIN tenant_customers tc ON tc.profile_id = p.id
+                    WHERE tc.tenant_id = $1
+                      AND tc.is_active = true
+                      AND (
+                          p.name ILIKE $4
+                          OR p.phone_number ILIKE $4
+                          OR p.fiscal_id ILIKE $4
+                          OR p.fiscal_business_name ILIKE $4
+                      )
+                )
+                SELECT
+                    id,
+                    name,
+                    phone_number,
+                    email,
+                    fiscal_id,
+                    fiscal_id_type,
+                    fiscal_business_name
+                FROM matching_customers
+                ORDER BY match_rank, name NULLS LAST, id
+                LIMIT $5
             """
 
-            rows = await conn.fetch(query, tenant_id, f"%{q}%", limit)
+            rows = await conn.fetch(
+                query,
+                tenant_id,
+                q,
+                f"{q}%",
+                f"%{q}%",
+                limit,
+            )
 
             data = [
                 CustomerSummary(
@@ -412,6 +445,7 @@ async def search_customers_by_query(
                     email=row['email'],
                     fiscal_id=row['fiscal_id'],
                     fiscal_id_type=row['fiscal_id_type'],
+                    fiscal_business_name=row['fiscal_business_name'],
                 )
                 for row in rows
             ]

--- a/tests/test_customer_identity_model.py
+++ b/tests/test_customer_identity_model.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 import pytest
 
-from app.models.customer import CustomerSearchOrCreate, CustomerUpdate
+from app.models.customer import CustomerSearchOrCreate, CustomerSummary, CustomerUpdate
 from app.services import customers_service
 
 
@@ -64,6 +64,17 @@ def test_customer_models_normalize_fiscal_id_for_invoicing():
 
     assert created.fiscal_id == "9001234567"
     assert updated.fiscal_id == "1063279307"
+
+
+def test_customer_summary_accepts_optional_business_name_without_fiscal_triplet():
+    summary = CustomerSummary(
+        id=uuid4(),
+        fiscal_business_name="ACME SAS",
+    )
+
+    assert summary.fiscal_business_name == "ACME SAS"
+    assert summary.fiscal_id is None
+    assert summary.fiscal_id_type is None
 
 
 @pytest.mark.asyncio
@@ -130,30 +141,67 @@ async def test_get_customer_by_id_uses_tenant_customers_as_source_of_truth():
 
 
 @pytest.mark.asyncio
-async def test_search_customers_by_query_uses_tenant_customers():
+async def test_search_customers_by_query_uses_tenant_customers_and_returns_fiscal_identity():
     tenant_id = uuid4()
-    profile_id = uuid4()
+    mixed_profile_id = uuid4()
+    no_fiscal_profile_id = uuid4()
     conn = MagicMock()
-    conn.fetch = AsyncMock(return_value=[
-        {
-            "id": profile_id,
-            "name": "Buyer",
-            "phone_number": "3001234567",
-            "email": "buyer@example.com",
-            "fiscal_id": None,
-            "fiscal_id_type": None,
-        }
-    ])
+    conn.fetch = AsyncMock(
+        return_value=[
+            {
+                "id": mixed_profile_id,
+                "name": "Rebel Rebel",
+                "phone_number": "3001234567",
+                "email": "buyer@example.com",
+                "fiscal_id": "900123456",
+                "fiscal_id_type": "NIT",
+                "fiscal_business_name": "ACME SAS",
+            },
+            {
+                "id": no_fiscal_profile_id,
+                "name": "Buyer",
+                "phone_number": "3007654321",
+                "email": None,
+                "fiscal_id": None,
+                "fiscal_id_type": None,
+                "fiscal_business_name": None,
+            },
+        ]
+    )
 
     session_patch, db_patch = _patch_customer_service_db(conn, tenant_id)
     with session_patch, db_patch:
-        result = await customers_service.search_customers_by_query(_request(), "Buyer")
+        result = await customers_service.search_customers_by_query(_request(), "ACME")
 
-    assert result.data[0].id == profile_id
+    assert result.data[0].id == mixed_profile_id
+    assert result.data[0].name == "Rebel Rebel"
+    assert result.data[0].fiscal_business_name == "ACME SAS"
+    assert result.data[1].id == no_fiscal_profile_id
+    assert result.data[1].fiscal_business_name is None
+
     query = conn.fetch.await_args.args[0]
+    assert "SELECT DISTINCT" in query
     assert "tenant_customers tc" in query
     assert "tenant_members" not in query
+    assert "tc.tenant_id = $1" in query
     assert "tc.is_active = true" in query
+    for placeholder in ("$2", "$3", "$4"):
+        for field in (
+            "p.name",
+            "p.phone_number",
+            "p.fiscal_id",
+            "p.fiscal_business_name",
+        ):
+            assert f"{field} ILIKE {placeholder}" in query
+    assert "ORDER BY match_rank, name NULLS LAST, id" in query
+    assert query.index("ILIKE $2") < query.index("ILIKE $3") < query.index("ILIKE $4")
+    assert conn.fetch.await_args.args[1:] == (
+        tenant_id,
+        "ACME",
+        "ACME%",
+        "%ACME%",
+        20,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- expose `fiscal_business_name` in customer search summaries
- search and rank name, phone, fiscal ID, and business name matches
- preserve active tenant scoping and deduplicate profiles before limiting results

## Tests
- `.venv-ship/bin/python -m pytest --noconftest tests/test_customer_identity_model.py -q` (7 passed)
- `git diff --check`
- full customer suite could not start locally because the existing environment is missing `babel`; no build was run as requested

Closes #655