### PR TITLE
feat(auth): distinguish registration emails from login via purpose param

### DIFF
--- a/.wr/666.yaml
+++ b/.wr/666.yaml
@@ -1,0 +1,39 @@
+issue: 666
+title: "Email de registro indistinguible del de login: agregar purpose a la plantilla magic link"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-666-registration-email-purpose
+
+paths:
+  - app/templates/magic_link_template.py
+  - app/services/magic_link_service.py
+  - tests/test_magic_link_registration_contract.py
+
+ac:
+  - "get_magic_link_template/get_magic_link_subject aceptan purpose (login|registration), default login retrocompatible"
+  - "registration -> asunto '✨ Completa tu registro en {brand}', copy de registro, botón 'Completar mi registro'"
+  - "login -> asunto y copy actuales sin cambios"
+  - "_deliver_magic_link propaga purpose; _issue_registration_challenge pasa 'registration'"
+  - "Tests de subject/copy por propósito + suite magic link verde"
+
+out_of_scope:
+  - identidad global cross-tenant (decisión de producto pendiente)
+  - rediseño visual de la plantilla
+  - QA general (validación manual del usuario)
+
+hints:
+  entry: "_deliver_magic_link (magic_link_service.py:96); call sites: :163 (registration), :308 (login)"
+  pattern: "template get_magic_link_template (magic_link_template.py:6), subject :66"
+  tests: "./venv/bin/python -m pytest tests/test_magic_link_registration_contract.py tests/test_magic_link_email_normalize.py tests/test_magic_link_cross_tenant.py tests/test_customer_internal_access.py -q"
+
+risk:
+  sensitive: true
+  areas: [auth, email]
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "auto review wr-review"

--- a/app/services/magic_link_service.py
+++ b/app/services/magic_link_service.py
@@ -3,7 +3,7 @@ import logging
 import secrets
 import random
 from datetime import datetime, timedelta
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 from uuid import UUID
 from urllib.parse import urlencode
 from fastapi import HTTPException, Request, Response
@@ -101,6 +101,7 @@ async def _deliver_magic_link(
     brand_name: str,
     tenant_name: str,
     tenant_email: Optional[str],
+    purpose: Literal["login", "registration"] = "login",
 ) -> None:
     from app.services.aws_ses_service import ses_service
     from app.services.email_sender import resolve_sender_email_value
@@ -116,11 +117,12 @@ async def _deliver_magic_link(
         from_email=resolve_sender_email_value(tenant_email),
         from_name=f"Saifer 101 (Anderson Arévalo) - {brand_name}",
         to_emails=[email],
-        subject=get_magic_link_subject(brand_name),
+        subject=get_magic_link_subject(brand_name, purpose),
         html_body=get_magic_link_template(
             magic_link_url,
             verification_code,
             template_context,
+            purpose,
         ),
     )
     if sent:
@@ -167,6 +169,7 @@ async def _issue_registration_challenge(
         brand_name=tenant_context.brand_name or "WARO",
         tenant_name=tenant_context.tenant_name or "WARO",
         tenant_email=tenant_context.tenant_email,
+        purpose="registration",
     )
 
 

--- a/app/templates/magic_link_template.py
+++ b/app/templates/magic_link_template.py
@@ -2,8 +2,22 @@
 Magic link email template for FastAPI authentication system
 Compatible with warolabs.com template structure and branding
 """
+from typing import Literal
 
-def get_magic_link_template(magic_link_url: str, verification_code: str, tenant_context: dict) -> str:
+EmailPurpose = Literal["login", "registration"]
+
+_PURPOSE_COPY = {
+    "login": {
+        "intro": "Has solicitado acceso a tu cuenta en {brand_name}. Haz clic en el siguiente enlace para ingresar de forma segura:",
+        "button": "🔑 Acceder a mi cuenta",
+    },
+    "registration": {
+        "intro": "Has iniciado tu registro en {brand_name}. Haz clic en el siguiente enlace para completarlo de forma segura:",
+        "button": "✨ Completar mi registro",
+    },
+}
+
+def get_magic_link_template(magic_link_url: str, verification_code: str, tenant_context: dict, purpose: EmailPurpose = "login") -> str:
     """
     Generate magic link email template with dynamic tenant branding
     Compatible with warolabs.com getMagicLinkTemplate function
@@ -12,6 +26,7 @@ def get_magic_link_template(magic_link_url: str, verification_code: str, tenant_
         magic_link_url: The complete magic link URL for authentication
         verification_code: 6-digit verification code
         tenant_context: Tenant configuration with branding information
+        purpose: "login" (default) or "registration" — selects subject/body copy
     
     Returns:
         HTML email template string
@@ -21,6 +36,9 @@ def get_magic_link_template(magic_link_url: str, verification_code: str, tenant_
     tenant_name = tenant_context.get('tenant_name', 'Waro Colombia')
     admin_name = tenant_context.get('admin_name', 'Saifer 101 (Anderson Arévalo)')
     admin_email = tenant_context.get('admin_email', 'anderson.arevalo@warolabs.com')
+    copy = _PURPOSE_COPY.get(purpose, _PURPOSE_COPY["login"])
+    intro = copy["intro"].format(brand_name=brand_name)
+    button_label = copy["button"]
     
     # Dynamic footer message based on tenant
     footer_message = 'Tecnología colombiana para el mundo. warocol.com' if tenant_name == 'Waro Colombia' else 'No olvides mirar al futuro.'
@@ -37,9 +55,9 @@ def get_magic_link_template(magic_link_url: str, verification_code: str, tenant_
     <div style="font-family: Arial, sans-serif; max-width: 600px; padding: 20px; border: 1px solid #ddd; border-radius: 8px;">
         <p>¡Hola!</p>
         
-        <p>Has solicitado acceso a tu cuenta en {brand_name}. Haz clic en el siguiente enlace para ingresar de forma segura:</p>
+        <p>{intro}</p>
         
-        <p><a href="{magic_link_url}" style="color: black; background-color: #f0f0f0; padding: 10px; border-radius: 4px; text-decoration: none; display: inline-block;">🔑 Acceder a mi cuenta</a></p>
+        <p><a href="{magic_link_url}" style="color: black; background-color: #f0f0f0; padding: 10px; border-radius: 4px; text-decoration: none; display: inline-block;">{button_label}</a></p>
 
         <p><strong>O usa este código de verificación:</strong></p>
         <p style="font-size: 28px; font-weight: bold; letter-spacing: 4px; color: #333; background-color: #f8f8f8; padding: 15px; border-radius: 8px; text-align: center; margin: 20px 0;">{verification_code}</p>
@@ -63,6 +81,8 @@ def get_magic_link_template(magic_link_url: str, verification_code: str, tenant_
 </html>
     """.strip()
 
-def get_magic_link_subject(brand_name: str) -> str:
+def get_magic_link_subject(brand_name: str, purpose: EmailPurpose = "login") -> str:
     """Generate email subject line for magic link"""
+    if purpose == "registration":
+        return f"✨ Completa tu registro en {brand_name}"
     return f"🔑 Tu acceso a {brand_name} está listo"

--- a/tests/test_magic_link_registration_contract.py
+++ b/tests/test_magic_link_registration_contract.py
@@ -161,6 +161,7 @@ async def test_registration_link_is_opaque_and_challenge_contains_no_raw_secret(
     link = deliver.await_args.kwargs["magic_link_url"]
     assert "purpose=registration" in link
     assert "email=" not in link
+    assert deliver.await_args.kwargs["purpose"] == "registration"
     insert = next(
         call for call in conn.execute.await_args_list
         if "INSERT INTO onboarding_email_challenges" in call.args[0]
@@ -272,6 +273,40 @@ async def test_registration_verifier_uses_token_only_and_dispatches_once_after_d
     notification.assert_called_once()
     create_task.assert_called_once()
     assert request.state.registration_notification is None
+
+
+def test_magic_link_email_copy_distinguishes_registration_from_login():
+    from app.templates.magic_link_template import (
+        get_magic_link_subject,
+        get_magic_link_template,
+    )
+
+    context = {
+        "brand_name": "WARO",
+        "tenant_name": "WARO Colombia",
+        "admin_name": "Admin",
+        "admin_email": "admin@warolabs.com",
+    }
+
+    login_subject = get_magic_link_subject("WARO")
+    registration_subject = get_magic_link_subject("WARO", "registration")
+    assert "acceso" in login_subject
+    assert "registro" in registration_subject
+    assert login_subject != registration_subject
+
+    login_html = get_magic_link_template("https://x.test/verify?token=1", "123456", context)
+    registration_html = get_magic_link_template(
+        "https://x.test/verify?token=1&purpose=registration",
+        "123456",
+        context,
+        "registration",
+    )
+    assert "Has solicitado acceso a tu cuenta" in login_html
+    assert "Acceder a mi cuenta" in login_html
+    assert "Has iniciado tu registro" in registration_html
+    assert "Completar mi registro" in registration_html
+    assert "Acceder a mi cuenta" not in registration_html
+    assert "123456" in registration_html
 
 
 def test_registration_payload_rejects_missing_consent_and_pii_attribution():


### PR DESCRIPTION
## Summary
- `get_magic_link_template` / `get_magic_link_subject` accept `purpose` (`login` | `registration`, default `login` — fully backward compatible).
- Registration challenge emails now read "✨ Completa tu registro en {brand}" with registration intro copy and a "✨ Completar mi registro" button; login emails are byte-identical to before.
- `_deliver_magic_link` propagates `purpose`; `_issue_registration_challenge` passes `"registration"`.

Closes #666

## Test plan
- [ ] Register with a new email → email subject/copy says "Completa tu registro".
- [ ] Login with an existing email → unchanged "Tu acceso a …" email.
- [ ] Contract suite stays green.

## Validation evidence
```text
$ ./venv/bin/python -m pytest tests/test_magic_link_registration_contract.py tests/test_magic_link_email_normalize.py tests/test_magic_link_cross_tenant.py tests/test_customer_internal_access.py -q
20 passed in 0.17s   (x3 consecutive runs — one earlier flaky
test_session_resolver_replaced_session failure did not reproduce)
```

## wr-context
See `.wr/666.yaml` on this branch (LLM contract).