### PR TITLE
fix(pos): add GET /pos/products/{id} for cashier product detail

### DIFF
--- a/app/routers/pos_products.py
+++ b/app/routers/pos_products.py
@@ -4,8 +4,8 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, Query, Request, Response
 
 from app.core.permissions import Module, require_module
-from app.models.product import ProductsListResponse
-from app.services.products_service import get_products_list
+from app.models.product import ProductResponse, ProductsListResponse
+from app.services.products_service import get_product_by_id, get_products_list
 
 
 router = APIRouter(prefix="/pos/products", tags=["pos"])
@@ -76,3 +76,16 @@ async def get_pos_products_endpoint(
         include_modifiers,
         include_all_types,
     )
+
+
+@router.get(
+    "/{product_id}",
+    response_model=ProductResponse,
+    dependencies=[Depends(require_module(Module.POS))],
+)
+async def get_pos_product_endpoint(
+    request: Request,
+    product_id: UUID,
+):
+    """POS-scoped single product read (modifiers included) for cashier product detail."""
+    return await get_product_by_id(request, product_id)

--- a/tests/test_pos_permissions.py
+++ b/tests/test_pos_permissions.py
@@ -23,6 +23,7 @@ from app.routers.tables import router as tables_router
 from app.routers.comandas import router as comandas_router
 from app.routers.pos_context import router as pos_context_router
 from app.routers.pos_products import router as pos_products_router
+from app.models.product import Product, ProductResponse
 
 
 # ─── Fixtures ─────────────────────────────────────────────────────────
@@ -226,3 +227,77 @@ def test_kitchen_role_denied_pos_products_under_enforce():
     assert response.status_code == 403
     assert "pos" in response.json()["detail"].lower()
     get_products.assert_not_awaited()
+
+
+def _minimal_product_response(product_id):
+    from datetime import datetime, timezone
+    from decimal import Decimal
+
+    now = datetime.now(timezone.utc)
+    return ProductResponse(
+        data=Product(
+            id=product_id,
+            tenant_id=uuid4(),
+            name="Test Product",
+            price=Decimal("10000"),
+            category_id=uuid4(),
+            created_at=now,
+            updated_at=now,
+        )
+    )
+
+
+def test_cashier_role_passes_pos_product_detail_under_enforce():
+    """Cashier reaches GET /pos/products/{id} under enforce without MENU."""
+    session = _build_session(role="cashier")
+    product_id = uuid4()
+    app = FastAPI()
+    app.include_router(pos_products_router)
+
+    cashier_modules = frozenset({Module.POS})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ), \
+         patch(
+             "app.routers.pos_products.get_product_by_id",
+             new=AsyncMock(return_value=_minimal_product_response(product_id)),
+         ) as get_one:
+        client = TestClient(app)
+        response = client.get(f"/pos/products/{product_id}")
+
+    assert response.status_code == 200
+    get_one.assert_awaited_once()
+    assert response.json()["data"]["name"] == "Test Product"
+
+
+def test_kitchen_role_denied_pos_product_detail_under_enforce():
+    """Kitchen role hits 403 on POS product detail because it lacks POS."""
+    session = _build_session(role="kitchen")
+    product_id = uuid4()
+    app = FastAPI()
+    app.include_router(pos_products_router)
+
+    kitchen_modules = frozenset({Module.DESPACHO})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=kitchen_modules),
+         ), \
+         patch(
+             "app.routers.pos_products.get_product_by_id",
+             new=AsyncMock(return_value=_minimal_product_response(product_id)),
+         ) as get_one:
+        client = TestClient(app)
+        response = client.get(f"/pos/products/{product_id}")
+
+    assert response.status_code == 403
+    assert "pos" in response.json()["detail"].lower()
+    get_one.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Add `GET /pos/products/{product_id}` gated under `Module.POS`, reusing `get_product_by_id` (modifiers with `included_quantity` / `option_type`).
- Extend `test_pos_permissions.py` for cashier 200 and kitchen 403 on product detail.

Companion front PR: uno0uno/warocol.com (branch `wr-680-pos-product-detail`)

Closes #680

## Test plan
- [ ] `pytest tests/test_pos_permissions.py -v` — all pass
- [ ] As cashier under enforce: deep-link `/pos/producto/{id}` loads modifiers (after front deploy)
- [ ] Kitchen role: `GET /pos/products/{id}` returns 403

## wr-context
See `.wr/680.yaml` locally (gitignored LLM contract).

Made with [Cursor](https://cursor.com)