### PR TITLE
fix(promotions): keep frozen promo snapshots out of the cross-line BOGO group

### DIFF
--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -1423,9 +1423,6 @@ def evaluate_cart_promotions(
 
     pending: List[Dict[str, Any]] = []
     bogo_group_indices: Dict[tuple[str, str], List[int]] = {}
-    active_promo_ids = {
-        str(p.get("id")) for p in promotions if isinstance(p, dict) and p.get("id")
-    }
 
     for line in lines:
         line_id = str(line["id"])
@@ -1446,24 +1443,10 @@ def evaluate_cart_promotions(
         if line.get("promo_opt_out"):
             promo = None
         elif locked_promo is not None:
+            # Frozen snapshot: a line keeps the promo it was granted when it was
+            # added (expected business behavior). Locked lines never rejoin the
+            # cross-line BOGO group — only fresh lines evaluate among themselves.
             promo = locked_promo
-            if (
-                locked_promo.get("promo_type") == "bogo"
-                and str(locked_promo["id"]) in active_promo_ids
-            ):
-                # The lock exists to preserve a promo snapshot when the promo is
-                # no longer evaluable (deactivated/expired). While the BOGO is
-                # still active, the fresh cross-line evaluation is authoritative
-                # so a growing (or shrinking) eligible pool recalibrates savings
-                # instead of truncating them to the stale snapshot (#665).
-                fresh_promo = _pick_best_promotion_for_line(
-                    promotions,
-                    product_id=product_id,
-                    category_id=category_id,
-                    promo_type_block_map=promo_type_block_map,
-                )
-                if fresh_promo is not None:
-                    promo = fresh_promo
         else:
             promo = _pick_best_promotion_for_line(
                 promotions,
@@ -1482,7 +1465,13 @@ def evaluate_cart_promotions(
             "promo": promo,
         })
 
-        if promo is not None and promo["promo_type"] == "bogo":
+        # Locked (frozen) lines keep their snapshot and stay out of the
+        # cross-line group; only fresh lines pool units together (#665 follow-up).
+        if (
+            promo is not None
+            and promo["promo_type"] == "bogo"
+            and promo.get("locked_savings") is None
+        ):
             group_key = (str(product_id), str(promo["id"]))
             bogo_group_indices.setdefault(group_key, []).append(idx)
 

--- a/tests/test_promo_cart_evaluation.py
+++ b/tests/test_promo_cart_evaluation.py
@@ -387,9 +387,11 @@ def _locked_bogo_line(*, promo, subtotal, quantity, locked_savings, product_id):
     }
 
 
-def test_locked_bogo_recalibrates_when_pool_grows():
-    """#665: 4+2 units in two tab rounds with BOGO 1+1 must grant 3 free units,
-    not truncate to the first round's locked savings (44000)."""
+def test_locked_bogo_frozen_and_fresh_line_evaluates_on_its_own():
+    """#665 follow-up: frozen snapshots are expected behavior. The locked line
+    keeps its granted savings and stays OUT of the cross-line group; the fresh
+    2-unit line evaluates among itself (1 free). Total 44000 + 22000 = 66000 —
+    the cross-line re-evaluation must not swallow the fresh line's free unit."""
     product_id = uuid4()
     promo = _promo(promo_type="bogo", value_json={"buy_qty": 1, "get_qty": 1})
     lines = [
@@ -402,11 +404,13 @@ def test_locked_bogo_recalibrates_when_pool_grows():
     result = evaluate_cart_promotions(lines, [promo])
     assert result["promo_savings"] == 66000
     assert result["subtotal_after_promos"] == 66000
+    assert result["lines"][0]["promo_savings"] == 44000
+    assert result["lines"][1]["promo_savings"] == 22000
 
 
-def test_locked_bogo_recalibrates_when_pool_shrinks():
-    """#665: a stale lock from a larger pool must shrink back when the tab now
-    only holds 4 eligible units (2 free)."""
+def test_locked_bogo_snapshot_stays_frozen_when_line_shrinks():
+    """Frozen semantics: once granted, the snapshot is kept (capped at the line
+    subtotal) even if the line later holds fewer units than the lock implies."""
     product_id = uuid4()
     promo = _promo(promo_type="bogo", value_json={"buy_qty": 1, "get_qty": 1})
     lines = [
@@ -416,8 +420,8 @@ def test_locked_bogo_recalibrates_when_pool_shrinks():
         ),
     ]
     result = evaluate_cart_promotions(lines, [promo])
-    assert result["promo_savings"] == 44000
-    assert result["subtotal_after_promos"] == 44000
+    assert result["promo_savings"] == 66000
+    assert result["subtotal_after_promos"] == 22000
 
 
 def test_locked_bogo_kept_when_promo_inactive():


### PR DESCRIPTION
## Summary

- El congelamiento de promos por tanda es el comportamiento esperado del negocio: cada línea conserva el ahorro que ganó al agregarse. El error era que la re-evaluación cross-line (#1023) metía las líneas congeladas al mismo grupo BOGO y se "comía" la gratis de la tanda nueva (mesa 11: 2 gratis en vez de 3).
- Ahora las líneas con lock conservan su snapshot y quedan fuera del grupo cross-line; solo las líneas nuevas se evalúan entre sí. Tanda 1 congelada (2 gratis, $44.000) + tanda 2 propia (1 gratis, $22.000) = $66.000 → $170.000, consistente entre mesa y checkout (verificado por simulación con los datos reales de la orden #16759).

Follow-up to #665.

## Test plan
- [x] Línea congelada (4 ud, 2 gratis) + línea fresca (2 ud) → 44.000 + 22.000 = 66.000
- [x] Snapshot congelado se conserva aunque la línea tenga menos unidades (tope: subtotal)
- [x] Snapshot se conserva con promo inactiva/vencida
- [x] Simulación con datos reales de la orden #16759: ambas rutas (mesa/checkout) → $170.000

## Validation evidence

```text
$ venv/bin/python -m pytest tests/ -q -k "promo or tab or table or order" (sin 2 tests rotos preexistentes en main)
320 passed, 8 skipped, 1152 deselected in 49.54s

$ simulación orden real #16759 (mesa 11):
preserve_persisted=False: savings=66000 after=170000  (línea1 44000 + línea2 22000)
preserve_persisted=True:  savings=66000 after=170000  (idéntico)
```
