### PR TITLE
fix(modifiers): hide removed options from editor after save

### DIFF
--- a/app/services/menu_history_service.py
+++ b/app/services/menu_history_service.py
@@ -634,7 +634,9 @@ async def get_modifier_group_snapshot(conn, modifier_group_id: UUID, tenant_id: 
                    ingredient_id, ingredient_quantity, ingredient_unit,
                    recipe_base_type_id, recipe_base_quantity,
                    linked_product_id, linked_product_quantity
-            FROM modifiers WHERE modifier_group_id = $1
+            FROM modifiers
+            WHERE modifier_group_id = $1
+              AND removed_at IS NULL
         """, modifier_group_id)
         recipe_lines = await conn.fetch("""
             SELECT mr.modifier_id, mr.ingredient_id, mr.quantity, mr.unit

--- a/app/services/modifiers_service.py
+++ b/app/services/modifiers_service.py
@@ -345,6 +345,7 @@ async def get_modifier_group_by_id(
                 LEFT JOIN product_base_types pbt ON m.recipe_base_type_id = pbt.id
                 LEFT JOIN product lp ON m.linked_product_id = lp.id
                 WHERE m.modifier_group_id = $1
+                  AND m.removed_at IS NULL
                 ORDER BY m.sort_order, m.name
             """
 
@@ -600,7 +601,12 @@ async def update_modifier_group(
                 if group_data.modifiers is not None:
                     # Get existing modifiers
                     existing_modifiers = await conn.fetch(
-                        "SELECT id, name, included_quantity FROM modifiers WHERE modifier_group_id = $1",
+                        """
+                        SELECT id, name, included_quantity
+                        FROM modifiers
+                        WHERE modifier_group_id = $1
+                          AND removed_at IS NULL
+                        """,
                         group_id
                     )
                     existing_names = {row['name']: row['id'] for row in existing_modifiers}
@@ -644,7 +650,8 @@ async def update_modifier_group(
                                     option_type = $8,
                                     ingredient_id = $9, ingredient_quantity = $10, ingredient_unit = $11,
                                     recipe_base_type_id = $12, recipe_base_quantity = $13,
-                                    linked_product_id = $14, linked_product_quantity = $15
+                                    linked_product_id = $14, linked_product_quantity = $15,
+                                    removed_at = NULL
                                 WHERE id = $1
                                 """,
                                 mod_id,
@@ -675,12 +682,17 @@ async def update_modifier_group(
                         else:
                             await _insert_modifier(conn, group_id, modifier)
 
-                    # Soft-delete removed modifiers (preserve order history)
-                    modifiers_to_disable = existing_ids - modifiers_to_keep
-                    if modifiers_to_disable:
+                    # Remove options omitted from PUT (preserve row for order history)
+                    modifiers_to_remove = existing_ids - modifiers_to_keep
+                    if modifiers_to_remove:
                         await conn.execute(
-                            "UPDATE modifiers SET is_available = false WHERE id = ANY($1::uuid[])",
-                            list(modifiers_to_disable)
+                            """
+                            UPDATE modifiers
+                            SET is_available = false,
+                                removed_at = NOW()
+                            WHERE id = ANY($1::uuid[])
+                            """,
+                            list(modifiers_to_remove)
                         )
 
                 # 4. Registrar cambios en historial

--- a/sql/20260721_modifiers_removed_at.sql
+++ b/sql/20260721_modifiers_removed_at.sql
@@ -1,0 +1,16 @@
+-- Distinguish "Eliminar" (removed from group editor) from "Disponible off" (is_available=false).
+-- Omitted options on PUT set removed_at; toggled unavailable keep removed_at NULL.
+
+ALTER TABLE modifiers
+    ADD COLUMN IF NOT EXISTS removed_at TIMESTAMPTZ NULL;
+
+CREATE INDEX IF NOT EXISTS idx_modifiers_active_group
+    ON modifiers (modifier_group_id, sort_order)
+    WHERE removed_at IS NULL;
+
+-- Legacy soft-deletes (is_available=false from old PUT omission) were hidden from POS but
+-- still reappeared in the editor; treat them as removed in the editor going forward.
+UPDATE modifiers
+SET removed_at = COALESCE(updated_at, created_at, NOW())
+WHERE is_available = false
+  AND removed_at IS NULL;


### PR DESCRIPTION
## Summary
- Add `removed_at` on `modifiers` to separate **Eliminar** from **Disponible off**
- Filter modifier group GET/snapshot queries with `removed_at IS NULL`
- Backfill legacy soft-deleted rows so they stop reappearing in the editor

## Migration
Run on prod before/with deploy:
`sql/20260721_modifiers_removed_at.sql`

## Test plan
- [ ] Apply migration on prod DB
- [ ] Edit SALSAS group, delete an option, save — option stays removed
- [ ] Toggle Disponible off, save — option remains visible with toggle off
- [ ] POS still hides unavailable modifiers

Made with [Cursor](https://cursor.com)