### PR TITLE
feat(queryspec): include unassigned orders as 'Sin identificar' in customers dataset

### DIFF
--- a/app/services/queries_service.py
+++ b/app/services/queries_service.py
@@ -95,7 +95,7 @@ DATASETS: dict[str, DatasetSpec] = {
     "customers": DatasetSpec(
         name="customers",
         label="Customers",
-        description="Identified customer purchase and frequency rows.",
+        description="Customer purchase and frequency rows, including unassigned orders as Sin identificar.",
         required_scope="customers:read",
         dimensions={
             "customer": QueryField("COALESCE(p.name, 'Sin identificar')", "string", "Customer", groupable=True),
@@ -110,7 +110,7 @@ DATASETS: dict[str, DatasetSpec] = {
         },
         filters={
             "date_range": {"type": "date_range", "field": "o.order_date"},
-            "customer": {"type": "string", "field": "p.name"},
+            "customer": {"type": "string", "field": "COALESCE(p.name, 'Sin identificar')"},
         },
         sortable={"customer", "order_count", "total_spent", "avg_ticket", "last_order_date", "waros_balance"},
         from_sql="""
@@ -122,7 +122,6 @@ DATASETS: dict[str, DatasetSpec] = {
             "o.tenant_id = $1",
             POS_LIKE_FILTER_ALIAS_O,
             "o.status = 'completed'",
-            "o.customer_id IS NOT NULL",
         ),
     ),
     "product_profitability": DatasetSpec(

--- a/tests/test_queries_service.py
+++ b/tests/test_queries_service.py
@@ -162,6 +162,25 @@ def test_compile_product_profitability_accepts_cost_source_dimension():
     assert "pc.cost_used_for_classification" in compiled["sql"]
 
 
+def test_compile_customers_queryspec_keeps_unidentified_customer_group():
+    compiled = queries_service.compile_queryspec(
+        {
+            "dataset": "customers",
+            "measures": ["order_count", "total_spent"],
+            "dimensions": ["customer"],
+            "filters": {"customer": "Sin identificar"},
+            "order_by": [{"field": "order_count", "direction": "desc"}],
+            "limit": 20,
+        }
+    )
+
+    sql = compiled["sql"]
+    assert "COALESCE(p.name, 'Sin identificar') AS customer" in sql
+    assert "o.customer_id IS NOT NULL" not in sql
+    assert "COALESCE(p.name, 'Sin identificar') = $2" in sql
+    assert compiled["params"] == ["Sin identificar", 20]
+
+
 def test_compile_inventory_stock_queryspec_uses_tenant_scope_and_latest_costs():
     compiled = queries_service.compile_queryspec(
         {


### PR DESCRIPTION
## Qué cambia

El dataset `customers` excluía los pedidos sin cliente identificado (`o.customer_id IS NOT NULL`), así que las ventas anónimas de POS desaparecían de los reportes de clientes.

- Se elimina ese filtro: los pedidos sin cliente ahora cuentan en el reporte
- Se agrupan bajo la etiqueta **'Sin identificar'** (vía `COALESCE(p.name, 'Sin identificar')`)
- El filtro `customer` acepta 'Sin identificar' para analizar cuánto del negocio es anónimo
- Test: `test_compile_customers_queryspec_keeps_unidentified_customer_group`

Misma idea que warocol.com#1692 (mesero 'No asignado' en detalle de venta), pero del lado de reportes.

## Validación

- `pytest tests/test_queries_service.py` → 16 passed

## Origen

Cambio rescatado de un stash local ('preserve-customer-queryspec-before-pr509-merge', jun 22) que nunca llegó a PR.