### PR TITLE
feat(blog): add articles.pillar column and API filter

### DIFF
--- a/app/models/article.py
+++ b/app/models/article.py
@@ -70,6 +70,7 @@ class Article(ArticleBase):
     draft: bool
     is_active: bool
     views: Optional[int] = 0
+    pillar: Optional[str] = None
     lang: str
     planet: str
     country: str
@@ -96,6 +97,7 @@ class ArticleSummary(BaseModel):
     cover: str
     tags: str
     views: Optional[int] = 0
+    pillar: Optional[str] = None
     published: bool
     created_at: datetime
     updated_at: Optional[datetime] = None

--- a/app/routers/articles.py
+++ b/app/routers/articles.py
@@ -19,9 +19,10 @@ async def get_articles_endpoint(
     request: Request,
     response: Response,
     page: int = Query(default=1, ge=1, description="Page number"),
-    limit: int = Query(default=10, ge=1, le=50, description="Items per page"),
+    limit: int = Query(default=10, ge=1, le=60, description="Items per page"),
     search: Optional[str] = Query(default=None, description="Search in title and description"),
-    tag: Optional[str] = Query(default=None, description="Filter by tag")
+    tag: Optional[str] = Query(default=None, description="Filter by tag"),
+    pillar: Optional[str] = Query(default=None, description="Filter by editorial pillar id")
 ):
     """
     Get published articles list for blog page.
@@ -33,7 +34,7 @@ async def get_articles_endpoint(
     """
     tenant_context = get_tenant_context(request)
     return await get_articles_list(
-        request, response, tenant_context.tenant_id, page, limit, search, tag
+        request, response, tenant_context.tenant_id, page, limit, search, tag, pillar
     )
 
 

--- a/app/services/articles_service.py
+++ b/app/services/articles_service.py
@@ -18,7 +18,8 @@ async def get_articles_list(
     page: int = 1,
     limit: int = 10,
     search: Optional[str] = None,
-    tag: Optional[str] = None
+    tag: Optional[str] = None,
+    pillar: Optional[str] = None
 ) -> ArticlesListResponse:
     """
     Get published articles list for a tenant (public endpoint for blog).
@@ -47,6 +48,11 @@ async def get_articles_list(
                 where_clauses.append(f"a.tags ILIKE ${param_count}")
                 params.append(f"%{tag}%")
 
+            if pillar:
+                param_count += 1
+                where_clauses.append(f"a.pillar = ${param_count}")
+                params.append(pillar)
+
             where_sql = " AND ".join(where_clauses)
 
             # Count total
@@ -73,6 +79,7 @@ async def get_articles_list(
                     a.thumbnail,
                     a.cover,
                     a.tags,
+                    a.pillar,
                     COALESCE(a.views, 0) as views,
                     a.published,
                     a.created_at,
@@ -98,6 +105,7 @@ async def get_articles_list(
                     thumbnail=row['thumbnail'],
                     cover=row['cover'],
                     tags=row['tags'],
+                    pillar=row['pillar'],
                     views=row['views'],
                     published=row['published'],
                     created_at=row['created_at'],
@@ -148,6 +156,7 @@ async def get_article_by_slug(
                     a.thumbnail,
                     a.cover,
                     a.tags,
+                    a.pillar,
                     COALESCE(a.views, 0) as views,
                     a.published,
                     a.draft,
@@ -214,6 +223,7 @@ async def get_article_by_slug(
                 thumbnail=row['thumbnail'],
                 cover=row['cover'],
                 tags=row['tags'],
+                pillar=row['pillar'],
                 views=row['views'] + (1 if increment_views else 0),
                 published=row['published'],
                 draft=row['draft'],
@@ -278,6 +288,7 @@ async def get_related_articles(
                     a.thumbnail,
                     a.cover,
                     a.tags,
+                    a.pillar,
                     COALESCE(a.views, 0) as views,
                     a.published,
                     a.created_at,
@@ -306,6 +317,7 @@ async def get_related_articles(
                     thumbnail=row['thumbnail'],
                     cover=row['cover'],
                     tags=row['tags'],
+                    pillar=row['pillar'],
                     views=row['views'],
                     published=row['published'],
                     created_at=row['created_at'],

--- a/dbdoc/public.articles.md
+++ b/dbdoc/public.articles.md
@@ -27,6 +27,7 @@
 | description | text |  | false |  |  |  |
 | updated_at | timestamp with time zone | now() | true |  |  |  |
 | tenant_id | uuid |  | true |  | [public.tenants](public.tenants.md) |  |
+| pillar | text |  | true |  |  | Editorial pillar id from content graph (e.g. software-para-restaurantes) |
 
 ## Constraints
 
@@ -46,6 +47,7 @@
 | articles_pkey | CREATE UNIQUE INDEX articles_pkey ON public.articles USING btree (id) |
 | articles_slug_key | CREATE UNIQUE INDEX articles_slug_key ON public.articles USING btree (slug) |
 | idx_articles_tenant_id | CREATE INDEX idx_articles_tenant_id ON public.articles USING btree (tenant_id) |
+| idx_articles_tenant_pillar | CREATE INDEX idx_articles_tenant_pillar ON public.articles USING btree (tenant_id, pillar) WHERE ((published = true) AND (is_active = true)) |
 
 ## Relations
 

--- a/sql/20260722_articles_pillar.sql
+++ b/sql/20260722_articles_pillar.sql
@@ -1,0 +1,11 @@
+-- warocol.com#1732 — editorial pillar id for blog magazine grouping (additive only)
+
+ALTER TABLE articles
+    ADD COLUMN IF NOT EXISTS pillar text NULL;
+
+CREATE INDEX IF NOT EXISTS idx_articles_tenant_pillar
+    ON articles (tenant_id, pillar)
+    WHERE published = true AND is_active = true;
+
+COMMENT ON COLUMN articles.pillar IS
+    'Editorial pillar id from content/pillar--*/ (e.g. software-para-restaurantes).';


### PR DESCRIPTION
## Summary
- Add nullable `articles.pillar` column + partial index for published blog articles
- Expose `pillar` on `GET /blog` list items and article detail
- Add `?pillar=` exact-match filter; raise list `limit` max from 50 to 60
- Additive only: no changes to article `content`, `tags`, titles, or slugs

Closes uno0uno/warocol.com#1732

## Deploy order (required)
**Run migration BEFORE container swap** — new code SELECTs `a.pillar`; without the column, `/blog` returns 500.

1. **Pre-deploy:** `psql -f sql/20260722_articles_pillar.sql`
2. **Pre-deploy or immediately after:** `content/_audits/sync_pillar_backfill_2026-07-22.py` (workspace script)
3. Deploy API (docker build + up -d)

## Validation evidence

Migration:
```
ALTER TABLE
CREATE INDEX
COMMENT
```

Backfill:
```
[commit] updated pillar for 51 articles; 0 unmapped; 51 published total
```

API:
```
total 51
pillar sample como-administrar-restaurante
with pillar 51
software total 25
```

## Test plan
- [ ] Migration applied on prod before deploy
- [ ] `GET /blog?limit=60` returns 51 items each with `pillar`
- [ ] `GET /blog?pillar=software-para-restaurantes` returns total 25
- [ ] Article detail pages unchanged (additive JSON field only)