### PR TITLE
fix(products): expose included_quantity in POS catalog modifier schema

### DIFF
--- a/app/models/product.py
+++ b/app/models/product.py
@@ -5,15 +5,26 @@ from uuid import UUID
 from datetime import datetime
 from decimal import Decimal
 
+from app.models.modifier import ModifierOptionType
+
 class Modifier(BaseModel):
     """Modifier option within a modifier group"""
     id: UUID
     name: str
     price: Decimal
     max_limit: int = Field(default=1, ge=1, description="Max times this option can be added")
+    included_quantity: int = Field(
+        default=0,
+        ge=0,
+        description="Units included before the additional price applies",
+    )
     is_available: Optional[bool] = True
     is_default: Optional[bool] = False
     sort_order: Optional[int] = None
+    option_type: ModifierOptionType = Field(
+        default="INGREDIENT",
+        description="INGREDIENT | RECIPE | PRODUCT | NONE",
+    )
 
     class Config:
         from_attributes = True

--- a/tests/test_product_catalog_modifier_fields.py
+++ b/tests/test_product_catalog_modifier_fields.py
@@ -10,6 +10,7 @@ def test_product_modifier_response_keeps_included_quantity_and_option_type():
     group_id = uuid4()
     product_id = uuid4()
     tenant_id = uuid4()
+    category_id = uuid4()
     now = datetime(2026, 7, 21, 12, 0, 0)
 
     response = ProductsListResponse(
@@ -18,6 +19,7 @@ def test_product_modifier_response_keeps_included_quantity_and_option_type():
         data=[{
             "id": product_id,
             "tenant_id": tenant_id,
+            "category_id": category_id,
             "name": "BUBASICO TRADICIONAL",
             "price": Decimal("14500"),
             "created_at": now,

--- a/tests/test_product_catalog_modifier_fields.py
+++ b/tests/test_product_catalog_modifier_fields.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+from decimal import Decimal
+from uuid import uuid4
+
+from app.models.product import Modifier, ProductsListResponse
+
+
+def test_product_modifier_response_keeps_included_quantity_and_option_type():
+    modifier_id = uuid4()
+    group_id = uuid4()
+    product_id = uuid4()
+    tenant_id = uuid4()
+    now = datetime(2026, 7, 21, 12, 0, 0)
+
+    response = ProductsListResponse(
+        success=True,
+        total=1,
+        data=[{
+            "id": product_id,
+            "tenant_id": tenant_id,
+            "name": "BUBASICO TRADICIONAL",
+            "price": Decimal("14500"),
+            "created_at": now,
+            "updated_at": now,
+            "modifier_groups": [{
+                "id": group_id,
+                "name": "SABORES DE HELADOS TRADICIONALES",
+                "min_qty": 1,
+                "max_qty": 2,
+                "is_required": True,
+                "modifiers": [{
+                    "id": modifier_id,
+                    "name": "H. AREQUIPE",
+                    "price": Decimal("6000"),
+                    "max_limit": 2,
+                    "included_quantity": 1,
+                    "option_type": "INGREDIENT",
+                    "is_available": True,
+                }],
+            }],
+        }],
+    )
+
+    payload = response.model_dump(mode="json")
+    modifier = payload["data"][0]["modifier_groups"][0]["modifiers"][0]
+    assert modifier["included_quantity"] == 1
+    assert modifier["option_type"] == "INGREDIENT"
+    assert modifier["price"] == "6000"
+
+
+def test_product_modifier_defaults_included_quantity_to_zero():
+    parsed = Modifier.model_validate({
+        "id": uuid4(),
+        "name": "Salsa",
+        "price": Decimal("0"),
+        "max_limit": 1,
+    })
+    assert parsed.included_quantity == 0
+    assert parsed.option_type == "INGREDIENT"


### PR DESCRIPTION
## Summary
- Add `included_quantity` and `option_type` to `app.models.product.Modifier` so `/pos/products` and `/menu/products?include_modifiers=true` serialize fields already fetched by `products_service`.
- POS was charging `price × quantity` for modifiers like H. AREQUIPE because the API response dropped `included_quantity` (client defaulted to 0).

## Root cause
CloudFront and DB migration were OK. Pydantic `response_model=ProductsListResponse` stripped undeclared modifier fields.

## Test plan
- [x] `tests/test_product_catalog_modifier_fields.py` — response keeps `included_quantity`
- [ ] Deploy API, reload `/pos`, pick BUBASICO TRADICIONAL → H. AREQUIPE ×2 should total **$6.000** modifier charge (1 incluida + 1 adicional), not $12.000
- [ ] Label should show included threshold text, not plain `+ $ 6.000` only


Made with [Cursor](https://cursor.com)