### PR TITLE
fix(cierre): evitar doble conteo de propinas en efectivo

### DIFF
--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -1230,19 +1230,15 @@ async def _resolve_suggested_opening_cash(
 def _compute_cash_expected(
     opening_cash: float,
     total_cash: float,
-    cash_tips: float,
-    total_sales: float,
     gastos_efectivo: float,
     cash_purchases: float = 0.0,
 ) -> float:
-    """Expected drawer cash: opening float + cash received − cash expenses.
+    """Expected drawer cash: opening float + settled cash − cash outflows.
 
-    When total_cash already includes tip settlement (all-cash), do not add
-    cash_tips again. Otherwise cash_tips is additive (split-pay / card tips).
+    ``total_cash`` comes from ``method_totals`` and already includes tip
+    settlement assigned to cash, so tips must not be added a second time.
     """
-    if total_cash >= total_sales + cash_tips:
-        return opening_cash + total_cash - gastos_efectivo - cash_purchases
-    return opening_cash + total_cash + cash_tips - gastos_efectivo - cash_purchases
+    return opening_cash + total_cash - gastos_efectivo - cash_purchases
 
 
 def _sum_advance_bucket(bucket: Dict[str, float]) -> float:
@@ -1656,8 +1652,6 @@ async def _compute_preview(
     cash_expected = _compute_cash_expected(
         float(opening_cash),
         total_cash,
-        cash_tips,
-        float(sales_row["total_sales"]),
         gastos_efectivo,
         cash_purchases,
     )

--- a/tests/test_cierre_preview_cash.py
+++ b/tests/test_cierre_preview_cash.py
@@ -11,46 +11,38 @@ def test_cash_expected_all_cash_tips_embedded_in_total_cash():
     result = _compute_cash_expected(
         opening_cash=200_000.0,
         total_cash=459_000.0,
-        cash_tips=99_000.0,
-        total_sales=360_000.0,
         gastos_efectivo=0.0,
     )
     assert result == 659_000.0
 
 
-def test_cash_expected_split_pay_cash_sales_only():
-    """Regression: cash portion excludes tips settled on card — keep additive branch."""
+def test_cash_expected_marimba_mixed_payments_does_not_duplicate_cash_tips():
+    """Marimba: totalCash 640.9k already contains the 41.9k cash tip settlement."""
+    result = _compute_cash_expected(
+        opening_cash=10_000.0,
+        total_cash=640_900.0,
+        gastos_efectivo=0.0,
+    )
+    assert result == 650_900.0
+
+
+def test_cash_expected_mixed_pay_cash_portion_without_cash_tips():
     result = _compute_cash_expected(
         opening_cash=50_000.0,
         total_cash=100_000.0,
-        cash_tips=0.0,
-        total_sales=360_000.0,
         gastos_efectivo=10_000.0,
     )
     assert result == 140_000.0
 
 
-def test_cash_expected_exact_equality_uses_embedded_branch():
-    result = _compute_cash_expected(
-        opening_cash=0.0,
-        total_cash=459_000.0,
-        cash_tips=99_000.0,
-        total_sales=360_000.0,
-        gastos_efectivo=5_000.0,
-    )
-    assert result == 454_000.0
-
-
-def test_cash_expected_additive_when_cash_tips_not_embedded():
-    """When total_cash is sales-only, cash_tips must be added."""
+def test_cash_expected_subtracts_expenses_and_cash_purchases_once():
     result = _compute_cash_expected(
         opening_cash=100_000.0,
         total_cash=200_000.0,
-        cash_tips=30_000.0,
-        total_sales=360_000.0,
-        gastos_efectivo=0.0,
+        gastos_efectivo=10_000.0,
+        cash_purchases=20_000.0,
     )
-    assert result == 330_000.0
+    assert result == 270_000.0
 
 
 def test_table_advance_partial_close_moves_amount_to_advance_tender():


### PR DESCRIPTION
## Summary

- trata `totalCash` como efectivo ya liquidado, incluidas las propinas
- elimina la heurística que duplicaba `cashTips` en días con pagos mixtos
- agrega la regresión exacta de Marimba y conserva la resta de egresos

## Tests

- `venv/bin/python -m pytest tests/test_cierre_preview_cash.py -q` — 7 passed
- `venv/bin/python -m pytest tests/test_cierre_shift_filters.py tests/test_cierre_open_shift.py -q` — 24 passed

Closes #660