### PR TITLE
feat(menu): persist online menu category order per tenant

### DIFF
--- a/app/models/category.py
+++ b/app/models/category.py
@@ -50,3 +50,8 @@ class CategoryResponse(BaseModel):
     """Single category response (for POST)"""
     success: bool = True
     data: Category
+
+
+class ReorderOnlineMenuCategoriesRequest(BaseModel):
+    """Payload for PATCH /menu/categories/online-menu/reorder."""
+    category_ids: List[UUID] = Field(..., min_length=1)

--- a/app/routers/categories.py
+++ b/app/routers/categories.py
@@ -12,7 +12,9 @@ from app.models.category import (
     CategoryCreate,
     CategoryResponse,
     CategoryUpdate,
+    ReorderOnlineMenuCategoriesRequest,
 )
+from app.services import categories_service
 
 router = APIRouter()
 
@@ -98,6 +100,29 @@ async def create_category_endpoint(request: Request, payload: CategoryCreate):
         )
 
     return CategoryResponse(success=True, data=Category(**dict(row)))
+
+
+# Static paths before /{category_id} (see stations.py:53-55).
+@router.get(
+    "/online-menu",
+    response_model=CategoriesListResponse,
+    dependencies=[Depends(require_module(Module.MI_NEGOCIO))],
+)
+async def get_online_menu_categories_endpoint(request: Request):
+    """Eligible online-menu categories in tenant saved order."""
+    return await categories_service.list_online_menu_categories(request)
+
+
+@router.patch(
+    "/online-menu/reorder",
+    dependencies=[Depends(require_module(Module.MI_NEGOCIO))],
+)
+async def reorder_online_menu_categories_endpoint(
+    request: Request,
+    body: ReorderOnlineMenuCategoriesRequest,
+):
+    """Persist drag order for public online menu category chips."""
+    return await categories_service.reorder_online_menu_categories(request, body.category_ids)
 
 
 async def _load_owned_category(conn, category_id: UUID, tenant_id: UUID):

--- a/app/services/categories_service.py
+++ b/app/services/categories_service.py
@@ -1,0 +1,151 @@
+"""Menu category helpers — online menu ordering (api-warolabs#690)."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from fastapi import Request
+
+from app.core.exceptions import APIError
+from app.core.middleware import require_valid_session
+from app.database import get_db_connection
+from app.models.category import Category
+
+logger = logging.getLogger(__name__)
+
+ONLINE_MENU_CATEGORY_ORDER_BY = "o.display_order NULLS LAST, c.name ASC"
+
+_ONLINE_MENU_PRODUCT_JOIN = """
+    JOIN product p ON p.category_id = c.id
+        AND p.tenant_id = $1
+        AND p.is_available = true
+        AND p.is_available_online = true
+"""
+
+_ONLINE_MENU_ORDER_JOIN = """
+    LEFT JOIN tenant_online_menu_category_orders o
+        ON o.category_id = c.id
+        AND o.tenant_id = $1
+"""
+
+
+def online_menu_categories_select_sql() -> str:
+    """SELECT fragment for public online menu categories (id, name, description)."""
+    return f"""
+        SELECT DISTINCT c.id, c.name, c.description
+        FROM categories c
+        {_ONLINE_MENU_PRODUCT_JOIN}
+        {_ONLINE_MENU_ORDER_JOIN}
+        ORDER BY {ONLINE_MENU_CATEGORY_ORDER_BY}
+    """
+
+
+def online_menu_products_order_by_sql() -> str:
+    """ORDER BY suffix for products grouped under ordered categories."""
+    return "o.display_order NULLS LAST, c.name ASC, p.name ASC"
+
+
+async def fetch_eligible_online_menu_category_ids(conn, tenant_id: UUID) -> List[UUID]:
+    rows = await conn.fetch(
+        f"""
+        SELECT DISTINCT c.id
+        FROM categories c
+        {_ONLINE_MENU_PRODUCT_JOIN}
+        WHERE (c.tenant_id IS NULL OR c.tenant_id = $1)
+        ORDER BY c.name ASC
+        """,
+        tenant_id,
+    )
+    return [row["id"] for row in rows]
+
+
+async def list_online_menu_categories(request: Request) -> Dict[str, Any]:
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+    if not tenant_id:
+        raise APIError("Tenant context is required", status_code=400)
+
+    async with get_db_connection() as conn:
+        rows = await conn.fetch(
+            f"""
+            SELECT DISTINCT
+                c.id, c.name, c.description, c.tenant_id, c.created_at, c.updated_at
+            FROM categories c
+            {_ONLINE_MENU_PRODUCT_JOIN}
+            {_ONLINE_MENU_ORDER_JOIN}
+            WHERE (c.tenant_id IS NULL OR c.tenant_id = $1)
+            ORDER BY {ONLINE_MENU_CATEGORY_ORDER_BY}
+            """,
+            tenant_id,
+        )
+
+    categories = [Category(**dict(row)) for row in rows]
+    return {
+        "success": True,
+        "total": len(categories),
+        "data": categories,
+    }
+
+
+async def reorder_online_menu_categories(request: Request, category_ids: List[UUID]) -> Dict[str, Any]:
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+    if not tenant_id:
+        raise APIError("Tenant context is required", status_code=400)
+
+    if not category_ids:
+        raise APIError("category_ids is required", status_code=400)
+
+    unique_ids = list(dict.fromkeys(category_ids))
+    if len(unique_ids) != len(category_ids):
+        raise APIError("category_ids contains duplicates", status_code=400)
+
+    async with get_db_connection() as conn:
+        async with conn.transaction():
+            eligible_ids = await fetch_eligible_online_menu_category_ids(conn, tenant_id)
+            eligible_set = set(eligible_ids)
+
+            if set(unique_ids) != eligible_set:
+                raise APIError(
+                    "category_ids must include every online-menu category exactly once",
+                    status_code=400,
+                )
+
+            visible_rows = await conn.fetch(
+                """
+                SELECT id
+                FROM categories
+                WHERE id = ANY($1::uuid[])
+                  AND (tenant_id IS NULL OR tenant_id = $2)
+                """,
+                unique_ids,
+                tenant_id,
+            )
+            if len(visible_rows) != len(unique_ids):
+                raise APIError("One or more categories were not found", status_code=404)
+
+            await conn.execute(
+                """
+                DELETE FROM tenant_online_menu_category_orders
+                WHERE tenant_id = $1
+                """,
+                tenant_id,
+            )
+            await conn.execute(
+                """
+                INSERT INTO tenant_online_menu_category_orders (tenant_id, category_id, display_order)
+                SELECT $1, id, ord::integer
+                FROM UNNEST($2::uuid[]) WITH ORDINALITY AS u(id, ord)
+                """,
+                tenant_id,
+                unique_ids,
+            )
+
+    return {
+        "success": True,
+        "message": "Orden de categorías del menú en línea actualizado",
+        "data": {
+            "category_ids": [str(category_id) for category_id in unique_ids],
+        },
+    }

--- a/app/services/public_restaurant_service.py
+++ b/app/services/public_restaurant_service.py
@@ -10,6 +10,7 @@ from app.services.billing_service import (
     ONLINE_ORDER_QUOTA_CUSTOMER_MESSAGE,
     get_public_online_order_quota_availability,
 )
+from app.services import categories_service
 from app.core.timezones import get_zoneinfo, normalize_timezone
 from app.database import get_db_connection
 import json
@@ -148,13 +149,7 @@ async def get_menu_by_slug(
             restaurant_name = profile['display_name']
 
             # 2. Get categories for this tenant
-            categories_query = """
-                SELECT DISTINCT c.id, c.name, c.description
-                FROM categories c
-                JOIN product p ON p.category_id = c.id
-                WHERE p.tenant_id = $1 AND p.is_available = true AND p.is_available_online = true
-                ORDER BY c.name
-            """
+            categories_query = categories_service.online_menu_categories_select_sql()
             categories_rows = await conn.fetch(categories_query, tenant_id)
             categories = [dict(row) for row in categories_rows]
 
@@ -172,6 +167,8 @@ async def get_menu_by_slug(
                     ) as has_modifiers
                 FROM product p
                 JOIN categories c ON p.category_id = c.id
+                LEFT JOIN tenant_online_menu_category_orders o
+                    ON o.category_id = c.id AND o.tenant_id = $1
                 WHERE p.tenant_id = $1 AND p.is_available = true AND p.is_available_online = true
             """
 
@@ -182,7 +179,7 @@ async def get_menu_by_slug(
                 products_query += " AND p.category_id = $2"
                 params.append(category_id)
 
-            products_query += " ORDER BY c.name, p.name"
+            products_query += f" ORDER BY {categories_service.online_menu_products_order_by_sql()}"
 
             products_rows = await conn.fetch(products_query, *params)
             products = [dict(row) for row in products_rows]
@@ -324,13 +321,7 @@ async def get_menu_by_tenant_id(
 
             restaurant_name = profile['display_name']
 
-            categories_query = """
-                SELECT DISTINCT c.id, c.name, c.description
-                FROM categories c
-                JOIN product p ON p.category_id = c.id
-                WHERE p.tenant_id = $1 AND p.is_available = true AND p.is_available_online = true
-                ORDER BY c.name
-            """
+            categories_query = categories_service.online_menu_categories_select_sql()
             categories_rows = await conn.fetch(categories_query, tenant_id)
             categories = [dict(row) for row in categories_rows]
 
@@ -347,6 +338,8 @@ async def get_menu_by_tenant_id(
                     ) as has_modifiers
                 FROM product p
                 JOIN categories c ON p.category_id = c.id
+                LEFT JOIN tenant_online_menu_category_orders o
+                    ON o.category_id = c.id AND o.tenant_id = $1
                 WHERE p.tenant_id = $1 AND p.is_available = true AND p.is_available_online = true
             """
 
@@ -356,7 +349,7 @@ async def get_menu_by_tenant_id(
                 products_query += " AND p.category_id = $2"
                 params.append(category_id)
 
-            products_query += " ORDER BY c.name, p.name"
+            products_query += f" ORDER BY {categories_service.online_menu_products_order_by_sql()}"
 
             products_rows = await conn.fetch(products_query, *params)
             products = [dict(row) for row in products_rows]

--- a/sql/20260722_tenant_online_menu_category_orders.sql
+++ b/sql/20260722_tenant_online_menu_category_orders.sql
@@ -1,0 +1,15 @@
+-- uno0uno/api-warolabs#690 — per-tenant order for online menu category chips.
+-- Additive only: globals stay on categories; order lives in junction rows.
+
+CREATE TABLE IF NOT EXISTS tenant_online_menu_category_orders (
+    tenant_id UUID NOT NULL,
+    category_id UUID NOT NULL REFERENCES categories(id) ON DELETE CASCADE,
+    display_order INTEGER NOT NULL,
+    PRIMARY KEY (tenant_id, category_id)
+);
+
+COMMENT ON TABLE tenant_online_menu_category_orders IS
+    'Per-tenant display order for categories shown on the public online menu (domicilios).';
+
+CREATE INDEX IF NOT EXISTS idx_tomco_tenant_display_order
+    ON tenant_online_menu_category_orders (tenant_id, display_order);

--- a/tests/test_categories_online_menu_order.py
+++ b/tests/test_categories_online_menu_order.py
@@ -1,0 +1,162 @@
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.exceptions import APIError
+from app.services import categories_service
+
+
+def _db_context(conn):
+    @asynccontextmanager
+    async def _ctx():
+        yield conn
+
+    return _ctx
+
+
+def _tx():
+    tx = MagicMock()
+    tx.__aenter__ = AsyncMock(return_value=None)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    return tx
+
+
+def _session(tenant_id=None):
+    return SimpleNamespace(user_id=uuid4(), tenant_id=tenant_id or uuid4())
+
+
+def _category_row(category_id, name="Burgers", *, tenant_id=None):
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return {
+        "id": category_id,
+        "name": name,
+        "description": None,
+        "tenant_id": tenant_id,
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+@pytest.mark.asyncio
+async def test_reorder_online_menu_categories_rejects_duplicate_ids():
+    category_id = uuid4()
+
+    with patch("app.services.categories_service.require_valid_session", return_value=_session()):
+        with pytest.raises(APIError) as exc:
+            await categories_service.reorder_online_menu_categories(
+                object(),
+                [category_id, category_id],
+            )
+
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_reorder_online_menu_categories_rejects_partial_set():
+    tenant_id = uuid4()
+    first_id = uuid4()
+    second_id = uuid4()
+    conn = MagicMock()
+    conn.transaction.return_value = _tx()
+    conn.fetch = AsyncMock(return_value=[{"id": first_id}, {"id": second_id}])
+
+    with (
+        patch("app.services.categories_service.require_valid_session", return_value=_session(tenant_id)),
+        patch("app.services.categories_service.get_db_connection", side_effect=_db_context(conn)),
+    ):
+        with pytest.raises(APIError) as exc:
+            await categories_service.reorder_online_menu_categories(object(), [first_id])
+
+    assert exc.value.status_code == 400
+    conn.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reorder_online_menu_categories_rejects_invisible_category():
+    tenant_id = uuid4()
+    first_id = uuid4()
+    second_id = uuid4()
+    conn = MagicMock()
+    conn.transaction.return_value = _tx()
+    conn.fetch = AsyncMock(side_effect=[
+        [{"id": first_id}, {"id": second_id}],
+        [{"id": first_id}],
+    ])
+
+    with (
+        patch("app.services.categories_service.require_valid_session", return_value=_session(tenant_id)),
+        patch("app.services.categories_service.get_db_connection", side_effect=_db_context(conn)),
+    ):
+        with pytest.raises(APIError) as exc:
+            await categories_service.reorder_online_menu_categories(
+                object(),
+                [first_id, second_id],
+            )
+
+    assert exc.value.status_code == 404
+    conn.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reorder_online_menu_categories_persists_order():
+    tenant_id = uuid4()
+    first_id = uuid4()
+    second_id = uuid4()
+    conn = MagicMock()
+    conn.transaction.return_value = _tx()
+    conn.fetch = AsyncMock(side_effect=[
+        [{"id": first_id}, {"id": second_id}],
+        [{"id": first_id}, {"id": second_id}],
+    ])
+    conn.execute = AsyncMock()
+
+    with (
+        patch("app.services.categories_service.require_valid_session", return_value=_session(tenant_id)),
+        patch("app.services.categories_service.get_db_connection", side_effect=_db_context(conn)),
+    ):
+        result = await categories_service.reorder_online_menu_categories(
+            object(),
+            [second_id, first_id],
+        )
+
+    assert result["success"] is True
+    assert result["data"]["category_ids"] == [str(second_id), str(first_id)]
+    assert conn.execute.await_count == 2
+    insert_query = conn.execute.await_args_list[1].args[0]
+    assert "INSERT INTO tenant_online_menu_category_orders" in insert_query
+
+
+@pytest.mark.asyncio
+async def test_list_online_menu_categories_orders_by_display_order():
+    tenant_id = uuid4()
+    first_id = uuid4()
+    second_id = uuid4()
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[
+        _category_row(first_id, "A"),
+        _category_row(second_id, "B"),
+    ])
+
+    with (
+        patch("app.services.categories_service.require_valid_session", return_value=_session(tenant_id)),
+        patch("app.services.categories_service.get_db_connection", side_effect=_db_context(conn)),
+    ):
+        result = await categories_service.list_online_menu_categories(object())
+
+    query = conn.fetch.await_args.args[0]
+    assert "tenant_online_menu_category_orders" in query
+    assert "o.display_order NULLS LAST" in query
+    assert [item.id for item in result["data"]] == [first_id, second_id]
+
+
+def test_public_menu_sql_uses_saved_category_order():
+    categories_sql = categories_service.online_menu_categories_select_sql()
+    products_order = categories_service.online_menu_products_order_by_sql()
+
+    assert "tenant_online_menu_category_orders" in categories_sql
+    assert "is_available_online = true" in categories_sql
+    assert "o.display_order NULLS LAST" in products_order


### PR DESCRIPTION
## Summary
- Add `tenant_online_menu_category_orders` junction table for per-tenant category order (supports global categories).
- Expose `GET /menu/categories/online-menu` and `PATCH /menu/categories/online-menu/reorder` (MI_NEGOCIO) for eligible domicilios categories only.
- Public restaurant menu (`get_menu_by_slug`, `get_menu_by_tenant_id`) returns categories/products using saved order.

Closes #690

Refs uno0uno/warocol.com#1734

## Validation evidence

```
pytest tests/test_categories_online_menu_order.py -v

tests/test_categories_online_menu_order.py::test_reorder_online_menu_categories_rejects_duplicate_ids PASSED
tests/test_categories_online_menu_order.py::test_reorder_online_menu_categories_rejects_partial_set PASSED
tests/test_categories_online_menu_order.py::test_reorder_online_menu_categories_rejects_invisible_category PASSED
tests/test_categories_online_menu_order.py::test_reorder_online_menu_categories_persists_order PASSED
tests/test_categories_online_menu_order.py::test_list_online_menu_categories_orders_by_display_order PASSED
tests/test_categories_online_menu_order.py::test_public_menu_sql_uses_saved_category_order PASSED

6 passed in 0.08s
```

## Deploy note
Run migration `sql/20260722_tenant_online_menu_category_orders.sql` on prod before shipping warocol.com#1735.

Made with [Cursor](https://cursor.com)