### PR TITLE
feat(auth): cap internal sessions at 24h and make session resolver tests deterministic

### DIFF
--- a/.wr/669.yaml
+++ b/.wr/669.yaml
@@ -1,0 +1,39 @@
+issue: 669
+title: "Auth: tests flaky del session resolver + sesiones internas máx 24h"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-669-session-ttl-flaky-tests
+
+paths:
+  - app/core/security.py
+  - app/services/magic_link_service.py
+  - app/services/auth_service.py
+  - app/services/invitation_service.py
+  - tests/test_customer_internal_access.py
+
+ac:
+  - "Constante INTERNAL_SESSION_HOURS=24 usada en 5 inserts de sesión + max_age de cookie"
+  - "Tests del session resolver deterministas (random parcheado); suite 10/10 verde"
+  - "Test: sesión recién creada expira ~24h (no 7 días)"
+  - "import random al tope del módulo en security.py"
+
+out_of_scope:
+  - CUSTOMER_SESSION_DAYS (portal customer, JWT separado)
+  - cambios de comportamiento del zombie-cleanup en producción
+
+hints:
+  entry: "security.py:185 (cookie max_age), :362-365 (random cleanup); inserts: magic_link_service.py:201,440,596; auth_service.py:293; invitation_service.py:328"
+  pattern: "CUSTOMER_SESSION_DAYS=7 (security.py:224) como patrón de constante"
+  tests: "./venv/bin/python -m pytest tests/test_customer_internal_access.py tests/test_magic_link_registration_contract.py tests/test_magic_link_cross_tenant.py tests/test_magic_link_email_normalize.py -q (x10)"
+
+risk:
+  sensitive: true
+  areas: [auth, sessions]
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "auto review wr-review + revisión humana obligatoria (auth)"

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,5 +1,6 @@
 import jwt
 import logging
+import random
 from datetime import datetime, timedelta
 from urllib.parse import unquote
 from uuid import UUID
@@ -12,6 +13,7 @@ from typing import List, Optional
 logger = logging.getLogger(__name__)
 
 SESSION_COOKIE_NAME = "session-token"
+INTERNAL_SESSION_HOURS = 24
 
 
 def _normalize_session_token(raw: str) -> Optional[str]:
@@ -182,7 +184,7 @@ async def set_session_cookie(response: Response, session_token: str, tenant_site
         httponly=True,
         secure=not settings.is_development,
         samesite="lax",  # Use lax for better proxy compatibility across environments
-        max_age=7 * 24 * 60 * 60,  # 7 days (1 week)
+        max_age=INTERNAL_SESSION_HOURS * 60 * 60,  # 24 hours
         domain=cookie_domain,
         path="/"  # Ensure cookie is available for all paths
     )
@@ -360,7 +362,6 @@ async def get_session_from_request(request: Request) -> Optional[dict]:
                         logger.info(f"🔒 Marked session {session_token[:8]}... as {end_reason}")
 
                     # Opportunistically clean up other zombie sessions (1 in 10 chance)
-                    import random
                     if random.random() < 0.1:
                         await cleanup_zombie_sessions(conn, limit=50)
 

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -5,7 +5,7 @@ from typing import Optional, Set
 from fastapi import HTTPException, Request, Response
 from app.config import settings
 from app.database import get_db_connection
-from app.core.security import collect_session_tokens, get_session_token, clear_session_cookie, set_session_cookie, get_client_ip
+from app.core.security import INTERNAL_SESSION_HOURS, collect_session_tokens, get_session_token, clear_session_cookie, set_session_cookie, get_client_ip
 from app.core.exceptions import AuthenticationError
 from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES, is_legacy_internal_team_role
 from app.core.onboarding_access import next_step_for_state
@@ -290,7 +290,7 @@ async def switch_tenant(request: Request, response: Response, tenant_slug: str) 
 
             # Create new session with new tenant
             new_session_id = secrets.token_hex(16)
-            expires_at = datetime.utcnow() + timedelta(days=7)  # 7 days (1 week)
+            expires_at = datetime.utcnow() + timedelta(hours=INTERNAL_SESSION_HOURS)  # 24 hours
             
             # Use current client info for new session
             current_client_ip = get_client_ip(request)

--- a/app/services/invitation_service.py
+++ b/app/services/invitation_service.py
@@ -5,7 +5,7 @@ from typing import Optional, List
 from uuid import uuid4
 from fastapi import Request, Response
 from app.database import get_db_connection
-from app.core.security import set_session_cookie, get_client_ip, get_current_user_id
+from app.core.security import INTERNAL_SESSION_HOURS, set_session_cookie, get_client_ip, get_current_user_id
 from app.core.middleware import require_valid_tenant, require_valid_session
 from app.core.exceptions import APIError, AuthenticationError, ValidationError, AuthorizationError
 from app.core.email_utils import normalize_email
@@ -325,7 +325,7 @@ async def accept_invitation(request: Request, response: Response, token: str) ->
 
             # Create session (same as magic link flow)
             session_id = secrets.token_hex(16)
-            expires_at = datetime.utcnow() + timedelta(days=7)
+            expires_at = datetime.utcnow() + timedelta(hours=INTERNAL_SESSION_HOURS)  # 24 hours
             client_ip = get_client_ip(request)
             user_agent = request.headers.get('user-agent')
 

--- a/app/services/magic_link_service.py
+++ b/app/services/magic_link_service.py
@@ -8,7 +8,7 @@ from uuid import UUID
 from urllib.parse import urlencode
 from fastapi import HTTPException, Request, Response
 from app.database import get_db_connection
-from app.core.security import set_session_cookie, get_client_ip
+from app.core.security import INTERNAL_SESSION_HOURS, set_session_cookie, get_client_ip
 from app.core.middleware import require_valid_tenant
 from app.core.exceptions import AuthenticationError, ValidationError
 from app.core.email_utils import normalize_email
@@ -198,7 +198,7 @@ async def _complete_registration_login(
         return None
 
     session_id = secrets.token_hex(16)
-    expires_at = datetime.utcnow() + timedelta(days=7)
+    expires_at = datetime.utcnow() + timedelta(hours=INTERNAL_SESSION_HOURS)  # 24 hours
     await conn.execute(
         """
         INSERT INTO sessions (
@@ -437,7 +437,7 @@ async def verify_code(request: Request, response: Response, email: str, code: st
 
             # Create session with user's tenant from token
             session_id = secrets.token_hex(16)
-            expires_at = datetime.utcnow() + timedelta(days=7)  # 7 days (1 week)
+            expires_at = datetime.utcnow() + timedelta(hours=INTERNAL_SESSION_HOURS)  # 24 hours
             user_tenant_id = token_data['tenant_id']
 
             # Get client info for analytics
@@ -593,7 +593,7 @@ async def verify_token(request: Request, response: Response, email: str, token: 
 
             # Create session with user's tenant from token
             session_id = secrets.token_hex(16)
-            expires_at = datetime.utcnow() + timedelta(days=7)  # 7 days (1 week)
+            expires_at = datetime.utcnow() + timedelta(hours=INTERNAL_SESSION_HOURS)  # 24 hours
             user_tenant_id = token_data['tenant_id']
 
             # Get client info for analytics

--- a/tests/test_customer_internal_access.py
+++ b/tests/test_customer_internal_access.py
@@ -129,6 +129,13 @@ async def test_verify_token_replaces_previous_active_admin_sessions():
         result = await verify_token(_request(), response, "admin@example.com", "token")
 
     assert result.success is True
+    session_inserts = [
+        call.args for call in conn.execute.await_args_list
+        if "INSERT INTO sessions" in call.args[0]
+    ]
+    assert len(session_inserts) == 1
+    ttl = session_inserts[0][4] - datetime.utcnow()
+    assert timedelta(hours=23, minutes=59) < ttl <= timedelta(hours=24)
     replacement_calls = [
         call.args for call in conn.execute.await_args_list
         if "replaced_by_new_login" in call.args[0]
@@ -212,7 +219,8 @@ async def test_session_resolver_invalidates_customer_internal_session():
     ])
 
     with patch("app.database.get_db_connection", side_effect=db_ctx), \
-         patch("app.core.security.get_session_token", new=AsyncMock(return_value=session_token)):
+         patch("app.core.security.get_session_token", new=AsyncMock(return_value=session_token)), \
+         patch("app.core.security.cleanup_zombie_sessions", new=AsyncMock()):
         result = await get_session_from_request(_request())
 
     assert result is None
@@ -237,7 +245,8 @@ async def test_session_resolver_replaced_session_returns_invalid_without_overwri
     ])
 
     with patch("app.database.get_db_connection", side_effect=db_ctx), \
-         patch("app.core.security.get_session_token", new=AsyncMock(return_value=session_token)):
+         patch("app.core.security.get_session_token", new=AsyncMock(return_value=session_token)), \
+         patch("app.core.security.cleanup_zombie_sessions", new=AsyncMock()):
         result = await get_session_from_request(_request())
 
     assert result is None


### PR DESCRIPTION
## Summary
- New `INTERNAL_SESSION_HOURS = 24` constant (`app/core/security.py`) now drives all 5 internal session inserts (`magic_link_service` ×3, `auth_service`, `invitation_service`) and the session cookie `max_age` — sessions live 24h instead of 7 days.
- Session resolver tests patch `cleanup_zombie_sessions` so the 10% random zombie-cleanup can no longer break strict `conn.execute` assertions (root cause of the ~10% flake); `import random` moved to module top.
- New TTL assertion: a session created via `verify_token` expires ~24h out.

⚠️ Sensitive area (auth/sessions): auto review done, human review required before merge.

Closes #669

## Test plan
- [ ] Login → DB session `expires_at` ≈ now + 24h; cookie `max_age` = 86400.
- [ ] Auth/magic-link suite green across repeated runs (no 10% flake).
- [ ] Out of scope: customer portal JWT (`CUSTOMER_SESSION_DAYS`) unchanged.

## Validation evidence
```text
$ ./venv/bin/python -m pytest tests/test_customer_internal_access.py tests/test_magic_link_registration_contract.py tests/test_magic_link_cross_tenant.py tests/test_magic_link_email_normalize.py -q   (x10 runs)
20 passed in ~0.14s   (10/10 green — previously ~10% flaky)

Note: tests/test_invitation_team_membership.py::test_send_invitation_allows_existing_customer_without_team_membership
fails on clean main too (KeyError: 'plan_slug') — pre-existing, unrelated to this diff.
```

## wr-context
See `.wr/669.yaml` on this branch (LLM contract).