### PR TITLE
feat(invoices): invoice email delivery history and open tracking (#657)

### DIFF
--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -502,6 +502,7 @@ async def session_validation_middleware(request: Request, call_next):
             '/supplier-portal',
             '/public/restaurant',
             '/public/table-qr',
+            '/public/email-tracking',
             '/payments/webhooks',
             '/billing/webhook',
         ]

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, pos_products, categories, recipe_bases, modifiers, ingredient_purchase_units, warehouse_categories, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, ai_agents, customer_portal, leads, waros, billing, legal, onboarding, payments_webhook, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router
+from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, pos_products, categories, recipe_bases, modifiers, ingredient_purchase_units, warehouse_categories, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, ai_agents, customer_portal, leads, waros, billing, legal, onboarding, payments_webhook, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router, email_tracking
 from app.config import settings
 from app.core.logging import setup_logging
 from app.core.exceptions import api_exception_handler, general_exception_handler, APIError
@@ -203,6 +203,7 @@ app.include_router(v1_ordering.customer_router_v1)  # V1 customer validate — A
 app.include_router(v1_ordering.product_router_v1)   # V1 product detail + modifiers — API key auth
 app.include_router(public_restaurant.router, prefix="/public/restaurant", tags=["public-restaurant"])
 app.include_router(public_table_qr.router, prefix="/public/table-qr", tags=["public-table-qr"])
+app.include_router(email_tracking.router, prefix="/public/email-tracking", tags=["public-email-tracking"])
 app.include_router(table_qr_requests.router, prefix="/table-qr-requests", tags=["table-qr-requests"])
 app.include_router(tenant_config.router, prefix="/api/tenant", tags=["tenant-config"])
 app.include_router(promotions.router)  # /api/promotions — tenant promotion CRUD (#980)

--- a/app/routers/email_tracking.py
+++ b/app/routers/email_tracking.py
@@ -1,0 +1,27 @@
+"""Public email tracking pixel endpoint (api-warolabs#657).
+
+No authentication — the URL is embedded in invoice emails as a 1x1 GIF.
+Response is byte-identical for valid and invalid tokens: unknown tokens are a
+silent no-op so the endpoint never leaks token validity.
+"""
+from fastapi import APIRouter, Response
+
+from app.services import invoice_email_tracking_service
+
+router = APIRouter()
+
+
+@router.get("/{token}.gif")
+async def email_tracking_pixel(token: str) -> Response:
+    """Record an open signal and return the 1x1 tracking GIF.
+
+    The raw token is never persisted — only its SHA-256 hash is looked up.
+    No IP or user-agent is stored. The same 200 + GIF + no-store headers are
+    returned whether the token exists or not.
+    """
+    token_hash = invoice_email_tracking_service.hash_tracking_token(token)
+    await invoice_email_tracking_service.record_pixel_open(token_hash)
+    return Response(
+        content=invoice_email_tracking_service.PIXEL_GIF_BYTES,
+        headers=dict(invoice_email_tracking_service.PIXEL_HEADERS),
+    )

--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, EmailStr, Field
 from app.core.dependencies import require_invoicing_ready
 from app.core.middleware import require_valid_session
 from app.core.permissions import Module, require_module
-from app.services import orders_service, facturacion_service
+from app.services import orders_service, facturacion_service, invoice_email_tracking_service
 
 router = APIRouter(prefix="/orders", tags=["Orders"])
 
@@ -546,3 +546,26 @@ async def send_order_invoice_email(
 ):
     """Send the fiscal receipt email for this order's accepted invoice."""
     return await orders_service.send_invoice_email(request, order_id, body.email)
+
+
+@router.get(
+    "/{order_id}/invoice/email-history",
+    tags=["Invoices"],
+    dependencies=[Depends(require_module(Module.VENTAS))],
+)
+async def get_order_invoice_email_history(
+    request: Request,
+    order_id: UUID,
+):
+    """Delivery history of invoice emails for this order (api-warolabs#657).
+
+    Newest first. `sent` means SES accepted the request — not proof of
+    delivery or human read. `open_count` is only an open-detection signal
+    from the tracking pixel.
+    """
+    session_context = require_valid_session(request)
+    deliveries = await invoice_email_tracking_service.list_deliveries_for_order(
+        tenant_id=session_context.tenant_id,
+        order_id=order_id,
+    )
+    return {"deliveries": deliveries}

--- a/app/services/aws_ses_service.py
+++ b/app/services/aws_ses_service.py
@@ -188,10 +188,14 @@ class AWSSESService:
         to_emails: List[str] = None,
         subject: str = "",
         text_body: Optional[str] = None,
+        html_body: Optional[str] = None,
         attachments: Optional[List[dict]] = None,
     ) -> bool:
         """
         Send email with multiple attachments using AWS SES raw email.
+
+        Body is wrapped as multipart/alternative (text + html) inside the
+        multipart/mixed envelope, so clients pick the best renderable part.
 
         attachments: list of { data: bytes, filename: str, content_type: str }
         """
@@ -210,7 +214,13 @@ class AWSSESService:
             msg['To'] = ', '.join(to_emails)
             msg['Subject'] = subject
 
-            if text_body:
+            if html_body:
+                alternative = MIMEMultipart('alternative')
+                if text_body:
+                    alternative.attach(MIMEText(text_body, 'plain', 'utf-8'))
+                alternative.attach(MIMEText(html_body, 'html', 'utf-8'))
+                msg.attach(alternative)
+            elif text_body:
                 msg.attach(MIMEText(text_body, 'plain', 'utf-8'))
 
             for att in (attachments or []):

--- a/app/services/email_helpers.py
+++ b/app/services/email_helpers.py
@@ -477,6 +477,34 @@ async def send_order_accepted_email(
         return False
 
 
+def _build_receipt_html_with_pixel(
+    text_body: str,
+    tracking_pixel_url: Optional[str],
+) -> Optional[str]:
+    """Wrap the plain-text receipt in a minimal HTML body with a 1x1 pixel.
+
+    Returns None when no pixel is requested, so existing flows (POS receipts
+    without tracking) keep sending text-only emails untouched.
+
+    The HTML is a faithful <pre> render of the text body — no extra content,
+    no claims of "read", just the open-detection signal (api-warolabs#657).
+    """
+    if not tracking_pixel_url:
+        return None
+    from html import escape
+
+    escaped_text = escape(text_body or "")
+    escaped_pixel = escape(tracking_pixel_url, quote=True)
+    return (
+        '<!DOCTYPE html><html><body style="margin:0;padding:0;">'
+        f'<pre style="font-family:monospace;font-size:13px;white-space:pre-wrap;'
+        f'word-wrap:break-word;margin:0;padding:16px;">{escaped_text}</pre>'
+        f'<img src="{escaped_pixel}" width="1" height="1" alt="" '
+        'style="display:block;width:1px;height:1px;border:0;" />'
+        "</body></html>"
+    )
+
+
 async def send_pos_receipt_email(
     customer_email: str,
     order_number: int,
@@ -507,6 +535,7 @@ async def send_pos_receipt_email(
     currency_code: Optional[str] = None,
     timezone: Optional[str] = None,
     return_details: bool = False,
+    tracking_pixel_url: Optional[str] = None,
 ) -> Any:
     """
     Send a POS receipt email to the customer after a point-of-sale order completes.
@@ -659,6 +688,10 @@ async def send_pos_receipt_email(
             locale=locale_settings.locale,
         )
 
+        # api-warolabs#657: when a tracking pixel is provided, wrap the text
+        # receipt in a minimal HTML body (text stays as multipart alternative).
+        html_body = _build_receipt_html_with_pixel(text_body, tracking_pixel_url)
+
         if attachments:
             success = await ses_service.send_email_with_attachments(
                 from_email=await resolve_sender_email_for_tenant(tenant_id),
@@ -666,6 +699,7 @@ async def send_pos_receipt_email(
                 to_emails=[customer_email],
                 subject=subject,
                 text_body=text_body,
+                html_body=html_body,
                 attachments=attachments,
             )
         else:
@@ -674,7 +708,7 @@ async def send_pos_receipt_email(
                 from_name=business_name or "WARO Colombia",
                 to_emails=[customer_email],
                 subject=subject,
-                html_body=None,
+                html_body=html_body,
                 text_body=text_body,
             )
 

--- a/app/services/invoice_email_tracking_service.py
+++ b/app/services/invoice_email_tracking_service.py
@@ -1,0 +1,166 @@
+"""
+Invoice email delivery tracking (api-warolabs#657).
+
+One row per send attempt. The pixel token is opaque (32 bytes urlsafe); only
+its SHA-256 hex digest is persisted. No IP, no user-agent, no raw token.
+
+Status semantics:
+  pending — row created before SES call, not yet finalized
+  sent    — SES accepted the request (NOT proof of delivery or human read)
+  failed  — SES rejected the request
+"""
+import hashlib
+import logging
+import secrets
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from app.config import settings
+from app.database import get_db_connection
+
+logger = logging.getLogger(__name__)
+
+# 1x1 transparent GIF (43 bytes). Served identically for valid/invalid tokens.
+PIXEL_GIF_BYTES = (
+    b"GIF89a\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00"
+    b"!\xf9\x04\x01\x00\x00\x00\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00"
+    b"\x02\x02D\x01\x00;"
+)
+
+PIXEL_HEADERS = {
+    "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+    "Pragma": "no-cache",
+    "Expires": "0",
+    "Content-Type": "image/gif",
+}
+
+
+def generate_tracking_token() -> str:
+    """Return a new opaque urlsafe token. Caller stores only the SHA-256."""
+    return secrets.token_urlsafe(32)
+
+
+def hash_tracking_token(token: str) -> str:
+    """SHA-256 hex digest of the raw token. This is the only persisted form."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def build_pixel_url(token: str) -> str:
+    """Public pixel URL embedded in the HTML body. Contains the RAW token."""
+    base = settings.base_url.rstrip("/")
+    return f"{base}/public/email-tracking/{token}.gif"
+
+
+async def create_pending_delivery(
+    *,
+    tenant_id: UUID,
+    order_id: UUID,
+    recipient_email: str,
+    tracking_token_hash: str,
+) -> Optional[UUID]:
+    """Insert a pending delivery row. Returns the delivery id.
+
+    Fail-open: returns None when the table/DB is unavailable so the email
+    flow keeps working exactly as before tracking existed (api-warolabs#657).
+    """
+    try:
+        async with get_db_connection(use_transaction=False) as conn:
+            row = await conn.fetchrow(
+                """
+                INSERT INTO invoice_email_deliveries
+                    (tenant_id, order_id, recipient_email, status, tracking_token_hash)
+                VALUES ($1, $2, $3, 'pending', $4)
+                RETURNING id
+                """,
+                tenant_id,
+                order_id,
+                recipient_email,
+                tracking_token_hash,
+            )
+    except Exception as e:
+        logger.error(f"invoice_email_deliveries: create_pending_delivery failed: {e}")
+        return None
+    return row["id"]
+
+
+async def mark_delivery_sent(delivery_id: UUID) -> None:
+    """Finalize as sent. Failure here must NOT trigger a resend; log + keep pending."""
+    try:
+        async with get_db_connection(use_transaction=False) as conn:
+            await conn.execute(
+                """
+                UPDATE invoice_email_deliveries
+                SET status = 'sent', sent_at = now(), updated_at = now()
+                WHERE id = $1
+                """,
+                delivery_id,
+            )
+    except Exception as e:
+        logger.error(
+            f"invoice_email_deliveries: SES accepted but mark_sent failed for {delivery_id}: {e}"
+        )
+
+
+async def mark_delivery_failed(delivery_id: UUID, failure_code: Optional[str] = None) -> None:
+    """Finalize as failed. failure_code is a short internal label, never user input."""
+    try:
+        async with get_db_connection(use_transaction=False) as conn:
+            await conn.execute(
+                """
+                UPDATE invoice_email_deliveries
+                SET status = 'failed', failed_at = now(), failure_code = $2, updated_at = now()
+                WHERE id = $1
+                """,
+                delivery_id,
+                (failure_code or "")[:120] or None,
+            )
+    except Exception as e:
+        logger.error(
+            f"invoice_email_deliveries: mark_failed failed for {delivery_id}: {e}"
+        )
+
+
+async def record_pixel_open(tracking_token_hash: str) -> None:
+    """Atomically bump open_count and set first/last opened timestamps.
+
+    Called by the public pixel endpoint. Unknown hashes are a silent no-op —
+    the endpoint returns the identical pixel regardless.
+    """
+    try:
+        async with get_db_connection(use_transaction=False) as conn:
+            await conn.execute(
+                """
+                UPDATE invoice_email_deliveries
+                SET open_count = open_count + 1,
+                    first_opened_at = COALESCE(first_opened_at, now()),
+                    last_opened_at = now(),
+                    updated_at = now()
+                WHERE tracking_token_hash = $1
+                """,
+                tracking_token_hash,
+            )
+    except Exception as e:
+        logger.error(f"invoice_email_deliveries: record_pixel_open failed: {e}")
+
+
+async def list_deliveries_for_order(
+    *,
+    tenant_id: UUID,
+    order_id: UUID,
+) -> List[Dict[str, Any]]:
+    """Tenant-scoped history for one order, newest first. Never cross-tenant."""
+    async with get_db_connection(use_transaction=False) as conn:
+        rows = await conn.fetch(
+            """
+            SELECT id, recipient_email, status,
+                   sent_at, failed_at, first_opened_at, last_opened_at,
+                   open_count, failure_code, created_at
+            FROM invoice_email_deliveries
+            WHERE tenant_id = $1 AND order_id = $2
+            ORDER BY created_at DESC
+            LIMIT 50
+            """,
+            tenant_id,
+            order_id,
+        )
+    return [dict(r) for r in rows]

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -31,6 +31,7 @@ from app.services.account_role_service import (
     resolve_account,
 )
 from app.services.email_helpers import send_pos_receipt_email
+from app.services import invoice_email_tracking_service
 from app.services.email_sender import resolve_sender_email_for_tenant
 from app.services.invoicing_presentation import (
     build_invoice_presentation,
@@ -4370,6 +4371,23 @@ async def send_invoice_email(
         or (_row_get(profile_row, "phone_number") if profile_row else None)
     )
 
+    # api-warolabs#657: persist the attempt before SES. Raw token goes only
+    # into the pixel URL; the DB stores its SHA-256 hash. Fail-open: when
+    # tracking persistence is unavailable, send exactly as before #657.
+    tracking_token = invoice_email_tracking_service.generate_tracking_token()
+    tracking_token_hash = invoice_email_tracking_service.hash_tracking_token(tracking_token)
+    delivery_id = await invoice_email_tracking_service.create_pending_delivery(
+        tenant_id=tenant_id,
+        order_id=order_id,
+        recipient_email=recipient_email,
+        tracking_token_hash=tracking_token_hash,
+    )
+    pixel_url = (
+        invoice_email_tracking_service.build_pixel_url(tracking_token)
+        if delivery_id is not None
+        else None
+    )
+
     send_result = await send_pos_receipt_email(
         customer_email=recipient_email,
         order_number=int(order_row['order_number']),
@@ -4395,6 +4413,7 @@ async def send_invoice_email(
         invoice_cufe=invoice_row['cufe'],
         invoice_presentation=invoice_presentation,
         return_details=True,
+        tracking_pixel_url=pixel_url,
     )
     if isinstance(send_result, dict):
         success = bool(send_result.get("success"))
@@ -4406,10 +4425,17 @@ async def send_invoice_email(
         attachment_warnings = []
 
     if not success:
+        if delivery_id is not None:
+            await invoice_email_tracking_service.mark_delivery_failed(
+                delivery_id, failure_code="ses_rejected"
+            )
         raise HTTPException(
             status_code=502,
             detail="No se pudo enviar el correo. Intentá nuevamente en unos segundos.",
         )
+
+    if delivery_id is not None:
+        await invoice_email_tracking_service.mark_delivery_sent(delivery_id)
 
     return {
         'success': True,

--- a/migrations/115_invoice_email_deliveries.sql
+++ b/migrations/115_invoice_email_deliveries.sql
@@ -1,0 +1,49 @@
+-- api-warolabs#657: invoice email delivery history + open-tracking signal.
+--
+-- One row per send attempt of an invoice email. `tracking_token_hash` is the
+-- SHA-256 of an opaque token embedded as a 1x1 pixel URL in the HTML body.
+-- The raw token is never persisted. No IP, no user-agent.
+--
+-- `status` semantics:
+--   pending — row created before SES call, not yet finalized
+--   sent    — SES accepted the request (NOT proof of delivery or human read)
+--   failed  — SES rejected the request
+--
+-- Idempotent: safe to re-run.
+
+CREATE TABLE IF NOT EXISTS invoice_email_deliveries (
+    id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id             uuid NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    order_id              uuid NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+    recipient_email       varchar(320) NOT NULL,
+    status                varchar(16) NOT NULL DEFAULT 'pending',
+    tracking_token_hash   varchar(64) NOT NULL,
+    sent_at               timestamptz,
+    failed_at             timestamptz,
+    first_opened_at       timestamptz,
+    last_opened_at        timestamptz,
+    open_count            integer NOT NULL DEFAULT 0,
+    failure_code          varchar(120),
+    created_at            timestamptz NOT NULL DEFAULT now(),
+    updated_at            timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE invoice_email_deliveries
+    DROP CONSTRAINT IF EXISTS invoice_email_deliveries_status_check;
+ALTER TABLE invoice_email_deliveries
+    ADD CONSTRAINT invoice_email_deliveries_status_check
+    CHECK (status IN ('pending', 'sent', 'failed'));
+
+ALTER TABLE invoice_email_deliveries
+    DROP CONSTRAINT IF EXISTS invoice_email_deliveries_open_count_check;
+ALTER TABLE invoice_email_deliveries
+    ADD CONSTRAINT invoice_email_deliveries_open_count_check
+    CHECK (open_count >= 0);
+
+-- Token hash is the lookup key for the public pixel endpoint.
+CREATE UNIQUE INDEX IF NOT EXISTS invoice_email_deliveries_token_hash_key
+    ON invoice_email_deliveries (tracking_token_hash);
+
+-- Tenant-scoped history per order, newest first.
+CREATE INDEX IF NOT EXISTS invoice_email_deliveries_tenant_order_created_idx
+    ON invoice_email_deliveries (tenant_id, order_id, created_at DESC);

--- a/tests/test_invoice_email_history.py
+++ b/tests/test_invoice_email_history.py
@@ -1,0 +1,292 @@
+"""
+Tests for invoice email delivery history + tracking pixel (api-warolabs#657).
+
+Covers:
+  - Token hashing: only SHA-256 hex is persisted, never the raw token.
+  - Lifecycle: pending insert → sent/failed finalization.
+  - record_pixel_open: hash-only lookup, silent on DB errors (never breaks SES flow).
+  - list_deliveries_for_order: always filtered by tenant_id + order_id.
+  - Pixel endpoint: identical 200 + 1x1 GIF + no-store for valid/invalid tokens.
+  - email-history endpoint: tenant_id comes from the session, not the caller.
+  - MIME: multipart/alternative (text+html) with attachments; plain text without html_body.
+
+Patches:
+  - app.services.invoice_email_tracking_service.get_db_connection → fake conn
+  - app.routers.orders.require_valid_session → fake session w/ tenant_id
+"""
+from email.parser import Parser
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.routers import orders as orders_router
+from app.services import invoice_email_tracking_service as svc
+from app.services.aws_ses_service import AWSSESService
+from app.services.email_helpers import _build_receipt_html_with_pixel
+
+
+_TENANT_ID = uuid4()
+_ORDER_ID = uuid4()
+_DELIVERY_ID = uuid4()
+
+
+class _Ctx:
+    """Minimal async context manager wrapping a fake connection."""
+
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *_):
+        return False
+
+
+def _patch_db(conn):
+    return patch.object(svc, "get_db_connection", lambda *a, **k: _Ctx(conn))
+
+
+# ── Token hashing ─────────────────────────────────────────────────────────────
+
+
+def test_hash_tracking_token_is_sha256_hex_not_raw():
+    token = svc.generate_tracking_token()
+    digest = svc.hash_tracking_token(token)
+    assert digest != token
+    assert len(digest) == 64
+    assert all(c in "0123456789abcdef" for c in digest)
+    assert svc.hash_tracking_token(token) == digest
+
+
+# ── Persistence lifecycle ─────────────────────────────────────────────────────
+
+
+async def test_create_pending_delivery_inserts_pending_row():
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={"id": _DELIVERY_ID})
+
+    with _patch_db(conn):
+        result = await svc.create_pending_delivery(
+            tenant_id=_TENANT_ID,
+            order_id=_ORDER_ID,
+            recipient_email="cliente@example.com",
+            tracking_token_hash="ab" * 32,
+        )
+
+    assert result == _DELIVERY_ID
+    sql, *params = conn.fetchrow.call_args.args
+    assert "INSERT INTO invoice_email_deliveries" in sql
+    assert "'pending'" in sql
+    assert params == [_TENANT_ID, _ORDER_ID, "cliente@example.com", "ab" * 32]
+
+
+async def test_mark_delivery_sent_sets_sent_status():
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+
+    with _patch_db(conn):
+        await svc.mark_delivery_sent(_DELIVERY_ID)
+
+    sql, delivery_id = conn.execute.call_args.args
+    assert "status = 'sent'" in sql
+    assert delivery_id == _DELIVERY_ID
+
+
+async def test_mark_delivery_failed_truncates_failure_code():
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+
+    with _patch_db(conn):
+        await svc.mark_delivery_failed(_DELIVERY_ID, failure_code="x" * 200)
+
+    sql, delivery_id, code = conn.execute.call_args.args
+    assert "status = 'failed'" in sql
+    assert delivery_id == _DELIVERY_ID
+    assert len(code) == 120
+
+
+async def test_mark_delivery_failed_empty_code_becomes_none():
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+
+    with _patch_db(conn):
+        await svc.mark_delivery_failed(_DELIVERY_ID, failure_code=None)
+
+    assert conn.execute.call_args.args[2] is None
+
+
+async def test_mark_delivery_sent_swallows_db_errors():
+    """SES already accepted — a DB failure must not propagate (no resend, no 502)."""
+    conn = MagicMock()
+    conn.execute = AsyncMock(side_effect=RuntimeError("db down"))
+
+    with _patch_db(conn):
+        await svc.mark_delivery_sent(_DELIVERY_ID)  # must not raise
+
+
+# ── Pixel open recording ──────────────────────────────────────────────────────
+
+
+async def test_record_pixel_open_updates_by_hash_only():
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+
+    with _patch_db(conn):
+        await svc.record_pixel_open("cd" * 32)
+
+    sql, token_hash = conn.execute.call_args.args
+    assert "WHERE tracking_token_hash = $1" in sql
+    assert "open_count = open_count + 1" in sql
+    assert token_hash == "cd" * 32
+
+
+async def test_record_pixel_open_is_silent_on_db_error():
+    conn = MagicMock()
+    conn.execute = AsyncMock(side_effect=RuntimeError("db down"))
+
+    with _patch_db(conn):
+        await svc.record_pixel_open("cd" * 32)  # must not raise
+
+
+# ── Tenant isolation ──────────────────────────────────────────────────────────
+
+
+async def test_list_deliveries_for_order_filters_tenant_and_order():
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[])
+
+    with _patch_db(conn):
+        result = await svc.list_deliveries_for_order(
+            tenant_id=_TENANT_ID, order_id=_ORDER_ID
+        )
+
+    assert result == []
+    sql, tenant_id, order_id = conn.fetch.call_args.args
+    assert "tenant_id = $1" in sql
+    assert "order_id = $2" in sql
+    assert tenant_id == _TENANT_ID
+    assert order_id == _ORDER_ID
+
+
+async def test_email_history_endpoint_uses_session_tenant():
+    fake_session = MagicMock()
+    fake_session.tenant_id = _TENANT_ID
+    expected = [{"id": str(_DELIVERY_ID), "status": "sent"}]
+
+    with patch.object(
+        orders_router, "require_valid_session", return_value=fake_session
+    ), patch.object(
+        svc, "list_deliveries_for_order", new=AsyncMock(return_value=expected)
+    ) as list_mock:
+        result = await orders_router.get_order_invoice_email_history(
+            request=MagicMock(), order_id=_ORDER_ID
+        )
+
+    assert result == {"deliveries": expected}
+    assert list_mock.call_args.kwargs["tenant_id"] == _TENANT_ID
+    assert list_mock.call_args.kwargs["order_id"] == _ORDER_ID
+
+
+# ── Pixel endpoint parity (valid vs invalid token) ────────────────────────────
+
+
+async def test_pixel_endpoint_identical_response_for_unknown_token(client):
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+
+    known_token = svc.generate_tracking_token()
+    unknown_token = svc.generate_tracking_token()
+
+    with _patch_db(conn):
+        resp_known = await client.get(f"/public/email-tracking/{known_token}.gif")
+        resp_unknown = await client.get(f"/public/email-tracking/{unknown_token}.gif")
+
+    assert resp_known.status_code == 200
+    assert resp_unknown.status_code == 200
+    assert resp_known.content == svc.PIXEL_GIF_BYTES
+    assert resp_unknown.content == svc.PIXEL_GIF_BYTES
+    for resp in (resp_known, resp_unknown):
+        assert resp.headers["content-type"] == "image/gif"
+        assert "no-store" in resp.headers["cache-control"]
+
+    # The DB lookup always receives the SHA-256 hash, never the raw token.
+    for call in conn.execute.call_args_list:
+        token_hash = call.args[1]
+        assert token_hash not in (known_token, unknown_token)
+        assert len(token_hash) == 64
+
+
+# ── HTML body + pixel ─────────────────────────────────────────────────────────
+
+
+def test_receipt_html_is_none_without_pixel():
+    assert _build_receipt_html_with_pixel("Hola", None) is None
+
+
+def test_receipt_html_embeds_pixel_and_escapes_text():
+    html = _build_receipt_html_with_pixel(
+        "Total <b>$10</b>", "https://api.example.com/public/email-tracking/tok.gif"
+    )
+    assert 'src="https://api.example.com/public/email-tracking/tok.gif"' in html
+    assert "Total &lt;b&gt;$10&lt;/b&gt;" in html
+    assert "<b>$10</b>" not in html
+
+
+# ── MIME structure ────────────────────────────────────────────────────────────
+
+
+def _ses_service_with_mock_client():
+    service = AWSSESService.__new__(AWSSESService)
+    service.client = MagicMock()
+    service.client.send_raw_email = MagicMock(return_value={"MessageId": "msg-1"})
+    return service
+
+
+def _sent_mime(service) -> dict:
+    raw = service.client.send_raw_email.call_args.kwargs["RawMessage"]["Data"]
+    return Parser().parsestr(raw)
+
+
+async def test_send_email_with_attachments_wraps_html_in_alternative():
+    service = _ses_service_with_mock_client()
+
+    ok = await service.send_email_with_attachments(
+        from_email="facturas@warocol.com",
+        to_emails=["cliente@example.com"],
+        subject="Factura",
+        text_body="texto plano",
+        html_body="<html><body><p>html</p><img src=\"pixel.gif\"/></body></html>",
+        attachments=[{"data": b"%PDF-1.4", "filename": "factura.pdf", "content_type": "application/pdf"}],
+    )
+
+    assert ok is True
+    msg = _sent_mime(service)
+    assert msg.get_content_type() == "multipart/mixed"
+    types = [part.get_content_type() for part in msg.get_payload()]
+    assert "multipart/alternative" in types
+    attachment = next(p for p in msg.get_payload() if p.get_filename() == "factura.pdf")
+    assert "application/pdf" in attachment.get_all("Content-Type")
+    alternative = next(p for p in msg.get_payload() if p.get_content_type() == "multipart/alternative")
+    alt_types = [p.get_content_type() for p in alternative.get_payload()]
+    assert alt_types == ["text/plain", "text/html"]
+
+
+async def test_send_email_with_attachments_text_only_without_html():
+    service = _ses_service_with_mock_client()
+
+    ok = await service.send_email_with_attachments(
+        from_email="facturas@warocol.com",
+        to_emails=["cliente@example.com"],
+        subject="Factura",
+        text_body="texto plano",
+        attachments=[{"data": b"%PDF-1.4", "filename": "factura.pdf", "content_type": "application/pdf"}],
+    )
+
+    assert ok is True
+    msg = _sent_mime(service)
+    types = [part.get_content_type() for part in msg.get_payload()]
+    assert "multipart/alternative" not in types
+    assert "text/plain" in types
+    assert any(p.get_filename() == "factura.pdf" for p in msg.get_payload())


### PR DESCRIPTION
## Summary

Implements uno0uno/api-warolabs#657: persist invoice email send attempts and expose a tenant-scoped history with a technical open signal.

- One row per send attempt in `invoice_email_deliveries` (migration 115, already applied to prod DB via tunnel)
- Public 1x1 pixel endpoint `/public/email-tracking/{token}.gif`; only the SHA-256 hash is persisted — no raw token, no IP, no user-agent; identical response for valid/invalid tokens
- Receipt email now sends multipart text+html (pixel in HTML part); text-only flow unchanged when no pixel is provided
- `GET /orders/{order_id}/invoice/email-history` — authenticated, tenant-scoped, newest first
- **Fail-open**: if tracking persistence fails (e.g. table missing), emails send exactly as before #657

## Verification

- `pytest tests/test_invoice_email_history.py tests/test_invoice_send_email.py tests/test_pos_receipt_template.py` — 33 passed
- Migration 115 verified applied in prod (table + 14 columns present)

## Deploy note

No deploy performed. When the API is next deployed, tracking activates automatically; the prod table already exists.