### PR TITLE
feat(tables): consolidate mesa session orders before checkout close

### DIFF
--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -84,6 +84,102 @@ def _completed_session_orders_payload(order_rows: List[Any]) -> Dict[str, Any]:
     return payload
 
 
+async def _recalc_order_total_from_items(conn, order_id: UUID) -> None:
+    """Recompute orders.total_amount from line net/subtotal after a merge."""
+    await conn.execute(
+        """
+        UPDATE orders
+        SET total_amount = COALESCE((
+            SELECT SUM(COALESCE(oi.net_total, oi.subtotal))
+            FROM order_items oi
+            WHERE oi.order_id = $1
+        ), 0)
+        WHERE id = $1
+        """,
+        order_id,
+    )
+
+
+async def _merge_order_into_primary(
+    conn,
+    primary_order_id: UUID,
+    secondary_order_id: UUID,
+) -> None:
+    """Move checkout lines and payments onto the primary order, then drop the shell."""
+    if primary_order_id == secondary_order_id:
+        return
+    await conn.execute(
+        "UPDATE order_items SET order_id = $1 WHERE order_id = $2",
+        primary_order_id,
+        secondary_order_id,
+    )
+    await conn.execute(
+        "UPDATE order_payments SET order_id = $1 WHERE order_id = $2",
+        primary_order_id,
+        secondary_order_id,
+    )
+    await conn.execute("DELETE FROM orders WHERE id = $1", secondary_order_id)
+
+
+async def _consolidate_session_orders_for_checkout(conn, session_id: UUID) -> None:
+    """
+    Ensure a table session checkout produces a single order where possible.
+
+    - Multiple pending orders → oldest pending absorbs the rest.
+    - Pending + completed/partial → pending lines fold into oldest completed.
+    - Multiple completed/partial → oldest completed absorbs siblings (split legacy).
+    """
+    pending_rows = await conn.fetch(
+        """
+        SELECT id FROM orders
+        WHERE table_session_id = $1 AND status = 'pending'
+        ORDER BY created_at, id
+        """,
+        session_id,
+    )
+    if len(pending_rows) > 1:
+        primary_id = pending_rows[0]["id"]
+        for row in pending_rows[1:]:
+            await _merge_order_into_primary(conn, primary_id, row["id"])
+        await _recalc_order_total_from_items(conn, primary_id)
+
+    pending_rows = await conn.fetch(
+        """
+        SELECT id FROM orders
+        WHERE table_session_id = $1 AND status = 'pending'
+        ORDER BY created_at, id
+        """,
+        session_id,
+    )
+    completed_rows = await conn.fetch(
+        """
+        SELECT id FROM orders
+        WHERE table_session_id = $1 AND status = 'completed'
+        ORDER BY created_at, id
+        """,
+        session_id,
+    )
+    if pending_rows and completed_rows:
+        primary_id = completed_rows[0]["id"]
+        for row in pending_rows:
+            await _merge_order_into_primary(conn, primary_id, row["id"])
+        await _recalc_order_total_from_items(conn, primary_id)
+
+    completed_rows = await conn.fetch(
+        """
+        SELECT id FROM orders
+        WHERE table_session_id = $1 AND status = 'completed'
+        ORDER BY created_at, id
+        """,
+        session_id,
+    )
+    if len(completed_rows) > 1:
+        primary_id = completed_rows[0]["id"]
+        for row in completed_rows[1:]:
+            await _merge_order_into_primary(conn, primary_id, row["id"])
+        await _recalc_order_total_from_items(conn, primary_id)
+
+
 def _modifier_unit_total(mod: dict) -> float:
     return float(
         modifier_line_subtotal(
@@ -1177,6 +1273,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
 
                 # Mark pending orders as completed if payment_method provided
                 if payment_method:
+                    await _consolidate_session_orders_for_checkout(conn, session_row["id"])
                     # Backend guard: credit / wallet require an identified (non-anonymous) customer
                     if payment_method in ('credit', 'customer_wallet') and customer_id:
                         cust_row = await conn.fetchrow(
@@ -2071,6 +2168,8 @@ async def add_session_payment(
                 )
                 if not session_row:
                     raise NotFoundError("No open session found for this table")
+
+                await _consolidate_session_orders_for_checkout(conn, session_row["id"])
 
                 # Get all completed (partial) orders for this session
                 order_rows = await conn.fetch(

--- a/tests/test_consolidate_session_orders.py
+++ b/tests/test_consolidate_session_orders.py
@@ -1,0 +1,107 @@
+"""Mesa checkout consolidation — one order per session close (#686)."""
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from app.services import tables_service
+
+
+@pytest.mark.asyncio
+async def test_consolidate_merges_multiple_pending_into_oldest():
+    session_id = uuid4()
+    primary_id = uuid4()
+    secondary_id = uuid4()
+    fetch_results = [
+        [{"id": primary_id}, {"id": secondary_id}],
+        [{"id": primary_id}],
+        [],
+        [],
+    ]
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(side_effect=fetch_results)
+    mock_conn.execute = AsyncMock()
+
+    await tables_service._consolidate_session_orders_for_checkout(mock_conn, session_id)
+
+    assert mock_conn.fetch.call_count == 4
+    merge_calls = [
+        c for c in mock_conn.execute.await_args_list
+        if "UPDATE order_items SET order_id" in str(c.args[0])
+    ]
+    assert len(merge_calls) == 1
+    assert merge_calls[0].args[1:] == (primary_id, secondary_id)
+    delete_calls = [c for c in mock_conn.execute.await_args_list if "DELETE FROM orders" in str(c.args[0])]
+    assert len(delete_calls) == 1
+    recalc_calls = [c for c in mock_conn.execute.await_args_list if "SET total_amount = COALESCE" in str(c.args[0])]
+    assert len(recalc_calls) == 1
+    assert recalc_calls[0].args[1] == primary_id
+
+
+@pytest.mark.asyncio
+async def test_consolidate_folds_pending_into_completed_partial():
+    session_id = uuid4()
+    completed_id = uuid4()
+    pending_id = uuid4()
+    fetch_results = [
+        [{"id": pending_id}],
+        [{"id": pending_id}],
+        [{"id": completed_id}],
+        [{"id": completed_id}],
+    ]
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(side_effect=fetch_results)
+    mock_conn.execute = AsyncMock()
+
+    await tables_service._consolidate_session_orders_for_checkout(mock_conn, session_id)
+
+    merge_calls = [
+        c for c in mock_conn.execute.await_args_list
+        if "UPDATE order_items SET order_id" in str(c.args[0])
+    ]
+    assert len(merge_calls) == 1
+    assert merge_calls[0].args[1:] == (completed_id, pending_id)
+
+
+@pytest.mark.asyncio
+async def test_consolidate_merges_multiple_completed_split_orders():
+    session_id = uuid4()
+    primary_id = uuid4()
+    sibling_id = uuid4()
+    fetch_results = [
+        [],
+        [],
+        [{"id": primary_id}, {"id": sibling_id}],
+        [{"id": primary_id}, {"id": sibling_id}],
+    ]
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(side_effect=fetch_results)
+    mock_conn.execute = AsyncMock()
+
+    await tables_service._consolidate_session_orders_for_checkout(mock_conn, session_id)
+
+    merge_calls = [
+        c for c in mock_conn.execute.await_args_list
+        if "UPDATE order_items SET order_id" in str(c.args[0])
+    ]
+    assert len(merge_calls) == 1
+    assert merge_calls[0].args[1:] == (primary_id, sibling_id)
+
+
+@pytest.mark.asyncio
+async def test_consolidate_noop_for_single_pending_order():
+    session_id = uuid4()
+    order_id = uuid4()
+    fetch_results = [
+        [{"id": order_id}],
+        [{"id": order_id}],
+        [],
+        [],
+    ]
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(side_effect=fetch_results)
+    mock_conn.execute = AsyncMock()
+
+    await tables_service._consolidate_session_orders_for_checkout(mock_conn, session_id)
+
+    mock_conn.execute.assert_not_called()


### PR DESCRIPTION
## Summary
- Merge duplicate pending, pending+partial, or multi-completed session orders into one primary order before mesa checkout
- Hook consolidation in `close_session` (normal and split) and `add_session_payment`
- Unit tests for the three merge paths plus single-order noop

Closes #686

## Test plan
- [ ] Mesa with legacy 2 pending orders → close → single `order_id` in response
- [ ] Split partial + new pending items → final payment → one completed order
- [ ] Single-order mesa close unchanged

## Validation evidence
```bash
venv/bin/pytest tests/test_consolidate_session_orders.py -q
# 4 passed in 0.05s
```

## wr-context
See `.wr/686.yaml` locally (gitignored); helpers in `tables_service.py`.

Made with [Cursor](https://cursor.com)