### PR TITLE
feat(ingredients): inherit parent purchase units on variant creation

### DIFF
--- a/app/services/ingredients_service.py
+++ b/app/services/ingredients_service.py
@@ -187,6 +187,38 @@ def resolve_purchase_units(purchase_units: list, base_unit: str) -> list:
         })
     return resolved
 
+
+async def _copy_parent_purchase_units(conn, parent_id: UUID, ingredient_id: UUID) -> None:
+    """Seed a new variant ingredient with independent copies of the parent's purchase units."""
+    parent_units = await conn.fetch(
+        """
+        SELECT purchase_unit, purchase_unit_label, conversion_factor, unit_cost,
+               is_default, is_active, notes
+        FROM ingredient_purchase_units
+        WHERE ingredient_id = $1
+        ORDER BY is_default DESC, purchase_unit_label
+        """,
+        parent_id,
+    )
+    for pu in parent_units:
+        await conn.execute(
+            """
+            INSERT INTO ingredient_purchase_units
+                (ingredient_id, purchase_unit, purchase_unit_label, conversion_factor,
+                 unit_cost, is_default, is_active, notes)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            """,
+            ingredient_id,
+            pu["purchase_unit"],
+            pu["purchase_unit_label"],
+            pu["conversion_factor"],
+            pu["unit_cost"],
+            pu["is_default"],
+            pu["is_active"],
+            pu["notes"],
+        )
+
+
 async def get_ingredients_list(
     request: Request,
     response: Response,
@@ -551,9 +583,10 @@ async def create_tenant_ingredient(
         result["parent_name"] = parent_name
 
     # Insert purchase units within the same transaction
+    from uuid import UUID as _UUID
+    ingredient_uuid = _UUID(ingredient_id_text)
+
     if data.purchase_units:
-        from uuid import UUID as _UUID
-        ingredient_uuid = _UUID(ingredient_id_text)
         resolved = resolve_purchase_units(data.purchase_units, data.unit)
         for pu in resolved:
             await conn.execute(
@@ -568,6 +601,8 @@ async def create_tenant_ingredient(
                 pu['conversion_factor'],
                 pu['is_default'],
             )
+    elif parent_uuid:
+        await _copy_parent_purchase_units(conn, parent_uuid, ingredient_uuid)
 
     return result
 

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -13,6 +13,7 @@ from fastapi import HTTPException
 from httpx import AsyncClient
 
 from app.models.ingredient import TenantIngredientCreate
+from app.models.ingredient import PurchaseUnitInput
 from app.services.ingredients_service import (
     _validate_unit_for_type,
     create_tenant_ingredient,
@@ -170,6 +171,142 @@ class TestIngredientUnitTypeValidation:
         data = TenantIngredientUpdate(unit="hr")
         result = await update_tenant_ingredient(conn, tenant_id, ingredient_id, data)
         assert result["unit"] == "hr"
+
+
+class TestVariantPurchaseUnitInheritance:
+    """Issue #68 — copy parent purchase units when creating a variant ingredient."""
+
+    @pytest.mark.asyncio
+    async def test_create_variant_copies_parent_purchase_units(self):
+        tenant_id = uuid4()
+        parent_id = uuid4()
+        ingredient_id = uuid4()
+        conn = AsyncMock()
+        conn.fetchrow = AsyncMock(
+            side_effect=[
+                {"id": parent_id, "name": "Tomate"},
+                {
+                    "id": str(ingredient_id),
+                    "name": "Tomate pack x12",
+                    "unit": "gr",
+                    "type": "food",
+                    "category": None,
+                    "warehouse_category_id": None,
+                    "costo_unitario": None,
+                    "parent_id": str(parent_id),
+                    "tenant_id": str(tenant_id),
+                    "is_resale": False,
+                    "unit_weight_gr": None,
+                    "unit_weight_unit": "gr",
+                    "created_at": None,
+                },
+            ]
+        )
+        conn.fetch = AsyncMock(return_value=[
+            {
+                "purchase_unit": "kg",
+                "purchase_unit_label": "Kilogramo",
+                "conversion_factor": 1000,
+                "unit_cost": None,
+                "is_default": True,
+                "is_active": True,
+                "notes": None,
+            },
+        ])
+        data = TenantIngredientCreate(
+            name="Tomate pack x12",
+            unit="gr",
+            type="food",
+            parent_id=str(parent_id),
+        )
+
+        result = await create_tenant_ingredient(conn, tenant_id, data)
+
+        assert result["parent_id"] == str(parent_id)
+        conn.fetch.assert_awaited_once()
+        assert conn.fetch.await_args.args[1] == parent_id
+        conn.execute.assert_awaited_once()
+        insert_args = conn.execute.await_args.args
+        assert insert_args[1] == ingredient_id
+        assert insert_args[2] == "kg"
+
+    @pytest.mark.asyncio
+    async def test_create_variant_parent_without_purchase_units(self):
+        tenant_id = uuid4()
+        parent_id = uuid4()
+        conn = AsyncMock()
+        conn.fetchrow = AsyncMock(
+            side_effect=[
+                {"id": parent_id, "name": "Tomate"},
+                {
+                    "id": str(uuid4()),
+                    "name": "Tomate pack x12",
+                    "unit": "gr",
+                    "type": "food",
+                    "category": None,
+                    "warehouse_category_id": None,
+                    "costo_unitario": None,
+                    "parent_id": str(parent_id),
+                    "tenant_id": str(tenant_id),
+                    "is_resale": False,
+                    "unit_weight_gr": None,
+                    "unit_weight_unit": "gr",
+                    "created_at": None,
+                },
+            ]
+        )
+        conn.fetch = AsyncMock(return_value=[])
+        data = TenantIngredientCreate(
+            name="Tomate pack x12",
+            unit="gr",
+            type="food",
+            parent_id=str(parent_id),
+        )
+
+        await create_tenant_ingredient(conn, tenant_id, data)
+
+        conn.fetch.assert_awaited_once()
+        conn.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_create_variant_explicit_purchase_units_skip_inheritance(self):
+        tenant_id = uuid4()
+        parent_id = uuid4()
+        ingredient_id = uuid4()
+        conn = AsyncMock()
+        conn.fetchrow = AsyncMock(
+            side_effect=[
+                {"id": parent_id, "name": "Tomate"},
+                {
+                    "id": str(ingredient_id),
+                    "name": "Tomate pack x12",
+                    "unit": "gr",
+                    "type": "food",
+                    "category": None,
+                    "warehouse_category_id": None,
+                    "costo_unitario": None,
+                    "parent_id": str(parent_id),
+                    "tenant_id": str(tenant_id),
+                    "is_resale": False,
+                    "unit_weight_gr": None,
+                    "unit_weight_unit": "gr",
+                    "created_at": None,
+                },
+            ]
+        )
+        data = TenantIngredientCreate(
+            name="Tomate pack x12",
+            unit="gr",
+            type="food",
+            parent_id=str(parent_id),
+            purchase_units=[PurchaseUnitInput(purchase_unit="libra", is_default=True)],
+        )
+
+        await create_tenant_ingredient(conn, tenant_id, data)
+
+        conn.fetch.assert_not_awaited()
+        conn.execute.assert_awaited_once()
+        assert conn.execute.await_args.args[2] == "libra"
 
 
 class TestIngredientCategorySearch:


### PR DESCRIPTION
## Summary
- When `POST /suppliers/ingredients` creates a tenant variant with `parent_id` and no explicit `purchase_units`, copy the parent's `ingredient_purchase_units` as new independent rows.
- Explicit `purchase_units` in the request still take precedence over inheritance.

Closes #68

## Test plan
- [ ] Create variant with `parent_id` whose parent has purchase units → variant gets copies
- [ ] Parent with zero purchase units → variant creates cleanly
- [ ] Variant with explicit `purchase_units` → no parent fetch/copy

## Validation evidence
```
pytest tests/test_ingredients.py::TestVariantPurchaseUnitInheritance -v
# 3 passed in 0.04s

pytest tests/test_ingredients.py::TestIngredientUnitTypeValidation -v
# 11 passed in 0.03s
```

## wr-context
Local `.wr/68.yaml` (gitignored LLM contract).

Made with [Cursor](https://cursor.com)