### PR TITLE
feat(auth): expose registration_required action on sign-in magic link

### DIFF
--- a/.wr/1695.yaml
+++ b/.wr/1695.yaml
@@ -1,0 +1,40 @@
+issue: 1695
+title: "Login magic link: redirigir a registro cuando el correo no está registrado"
+repo: both
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA
+stack: both
+branch: wr-1695-login-registration-redirect
+
+paths:
+  - api_warocol.com/app/models/auth.py
+  - api_warocol.com/app/services/magic_link_service.py
+  - api_warocol.com/tests/test_magic_link_registration_contract.py
+  - front_nuxt/components/Auth/LoginForm.vue
+
+ac:
+  - "MagicLinkResponse incluye action ('email_sent' | 'registration_required'), default retrocompatible"
+  - "send_magic_link devuelve registration_required cuando no hay identidad interna ni draft"
+  - "Tests de contrato: correo inexistente -> registration_required; draft -> email_sent; registrado -> login normal"
+  - "Front: action=registration_required -> prefillRegistrationEmail + toast + navigateTo('/registro')"
+  - "Front: flujo normal (registrado -> revisa tu correo) sin cambios"
+
+out_of_scope:
+  - cambios al endpoint de registro existente
+  - nuevas keys i18n (se reusan auth.noAccount + auth.createAccount)
+  - QA/regresión general (validación manual del usuario)
+
+hints:
+  entry: "POST /auth/sign-in-magic-link -> send_magic_link (magic_link_service.py:245)"
+  pattern: "RegistrationMagicLinkResponse.action (models/auth.py:83) ya expone Literal action"
+  tests: "cd api_warocol.com && pytest tests/test_magic_link_registration_contract.py -q"
+
+risk:
+  sensitive: true
+  areas: [auth]
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "auto review wr-review sobre ambos PRs"

--- a/app/models/auth.py
+++ b/app/models/auth.py
@@ -76,6 +76,7 @@ class MagicLinkRequest(BaseModel):
 class MagicLinkResponse(BaseModel):
     success: bool = True
     message: str = "Magic link sent successfully"
+    action: Literal["email_sent", "registration_required"] = "email_sent"
 
 
 class RegistrationMagicLinkResponse(BaseModel):

--- a/app/services/magic_link_service.py
+++ b/app/services/magic_link_service.py
@@ -256,7 +256,7 @@ async def send_magic_link(request: Request, email: str, redirect: Optional[str] 
                 registration_draft = None
 
             if not user_result and not registration_draft:
-                return MagicLinkResponse()
+                return MagicLinkResponse(action="registration_required")
 
             if not registration_draft:
                 token = secrets.token_hex(32)

--- a/tests/test_magic_link_registration_contract.py
+++ b/tests/test_magic_link_registration_contract.py
@@ -56,7 +56,7 @@ def _payload(**overrides):
 
 
 @pytest.mark.asyncio
-async def test_unknown_login_is_generic_and_has_no_side_effects():
+async def test_unknown_login_requests_registration_and_has_no_side_effects():
     conn = AsyncMock()
     conn.fetchrow = AsyncMock(return_value=None)
 
@@ -74,6 +74,38 @@ async def test_unknown_login_is_generic_and_has_no_side_effects():
     assert result.action == "registration_required"
     conn.execute.assert_not_awaited()
     ses.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_registered_identity_login_returns_email_sent_action():
+    user_row = {
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "role": "owner",
+        "email": "dueno@example.com",
+        "name": "Dueña",
+    }
+    branding_row = {
+        "tenant_name": "WARO Colombia",
+        "tenant_email": "soporte@warolabs.com",
+        "brand_name": "WARO",
+    }
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(side_effect=[user_row, branding_row])
+
+    @asynccontextmanager
+    async def db_ctx(**_kwargs):
+        yield conn
+
+    deliver = AsyncMock()
+    with patch("app.services.magic_link_service.get_db_connection", side_effect=db_ctx), patch(
+        "app.services.magic_link_service.require_valid_tenant", return_value=_tenant()
+    ), patch("app.services.magic_link_service._deliver_magic_link", deliver):
+        result = await send_magic_link(_request(), "dueno@example.com")
+
+    assert result.success is True
+    assert result.action == "email_sent"
+    deliver.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_magic_link_registration_contract.py
+++ b/tests/test_magic_link_registration_contract.py
@@ -71,6 +71,7 @@ async def test_unknown_login_is_generic_and_has_no_side_effects():
         result = await send_magic_link(_request(), "missing@example.com")
 
     assert result.success is True
+    assert result.action == "registration_required"
     conn.execute.assert_not_awaited()
     ses.assert_not_awaited()
 
@@ -100,6 +101,7 @@ async def test_unverified_registration_login_reissues_consented_challenge():
         result = await send_magic_link(_request(), "nuevo@example.com")
 
     assert result.success is True
+    assert result.action == "email_sent"
     issue.assert_awaited_once()
     assert issue.await_args.kwargs["email"] == "nuevo@example.com"
     assert issue.await_args.kwargs["draft"] == draft


### PR DESCRIPTION
## Summary
- `MagicLinkResponse` gains `action` (`email_sent` | `registration_required`), default retrocompatible — same pattern as `RegistrationMagicLinkResponse`.
- `send_magic_link` returns `registration_required` when the email has no internal identity and no resumable registration draft (previously a silent generic 200).
- Contract tests updated: unknown email → `registration_required`; pending draft → `email_sent`.

Closes #1695

## Test plan
- [ ] Unregistered email on warocol.com login → response `action: "registration_required"` (no email sent, no DB writes).
- [ ] Registered email → unchanged `email_sent` flow.
- [ ] Email with pending registration draft → challenge reissued, `email_sent`.

## Validation evidence
```text
$ ./venv/bin/python -m pytest tests/test_magic_link_registration_contract.py tests/test_magic_link_email_normalize.py tests/test_magic_link_cross_tenant.py -q
collected 11 items
tests/test_magic_link_registration_contract.py .........  [ 81%]
tests/test_magic_link_email_normalize.py .               [ 90%]
tests/test_magic_link_cross_tenant.py .                  [100%]
11 passed in 0.14s
```

## wr-context
See `.wr/1695.yaml` on this branch (LLM contract).