### PR TITLE
Batch 2: Starter API enforcement — write quotas, toggles, plan modules

### DIFF
--- a/app/core/permissions.py
+++ b/app/core/permissions.py
@@ -361,6 +361,20 @@ def require_module(module: Module) -> Callable[[Request], Awaitable[None]]:
         if not tenant_id:
             return  # no tenant resolved → cannot gate; let handler decide
 
+        from app.services.billing_service import (
+            STARTER_PLAN_MODULE_VALUES,
+            STARTER_PLAN_SLUG,
+            get_effective_plan_slug,
+        )
+
+        async with get_db_connection() as conn:
+            plan_slug = await get_effective_plan_slug(conn, tenant_id)
+        if plan_slug == STARTER_PLAN_SLUG and module.value not in STARTER_PLAN_MODULE_VALUES:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Módulo no disponible en el plan Starter: {module.value}",
+            )
+
         mode = await get_enforcement_mode(tenant_id)
         if mode == "disabled":
             return

--- a/app/models/me.py
+++ b/app/models/me.py
@@ -12,13 +12,15 @@ class AccessResponse(BaseModel):
       has no membership row yet — e.g. fresh-tenant owner pre-bootstrap,
       KDS-token synthetic session).
     - `modules`: sorted list of module string values the user can access,
-      already accounting for tenant-specific overrides.
+      already accounting for tenant-specific overrides and plan limits.
+    - `plan_slug`: effective billing plan slug when a tenant is resolved.
     - `enforcement_mode`: the tenant's current permissions mode, one of
       'disabled' | 'shadow' | 'enforce'.
     - `features`: tenant feature capabilities that are not RBAC modules.
     """
     role: Optional[str] = None
     modules: List[str] = []
+    plan_slug: Optional[str] = None
     enforcement_mode: str = "disabled"
     features: Dict[str, bool] = Field(
         default_factory=lambda: {"kali_enabled": False}

--- a/app/routers/me.py
+++ b/app/routers/me.py
@@ -4,14 +4,18 @@ from app.core.middleware import SessionContext, require_valid_session
 from app.core.permissions import Module, get_enforcement_mode, get_role_modules
 from app.database import get_db_connection
 from app.models.me import AccessResponse
-from app.services.billing_service import STARTER_PLAN_MODULE_VALUES, get_effective_plan_slug
+from app.services.billing_service import (
+    STARTER_PLAN_MODULE_VALUES,
+    STARTER_PLAN_SLUG,
+    get_effective_plan_slug,
+)
 from app.services.kali_access_service import get_kali_access_features
 
 router = APIRouter()
 
 
 def _intersect_plan_modules(role_modules, plan_slug: Optional[str]):
-    if plan_slug != "starter":
+    if plan_slug != STARTER_PLAN_SLUG:
         return role_modules
     allowed = {Module(value) for value in STARTER_PLAN_MODULE_VALUES}
     return frozenset(m for m in role_modules if m in allowed)
@@ -56,7 +60,7 @@ async def get_my_access(
     async with get_db_connection() as conn:
         plan_slug = await get_effective_plan_slug(conn, session.tenant_id)
     modules = _intersect_plan_modules(modules, plan_slug)
-    if plan_slug == "starter":
+    if plan_slug == STARTER_PLAN_SLUG:
         features = {**features, "kali_enabled": False}
     return AccessResponse(
         role=session.role,

--- a/app/routers/me.py
+++ b/app/routers/me.py
@@ -1,10 +1,20 @@
 from fastapi import APIRouter, Depends, Request
+from typing import Optional
 from app.core.middleware import SessionContext, require_valid_session
-from app.core.permissions import get_enforcement_mode, get_role_modules
+from app.core.permissions import Module, get_enforcement_mode, get_role_modules
+from app.database import get_db_connection
 from app.models.me import AccessResponse
+from app.services.billing_service import STARTER_PLAN_MODULE_VALUES, get_effective_plan_slug
 from app.services.kali_access_service import get_kali_access_features
 
 router = APIRouter()
+
+
+def _intersect_plan_modules(role_modules, plan_slug: Optional[str]):
+    if plan_slug != "starter":
+        return role_modules
+    allowed = {Module(value) for value in STARTER_PLAN_MODULE_VALUES}
+    return frozenset(m for m in role_modules if m in allowed)
 
 
 @router.get("/access", response_model=AccessResponse)
@@ -43,9 +53,15 @@ async def get_my_access(
         )
 
     modules = await get_role_modules(session.tenant_id, session.role)
+    async with get_db_connection() as conn:
+        plan_slug = await get_effective_plan_slug(conn, session.tenant_id)
+    modules = _intersect_plan_modules(modules, plan_slug)
+    if plan_slug == "starter":
+        features = {**features, "kali_enabled": False}
     return AccessResponse(
         role=session.role,
         modules=sorted(m.value for m in modules),
+        plan_slug=plan_slug,
         enforcement_mode=enforcement_mode,
         features=features,
     )

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -37,6 +37,12 @@ STARTER_OPERATIONAL_QUOTAS = {
     "active_qr_tables": 0,
     "completed_online_orders_per_month": 30,
     "electronic_invoices_per_period": 0,
+    "menu_products": 10,
+    "tenant_ingredients": 5,
+    "modifier_groups": 2,
+    "recipe_lines_per_product": 4,
+    "modifier_options_per_group": 6,
+    "recipe_base_template_lines": 4,
 }
 QUOTA_KEYS = (
     "admin_users",
@@ -46,7 +52,14 @@ QUOTA_KEYS = (
     "active_qr_tables",
     "completed_online_orders_per_month",
     "electronic_invoices_per_period",
+    "menu_products",
+    "tenant_ingredients",
+    "modifier_groups",
+    "recipe_lines_per_product",
+    "modifier_options_per_group",
+    "recipe_base_template_lines",
 )
+CATALOG_UNLIMITED = 1_000_000
 BASE_OPERATIONAL_QUOTAS = {
     "admin_users": 6,
     "active_sessions_per_admin_user": 1,
@@ -54,6 +67,12 @@ BASE_OPERATIONAL_QUOTAS = {
     "active_tables_including_bar": 20,
     "active_qr_tables": 20,
     "completed_online_orders_per_month": 300,
+    "menu_products": CATALOG_UNLIMITED,
+    "tenant_ingredients": CATALOG_UNLIMITED,
+    "modifier_groups": CATALOG_UNLIMITED,
+    "recipe_lines_per_product": 100,
+    "modifier_options_per_group": 50,
+    "recipe_base_template_lines": 75,
 }
 PLAN_QUOTA_DEFAULTS = {
     STARTER_PLAN_SLUG: {
@@ -81,6 +100,14 @@ ENFORCEABLE_QUOTA_RESOURCES = {
     "active_kitchens",
     "active_tables_including_bar",
     "active_qr_tables",
+    "menu_products",
+    "tenant_ingredients",
+    "modifier_groups",
+}
+SCOPED_QUOTA_RESOURCES = {
+    "recipe_lines_per_product",
+    "modifier_options_per_group",
+    "recipe_base_template_lines",
 }
 
 
@@ -227,6 +254,42 @@ async def get_effective_plan_quotas(conn, tenant_id: UUID) -> Dict[str, int]:
     return _normalize_plan_quotas(plan_slug, features)
 
 
+STARTER_PLAN_MODULE_VALUES = frozenset({
+    "pos",
+    "ventas",
+    "menu",
+    "operaciones",
+    "abastecimiento",
+    "mi_negocio",
+    "mi_plan",
+})
+STARTER_LOCKED_OPERATION_TOGGLES = frozenset({
+    "tables_enabled",
+    "comandas_enabled",
+    "kds_enabled",
+})
+
+
+async def is_starter_plan(conn, tenant_id: UUID) -> bool:
+    return await get_effective_plan_slug(conn, tenant_id) == STARTER_PLAN_SLUG
+
+
+async def assert_starter_toggle_allowed(conn, tenant_id: UUID, column_name: str, enabled: bool) -> None:
+    if not enabled or column_name not in STARTER_LOCKED_OPERATION_TOGGLES:
+        return
+    if await is_starter_plan(conn, tenant_id):
+        raise APIError(
+            "Función no disponible en el plan Starter",
+            status_code=403,
+            details={
+                "code": "starter_plan_restriction",
+                "toggle": column_name,
+                "upgrade_url": QUOTA_UPGRADE_URL,
+                "message": QUOTA_CONTACT_MESSAGE,
+            },
+        )
+
+
 async def _default_scan_limit_for_tenant(conn, tenant_id: UUID) -> int:
     plan_slug = await get_effective_plan_slug(conn, tenant_id)
     if plan_slug == STARTER_PLAN_SLUG:
@@ -359,6 +422,61 @@ async def check_plan_quota_growth(
     )
 
 
+async def check_plan_quota_scoped(
+    conn,
+    tenant_id: UUID,
+    resource: str,
+    scope_id: UUID,
+    *,
+    projected_count: Optional[int] = None,
+) -> None:
+    """Block scoped resource growth (per product/group/template)."""
+    if resource not in SCOPED_QUOTA_RESOURCES:
+        raise ValueError(f"Unsupported scoped quota resource: {resource}")
+
+    plan = await _fetch_plan_quota_context(conn, tenant_id, resource)
+    if not plan:
+        return
+
+    quotas = _normalize_plan_quotas(plan["plan_slug"], plan["plan_features"])
+    quota = _effective_quota_from_row(resource, quotas.get(resource, 0), plan)
+    if quota.limit is None:
+        return
+
+    if projected_count is not None:
+        used = projected_count
+    else:
+        used = await _count_scoped_quota_usage(conn, resource, scope_id) + 1
+
+    if used <= quota.limit:
+        return
+
+    _log_quota_block(
+        tenant_id=tenant_id,
+        resource=resource,
+        used=used,
+        quota=quota,
+        plan_slug=plan["plan_slug"],
+    )
+    raise APIError(
+        "Límite del plan alcanzado",
+        status_code=429,
+        details={
+            "code": "quota_exceeded",
+            "error": "quota_exceeded",
+            "resource": resource,
+            "scope_id": str(scope_id),
+            "used": used,
+            "limit": quota.limit,
+            "plan_limit": quota.plan_limit,
+            "plan_slug": plan["plan_slug"],
+            "override": _quota_override_payload(quota),
+            "upgrade_url": QUOTA_UPGRADE_URL,
+            "message": QUOTA_CONTACT_MESSAGE,
+        },
+    )
+
+
 async def _get_completed_online_order_quota_state(conn, tenant_id: UUID) -> Optional[OnlineOrderQuotaState]:
     """
     Read current online-order quota state.
@@ -392,7 +510,34 @@ async def _get_completed_online_order_quota_state(conn, tenant_id: UUID) -> Opti
         ONLINE_ORDER_QUOTA_RESOURCE,
     )
     if not plan:
-        return None
+        effective_slug = await get_effective_plan_slug(conn, tenant_id)
+        if effective_slug != STARTER_PLAN_SLUG:
+            return None
+        plan = await conn.fetchrow(
+            """
+            SELECT
+                sp.slug AS plan_slug,
+                sp.features AS plan_features,
+                date_trunc('month', now()) AS current_period_start,
+                date_trunc('month', now()) + interval '1 month' AS current_period_end,
+                tq.id AS override_id,
+                tq.limit_override,
+                COALESCE(tq.disabled, false) AS override_disabled,
+                tq.reason AS override_reason
+            FROM subscription_plans sp
+            LEFT JOIN tenant_quota_overrides tq
+              ON tq.tenant_id = $1
+             AND tq.resource = $2
+            WHERE sp.slug = $3
+              AND sp.is_active = true
+            LIMIT 1
+            """,
+            tenant_id,
+            ONLINE_ORDER_QUOTA_RESOURCE,
+            STARTER_PLAN_SLUG,
+        )
+        if not plan:
+            return None
 
     quotas = _normalize_plan_quotas(plan["plan_slug"], plan["plan_features"])
     quota = _effective_quota_from_row(
@@ -706,8 +851,72 @@ async def _count_quota_resource_usage(
             """,
             tenant_id,
         )
+    elif resource == "menu_products":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM product
+            WHERE tenant_id = $1
+            """,
+            tenant_id,
+        )
+    elif resource == "tenant_ingredients":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM ingredients
+            WHERE tenant_id = $1
+              AND is_active = TRUE
+            """,
+            tenant_id,
+        )
+    elif resource == "modifier_groups":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM modifier_groups
+            WHERE tenant_id = $1
+            """,
+            tenant_id,
+        )
     else:
         raise ValueError(f"Unsupported quota resource: {resource}")
+
+    return int(value or 0)
+
+
+async def _count_scoped_quota_usage(conn, resource: str, scope_id: UUID) -> int:
+    if resource == "recipe_lines_per_product":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM product_recipes
+            WHERE product_id = $1
+            """,
+            scope_id,
+        )
+    elif resource == "modifier_options_per_group":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM modifiers
+            WHERE modifier_group_id = $1
+              AND is_available = TRUE
+              AND removed_at IS NULL
+            """,
+            scope_id,
+        )
+    elif resource == "recipe_base_template_lines":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM base_recipe_templates
+            WHERE product_base_type_id = $1
+            """,
+            scope_id,
+        )
+    else:
+        raise ValueError(f"Unsupported scoped quota resource: {resource}")
 
     return int(value or 0)
 

--- a/app/services/ingredients_service.py
+++ b/app/services/ingredients_service.py
@@ -11,6 +11,7 @@ from app.services.warehouse_categories_service import (
     list_warehouse_categories,
     resolve_assignable_warehouse_category,
 )
+from app.services.billing_service import check_plan_quota_growth
 
 logger = logging.getLogger(__name__)
 
@@ -546,6 +547,8 @@ async def create_tenant_ingredient(
         data.warehouse_category_id,
         data.category,
     )
+
+    await check_plan_quota_growth(conn, tenant_id, "tenant_ingredients")
 
     try:
         row = await conn.fetchrow(

--- a/app/services/modifiers_service.py
+++ b/app/services/modifiers_service.py
@@ -16,6 +16,7 @@ from app.services.modifier_option_service import (
     calculated_modifier_option_unit_cost,
     validate_modifier_option_fields,
 )
+from app.services.billing_service import check_plan_quota_growth, check_plan_quota_scoped
 import logging
 
 logger = logging.getLogger(__name__)
@@ -165,9 +166,22 @@ async def _build_modifier(
     return Modifier(**mod_dict)
 
 
-async def _insert_modifier(conn, group_id: UUID, modifier) -> UUID:
+async def _insert_modifier(conn, group_id: UUID, modifier, *, skip_quota_check: bool = False) -> UUID:
     validate_modifier_option_fields(modifier)
     option_type = (modifier.option_type or "INGREDIENT").upper()
+
+    if not skip_quota_check:
+        tenant_id = await conn.fetchval(
+            "SELECT tenant_id FROM modifier_groups WHERE id = $1",
+            group_id,
+        )
+        if tenant_id:
+            await check_plan_quota_scoped(
+                conn,
+                tenant_id,
+                "modifier_options_per_group",
+                group_id,
+            )
 
     ing_qty = modifier.ingredient_quantity
     ing_unit = modifier.ingredient_unit
@@ -231,6 +245,7 @@ async def create_modifier_group(
 
         async with get_db_connection() as conn:
             async with conn.transaction():
+                await check_plan_quota_growth(conn, tenant_id, "modifier_groups")
                 # 1. Insert modifier group (without product_id)
                 group_query = """
                     INSERT INTO modifier_groups (
@@ -269,8 +284,15 @@ async def create_modifier_group(
 
                 # 3. Insert modifiers (option types + optional modifier_recipes)
                 if group_data.modifiers:
+                    await check_plan_quota_scoped(
+                        conn,
+                        tenant_id,
+                        "modifier_options_per_group",
+                        group_id,
+                        projected_count=len(group_data.modifiers),
+                    )
                     for modifier in group_data.modifiers:
-                        await _insert_modifier(conn, group_id, modifier)
+                        await _insert_modifier(conn, group_id, modifier, skip_quota_check=True)
 
                 # 4. Registrar en historial
                 user_id = session_context.user_id if hasattr(session_context, 'user_id') else None

--- a/app/services/operaciones_context_service.py
+++ b/app/services/operaciones_context_service.py
@@ -32,6 +32,7 @@ from app.services.open_priced_service import (
     fetch_open_sale_product,
 )
 from app.services.pos_context_service import get_restaurant_context as _pos_get_context
+from app.services.billing_service import assert_starter_toggle_allowed
 
 
 ALLOWED_TOGGLES = frozenset({
@@ -98,6 +99,7 @@ async def update_toggle(
     """
 
     async with get_db_connection() as conn:
+        await assert_starter_toggle_allowed(conn, tenant_id, column_name, enabled)
         await conn.execute(query, tenant_id, enabled)
 
     return {"success": True, "data": {column_name: enabled}}

--- a/app/services/products_service.py
+++ b/app/services/products_service.py
@@ -15,6 +15,7 @@ from app.services.aws_s3_service import AWSS3Service
 from app.services.ingredient_purchase_units_service import resolve_to_base_unit
 from app.services.open_priced_service import assert_single_open_priced_per_tenant
 from app.services.ingredients_service import create_tenant_ingredient
+from app.services.billing_service import check_plan_quota_growth, check_plan_quota_scoped
 from app.models.ingredient import TenantIngredientCreate, PurchaseUnitInput
 import asyncpg
 import logging
@@ -168,6 +169,7 @@ async def create_product_with_recipe(
         async with get_db_connection() as conn:
             # Start transaction
             async with conn.transaction():
+                await check_plan_quota_growth(conn, tenant_id, "menu_products")
                 if product_data.open_priced:
                     await assert_single_open_priced_per_tenant(conn, tenant_id)
 
@@ -237,6 +239,18 @@ async def create_product_with_recipe(
                 )
 
                 product_id = product_result['id']
+
+                recipe_line_count = len(product_data.ingredients or [])
+                if auto_resale_ingredient_id:
+                    recipe_line_count += 1
+                if recipe_line_count:
+                    await check_plan_quota_scoped(
+                        conn,
+                        tenant_id,
+                        "recipe_lines_per_product",
+                        product_id,
+                        projected_count=recipe_line_count,
+                    )
 
                 # 2. Insert recipe base associations (with per-product quantity, Issue #517)
                 if normalized_bases:
@@ -1252,6 +1266,14 @@ async def update_product_with_recipe(
                 # 3. Update recipe if ingredients provided.
                 # Empty list is now valid — product becomes "no inventory tracking".
                 if product_data.ingredients is not None:
+                    if product_data.ingredients:
+                        await check_plan_quota_scoped(
+                            conn,
+                            tenant_id,
+                            "recipe_lines_per_product",
+                            product_id,
+                            projected_count=len(product_data.ingredients),
+                        )
                     # Delete existing recipe
                     delete_recipe_query = "DELETE FROM product_recipes WHERE product_id = $1"
                     await conn.execute(delete_recipe_query, product_id)

--- a/app/services/public_restaurant_service.py
+++ b/app/services/public_restaurant_service.py
@@ -45,21 +45,6 @@ _PUBLIC_TENANT_BILLING_ELIGIBILITY_SQL = """
 )
 """
 
-_PUBLIC_DIRECTORY_TENANT_ELIGIBILITY_FILTER = """
-(
-  ts.status IN ('active', 'past_due')
-  OR (
-    ts.tenant_id IS NULL
-    AND NOT EXISTS (
-      SELECT 1
-      FROM tenant_onboarding tob
-      WHERE tob.tenant_id = tpp.tenant_id
-        AND tob.state = 'payment_pending'
-    )
-  )
-)
-"""
-
 
 async def get_profile_by_slug(slug: str) -> Optional[Dict[str, Any]]:
     """
@@ -720,9 +705,7 @@ async def list_restaurants(
     """
     try:
         async with get_db_connection() as conn:
-            # Gate by billing: only tenants with an active or past_due
-            # subscription appear in the public directory. INNER JOIN drops
-            # tenants with no subscription row (free / never paid).
+            # Paid subscription or permanent Starter (same predicate as profile/menu).
             query = f"""
                 SELECT
                     tpp.id, tpp.tenant_id, tpp.slug, tpp.is_active,
@@ -845,13 +828,11 @@ async def list_cities(include_empty: bool = False) -> List[Dict[str, Any]]:
                     pc.sort_order,
                     COUNT(tpp.id) FILTER (
                         WHERE tpp.is_active = true
-                          AND {_PUBLIC_DIRECTORY_TENANT_ELIGIBILITY_FILTER}
+                          AND {_PUBLIC_TENANT_BILLING_ELIGIBILITY_SQL}
                     ) AS tenant_count
                 FROM public_cities pc
                 LEFT JOIN tenant_public_profiles tpp
                        ON tpp.city_slug = pc.city_slug
-                LEFT JOIN tenant_subscriptions ts
-                       ON ts.tenant_id = tpp.tenant_id
                 WHERE pc.is_active = true
                 GROUP BY
                     pc.country,

--- a/app/services/public_restaurant_service.py
+++ b/app/services/public_restaurant_service.py
@@ -18,6 +18,48 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+_PUBLIC_TENANT_BILLING_ELIGIBILITY_SQL = """
+(
+  EXISTS (
+    SELECT 1
+    FROM tenant_subscriptions ts
+    WHERE ts.tenant_id = tpp.tenant_id
+      AND ts.status IN ('active', 'past_due')
+      AND ts.current_period_end > now()
+  )
+  OR (
+    NOT EXISTS (
+      SELECT 1
+      FROM tenant_subscriptions ts
+      WHERE ts.tenant_id = tpp.tenant_id
+        AND ts.status IN ('active', 'past_due')
+        AND ts.current_period_end > now()
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM tenant_onboarding tob
+      WHERE tob.tenant_id = tpp.tenant_id
+        AND tob.state = 'payment_pending'
+    )
+  )
+)
+"""
+
+_PUBLIC_DIRECTORY_TENANT_ELIGIBILITY_FILTER = """
+(
+  ts.status IN ('active', 'past_due')
+  OR (
+    ts.tenant_id IS NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM tenant_onboarding tob
+      WHERE tob.tenant_id = tpp.tenant_id
+        AND tob.state = 'payment_pending'
+    )
+  )
+)
+"""
+
 
 async def get_profile_by_slug(slug: str) -> Optional[Dict[str, Any]]:
     """
@@ -31,13 +73,8 @@ async def get_profile_by_slug(slug: str) -> Optional[Dict[str, Any]]:
     """
     try:
         async with get_db_connection() as conn:
-            # JOIN tenant_subscriptions to gate out tenants without an active
-            # paid subscription. INNER JOIN drops tenants with no row at all
-            # (the "free / never paid" case). Visible statuses follow the
-            # canonical predicate used elsewhere in billing_service: 'active'
-            # plus 'past_due' (any age — only flips dark when billing actually
-            # marks the row as 'cancelled').
-            query = """
+            # Paid subscription or permanent Starter plan (no payment_pending).
+            query = f"""
                 SELECT
                     tpp.id, tpp.tenant_id, tpp.slug, tpp.is_active,
                     tpp.display_name, tpp.description, tpp.logo_url, tpp.banner_url,
@@ -51,10 +88,9 @@ async def get_profile_by_slug(slug: str) -> Optional[Dict[str, Any]]:
                     tpp.tip_enabled, tpp.tip_default_percentages, tpp.tip_preselect_index,
                     tpp.created_at, tpp.updated_at
                 FROM tenant_public_profiles tpp
-                JOIN tenant_subscriptions ts ON ts.tenant_id = tpp.tenant_id
                 WHERE tpp.slug = $1
                   AND tpp.is_active = true
-                  AND ts.status IN ('active', 'past_due')
+                  AND {_PUBLIC_TENANT_BILLING_ELIGIBILITY_SQL}
             """
 
             row = await conn.fetchrow(query, slug)
@@ -129,13 +165,12 @@ async def get_menu_by_slug(
             # 1. Get tenant_id from profile (gated by billing subscription —
             # mirror the predicate from get_profile_by_slug so a hidden tenant
             # cannot leak menu data either).
-            profile_query = """
+            profile_query = f"""
                 SELECT tpp.tenant_id, tpp.display_name
                 FROM tenant_public_profiles tpp
-                JOIN tenant_subscriptions ts ON ts.tenant_id = tpp.tenant_id
                 WHERE tpp.slug = $1
                   AND tpp.is_active = true
-                  AND ts.status IN ('active', 'past_due')
+                  AND {_PUBLIC_TENANT_BILLING_ELIGIBILITY_SQL}
             """
             profile = await conn.fetchrow(profile_query, slug)
 
@@ -688,7 +723,7 @@ async def list_restaurants(
             # Gate by billing: only tenants with an active or past_due
             # subscription appear in the public directory. INNER JOIN drops
             # tenants with no subscription row (free / never paid).
-            query = """
+            query = f"""
                 SELECT
                     tpp.id, tpp.tenant_id, tpp.slug, tpp.is_active,
                     tpp.display_name, tpp.description, tpp.logo_url, tpp.banner_url,
@@ -699,9 +734,8 @@ async def list_restaurants(
                     tpp.accepts_online_orders,
                     tpp.created_at, tpp.updated_at
                 FROM tenant_public_profiles tpp
-                JOIN tenant_subscriptions ts ON ts.tenant_id = tpp.tenant_id
                 WHERE tpp.is_active = true
-                  AND ts.status IN ('active', 'past_due')
+                  AND {_PUBLIC_TENANT_BILLING_ELIGIBILITY_SQL}
             """
             params: List[Any] = []
 
@@ -797,7 +831,7 @@ async def list_cities(include_empty: bool = False) -> List[Dict[str, Any]]:
     try:
         async with get_db_connection() as conn:
             rows = await conn.fetch(
-                """
+                f"""
                 SELECT
                     pc.country,
                     pc.city,
@@ -811,7 +845,7 @@ async def list_cities(include_empty: bool = False) -> List[Dict[str, Any]]:
                     pc.sort_order,
                     COUNT(tpp.id) FILTER (
                         WHERE tpp.is_active = true
-                          AND ts.status IN ('active', 'past_due')
+                          AND {_PUBLIC_DIRECTORY_TENANT_ELIGIBILITY_FILTER}
                     ) AS tenant_count
                 FROM public_cities pc
                 LEFT JOIN tenant_public_profiles tpp

--- a/app/services/recipe_bases_service.py
+++ b/app/services/recipe_bases_service.py
@@ -19,6 +19,7 @@ from app.models.recipe_base import (
 )
 from app.services import menu_history_service
 from app.services.ingredient_purchase_units_service import resolve_to_base_unit
+from app.services.billing_service import check_plan_quota_scoped
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +76,15 @@ async def create_recipe_base_type(
             )
 
             base_type_id = base_type_row['id']
+
+            if recipe_data.ingredients:
+                await check_plan_quota_scoped(
+                    conn,
+                    tenant_id,
+                    "recipe_base_template_lines",
+                    base_type_id,
+                    projected_count=len(recipe_data.ingredients),
+                )
 
             # Insert ingredients into base_recipe_templates
             ingredients = []
@@ -481,6 +491,15 @@ async def update_recipe_base_type(
                     WHERE product_base_type_id = $1 AND tenant_id = $2
                 """
                 await conn.execute(delete_ingredients_query, recipe_base_id, tenant_id)
+
+                if update_data.ingredients:
+                    await check_plan_quota_scoped(
+                        conn,
+                        tenant_id,
+                        "recipe_base_template_lines",
+                        recipe_base_id,
+                        projected_count=len(update_data.ingredients),
+                    )
 
                 # Insert new ingredients
                 for ingredient_data in update_data.ingredients:

--- a/sql/20260722_starter_catalog_quotas.sql
+++ b/sql/20260722_starter_catalog_quotas.sql
@@ -1,0 +1,20 @@
+-- api-warolabs#694: Starter catalog quota keys (non-destructive).
+-- Merges catalog caps into the starter plan features.quotas JSON.
+
+UPDATE subscription_plans
+SET
+    features = jsonb_set(
+        COALESCE(features, '{}'::jsonb),
+        '{quotas}',
+        COALESCE(features->'quotas', '{}'::jsonb) || '{
+          "menu_products": 10,
+          "tenant_ingredients": 5,
+          "modifier_groups": 2,
+          "recipe_lines_per_product": 4,
+          "modifier_options_per_group": 6,
+          "recipe_base_template_lines": 4
+        }'::jsonb,
+        true
+    ),
+    updated_at = now()
+WHERE slug = 'starter';

--- a/tests/test_me_access.py
+++ b/tests/test_me_access.py
@@ -72,6 +72,8 @@ def test_owner_returns_all_modules():
     with patch("app.core.middleware.get_session_context", return_value=session), \
          patch("app.routers.me.require_valid_session", return_value=session), \
          patch("app.core.permissions.get_db_connection", side_effect=_mock_db_ctx("disabled")), \
+         patch("app.routers.me.get_db_connection", side_effect=_mock_db_ctx("disabled")), \
+         patch("app.routers.me.get_effective_plan_slug", new=AsyncMock(return_value="pro")), \
          patch(
              "app.routers.me.get_kali_access_features",
              new=AsyncMock(return_value={"kali_enabled": True}),
@@ -85,8 +87,37 @@ def test_owner_returns_all_modules():
     # Owner gets every module in the enum, sorted.
     expected = sorted(m.value for m in Module)
     assert body["modules"] == expected
+    assert body["plan_slug"] == "pro"
     assert body["enforcement_mode"] == "disabled"
     assert body["features"]["kali_enabled"] is True
+
+
+def test_starter_owner_excludes_finanzas_and_facturacion():
+    """Starter plan intersects owner modules — paid-only modules hidden."""
+    session = _build_session(role="owner")
+    app = FastAPI()
+    app.include_router(me_router, prefix="/me")
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.routers.me.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_mock_db_ctx("disabled")), \
+         patch("app.routers.me.get_db_connection", side_effect=_mock_db_ctx("disabled")), \
+         patch("app.routers.me.get_effective_plan_slug", new=AsyncMock(return_value="starter")), \
+         patch(
+             "app.routers.me.get_kali_access_features",
+             new=AsyncMock(return_value={"kali_enabled": True}),
+         ):
+        client = TestClient(app)
+        response = client.get("/me/access")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["plan_slug"] == "starter"
+    assert "finanzas" not in body["modules"]
+    assert "facturacion" not in body["modules"]
+    assert "equipo" not in body["modules"]
+    assert "pos" in body["modules"]
+    assert body["features"]["kali_enabled"] is False
 
 
 @pytest.mark.parametrize("role", ["cashier", "employee"])
@@ -101,6 +132,8 @@ def test_cashier_and_legacy_employee_return_pos_only(role):
     with patch("app.core.middleware.get_session_context", return_value=session), \
          patch("app.routers.me.require_valid_session", return_value=session), \
          patch("app.core.permissions.get_db_connection", side_effect=_mock_db_ctx("disabled")), \
+         patch("app.routers.me.get_db_connection", side_effect=_mock_db_ctx("disabled")), \
+         patch("app.routers.me.get_effective_plan_slug", new=AsyncMock(return_value="pro")), \
          patch(
              "app.routers.me.get_kali_access_features",
              new=AsyncMock(return_value={"kali_enabled": False}),
@@ -183,6 +216,8 @@ def test_enforcement_mode_disabled_reported():
     with patch("app.core.middleware.get_session_context", return_value=session), \
          patch("app.routers.me.require_valid_session", return_value=session), \
          patch("app.core.permissions.get_db_connection", side_effect=_mock_db_ctx("disabled")), \
+         patch("app.routers.me.get_db_connection", side_effect=_mock_db_ctx("disabled")), \
+         patch("app.routers.me.get_effective_plan_slug", new=AsyncMock(return_value="pro")), \
          patch(
              "app.routers.me.get_kali_access_features",
              new=AsyncMock(return_value={"kali_enabled": False}),
@@ -209,6 +244,8 @@ def test_enforcement_mode_enforce_reported():
     with patch("app.core.middleware.get_session_context", return_value=session), \
          patch("app.routers.me.require_valid_session", return_value=session), \
          patch("app.core.permissions.get_db_connection", side_effect=_mock_db_ctx("enforce")), \
+         patch("app.routers.me.get_db_connection", side_effect=_mock_db_ctx("enforce")), \
+         patch("app.routers.me.get_effective_plan_slug", new=AsyncMock(return_value="pro")), \
          patch(
              "app.routers.me.get_kali_access_features",
              new=AsyncMock(return_value={"kali_enabled": False}),

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -845,3 +845,97 @@ async def test_assert_starter_toggle_rejects_tables_enabled():
 
     assert exc.value.status_code == 403
     assert exc.value.details["code"] == "starter_plan_restriction"
+
+
+@pytest.mark.asyncio
+async def test_starter_modifier_groups_quota_blocks_at_limit():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_starter_plan_row("modifier_groups", 2))
+    conn.fetchval = AsyncMock(return_value=2)
+
+    with pytest.raises(APIError) as exc:
+        await billing_service.check_plan_quota_growth(conn, tenant_id, "modifier_groups")
+
+    assert exc.value.details["resource"] == "modifier_groups"
+
+
+@pytest.mark.asyncio
+async def test_scoped_recipe_base_template_lines_quota_blocks_over_limit():
+    tenant_id = uuid4()
+    base_type_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_starter_plan_row("recipe_base_template_lines", 4))
+    conn.fetchval = AsyncMock(return_value=0)
+
+    with pytest.raises(APIError) as exc:
+        await billing_service.check_plan_quota_scoped(
+            conn,
+            tenant_id,
+            "recipe_base_template_lines",
+            base_type_id,
+            projected_count=5,
+        )
+
+    assert exc.value.details["resource"] == "recipe_base_template_lines"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("toggle", ["comandas_enabled", "kds_enabled"])
+async def test_assert_starter_toggle_rejects_locked_operaciones_toggles(toggle):
+    tenant_id = uuid4()
+    conn = MagicMock()
+
+    with patch.object(
+        billing_service,
+        "get_effective_plan_slug",
+        new=AsyncMock(return_value="starter"),
+    ):
+        with pytest.raises(APIError) as exc:
+            await billing_service.assert_starter_toggle_allowed(conn, tenant_id, toggle, True)
+
+    assert exc.value.details["code"] == "starter_plan_restriction"
+
+
+@pytest.mark.asyncio
+async def test_default_scan_limit_for_starter_is_ten():
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={"scan_limit": 10})
+
+    with patch.object(
+        billing_service,
+        "get_effective_plan_slug",
+        new=AsyncMock(return_value="starter"),
+    ):
+        limit = await billing_service._default_scan_limit_for_tenant(conn, uuid4())
+
+    assert limit == 10
+
+
+@pytest.mark.asyncio
+async def test_require_module_blocks_finanzas_for_starter_plan():
+    from app.core.permissions import Module, require_module
+
+    session = SimpleNamespace(
+        is_valid=True,
+        tenant_id=uuid4(),
+        user_id=uuid4(),
+        role="owner",
+    )
+    dep = require_module(Module.FINANZAS)
+    request = MagicMock()
+    request.url.path = "/financiero/tir-metrics"
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch(
+             "app.services.billing_service.get_effective_plan_slug",
+             new=AsyncMock(return_value="starter"),
+         ), \
+         patch("app.core.permissions.get_db_connection") as db_ctx:
+        db_ctx.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+        db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+        with pytest.raises(HTTPException) as exc:
+            await dep(request)
+
+    assert exc.value.status_code == 403
+    assert "Starter" in exc.value.detail

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -195,7 +195,12 @@ async def test_check_plan_quota_growth_without_active_subscription_is_noop():
     conn.fetchrow = AsyncMock(return_value=None)
     conn.fetchval = AsyncMock()
 
-    await billing_service.check_plan_quota_growth(conn, uuid4(), "active_tables_including_bar")
+    with patch.object(
+        billing_service,
+        "get_effective_plan_slug",
+        new=AsyncMock(return_value=None),
+    ):
+        await billing_service.check_plan_quota_growth(conn, uuid4(), "active_tables_including_bar")
 
     conn.fetchval.assert_not_awaited()
 
@@ -437,7 +442,12 @@ async def test_completed_online_order_quota_without_active_subscription_is_noop(
     conn.fetchrow = AsyncMock(return_value=None)
     conn.fetchval = AsyncMock()
 
-    await billing_service.check_completed_online_order_quota(conn, uuid4())
+    with patch.object(
+        billing_service,
+        "get_effective_plan_slug",
+        new=AsyncMock(return_value=None),
+    ):
+        await billing_service.check_completed_online_order_quota(conn, uuid4())
 
     conn.fetchval.assert_not_awaited()
 
@@ -699,3 +709,139 @@ async def test_checkout_checked_out_cart_without_order_stays_conflict():
             await online_cart_service.checkout_cart(cart_id)
 
     assert exc.value.status_code == 409
+
+
+def _starter_plan_row(resource: str, limit: int):
+    return {
+        "plan_slug": "starter",
+        "plan_features": {"quotas": {resource: limit}},
+        "override_id": None,
+        "limit_override": None,
+        "override_disabled": False,
+        "override_reason": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_starter_menu_products_quota_blocks_at_limit():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_starter_plan_row("menu_products", 10))
+    conn.fetchval = AsyncMock(return_value=10)
+
+    with pytest.raises(APIError) as exc:
+        await billing_service.check_plan_quota_growth(conn, tenant_id, "menu_products")
+
+    assert exc.value.status_code == 429
+    assert exc.value.details["code"] == "quota_exceeded"
+    assert exc.value.details["resource"] == "menu_products"
+
+
+@pytest.mark.asyncio
+async def test_starter_tenant_ingredients_quota_blocks_at_limit():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_starter_plan_row("tenant_ingredients", 5))
+    conn.fetchval = AsyncMock(return_value=5)
+
+    with pytest.raises(APIError) as exc:
+        await billing_service.check_plan_quota_growth(conn, tenant_id, "tenant_ingredients")
+
+    assert exc.value.details["resource"] == "tenant_ingredients"
+
+
+@pytest.mark.asyncio
+async def test_scoped_recipe_lines_quota_blocks_over_limit():
+    tenant_id = uuid4()
+    product_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_starter_plan_row("recipe_lines_per_product", 4))
+    conn.fetchval = AsyncMock(return_value=0)
+
+    with pytest.raises(APIError) as exc:
+        await billing_service.check_plan_quota_scoped(
+            conn,
+            tenant_id,
+            "recipe_lines_per_product",
+            product_id,
+            projected_count=5,
+        )
+
+    assert exc.value.details["resource"] == "recipe_lines_per_product"
+    assert exc.value.details["used"] == 5
+
+
+@pytest.mark.asyncio
+async def test_scoped_modifier_options_quota_blocks_over_limit():
+    tenant_id = uuid4()
+    group_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_starter_plan_row("modifier_options_per_group", 6))
+    conn.fetchval = AsyncMock(return_value=0)
+
+    with pytest.raises(APIError) as exc:
+        await billing_service.check_plan_quota_scoped(
+            conn,
+            tenant_id,
+            "modifier_options_per_group",
+            group_id,
+            projected_count=7,
+        )
+
+    assert exc.value.details["resource"] == "modifier_options_per_group"
+
+
+@pytest.mark.asyncio
+async def test_starter_online_order_quota_enforced_without_paid_subscription():
+    tenant_id = uuid4()
+    period_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    period_end = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    conn = MagicMock()
+
+    async def fetchrow(query, *args):
+        if "FROM tenant_subscriptions ts" in query and "date_trunc('month'" not in query:
+            return None
+        if "FROM subscription_plans sp" in query and "date_trunc('month'" in query:
+            return {
+                "plan_slug": "starter",
+                "plan_features": {"quotas": {"completed_online_orders_per_month": 30}},
+                "current_period_start": period_start,
+                "current_period_end": period_end,
+                "override_id": None,
+                "limit_override": None,
+                "override_disabled": False,
+                "override_reason": None,
+            }
+        return None
+
+    conn.fetchrow = AsyncMock(side_effect=fetchrow)
+    conn.fetchval = AsyncMock(return_value=30)
+
+    with patch.object(
+        billing_service,
+        "get_effective_plan_slug",
+        new=AsyncMock(return_value="starter"),
+    ):
+        with pytest.raises(APIError) as exc:
+            await billing_service.check_completed_online_order_quota(conn, tenant_id)
+
+    assert exc.value.details["code"] == "online_order_quota_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_assert_starter_toggle_rejects_tables_enabled():
+    tenant_id = uuid4()
+    conn = MagicMock()
+
+    with patch.object(
+        billing_service,
+        "get_effective_plan_slug",
+        new=AsyncMock(return_value="starter"),
+    ):
+        with pytest.raises(APIError) as exc:
+            await billing_service.assert_starter_toggle_allowed(
+                conn, tenant_id, "tables_enabled", True
+            )
+
+    assert exc.value.status_code == 403
+    assert exc.value.details["code"] == "starter_plan_restriction"


### PR DESCRIPTION
## Summary
- Extend quota engine with catalog caps (`menu_products`, `tenant_ingredients`, `modifier_groups`) and scoped caps (recipe lines, modifier options, recipe base templates)
- Hook write paths in products, ingredients, modifiers, recipe bases; enforce starter online-order monthly quota without paid subscription
- Block starter operaciones toggles (tables/comandas/kds); intersect `/me/access` modules with plan; always-on plan guard in `require_module`
- Allow starter tenants on public profile/menu; seed catalog quotas via migration SQL

## Test plan
- [x] `./venv/bin/pytest tests/test_quota_enforcement.py tests/test_me_access.py -q` (39 passed)

## Validation evidence
```
============================= test session starts ==============================
collected 39 items

tests/test_quota_enforcement.py ..............................           [ 76%]
tests/test_me_access.py .........                                        [100%]

============================== 39 passed in 0.20s ==============================
```

Closes #694

Made with [Cursor](https://cursor.com)