### PR TITLE
fix(tables): harden mesa order consolidation merge paths

### DIFF
--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -108,8 +108,51 @@ async def _merge_order_into_primary(
     """Move checkout lines and payments onto the primary order, then drop the shell."""
     if primary_order_id == secondary_order_id:
         return
+
+    collisions = await conn.fetch(
+        """
+        SELECT sec.id AS secondary_item_id,
+               pri.id AS primary_item_id,
+               sec.quantity AS sec_qty,
+               sec.subtotal AS sec_subtotal,
+               COALESCE(sec.net_total, sec.subtotal) AS sec_net,
+               COALESCE(sec.discount_allocated, 0) AS sec_discount
+        FROM order_items sec
+        JOIN order_items pri
+          ON pri.order_id = $1
+         AND sec.order_id = $2
+         AND sec.variant_id IS NOT NULL
+         AND pri.variant_id = sec.variant_id
+        """,
+        primary_order_id,
+        secondary_order_id,
+    )
+    for row in collisions:
+        await conn.execute(
+            """
+            UPDATE order_items
+            SET quantity = quantity + $2,
+                subtotal = subtotal + $3,
+                net_total = COALESCE(net_total, subtotal) + $4,
+                discount_allocated = COALESCE(discount_allocated, 0) + $5,
+                updated_at = now()
+            WHERE id = $1
+            """,
+            row["primary_item_id"],
+            row["sec_qty"],
+            row["sec_subtotal"],
+            row["sec_net"],
+            row["sec_discount"],
+        )
+        await conn.execute(
+            "UPDATE comanda_items SET order_item_id = $1 WHERE order_item_id = $2",
+            row["primary_item_id"],
+            row["secondary_item_id"],
+        )
+        await conn.execute("DELETE FROM order_items WHERE id = $1", row["secondary_item_id"])
+
     await conn.execute(
-        "UPDATE order_items SET order_id = $1 WHERE order_id = $2",
+        "UPDATE order_items SET order_id = $1, updated_at = now() WHERE order_id = $2",
         primary_order_id,
         secondary_order_id,
     )
@@ -118,66 +161,92 @@ async def _merge_order_into_primary(
         primary_order_id,
         secondary_order_id,
     )
+    await conn.execute(
+        "UPDATE comandas SET order_id = $1, updated_at = now() WHERE order_id = $2",
+        primary_order_id,
+        secondary_order_id,
+    )
     await conn.execute("DELETE FROM orders WHERE id = $1", secondary_order_id)
 
 
-async def _consolidate_session_orders_for_checkout(conn, session_id: UUID) -> None:
+async def _merge_duplicate_pending_orders_for_session(conn, session_id: UUID) -> None:
+    pending_rows = await conn.fetch(
+        """
+        SELECT id FROM orders
+        WHERE table_session_id = $1 AND status = 'pending'
+        ORDER BY created_at, id
+        """,
+        session_id,
+    )
+    if len(pending_rows) <= 1:
+        return
+    primary_id = pending_rows[0]["id"]
+    for row in pending_rows[1:]:
+        await _merge_order_into_primary(conn, primary_id, row["id"])
+    await _recalc_order_total_from_items(conn, primary_id)
+
+
+async def _fold_pending_orders_into_completed_for_session(conn, session_id: UUID) -> None:
+    pending_rows = await conn.fetch(
+        """
+        SELECT id FROM orders
+        WHERE table_session_id = $1 AND status = 'pending'
+        ORDER BY created_at, id
+        """,
+        session_id,
+    )
+    completed_rows = await conn.fetch(
+        """
+        SELECT id FROM orders
+        WHERE table_session_id = $1 AND status = 'completed'
+        ORDER BY created_at, id
+        """,
+        session_id,
+    )
+    if not pending_rows or not completed_rows:
+        return
+    primary_id = completed_rows[0]["id"]
+    for row in pending_rows:
+        await _merge_order_into_primary(conn, primary_id, row["id"])
+    await _recalc_order_total_from_items(conn, primary_id)
+
+
+async def _merge_duplicate_completed_orders_for_session(conn, session_id: UUID) -> None:
+    completed_rows = await conn.fetch(
+        """
+        SELECT id FROM orders
+        WHERE table_session_id = $1 AND status = 'completed'
+        ORDER BY created_at, id
+        """,
+        session_id,
+    )
+    if len(completed_rows) <= 1:
+        return
+    primary_id = completed_rows[0]["id"]
+    for row in completed_rows[1:]:
+        await _merge_order_into_primary(conn, primary_id, row["id"])
+    await _recalc_order_total_from_items(conn, primary_id)
+
+
+async def _consolidate_session_orders_for_checkout(
+    conn,
+    session_id: UUID,
+    *,
+    fold_pending_into_completed: bool = True,
+) -> None:
     """
     Ensure a table session checkout produces a single order where possible.
 
     - Multiple pending orders → oldest pending absorbs the rest.
-    - Pending + completed/partial → pending lines fold into oldest completed.
+    - Pending + completed/partial → pending lines fold into oldest completed (optional).
     - Multiple completed/partial → oldest completed absorbs siblings (split legacy).
+
+    close_session defers fold_pending_into_completed until after pending settlement.
     """
-    pending_rows = await conn.fetch(
-        """
-        SELECT id FROM orders
-        WHERE table_session_id = $1 AND status = 'pending'
-        ORDER BY created_at, id
-        """,
-        session_id,
-    )
-    if len(pending_rows) > 1:
-        primary_id = pending_rows[0]["id"]
-        for row in pending_rows[1:]:
-            await _merge_order_into_primary(conn, primary_id, row["id"])
-        await _recalc_order_total_from_items(conn, primary_id)
-
-    pending_rows = await conn.fetch(
-        """
-        SELECT id FROM orders
-        WHERE table_session_id = $1 AND status = 'pending'
-        ORDER BY created_at, id
-        """,
-        session_id,
-    )
-    completed_rows = await conn.fetch(
-        """
-        SELECT id FROM orders
-        WHERE table_session_id = $1 AND status = 'completed'
-        ORDER BY created_at, id
-        """,
-        session_id,
-    )
-    if pending_rows and completed_rows:
-        primary_id = completed_rows[0]["id"]
-        for row in pending_rows:
-            await _merge_order_into_primary(conn, primary_id, row["id"])
-        await _recalc_order_total_from_items(conn, primary_id)
-
-    completed_rows = await conn.fetch(
-        """
-        SELECT id FROM orders
-        WHERE table_session_id = $1 AND status = 'completed'
-        ORDER BY created_at, id
-        """,
-        session_id,
-    )
-    if len(completed_rows) > 1:
-        primary_id = completed_rows[0]["id"]
-        for row in completed_rows[1:]:
-            await _merge_order_into_primary(conn, primary_id, row["id"])
-        await _recalc_order_total_from_items(conn, primary_id)
+    await _merge_duplicate_pending_orders_for_session(conn, session_id)
+    if fold_pending_into_completed:
+        await _fold_pending_orders_into_completed_for_session(conn, session_id)
+    await _merge_duplicate_completed_orders_for_session(conn, session_id)
 
 
 def _modifier_unit_total(mod: dict) -> float:
@@ -1273,7 +1342,11 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
 
                 # Mark pending orders as completed if payment_method provided
                 if payment_method:
-                    await _consolidate_session_orders_for_checkout(conn, session_row["id"])
+                    await _consolidate_session_orders_for_checkout(
+                        conn,
+                        session_row["id"],
+                        fold_pending_into_completed=False,
+                    )
                     # Backend guard: credit / wallet require an identified (non-anonymous) customer
                     if payment_method in ('credit', 'customer_wallet') and customer_id:
                         cust_row = await conn.fetchrow(
@@ -1512,6 +1585,8 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                         f"(payment_method={payment_method}, payment_status={payment_status}, "
                         f"discount_amount={_discount_amount}) for session {session_row['id']}"
                     )
+
+                    await _merge_duplicate_completed_orders_for_session(conn, session_row["id"])
 
                     # warocol.com#663 — checkout waiter attribution on all completed session orders
                     if resolved_served_by is not None:

--- a/tests/test_consolidate_session_orders.py
+++ b/tests/test_consolidate_session_orders.py
@@ -7,8 +7,79 @@ import pytest
 from app.services import tables_service
 
 
+def _sql_contains(args, needle: str) -> bool:
+    return needle in str(args[0])
+
+
+@pytest.fixture
+def stub_merge(monkeypatch):
+    merge_mock = AsyncMock()
+    recalc_mock = AsyncMock()
+    monkeypatch.setattr(tables_service, "_merge_order_into_primary", merge_mock)
+    monkeypatch.setattr(tables_service, "_recalc_order_total_from_items", recalc_mock)
+    return merge_mock
+
+
 @pytest.mark.asyncio
-async def test_consolidate_merges_multiple_pending_into_oldest():
+async def test_merge_order_repoints_comandas_and_items():
+    primary_id = uuid4()
+    secondary_id = uuid4()
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(return_value=[])
+    mock_conn.execute = AsyncMock()
+
+    await tables_service._merge_order_into_primary(mock_conn, primary_id, secondary_id)
+
+    execute_sql = [str(c.args[0]) for c in mock_conn.execute.await_args_list]
+    assert any("UPDATE order_items SET order_id" in s for s in execute_sql)
+    assert any("UPDATE order_payments SET order_id" in s for s in execute_sql)
+    assert any("UPDATE comandas SET order_id" in s for s in execute_sql)
+    assert any("DELETE FROM orders" in s for s in execute_sql)
+
+
+@pytest.mark.asyncio
+async def test_merge_order_sums_overlapping_variant_lines():
+    primary_id = uuid4()
+    secondary_id = uuid4()
+    primary_item_id = uuid4()
+    secondary_item_id = uuid4()
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(
+        return_value=[
+            {
+                "secondary_item_id": secondary_item_id,
+                "primary_item_id": primary_item_id,
+                "sec_qty": 2,
+                "sec_subtotal": 20.0,
+                "sec_net": 18.0,
+                "sec_discount": 2.0,
+            }
+        ]
+    )
+    mock_conn.execute = AsyncMock()
+
+    await tables_service._merge_order_into_primary(mock_conn, primary_id, secondary_id)
+
+    update_calls = [
+        c for c in mock_conn.execute.await_args_list
+        if _sql_contains(c.args, "quantity = quantity +")
+    ]
+    assert len(update_calls) == 1
+    assert update_calls[0].args[1:] == (primary_item_id, 2, 20.0, 18.0, 2.0)
+    comanda_item_updates = [
+        c for c in mock_conn.execute.await_args_list
+        if _sql_contains(c.args, "UPDATE comanda_items SET order_item_id")
+    ]
+    assert len(comanda_item_updates) == 1
+    delete_item_calls = [
+        c for c in mock_conn.execute.await_args_list
+        if _sql_contains(c.args, "DELETE FROM order_items WHERE id")
+    ]
+    assert len(delete_item_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_consolidate_merges_multiple_pending_into_oldest(stub_merge):
     session_id = uuid4()
     primary_id = uuid4()
     secondary_id = uuid4()
@@ -20,26 +91,14 @@ async def test_consolidate_merges_multiple_pending_into_oldest():
     ]
     mock_conn = AsyncMock()
     mock_conn.fetch = AsyncMock(side_effect=fetch_results)
-    mock_conn.execute = AsyncMock()
 
     await tables_service._consolidate_session_orders_for_checkout(mock_conn, session_id)
 
-    assert mock_conn.fetch.call_count == 4
-    merge_calls = [
-        c for c in mock_conn.execute.await_args_list
-        if "UPDATE order_items SET order_id" in str(c.args[0])
-    ]
-    assert len(merge_calls) == 1
-    assert merge_calls[0].args[1:] == (primary_id, secondary_id)
-    delete_calls = [c for c in mock_conn.execute.await_args_list if "DELETE FROM orders" in str(c.args[0])]
-    assert len(delete_calls) == 1
-    recalc_calls = [c for c in mock_conn.execute.await_args_list if "SET total_amount = COALESCE" in str(c.args[0])]
-    assert len(recalc_calls) == 1
-    assert recalc_calls[0].args[1] == primary_id
+    stub_merge.assert_awaited_once_with(mock_conn, primary_id, secondary_id)
 
 
 @pytest.mark.asyncio
-async def test_consolidate_folds_pending_into_completed_partial():
+async def test_consolidate_folds_pending_into_completed_partial(stub_merge):
     session_id = uuid4()
     completed_id = uuid4()
     pending_id = uuid4()
@@ -51,45 +110,57 @@ async def test_consolidate_folds_pending_into_completed_partial():
     ]
     mock_conn = AsyncMock()
     mock_conn.fetch = AsyncMock(side_effect=fetch_results)
-    mock_conn.execute = AsyncMock()
 
     await tables_service._consolidate_session_orders_for_checkout(mock_conn, session_id)
 
-    merge_calls = [
-        c for c in mock_conn.execute.await_args_list
-        if "UPDATE order_items SET order_id" in str(c.args[0])
-    ]
-    assert len(merge_calls) == 1
-    assert merge_calls[0].args[1:] == (completed_id, pending_id)
+    stub_merge.assert_awaited_once_with(mock_conn, completed_id, pending_id)
 
 
 @pytest.mark.asyncio
-async def test_consolidate_merges_multiple_completed_split_orders():
+async def test_consolidate_skips_pending_fold_when_disabled(stub_merge):
+    session_id = uuid4()
+    completed_id = uuid4()
+    pending_id = uuid4()
+    sibling_id = uuid4()
+    fetch_results = [
+        [{"id": pending_id}],
+        [{"id": completed_id}, {"id": sibling_id}],
+    ]
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(side_effect=fetch_results)
+
+    await tables_service._consolidate_session_orders_for_checkout(
+        mock_conn,
+        session_id,
+        fold_pending_into_completed=False,
+    )
+
+    stub_merge.assert_awaited_once_with(mock_conn, completed_id, sibling_id)
+
+
+@pytest.mark.asyncio
+async def test_consolidate_merges_multiple_completed_split_orders(stub_merge):
     session_id = uuid4()
     primary_id = uuid4()
     sibling_id = uuid4()
     fetch_results = [
         [],
-        [],
-        [{"id": primary_id}, {"id": sibling_id}],
         [{"id": primary_id}, {"id": sibling_id}],
     ]
     mock_conn = AsyncMock()
     mock_conn.fetch = AsyncMock(side_effect=fetch_results)
-    mock_conn.execute = AsyncMock()
 
-    await tables_service._consolidate_session_orders_for_checkout(mock_conn, session_id)
+    await tables_service._consolidate_session_orders_for_checkout(
+        mock_conn,
+        session_id,
+        fold_pending_into_completed=False,
+    )
 
-    merge_calls = [
-        c for c in mock_conn.execute.await_args_list
-        if "UPDATE order_items SET order_id" in str(c.args[0])
-    ]
-    assert len(merge_calls) == 1
-    assert merge_calls[0].args[1:] == (primary_id, sibling_id)
+    stub_merge.assert_awaited_once_with(mock_conn, primary_id, sibling_id)
 
 
 @pytest.mark.asyncio
-async def test_consolidate_noop_for_single_pending_order():
+async def test_consolidate_noop_for_single_pending_order(stub_merge):
     session_id = uuid4()
     order_id = uuid4()
     fetch_results = [
@@ -100,8 +171,7 @@ async def test_consolidate_noop_for_single_pending_order():
     ]
     mock_conn = AsyncMock()
     mock_conn.fetch = AsyncMock(side_effect=fetch_results)
-    mock_conn.execute = AsyncMock()
 
     await tables_service._consolidate_session_orders_for_checkout(mock_conn, session_id)
 
-    mock_conn.execute.assert_not_called()
+    stub_merge.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Merge overlapping `variant_id` lines by summing qty/subtotals instead of violating the unique constraint.
- Repoint `comandas` (and `comanda_items` on collision) before deleting secondary orders.
- In `close_session`, defer pending→completed fold until after pending settlement; merge completed siblings afterward.

Closes #686

## Test plan
- [ ] Mesa with duplicate pending orders (same product) closes without DB error
- [ ] Split partial + new items → final close leaves one completed order with correct payment_status
- [ ] Comandas-enabled tenant keeps KDS tickets after merge

## Validation evidence
```
venv/bin/pytest tests/test_consolidate_session_orders.py -q
.......                                                                  [100%]
7 passed in 0.06s
```

Made with [Cursor](https://cursor.com)