### PR TITLE
Batch 1: Starter plan API foundation — onboarding, access level, quota defaults

### DIFF
--- a/app/core/onboarding_access.py
+++ b/app/core/onboarding_access.py
@@ -5,6 +5,7 @@ _NEXT_STEP_BY_STATE = {
     "email_verified": "business_profile",
     "business_profile_pending": "business_profile",
     "terms_pending": "terms",
+    "starter_active": "setup",
     "payment_pending": "payment",
     "paid": "activation",
     "active": "setup",

--- a/app/models/onboarding.py
+++ b/app/models/onboarding.py
@@ -17,6 +17,7 @@ OnboardingState = Literal[
     "email_verified",
     "business_profile_pending",
     "terms_pending",
+    "starter_active",
     "payment_pending",
     "paid",
     "active",

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -364,7 +364,7 @@ async def get_access_status(request: Request):
     Return the subscription access level for the authenticated tenant.
 
     Levels:
-      free             — no subscription; limited free plan
+      starter          — no paid subscription; permanent Starter plan
       full             — active subscription
       full_with_warning — past_due, ≤ 3 days overdue
       read_only        — past_due, 3-7 days overdue
@@ -373,12 +373,20 @@ async def get_access_status(request: Request):
     session = require_valid_session(request)
     async with get_db_connection(use_transaction=False) as conn:
         access = await billing_service.get_subscription_access(session.tenant_id, conn)
+        plan_slug = await billing_service.get_effective_plan_slug(conn, session.tenant_id)
+        quotas = (
+            await billing_service.get_effective_plan_quotas(conn, session.tenant_id)
+            if plan_slug
+            else {}
+        )
         return {
             "level": access.level,
             "grace_days_remaining": access.grace_days_remaining,
             "subscription_status": access.subscription_status,
             "next_payment_date": access.next_payment_date,
             "message": access.message,
+            "plan_slug": plan_slug,
+            "quotas": quotas,
         }
 
 

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -24,9 +24,20 @@ from app.services import onboarding_service
 logger = logging.getLogger(__name__)
 
 ELECTRONIC_INVOICE_PLAN_SLUG = "facturacion-electronica"
+STARTER_PLAN_SLUG = "starter"
+STARTER_SCAN_LIMIT = 10
 ELECTRONIC_INVOICE_PERIOD_LIMIT = 200
 ELECTRONIC_INVOICE_LIMIT_FEATURE = "electronic_invoice_limit"
 QUOTAS_FEATURE = "quotas"
+STARTER_OPERATIONAL_QUOTAS = {
+    "admin_users": 1,
+    "active_sessions_per_admin_user": 1,
+    "active_kitchens": 0,
+    "active_tables_including_bar": 0,
+    "active_qr_tables": 0,
+    "completed_online_orders_per_month": 30,
+    "electronic_invoices_per_period": 0,
+}
 QUOTA_KEYS = (
     "admin_users",
     "active_sessions_per_admin_user",
@@ -45,6 +56,9 @@ BASE_OPERATIONAL_QUOTAS = {
     "completed_online_orders_per_month": 300,
 }
 PLAN_QUOTA_DEFAULTS = {
+    STARTER_PLAN_SLUG: {
+        **STARTER_OPERATIONAL_QUOTAS,
+    },
     "pro": {
         **BASE_OPERATIONAL_QUOTAS,
         "electronic_invoices_per_period": 0,
@@ -164,22 +178,75 @@ async def check_scan_quota(tenant_id: UUID, conn) -> None:
     await _upsert_monthly_log(tenant_id, conn)
 
 
-async def check_plan_quota_growth(
-    conn,
-    tenant_id: UUID,
-    resource: str,
-    *,
-    exclude_pending_invitation_id: Optional[UUID] = None,
-) -> None:
+async def get_effective_plan_slug(conn, tenant_id: UUID) -> Optional[str]:
     """
-    Block active resource growth once the tenant reaches the plan quota.
-
-    This is intentionally non-destructive: it never modifies existing rows and
-    should be called only before create/reactivate/enable transitions.
+    Paid subscription wins. Otherwise Starter applies unless onboarding is still
+    waiting on payment (legacy paid-first path).
     """
-    if resource not in ENFORCEABLE_QUOTA_RESOURCES:
-        raise ValueError(f"Unsupported quota resource: {resource}")
+    paid = await conn.fetchrow(
+        """
+        SELECT sp.slug AS plan_slug
+        FROM tenant_subscriptions ts
+        JOIN subscription_plans sp ON sp.id = ts.plan_id
+        WHERE ts.tenant_id = $1
+          AND ts.status IN ('active', 'past_due')
+          AND ts.current_period_end > now()
+        ORDER BY ts.current_period_end DESC
+        LIMIT 1
+        """,
+        tenant_id,
+    )
+    if paid:
+        return paid["plan_slug"]
 
+    onboarding_state = await conn.fetchval(
+        "SELECT state FROM tenant_onboarding WHERE tenant_id = $1",
+        tenant_id,
+    )
+    if onboarding_state == "payment_pending":
+        return None
+
+    return STARTER_PLAN_SLUG
+
+
+async def get_effective_plan_quotas(conn, tenant_id: UUID) -> Dict[str, int]:
+    plan_slug = await get_effective_plan_slug(conn, tenant_id)
+    if not plan_slug:
+        plan_slug = STARTER_PLAN_SLUG
+    row = await conn.fetchrow(
+        """
+        SELECT features
+        FROM subscription_plans
+        WHERE slug = $1
+          AND is_active = true
+        LIMIT 1
+        """,
+        plan_slug,
+    )
+    features = row["features"] if row else {}
+    return _normalize_plan_quotas(plan_slug, features)
+
+
+async def _default_scan_limit_for_tenant(conn, tenant_id: UUID) -> int:
+    plan_slug = await get_effective_plan_slug(conn, tenant_id)
+    if plan_slug == STARTER_PLAN_SLUG:
+        row = await conn.fetchrow(
+            """
+            SELECT scan_limit
+            FROM subscription_plans
+            WHERE slug = $1
+              AND is_active = true
+            LIMIT 1
+            """,
+            STARTER_PLAN_SLUG,
+        )
+        if row and row["scan_limit"] is not None:
+            return int(row["scan_limit"])
+        return STARTER_SCAN_LIMIT
+    return 1000
+
+
+async def _fetch_plan_quota_context(conn, tenant_id: UUID, resource: str):
     plan = await conn.fetchrow(
         """
         SELECT
@@ -203,6 +270,53 @@ async def check_plan_quota_growth(
         tenant_id,
         resource,
     )
+    if plan:
+        return plan
+
+    effective_slug = await get_effective_plan_slug(conn, tenant_id)
+    if effective_slug != STARTER_PLAN_SLUG:
+        return None
+
+    return await conn.fetchrow(
+        """
+        SELECT
+            sp.slug AS plan_slug,
+            sp.features AS plan_features,
+            tq.id AS override_id,
+            tq.limit_override,
+            COALESCE(tq.disabled, false) AS override_disabled,
+            tq.reason AS override_reason
+        FROM subscription_plans sp
+        LEFT JOIN tenant_quota_overrides tq
+          ON tq.tenant_id = $1
+         AND tq.resource = $2
+        WHERE sp.slug = $3
+          AND sp.is_active = true
+        LIMIT 1
+        """,
+        tenant_id,
+        resource,
+        STARTER_PLAN_SLUG,
+    )
+
+
+async def check_plan_quota_growth(
+    conn,
+    tenant_id: UUID,
+    resource: str,
+    *,
+    exclude_pending_invitation_id: Optional[UUID] = None,
+) -> None:
+    """
+    Block active resource growth once the tenant reaches the plan quota.
+
+    This is intentionally non-destructive: it never modifies existing rows and
+    should be called only before create/reactivate/enable transitions.
+    """
+    if resource not in ENFORCEABLE_QUOTA_RESOURCES:
+        raise ValueError(f"Unsupported quota resource: {resource}")
+
+    plan = await _fetch_plan_quota_context(conn, tenant_id, resource)
     if not plan:
         return
 
@@ -617,7 +731,7 @@ async def _create_period_usage(tenant_id: UUID, conn) -> None:
     """, tenant_id)
 
     subscription_id: Optional[UUID] = sub["subscription_id"] if sub else None
-    scan_limit: int = sub["scan_limit"] if sub else 1000
+    scan_limit: int = sub["scan_limit"] if sub else await _default_scan_limit_for_tenant(conn, tenant_id)
 
     await conn.execute("""
         INSERT INTO scan_usage
@@ -701,9 +815,10 @@ async def get_scan_usage(tenant_id: UUID, conn) -> Dict[str, Any]:
     """, tenant_id)
 
     if row is None:
+        scans_limit = await _default_scan_limit_for_tenant(conn, tenant_id)
         return {
             "scans_used": 0,
-            "scans_limit": 1000,
+            "scans_limit": scans_limit,
             "period_start": None,
             "period_end": None,
             "percentage": 0.0,
@@ -1913,7 +2028,8 @@ class SubscriptionAccess:
     Represents the access level for a tenant based on subscription status.
 
     Levels:
-      free             — no subscription row; default 1000 scans/month
+      starter          — no paid subscription; permanent free Starter plan
+      free             — legacy alias; treated as starter for access
       full             — active subscription
       full_with_warning — past_due, < 3 days overdue — access OK but banner shown
       read_only        — past_due, 3-7 days overdue — IA scanner blocked
@@ -1956,11 +2072,11 @@ async def get_subscription_access(tenant_id: UUID, conn) -> SubscriptionAccess:
                 ),
             )
         return SubscriptionAccess(
-            level="free",
+            level="starter",
             grace_days_remaining=0,
             subscription_status=None,
             next_payment_date=None,
-            message="Estás en el plan gratuito con 1000 escaneos al mes.",
+            message="Estás en el plan Starter con límites operativos gratuitos.",
         )
 
     status = sub["status"]

--- a/app/services/onboarding_service.py
+++ b/app/services/onboarding_service.py
@@ -26,6 +26,7 @@ MAX_VERIFY_ATTEMPTS = 5
 PRE_PAYMENT_FINANCIAL_STATES = frozenset({
     "business_profile_pending",
     "terms_pending",
+    "starter_active",
     "payment_pending",
 })
 
@@ -562,7 +563,7 @@ def _ensure_pending_financial_state(row: Any) -> None:
     is_pending = row["lifecycle_status"] == "pending"
     is_promoted = (
         row["lifecycle_status"] == "active"
-        and row["state"] == "payment_pending"
+        and row["state"] in {"starter_active", "payment_pending"}
     )
     if not is_pending and not is_promoted:
         raise HTTPException(
@@ -597,13 +598,13 @@ async def _promote_onboarding_identity(conn, tenant_id: UUID) -> str:
     state_row = await conn.fetchrow(
         """
         UPDATE tenant_onboarding
-        SET state = 'payment_pending',
+        SET state = 'starter_active',
             updated_at = CASE
-                WHEN state IS DISTINCT FROM 'payment_pending' THEN NOW()
+                WHEN state IS DISTINCT FROM 'starter_active' THEN NOW()
                 ELSE updated_at
             END
         WHERE tenant_id = $1
-          AND state IN ('business_profile_pending', 'terms_pending', 'payment_pending')
+          AND state IN ('business_profile_pending', 'terms_pending', 'starter_active')
         RETURNING state
         """,
         tenant_id,
@@ -663,7 +664,7 @@ async def update_onboarding_financial_profile(
     country_code, currency_code = financial_service.validate_country_currency_pair(
         data.country_code, data.base_currency_code
     )
-    if context["state"] == "payment_pending":
+    if context["state"] == "starter_active":
         profile = await conn.fetchrow(
             """
             SELECT tenant_id AS profile_tenant_id,
@@ -801,7 +802,7 @@ async def accept_onboarding_terms(
         """
         UPDATE tenant_onboarding
         SET state = CASE
-                WHEN state = 'terms_pending' THEN 'payment_pending'
+                WHEN state = 'terms_pending' THEN 'starter_active'
                 ELSE state
             END,
             updated_at = CASE

--- a/sql/20260722_starter_subscription_plan.sql
+++ b/sql/20260722_starter_subscription_plan.sql
@@ -1,0 +1,43 @@
+-- api-warolabs#693: permanent Starter plan metadata (non-destructive).
+-- Seeds subscription_plans only; does not modify tenants or subscriptions.
+
+INSERT INTO subscription_plans (
+    name,
+    slug,
+    description,
+    price_monthly,
+    price_annual,
+    scan_limit,
+    is_active,
+    features
+)
+VALUES (
+    'Starter',
+    'starter',
+    'Plan gratuito permanente — POS mostrador con cuotas operativas limitadas',
+    0,
+    0,
+    10,
+    true,
+    '{
+      "quotas": {
+        "admin_users": 1,
+        "active_sessions_per_admin_user": 1,
+        "active_kitchens": 0,
+        "active_tables_including_bar": 0,
+        "active_qr_tables": 0,
+        "completed_online_orders_per_month": 30,
+        "electronic_invoices_per_period": 0
+      }
+    }'::jsonb
+)
+ON CONFLICT (slug) DO UPDATE
+SET
+    name = EXCLUDED.name,
+    description = EXCLUDED.description,
+    price_monthly = EXCLUDED.price_monthly,
+    price_annual = EXCLUDED.price_annual,
+    scan_limit = EXCLUDED.scan_limit,
+    is_active = EXCLUDED.is_active,
+    features = EXCLUDED.features,
+    updated_at = now();

--- a/tests/test_billing_subscription_access.py
+++ b/tests/test_billing_subscription_access.py
@@ -1,10 +1,11 @@
 """Grace-period access levels via get_subscription_access (#62, #363)."""
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 
+from app.core.exceptions import APIError
 from app.services import billing_service
 
 
@@ -109,7 +110,7 @@ async def test_expired_subscription_returns_blocked():
 
 
 @pytest.mark.asyncio
-async def test_no_subscription_returns_free():
+async def test_no_subscription_returns_starter():
     tenant_id = uuid4()
     conn = MagicMock()
     conn.fetchrow = AsyncMock(return_value=None)
@@ -117,7 +118,7 @@ async def test_no_subscription_returns_free():
 
     access = await billing_service.get_subscription_access(tenant_id, conn)
 
-    assert access.level == "free"
+    assert access.level == "starter"
     conn.fetchrow.assert_called_once()
 
 
@@ -134,3 +135,49 @@ async def test_payment_pending_onboarding_without_subscription_is_blocked():
     assert access.subscription_status == "payment_pending"
     assert "Mi Plan" in access.message
     assert "completa el pago" in access.message
+
+
+@pytest.mark.asyncio
+async def test_get_effective_plan_slug_returns_starter_without_paid_sub():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[None, None])
+    conn.fetchval = AsyncMock(return_value="starter_active")
+
+    slug = await billing_service.get_effective_plan_slug(conn, tenant_id)
+
+    assert slug == billing_service.STARTER_PLAN_SLUG
+
+
+@pytest.mark.asyncio
+async def test_check_plan_quota_growth_blocks_starter_table_growth_at_zero():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        None,
+        None,
+        {
+            "plan_slug": billing_service.STARTER_PLAN_SLUG,
+            "plan_features": {"quotas": billing_service.STARTER_OPERATIONAL_QUOTAS},
+            "override_id": None,
+            "limit_override": None,
+            "override_disabled": False,
+            "override_reason": None,
+        },
+    ])
+    conn.fetchval = AsyncMock(return_value="starter_active")
+
+    with patch.object(
+        billing_service,
+        "_count_quota_resource_usage",
+        new=AsyncMock(return_value=0),
+    ):
+        with pytest.raises(APIError) as exc:
+            await billing_service.check_plan_quota_growth(
+                conn,
+                tenant_id,
+                "active_tables_including_bar",
+            )
+
+    assert exc.value.details["code"] == "quota_exceeded"
+    assert exc.value.details["plan_slug"] == billing_service.STARTER_PLAN_SLUG

--- a/tests/test_onboarding_country_terms.py
+++ b/tests/test_onboarding_country_terms.py
@@ -51,7 +51,7 @@ async def test_initial_selection_atomically_promotes_identity_to_billing_boundar
     conn.fetchrow = AsyncMock(side_effect=[
         {"lifecycle_status": "pending", "state": "business_profile_pending"},
         profile,
-        {"state": "payment_pending"},
+        {"state": "starter_active"},
     ])
     conn.execute = AsyncMock(side_effect=[
         "UPDATE 1",
@@ -72,8 +72,8 @@ async def test_initial_selection_atomically_promotes_identity_to_billing_boundar
     assert result.data.profile.country_code == "US"
     assert result.data.business_name == "Cafe Central"
     assert result.data.profile.selection_revision == 1
-    assert result.data.state == "payment_pending"
-    assert result.data.next_step == "payment"
+    assert result.data.state == "starter_active"
+    assert result.data.next_step == "setup"
     lock_query = conn.fetchrow.await_args_list[0].args[0]
     upsert_query = conn.fetchrow.await_args_list[1].args[0]
     assert "FOR UPDATE OF t, o" in lock_query
@@ -93,11 +93,11 @@ async def test_idempotent_selection_keeps_database_revision():
     conn.fetchrow = AsyncMock(side_effect=[
         {
             "lifecycle_status": "active",
-            "state": "payment_pending",
+            "state": "starter_active",
             "business_name": "Cafe Central",
         },
         _profile_row(tenant_id, revision=4),
-        {"state": "payment_pending"},
+        {"state": "starter_active"},
     ])
     conn.execute = AsyncMock(side_effect=["UPDATE 1", "UPDATE 1"])
 
@@ -112,18 +112,18 @@ async def test_idempotent_selection_keeps_database_revision():
     )
 
     assert result.data.profile.selection_revision == 4
-    assert result.data.state == "payment_pending"
+    assert result.data.state == "starter_active"
     assert conn.execute.await_count == 2
 
 
 @pytest.mark.asyncio
-async def test_payment_pending_rejects_changes_after_legal_acceptance():
+async def test_starter_active_rejects_changes_after_legal_acceptance():
     tenant_id = uuid4()
     conn = AsyncMock()
     conn.fetchrow = AsyncMock(side_effect=[
         {
             "lifecycle_status": "pending",
-            "state": "payment_pending",
+            "state": "starter_active",
             "business_name": "Cafe Central",
         },
         _profile_row(tenant_id, country="CO", currency="COP", revision=2),
@@ -143,7 +143,7 @@ async def test_payment_pending_rejects_changes_after_legal_acceptance():
     assert exc.value.status_code == 409
     assert exc.value.detail == {
         "code": "ONBOARDING_FINANCIAL_PROFILE_LOCKED",
-        "state": "payment_pending",
+        "state": "starter_active",
     }
     conn.execute.assert_not_awaited()
 
@@ -191,7 +191,7 @@ async def test_pending_acceptance_requires_financial_profile():
 
 
 @pytest.mark.asyncio
-async def test_pending_acceptance_uses_canonical_source_and_advances_payment():
+async def test_pending_acceptance_uses_canonical_source_and_advances_starter():
     tenant_id = uuid4()
     conn = AsyncMock()
     conn.fetchrow = AsyncMock(side_effect=[
@@ -200,7 +200,7 @@ async def test_pending_acceptance_uses_canonical_source_and_advances_payment():
             "state": "terms_pending",
             "country_code": "CO",
         },
-        {"state": "payment_pending"},
+        {"state": "starter_active"},
     ])
     conn.execute = AsyncMock()
     session = SimpleNamespace(tenant_id=tenant_id)
@@ -217,8 +217,8 @@ async def test_pending_acceptance_uses_canonical_source_and_advances_payment():
 
     assert accept.await_args.kwargs["source"] == "onboarding"
     assert result["data"]["onboarding"] == {
-        "state": "payment_pending",
-        "nextStep": "payment",
+        "state": "starter_active",
+        "nextStep": "setup",
     }
     conn.execute.assert_not_awaited()
 
@@ -317,7 +317,7 @@ async def test_resume_status_includes_profile_and_current_acceptance():
         "tenant_id": tenant_id,
         "business_name": "Cafe Central",
         "lifecycle_status": "pending",
-        "state": "payment_pending",
+        "state": "starter_active",
         "email_verified_at": datetime.now(timezone.utc),
         **_profile_row(tenant_id, country="CO", currency="COP", revision=2),
     }
@@ -340,7 +340,7 @@ async def test_resume_status_includes_profile_and_current_acceptance():
     assert result.data.financial_profile.selection_revision == 2
     assert result.data.terms_accepted is True
     assert result.data.terms_version == "1.1"
-    assert result.data.next_step == "payment"
+    assert result.data.next_step == "setup"
 
 
 @pytest.mark.asyncio

--- a/tests/test_onboarding_registration.py
+++ b/tests/test_onboarding_registration.py
@@ -135,8 +135,8 @@ async def test_verified_challenge_atomically_creates_pending_owner():
 
     financial = AsyncMock(return_value=SimpleNamespace(data=SimpleNamespace(
         business_name="Restaurante Nuevo",
-        state="payment_pending",
-        next_step="payment",
+        state="starter_active",
+        next_step="setup",
     )))
     with patch("app.services.onboarding_service.settings.auth_secret", "test-secret"), patch(
         "app.services.onboarding_service.uuid4", return_value=tenant_id
@@ -154,8 +154,8 @@ async def test_verified_challenge_atomically_creates_pending_owner():
     assert identity["tenant_id"] == tenant_id
     assert identity["lifecycle_status"] == "active"
     assert identity["tenant_name"] == "Restaurante Nuevo"
-    assert identity["onboarding_state"] == "payment_pending"
-    assert identity["next_step"] == "payment"
+    assert identity["onboarding_state"] == "starter_active"
+    assert identity["next_step"] == "setup"
     financial.assert_awaited_once()
     assert identity["registration_notification"]["source"] == "blog"
     assert identity["registration_notification"]["variant"] == "b"


### PR DESCRIPTION
## Summary
- Add permanent `starter` plan slug with operational quota defaults
- Onboarding completes without payment → `level=starter` access
- `get_effective_plan_slug()` resolves starter when no paid subscription
- Quota enforcement works without `tenant_subscriptions` row (admin users, tables, scans)

## Test plan
- [x] Billing/onboarding subscription access tests

Closes #693

Made with [Cursor](https://cursor.com)