### PR TITLE
fix(promotions): recalibrate mesa BOGO lock when eligible pool changes

### DIFF
--- a/.wr/665.yaml
+++ b/.wr/665.yaml
@@ -1,0 +1,44 @@
+issue: 665
+repo: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-665-bogo-lock-growing-pool
+title: fix(promotions) mesa BOGO lock trunca el ahorro cuando el pool elegible crece entre tandas
+
+paths:
+  - app/services/promotions_service.py
+  - app/services/tables_service.py
+  - tests/test_tables_tab_promo_persist.py
+  - tests/test_promo_cart_evaluation.py
+
+ac:
+  - Caso 4+2 unidades elegibles en dos tandas de tab de mesa con BOGO 1+1 aplica
+    3 unidades gratis (ahorro 66000), no trunca al lock de la primera tanda.
+  - El lock/persisted promo solo se conserva cuando la promo ya no es evaluable
+    (desactivada/vencida); si sigue activa, la asignacion cross-line fresca manda.
+  - Remove / qty-change de lineas del tab re-evalua promos via
+    persist_session_tab_promos en vez de solo ajuste aritmetico del total.
+  - Tests de regresion: BOGO cross-line con lock previo y pool creciente;
+    remove/qty-change con promo aplicada; control 2 unidades sin lock -> 1 gratis.
+
+hints:
+  root_cause_1: promotions_service.py evaluate_cart_promotions ~1437-1501 — el lock
+    (locked_promo_from_line / persisted) se aplica incondicional y trunca
+    savings a min(locked, subtotal) aunque el grupo BOGO cross-line asigne mas.
+  root_cause_2: tables_service.py remove tab item (~3628) y qty-change (~3727)
+    ajustan orders.total_amount aritmeticamente sin re-evaluar promos.
+  lock_purpose: commit 4484b6d — preservar snapshot de promo cuando la promo ya no
+    es evaluable (desactivada/vencida) al cerrar la mesa; no congelar el ahorro.
+  tests:
+    - venv/bin/pytest tests/test_tables_tab_promo_persist.py tests/test_promo_cart_evaluation.py -x -q
+  case_real: orden 16759 mesa 11 Rebel Rebel 2026-07-19 — 6 oktobert (4+2) BOGO 1+1
+    deberia dar 3 gratis (66000) pero muestra 44000; diferencia 22000.
+
+plan:
+  - En evaluate_cart_promotions: si el locked/persisted promo es bogo y existe una
+    promo activa evaluable con el mismo id, usar la promo real (evaluacion fresca
+    cross-line manda). Solo conservar el snapshot locked cuando la promo no esta
+    en el set activo.
+  - En tables_service remove tab item y qty-change: llamar
+    persist_session_tab_promos tras la mutacion (igual que el add).
+  - Tests de regresion y control.

--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -1423,6 +1423,9 @@ def evaluate_cart_promotions(
 
     pending: List[Dict[str, Any]] = []
     bogo_group_indices: Dict[tuple[str, str], List[int]] = {}
+    active_promo_ids = {
+        str(p.get("id")) for p in promotions if isinstance(p, dict) and p.get("id")
+    }
 
     for line in lines:
         line_id = str(line["id"])
@@ -1444,6 +1447,23 @@ def evaluate_cart_promotions(
             promo = None
         elif locked_promo is not None:
             promo = locked_promo
+            if (
+                locked_promo.get("promo_type") == "bogo"
+                and str(locked_promo["id"]) in active_promo_ids
+            ):
+                # The lock exists to preserve a promo snapshot when the promo is
+                # no longer evaluable (deactivated/expired). While the BOGO is
+                # still active, the fresh cross-line evaluation is authoritative
+                # so a growing (or shrinking) eligible pool recalibrates savings
+                # instead of truncating them to the stale snapshot (#665).
+                fresh_promo = _pick_best_promotion_for_line(
+                    promotions,
+                    product_id=product_id,
+                    category_id=category_id,
+                    promo_type_block_map=promo_type_block_map,
+                )
+                if fresh_promo is not None:
+                    promo = fresh_promo
         else:
             promo = _pick_best_promotion_for_line(
                 promotions,

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -3631,6 +3631,15 @@ async def remove_tab_item(
                 new_total, row["order_id"],
             )
 
+            # Re-evaluate promos for the remaining tab lines: the arithmetic
+            # adjustment above ignores promo savings, so without this the locked
+            # savings go stale when the eligible pool shrinks (#665).
+            from app.services.promotions_service import persist_session_tab_promos
+
+            await persist_session_tab_promos(
+                conn, UUID(str(tenant_id)), row["table_session_id"]
+            )
+
         return {"success": True, "data": {"removed": str(order_item_id)}}
     except (AuthenticationError, NotFoundError, APIError):
         raise
@@ -3728,6 +3737,15 @@ async def update_tab_item_quantity(
             await conn.execute(
                 "UPDATE orders SET total_amount = $1 WHERE id = $2",
                 new_total, row["order_id"],
+            )
+
+            # Re-evaluate promos after the quantity change: the arithmetic
+            # adjustment above ignores promo savings, so without this the locked
+            # savings go stale when the eligible pool grows or shrinks (#665).
+            from app.services.promotions_service import persist_session_tab_promos
+
+            await persist_session_tab_promos(
+                conn, UUID(str(tenant_id)), row["table_session_id"]
             )
 
             payload = _build_tab_item_payload(

--- a/tests/test_promo_cart_evaluation.py
+++ b/tests/test_promo_cart_evaluation.py
@@ -375,3 +375,63 @@ def test_cross_line_bogo_uses_eligible_unit_price_and_cap():
     assert by_subtotal[20000] == 10000
     assert by_subtotal[12000] == 0
     assert by_subtotal[11000] == 0
+
+
+def _locked_bogo_line(*, promo, subtotal, quantity, locked_savings, product_id):
+    return {
+        **_line(subtotal=subtotal, quantity=quantity, product_id=product_id),
+        "locked_promotion_id": str(promo["id"]),
+        "locked_promotion_name": promo["name"],
+        "locked_promo_type": "bogo",
+        "locked_promo_savings": locked_savings,
+    }
+
+
+def test_locked_bogo_recalibrates_when_pool_grows():
+    """#665: 4+2 units in two tab rounds with BOGO 1+1 must grant 3 free units,
+    not truncate to the first round's locked savings (44000)."""
+    product_id = uuid4()
+    promo = _promo(promo_type="bogo", value_json={"buy_qty": 1, "get_qty": 1})
+    lines = [
+        _locked_bogo_line(
+            promo=promo, subtotal=88000, quantity=4,
+            locked_savings=44000, product_id=product_id,
+        ),
+        _line(subtotal=44000, quantity=2, product_id=product_id),
+    ]
+    result = evaluate_cart_promotions(lines, [promo])
+    assert result["promo_savings"] == 66000
+    assert result["subtotal_after_promos"] == 66000
+
+
+def test_locked_bogo_recalibrates_when_pool_shrinks():
+    """#665: a stale lock from a larger pool must shrink back when the tab now
+    only holds 4 eligible units (2 free)."""
+    product_id = uuid4()
+    promo = _promo(promo_type="bogo", value_json={"buy_qty": 1, "get_qty": 1})
+    lines = [
+        _locked_bogo_line(
+            promo=promo, subtotal=88000, quantity=4,
+            locked_savings=66000, product_id=product_id,
+        ),
+    ]
+    result = evaluate_cart_promotions(lines, [promo])
+    assert result["promo_savings"] == 44000
+    assert result["subtotal_after_promos"] == 44000
+
+
+def test_locked_bogo_kept_when_promo_inactive():
+    """The snapshot lock still protects savings when the BOGO is no longer
+    evaluable (deactivated/expired) — its original purpose (#4484b6d)."""
+    product_id = uuid4()
+    promo = _promo(promo_type="bogo", value_json={"buy_qty": 1, "get_qty": 1})
+    lines = [
+        _locked_bogo_line(
+            promo=promo, subtotal=88000, quantity=4,
+            locked_savings=44000, product_id=product_id,
+        ),
+    ]
+    result = evaluate_cart_promotions(lines, [])
+    assert result["promo_savings"] == 44000
+    assert result["lines"][0]["promotion_id"] == str(promo["id"])
+    assert result["lines"][0]["promotion_name"] == "Test promo"

--- a/tests/test_tables_tab_modifier_inventory.py
+++ b/tests/test_tables_tab_modifier_inventory.py
@@ -197,6 +197,7 @@ async def test_remove_tab_item_returns_inventory_from_snapshots():
 
     mock_conn = AsyncMock()
     mock_conn.fetchrow = AsyncMock(side_effect=[row, None])
+    mock_conn.fetch = AsyncMock(return_value=[])
     mock_conn.execute = AsyncMock()
     return_mock = AsyncMock()
 

--- a/tests/test_tables_tab_operation_events.py
+++ b/tests/test_tables_tab_operation_events.py
@@ -653,3 +653,119 @@ async def test_clear_tab_records_reason_on_tab_cleared():
 
     assert len(recorded) == 1
     assert recorded[0]["reason"] == "Cliente se fue"
+
+
+@pytest.mark.asyncio
+async def test_remove_tab_item_reevaluates_promos():
+    """#665: removing a tab line must re-run promo persistence so locked BOGO
+    savings do not go stale."""
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    order_item_id = uuid4()
+    order_id = uuid4()
+    session_id = uuid4()
+
+    row = {
+        "id": order_item_id,
+        "product_id": uuid4(),
+        "quantity": 2,
+        "price_at_purchase": 22000.0,
+        "subtotal": 44000.0,
+        "notes": None,
+        "order_id": order_id,
+        "total_amount": 172000.0,
+        "order_number": 16759,
+        "table_session_id": session_id,
+        "product_name": "Hofbrau oktobert 500ml",
+        "table_name": "Mesa 11",
+        "is_bar": False,
+        "effective_waiter_member_id": None,
+        "fulfillment_status": "new",
+    }
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(side_effect=[row, None])
+    mock_conn.fetch = AsyncMock(return_value=[])
+    mock_conn.execute = AsyncMock()
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    persist_mock = AsyncMock(return_value={})
+    mock_request = MagicMock()
+    with patch("app.services.tables_service.require_valid_session") as mock_sess, \
+         patch("app.services.tables_service.get_db_connection", return_value=mock_cm), \
+         patch(
+             "app.services.tables_service._record_tab_operation_event",
+             new=AsyncMock(),
+         ), patch(
+             "app.services.tables_service._return_tab_item_inventory_from_snapshots",
+             new=AsyncMock(),
+         ), patch(
+             "app.services.promotions_service.persist_session_tab_promos",
+             persist_mock,
+         ):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+        await tables_service.remove_tab_item(mock_request, table_id, order_item_id)
+
+    persist_mock.assert_awaited_once_with(mock_conn, tenant_id, session_id)
+
+
+@pytest.mark.asyncio
+async def test_update_tab_item_quantity_reevaluates_promos():
+    """#665: changing quantity must re-run promo persistence so locked BOGO
+    savings recalibrate with the new eligible pool."""
+    tenant_id = uuid4()
+    user_id = uuid4()
+    table_id = uuid4()
+    order_item_id = uuid4()
+    order_id = uuid4()
+    session_id = uuid4()
+
+    row = {
+        "id": order_item_id,
+        "product_id": uuid4(),
+        "quantity": 4,
+        "price_at_purchase": 22000.0,
+        "subtotal": 88000.0,
+        "notes": None,
+        "order_id": order_id,
+        "total_amount": 172000.0,
+        "order_number": 16759,
+        "table_session_id": session_id,
+        "product_name": "Hofbrau oktobert 500ml",
+        "table_name": "Mesa 11",
+        "is_bar": False,
+        "effective_waiter_member_id": None,
+        "fulfillment_status": "new",
+    }
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(side_effect=[row, None])
+    mock_conn.fetchval = AsyncMock(return_value=0)
+    mock_conn.fetch = AsyncMock(return_value=[])
+    mock_conn.execute = AsyncMock()
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    persist_mock = AsyncMock(return_value={})
+    mock_request = MagicMock()
+    with patch("app.services.tables_service.require_valid_session") as mock_sess, \
+         patch("app.services.tables_service.get_db_connection", return_value=mock_cm), \
+         patch(
+             "app.services.tables_service._record_tab_operation_event",
+             new=AsyncMock(),
+         ), patch(
+             "app.services.promotions_service.persist_session_tab_promos",
+             persist_mock,
+         ):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+        await tables_service.update_tab_item_quantity(
+            mock_request, table_id, order_item_id, 2,
+        )
+
+    persist_mock.assert_awaited_once_with(mock_conn, tenant_id, session_id)


### PR DESCRIPTION
## Summary

- Mesa BOGO: el lock de promo persistida truncaba el ahorro al snapshot de la primera tanda aunque el pool elegible creciera (caso real orden #16759: 6 unidades 4+2 con BOGO 1+1 daban 3 gratis / $66.000, pero se cobraban $172.000 en vez de $150.000). Ahora, si el BOGO sigue activo, la evaluación cross-line fresca es autoritativa; el snapshot solo se conserva cuando la promo ya no es evaluable.
- `remove_tab_item` / `update_tab_item_quantity` ajustaban el total aritméticamente sin re-evaluar promos; ahora re-ejecutan `persist_session_tab_promos` tras la mutación.

Closes #665

## Test plan
- [x] Regresión: 4+2 unidades en dos tandas → 3 gratis ($66.000)
- [x] Regresión: pool que se encoge → el ahorro se recalibra a la baja
- [x] Lock se conserva cuando la promo está inactiva/vencida
- [x] remove / qty-change re-evalúan promos
- [x] Suite promo/tab/order sin regresiones

## Validation evidence

```text
$ venv/bin/python -m pytest tests/test_promo_cart_evaluation.py tests/test_tables_tab_promo_persist.py tests/test_tables_tab_operation_events.py -q
41 passed in 0.24s   (suite base)

$ venv/bin/python -m pytest tests/ -q -k "promo or tab or table or order" (sin 2 tests rotos preexistentes en main)
320 passed, 8 skipped, 1151 deselected in 55.35s
```

Nota: los 2 tests deseleccionados de `test_close_session_release.py` ya fallan en `main` (referencian `_cancel_pending_session_orders_on_release`, atributo inexistente) — fallo preexistente, no causado por este PR.

## wr-context
See `.wr/665.yaml` on this branch (LLM contract).
