### PR TITLE
feat(ingredients): catalog list filters for unit, cost, and gr/und (#1706)

### DIFF
--- a/app/models/ingredient.py
+++ b/app/models/ingredient.py
@@ -86,6 +86,7 @@ class Ingredient(IngredientBase):
     has_variants: Optional[int] = None  # count of variants via ingredient_global_hierarchy
     is_custom: Optional[bool] = None
     is_resale: Optional[bool] = None
+    costo_unitario: Optional[float] = None
     parent_name: Optional[str] = None
     default_purchase_unit_label: Optional[str] = None
     default_purchase_unit_factor: Optional[float] = None

--- a/app/routers/ingredients.py
+++ b/app/routers/ingredients.py
@@ -64,13 +64,17 @@ async def get_ingredients_endpoint(
     base_only: Optional[bool] = Query(default=None, description="When true, exclude variant ingredients (those with a base assigned)"),
     tenant_only: Optional[bool] = Query(default=None, description="When true, return only tenant-scoped custom ingredients"),
     show_archived: Optional[bool] = Query(default=None, description="When true, return archived (is_active=false) ingredients instead of active ones"),
+    unit: Optional[str] = Query(default=None, description="Filter by unit of measure"),
+    has_cost: Optional[bool] = Query(default=None, description="When true, only ingredients with unit cost; when false, only without"),
+    has_unit_weight: Optional[bool] = Query(default=None, description="When true, only ingredients with gr/und weight; when false, only without"),
 ):
     """
     Get ingredients list with tenant isolation
     Requires valid session with tenant context
     """
     return await get_ingredients_list(
-        request, response, page, limit, search, category, supplier_id, type, is_resale, base_only, tenant_only, show_archived
+        request, response, page, limit, search, category, supplier_id, type, is_resale,
+        base_only, tenant_only, show_archived, unit, has_cost, has_unit_weight,
     )
 
 

--- a/app/services/ingredients_service.py
+++ b/app/services/ingredients_service.py
@@ -197,6 +197,9 @@ async def get_ingredients_list(
     base_only: Optional[bool] = None,
     tenant_only: Optional[bool] = None,
     show_archived: Optional[bool] = None,
+    unit: Optional[str] = None,
+    has_cost: Optional[bool] = None,
+    has_unit_weight: Optional[bool] = None,
 ) -> IngredientsListResponse:
     """
     Fetches a list of ingredients from the database with tenant isolation,
@@ -226,6 +229,7 @@ async def get_ingredients_list(
                     CAST(i.unit_weight_gr AS float) as unit_weight_gr,
                     i.unit_weight_unit,
                     i.is_resale,
+                    CAST(i.costo_unitario AS float) as costo_unitario,
                     i.created_at,
                     i.updated_at,
                     CAST(COALESCE(tsp.unit_price, tim.cost_per_unit) AS float) as price,
@@ -338,6 +342,28 @@ async def get_ingredients_list(
                 # Override the is_active=TRUE filter added in the base WHERE clause
                 base_query = base_query.replace("AND i.is_active = TRUE", "AND i.is_active = FALSE")
                 count_query = count_query.replace("AND is_active = TRUE", "AND is_active = FALSE")
+
+            if unit:
+                base_query += f" AND LOWER(i.unit) = LOWER(${base_param_count})"
+                count_query += f" AND LOWER(unit) = LOWER(${count_param_count})"
+                base_params.append(unit)
+                count_params.append(unit)
+                base_param_count += 1
+                count_param_count += 1
+
+            if has_cost is True:
+                base_query += " AND i.costo_unitario IS NOT NULL AND i.costo_unitario > 0"
+                count_query += " AND costo_unitario IS NOT NULL AND costo_unitario > 0"
+            elif has_cost is False:
+                base_query += " AND (i.costo_unitario IS NULL OR i.costo_unitario <= 0)"
+                count_query += " AND (costo_unitario IS NULL OR costo_unitario <= 0)"
+
+            if has_unit_weight is True:
+                base_query += " AND i.unit_weight_gr IS NOT NULL AND i.unit_weight_gr > 0"
+                count_query += " AND unit_weight_gr IS NOT NULL AND unit_weight_gr > 0"
+            elif has_unit_weight is False:
+                base_query += " AND (i.unit_weight_gr IS NULL OR i.unit_weight_gr <= 0)"
+                count_query += " AND (unit_weight_gr IS NULL OR unit_weight_gr <= 0)"
 
             # Add pagination
             offset = (page - 1) * limit


### PR DESCRIPTION
## Summary
- Add `unit`, `has_cost`, and `has_unit_weight` query params to `GET /suppliers/ingredients`
- Return `costo_unitario` on list rows for warehouse catalog cost column/filtering
- Companion to warocol.com PR for #1706 header filters on `/abastecimiento/ingredientes-propios`

Closes #1706

## Test plan
- [ ] Filter ingredients by unit (`?unit=kg`)
- [ ] Filter by cost presence (`?has_cost=true` / `?has_cost=false`)
- [ ] Filter by gr/und presence (`?has_unit_weight=true` / `?has_unit_weight=false`)

## Validation evidence
```bash
cd api_warocol.com && ./venv/bin/pytest tests/test_ingredients.py -q
```
```
26 passed in 2.18s
```

## wr-context
See `.wr/1706.yaml` locally (gitignored); front companion PR carries UX contract.

Made with [Cursor](https://cursor.com)