### PR TITLE
fix(pos): POS-scoped checkout customer and invoice endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, pos_products, categories, recipe_bases, modifiers, ingredient_purchase_units, warehouse_categories, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, ai_agents, customer_portal, leads, waros, billing, legal, onboarding, payments_webhook, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router, email_tracking
+from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, pos_products, pos_customers, pos_orders, categories, recipe_bases, modifiers, ingredient_purchase_units, warehouse_categories, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, ai_agents, customer_portal, leads, waros, billing, legal, onboarding, payments_webhook, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router, email_tracking
 from app.config import settings
 from app.core.logging import setup_logging
 from app.core.exceptions import api_exception_handler, general_exception_handler, APIError
@@ -173,6 +173,8 @@ app.include_router(customers.router, prefix="/customers", tags=["customers"])
 app.include_router(pos_cart.router)
 app.include_router(pos_context.router)  # POS-scoped aggregator (BFF for /pos/restaurant-context)
 app.include_router(pos_products.router)  # POS-scoped product catalog read endpoint
+app.include_router(pos_customers.router)  # POS-scoped customer endpoints for checkout
+app.include_router(pos_orders.router)  # POS-scoped invoice emit/read for checkout
 app.include_router(operaciones_context.router)  # OPERACIONES-scoped aggregator + 5 toggle PATCH endpoints
 app.include_router(operaciones_shifts.router)  # OPERACIONES shift templates CRUD (#682)
 app.include_router(operaciones_operation_events.router)  # Bitácora POS events list (#782)

--- a/app/routers/pos_customers.py
+++ b/app/routers/pos_customers.py
@@ -1,0 +1,94 @@
+"""POS-scoped customer endpoints for checkout (cashier RBAC).
+
+Mirrors the minimal VENTAS customer subset used by POS checkout without
+granting cashiers Module.VENTAS.
+"""
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query, Request
+
+from app.core.permissions import Module, require_module
+from app.models.customer import (
+    CustomerInsightsResponse,
+    CustomerQuerySearchResponse,
+    CustomerResponse,
+    CustomerSearchOrCreate,
+    CustomerUpdate,
+    CustomerUpdateResponse,
+)
+from app.services.customers_service import (
+    get_customer_by_id,
+    get_customer_insights,
+    search_customers_by_query,
+    search_or_create_customer,
+    update_customer,
+)
+
+router = APIRouter(prefix="/pos/customers", tags=["pos"])
+
+
+@router.post(
+    "/search-or-create",
+    response_model=CustomerResponse,
+    status_code=200,
+    dependencies=[Depends(require_module(Module.POS))],
+)
+async def pos_search_or_create_customer_endpoint(
+    request: Request,
+    customer_data: CustomerSearchOrCreate,
+):
+    return await search_or_create_customer(request, customer_data)
+
+
+@router.get(
+    "/search-by-query",
+    response_model=CustomerQuerySearchResponse,
+    status_code=200,
+    dependencies=[Depends(require_module(Module.POS))],
+)
+async def pos_search_customers_by_query_endpoint(
+    request: Request,
+    q: str = Query(..., min_length=1, max_length=100),
+    limit: int = Query(20, ge=1, le=50),
+):
+    return await search_customers_by_query(request, q, limit)
+
+
+@router.get(
+    "/{customer_id}",
+    response_model=CustomerUpdateResponse,
+    status_code=200,
+    dependencies=[Depends(require_module(Module.POS))],
+)
+async def pos_get_customer_by_id_endpoint(
+    request: Request,
+    customer_id: UUID,
+):
+    return await get_customer_by_id(request, customer_id)
+
+
+@router.patch(
+    "/{customer_id}",
+    response_model=CustomerUpdateResponse,
+    status_code=200,
+    dependencies=[Depends(require_module(Module.POS))],
+)
+async def pos_update_customer_endpoint(
+    request: Request,
+    customer_id: UUID,
+    update_data: CustomerUpdate,
+):
+    return await update_customer(request, customer_id, update_data)
+
+
+@router.get(
+    "/{customer_id}/insights",
+    response_model=CustomerInsightsResponse,
+    status_code=200,
+    dependencies=[Depends(require_module(Module.POS))],
+)
+async def pos_get_customer_insights_endpoint(
+    request: Request,
+    customer_id: UUID,
+):
+    return await get_customer_insights(request, customer_id)

--- a/app/routers/pos_orders.py
+++ b/app/routers/pos_orders.py
@@ -1,0 +1,48 @@
+"""POS-scoped order invoice endpoints for checkout (cashier RBAC)."""
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Request
+
+from app.core.dependencies import require_invoicing_ready
+from app.core.middleware import require_valid_session
+from app.core.permissions import Module, require_module
+from app.services import facturacion_service
+
+router = APIRouter(prefix="/pos/orders", tags=["pos"])
+
+
+@router.post(
+    "/{order_id}/invoice",
+    tags=["Invoices"],
+    dependencies=[Depends(require_module(Module.POS))],
+)
+async def pos_emit_order_invoice(
+    request: Request,
+    order_id: UUID,
+    _readiness: dict = Depends(require_invoicing_ready),
+):
+    session_context = require_valid_session(request)
+    return await facturacion_service.emit_invoice(
+        order_id=str(order_id),
+        tenant_id=str(session_context.tenant_id),
+        order_type="pos",
+    )
+
+
+@router.get(
+    "/{order_id}/invoice",
+    tags=["Invoices"],
+    dependencies=[Depends(require_module(Module.POS))],
+)
+async def pos_get_order_invoice(
+    request: Request,
+    order_id: UUID,
+):
+    session_context = require_valid_session(request)
+    result = await facturacion_service.get_order_invoice(
+        order_id=str(order_id),
+        tenant_id=str(session_context.tenant_id),
+    )
+    if result is None:
+        return None
+    return result

--- a/tests/test_pos_permissions.py
+++ b/tests/test_pos_permissions.py
@@ -9,6 +9,7 @@ Sub-task E2.3 of Epic 2 (#188). Validates that:
 Pairs with `test_billing_permissions.py` (#185 / E2.14 reference impl).
 """
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -23,6 +24,8 @@ from app.routers.tables import router as tables_router
 from app.routers.comandas import router as comandas_router
 from app.routers.pos_context import router as pos_context_router
 from app.routers.pos_products import router as pos_products_router
+from app.routers.pos_customers import router as pos_customers_router
+from app.routers.pos_orders import router as pos_orders_router
 from app.models.product import Product, ProductResponse
 
 
@@ -301,3 +304,97 @@ def test_kitchen_role_denied_pos_product_detail_under_enforce():
     assert response.status_code == 403
     assert "pos" in response.json()["detail"].lower()
     get_one.assert_not_awaited()
+
+
+def test_cashier_role_passes_pos_customer_search_or_create_under_enforce():
+    """Cashier reaches POST /pos/customers/search-or-create without VENTAS."""
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(pos_customers_router)
+
+    cashier_modules = frozenset({Module.POS})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ), \
+         patch(
+             "app.routers.pos_customers.search_or_create_customer",
+             new=AsyncMock(return_value={
+                 "success": True,
+                 "data": {
+                     "id": str(uuid4()),
+                     "phone_number": "3001234567",
+                     "created_at": datetime.now(timezone.utc).isoformat(),
+                 },
+                 "is_new": False,
+             }),
+         ) as search_or_create:
+        client = TestClient(app)
+        response = client.post(
+            "/pos/customers/search-or-create",
+            json={"phone_number": "3001234567", "name": "Test"},
+        )
+
+    assert response.status_code == 200
+    search_or_create.assert_awaited_once()
+
+
+def test_cashier_role_passes_pos_order_invoice_read_under_enforce():
+    """Cashier reaches GET /pos/orders/{id}/invoice without VENTAS."""
+    session = _build_session(role="cashier")
+    order_id = uuid4()
+    app = FastAPI()
+    app.include_router(pos_orders_router)
+
+    cashier_modules = frozenset({Module.POS})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.pos_orders.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ), \
+         patch(
+             "app.routers.pos_orders.facturacion_service.get_order_invoice",
+             new=AsyncMock(return_value={"status": "accepted", "prefix": "FE", "invoice_number": 1}),
+         ) as get_invoice:
+        client = TestClient(app)
+        response = client.get(f"/pos/orders/{order_id}/invoice")
+
+    assert response.status_code == 200
+    get_invoice.assert_awaited_once()
+
+
+def test_kitchen_role_denied_pos_customers_under_enforce():
+    """Kitchen role hits 403 on POS customer endpoints because it lacks POS."""
+    session = _build_session(role="kitchen")
+    app = FastAPI()
+    app.include_router(pos_customers_router)
+
+    kitchen_modules = frozenset({Module.DESPACHO})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=kitchen_modules),
+         ), \
+         patch(
+             "app.routers.pos_customers.search_or_create_customer",
+             new=AsyncMock(),
+         ) as search_or_create:
+        client = TestClient(app)
+        response = client.post(
+            "/pos/customers/search-or-create",
+            json={"phone_number": "3001234567"},
+        )
+
+    assert response.status_code == 403
+    assert "pos" in response.json()["detail"].lower()
+    search_or_create.assert_not_awaited()

--- a/tests/test_ventas_permissions.py
+++ b/tests/test_ventas_permissions.py
@@ -22,6 +22,7 @@ from app.core import permissions
 from app.core.middleware import SessionContext
 from app.core.permissions import Module
 from app.routers.orders import router as orders_router
+from app.routers.customers import router as customers_router
 
 
 # ─── Fixtures ─────────────────────────────────────────────────────────
@@ -126,3 +127,33 @@ def test_cashier_role_denied_ventas_endpoint_under_enforce():
     assert response.status_code == 403
     assert "ventas" in response.json()["detail"].lower()
     dashboard.assert_not_awaited()
+
+
+def test_cashier_role_still_denied_ventas_customer_search_or_create_under_enforce():
+    """Cashier still hits 403 on VENTAS /customers/search-or-create (POS uses /pos/customers)."""
+    session = _build_session(role="cashier")
+    app = FastAPI()
+    app.include_router(customers_router, prefix="/customers")
+
+    cashier_modules = frozenset({Module.POS})
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch(
+             "app.core.permissions.get_role_modules",
+             new=AsyncMock(return_value=cashier_modules),
+         ), \
+         patch(
+             "app.routers.customers.search_or_create_customer",
+             new=AsyncMock(return_value={"success": True, "data": {}, "is_new": False}),
+         ) as search_or_create:
+        client = TestClient(app)
+        response = client.post(
+            "/customers/search-or-create",
+            json={"phone_number": "3001234567"},
+        )
+
+    assert response.status_code == 403
+    assert "ventas" in response.json()["detail"].lower()
+    search_or_create.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Add `/pos/customers/*` (search-or-create, search-by-query, get, patch, insights) gated under `Module.POS`.
- Add `/pos/orders/{id}/invoice` POST/GET for DIAN emit/read during POS checkout.
- Permission tests: cashier OK on POS routes; still 403 on VENTAS `/customers/search-or-create`.

Companion front PR: uno0uno/warocol.com (branch `wr-681-pos-checkout-endpoints`)

Closes #681

## Test plan
- [ ] Cashier under enforce: counter checkout with customer attach + optional invoice
- [ ] Cashier still 403 on `POST /customers/search-or-create` (VENTAS)

## Validation evidence
```
pytest tests/test_pos_permissions.py tests/test_ventas_permissions.py -v
# 15 passed in 0.12s
```

## wr-context
Local `.wr/681.yaml` (gitignored LLM contract).

Made with [Cursor](https://cursor.com)