### PR TITLE
feat(ingredients): exclude resale from category resolve (#1708)

### DIFF
--- a/app/models/ingredient.py
+++ b/app/models/ingredient.py
@@ -126,6 +126,7 @@ class IngredientCategoriesResponse(BaseModel):
 class IngredientCategoryResolutionRequest(BaseModel):
     category_ids: List[UUID] = Field(..., min_length=1, max_length=100)
     exclude_ingredient_ids: List[UUID] = Field(default_factory=list, max_length=10000)
+    exclude_resale: bool = Field(default=False, description="When true, omit resale warehouse items")
 
 
 class IngredientCategoryCandidate(BaseModel):

--- a/app/models/modifier.py
+++ b/app/models/modifier.py
@@ -22,6 +22,7 @@ class IngredientInfo(BaseModel):
     unit: str
     costo_unitario: Optional[Decimal] = None
     controla_inventario: bool = False
+    is_resale: bool = False
 
 
 class RecipeBaseInfo(BaseModel):

--- a/app/routers/ingredients.py
+++ b/app/routers/ingredients.py
@@ -123,6 +123,7 @@ async def resolve_ingredients_by_warehouse_categories_endpoint(
             tenant_id,
             body.category_ids,
             body.exclude_ingredient_ids,
+            body.exclude_resale,
         )
 
     return {"success": True, "data": data}

--- a/app/services/ingredients_service.py
+++ b/app/services/ingredients_service.py
@@ -84,6 +84,7 @@ async def resolve_ingredients_by_warehouse_categories(
     tenant_id: UUID,
     category_ids: List[UUID],
     exclude_ingredient_ids: Optional[List[UUID]] = None,
+    exclude_resale: bool = False,
 ) -> Dict[str, Any]:
     """Resolve visible active ingredients for ordered warehouse categories."""
     ordered_category_ids = list(dict.fromkeys(category_ids))
@@ -119,12 +120,14 @@ async def resolve_ingredients_by_warehouse_categories(
          AND ingredient.is_active = TRUE
          AND (ingredient.tenant_id IS NULL OR ingredient.tenant_id = $1)
          AND NOT (ingredient.id = ANY($3::uuid[]))
+         AND ($4::boolean IS FALSE OR COALESCE(ingredient.is_resale, FALSE) = FALSE)
         ORDER BY category.position, LOWER(ingredient.name) NULLS LAST,
                  ingredient.name NULLS LAST, ingredient.id
         """,
         tenant_id,
         ordered_category_ids,
         excluded_ids,
+        exclude_resale,
     )
 
     ingredients: List[Dict[str, Any]] = []

--- a/app/services/modifiers_service.py
+++ b/app/services/modifiers_service.py
@@ -98,7 +98,7 @@ async def _fetch_modifier_recipe_lines(conn, modifier_id: UUID) -> List[Modifier
             unit=r["ingredient_base_unit"],
             costo_unitario=r["costo_unitario"],
             controla_inventario=r["controla_inventario"] or False,
-            is_resale=bool(r.get("ingredient_is_resale")),
+            is_resale=bool(r.get("is_resale")),
         )
         lines.append(
             ModifierRecipeLine(

--- a/app/services/modifiers_service.py
+++ b/app/services/modifiers_service.py
@@ -44,6 +44,7 @@ _MODIFIER_SELECT_COLS = """
     i.unit as ingredient_base_unit,
     i.costo_unitario,
     i.controla_inventario,
+    i.is_resale as ingredient_is_resale,
     pbt.name as recipe_base_name,
     lp.name as linked_product_name
 """
@@ -81,7 +82,7 @@ async def _fetch_modifier_recipe_lines(conn, modifier_id: UUID) -> List[Modifier
         """
         SELECT mr.id, mr.ingredient_id, mr.quantity, mr.unit,
                i.name as ingredient_name, i.unit as ingredient_base_unit,
-               i.costo_unitario, i.controla_inventario
+               i.costo_unitario, i.controla_inventario, i.is_resale
         FROM modifier_recipes mr
         JOIN ingredients i ON mr.ingredient_id = i.id
         WHERE mr.modifier_id = $1
@@ -97,6 +98,7 @@ async def _fetch_modifier_recipe_lines(conn, modifier_id: UUID) -> List[Modifier
             unit=r["ingredient_base_unit"],
             costo_unitario=r["costo_unitario"],
             controla_inventario=r["controla_inventario"] or False,
+            is_resale=bool(r.get("ingredient_is_resale")),
         )
         lines.append(
             ModifierRecipeLine(
@@ -145,6 +147,7 @@ async def _build_modifier(
             unit=row["ingredient_base_unit"],
             costo_unitario=row["costo_unitario"],
             controla_inventario=row["controla_inventario"] or False,
+            is_resale=bool(row.get("ingredient_is_resale")),
         )
     if row["recipe_base_type_id"] and row.get("recipe_base_name"):
         mod_dict["recipe_base"] = RecipeBaseInfo(

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -283,6 +283,7 @@ class TestIngredientCategoryResolution:
             tenant_id,
             [first_category_id, second_category_id],
             [excluded_ingredient_id],
+            False,
         ]
         conn.fetch.assert_awaited_once()
 


### PR DESCRIPTION
## Summary
- Add `exclude_resale` to `POST /suppliers/ingredients/resolve-by-warehouse-categories`
- Modifier warehouse category bulk-add sends `exclude_resale=true` so only non-resale catalog items become options

Companion to warocol.com #1708

## Test plan
- [ ] Resolve categories with `exclude_resale=true` omits `is_resale` ingredients
- [ ] Default `exclude_resale=false` keeps existing productos/recetas behavior

## Validation evidence
```bash
cd api_warocol.com && ./venv/bin/pytest tests/test_ingredients.py::TestIngredientCategoryResolution -q
```
```
2 passed in 0.04s
```

Made with [Cursor](https://cursor.com)