### PR TITLE
fix(menu): sync resale mi costo to warehouse cost when no purchases

### DIFF
--- a/.wr/700.yaml
+++ b/.wr/700.yaml
@@ -1,0 +1,39 @@
+# Compact plan — wr-fast #700. Keep <=80 lines.
+issue: 700
+title: "fix(menu): sync resale mi costo to warehouse cost when no purchases"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-700-resale-mi-costo-sync
+
+paths:
+  - app/services/products_service.py
+  - app/services/cost_resolution_service.py
+  - tests/test_product_resale_mi_costo_sync.py
+  - tests/test_product_perceived_cost.py
+  - .wr/700.yaml
+
+ac:
+  - Resale edit of costo_percibido with no purchase unit_cost syncs ingredients.costo_unitario and recalculates costo_calculado
+  - With purchase unit_cost, do not overwrite warehouse/purchase-driven cost
+  - Create path unchanged; non-resale unchanged
+  - Tests cover both cases
+
+out_of_scope:
+  - FX/display currency, recipe products rewriting line costs, front copy
+
+hints:
+  entry: "update_product_with_recipe after product UPDATE, before persist_product_costo_calculado"
+  pattern: "create auto_resale copies costo_percibido → costo_unitario (~184); cost_resolution purchase priority"
+  tests: "pytest tests/test_product_resale_mi_costo_sync.py tests/test_product_perceived_cost.py -q"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "ready-for-review + wr-review"

--- a/app/services/cost_resolution_service.py
+++ b/app/services/cost_resolution_service.py
@@ -171,6 +171,10 @@ async def sync_resale_mi_costo_to_ingredient(
     if ingredient_id is None:
         return False
 
+    # Match create seeding: only write a concrete Mi costo, never wipe via null.
+    if costo_percibido is None:
+        return False
+
     if await ingredient_has_purchase_unit_cost(
         conn,
         tenant_id=tenant_id,
@@ -187,7 +191,7 @@ async def sync_resale_mi_costo_to_ingredient(
           AND tenant_id = $3
         """,
         ingredient_id,
-        float(costo_percibido) if costo_percibido is not None else None,
+        float(costo_percibido),
         tenant_id,
     )
     return True

--- a/app/services/cost_resolution_service.py
+++ b/app/services/cost_resolution_service.py
@@ -114,6 +114,85 @@ async def product_has_any_recipe(product_id: UUID, conn) -> bool:
     )
 
 
+async def ingredient_has_purchase_unit_cost(
+    conn,
+    *,
+    tenant_id: UUID,
+    ingredient_id: UUID,
+) -> bool:
+    """True when a purchase line supplies a positive unit_cost for this ingredient."""
+    return bool(
+        await conn.fetchval(
+            """
+            SELECT EXISTS(
+                SELECT 1
+                FROM tenant_purchase_items pi
+                JOIN tenant_purchases tp ON pi.purchase_id = tp.id
+                WHERE tp.tenant_id = $1
+                  AND pi.ingredient_id = $2
+                  AND pi.unit_cost IS NOT NULL
+                  AND pi.unit_cost > 0
+            )
+            """,
+            tenant_id,
+            ingredient_id,
+        )
+    )
+
+
+async def sync_resale_mi_costo_to_ingredient(
+    conn,
+    *,
+    tenant_id: UUID,
+    product_id: UUID,
+    costo_percibido: Optional[Decimal],
+) -> bool:
+    """
+    For resale products, seed linked warehouse ingredient.costo_unitario from Mi costo
+    when no purchase-based unit cost exists. Returns True if the ingredient was updated.
+    """
+    ingredient_id = await conn.fetchval(
+        """
+        SELECT i.id
+        FROM product p
+        JOIN product_recipes pr ON pr.product_id = p.id
+        JOIN ingredients i ON i.id = pr.ingredient_id
+        WHERE p.id = $1
+          AND p.tenant_id = $2
+          AND p.is_resale = true
+          AND i.tenant_id = $2
+          AND i.is_resale = true
+        ORDER BY pr.created_at ASC
+        LIMIT 1
+        """,
+        product_id,
+        tenant_id,
+    )
+    if ingredient_id is None:
+        return False
+
+    if await ingredient_has_purchase_unit_cost(
+        conn,
+        tenant_id=tenant_id,
+        ingredient_id=ingredient_id,
+    ):
+        return False
+
+    await conn.execute(
+        """
+        UPDATE ingredients
+        SET costo_unitario = $2,
+            updated_at = NOW()
+        WHERE id = $1
+          AND tenant_id = $3
+        """,
+        ingredient_id,
+        float(costo_percibido) if costo_percibido is not None else None,
+        tenant_id,
+    )
+    return True
+
+
 async def persist_product_costo_calculado(
     product_id: UUID,
     tenant_id: UUID,

--- a/app/services/products_service.py
+++ b/app/services/products_service.py
@@ -1153,7 +1153,7 @@ async def update_product_with_recipe(
 
         async with get_db_connection() as conn:
             # Verify product exists and belongs to tenant
-            verify_query = "SELECT id, name FROM product WHERE id = $1 AND tenant_id = $2"
+            verify_query = "SELECT id, name, is_resale FROM product WHERE id = $1 AND tenant_id = $2"
             product_exists = await conn.fetchrow(verify_query, product_id, tenant_id)
 
             if not product_exists:
@@ -1228,6 +1228,23 @@ async def update_product_with_recipe(
                     """
                     update_values.extend([product_id, tenant_id])
                     await conn.execute(update_query, *update_values)
+
+                # 1b. Resale: keep warehouse seed cost in sync with Mi costo when no purchases
+                # drive real cost yet (#700). Purchase unit_cost still wins in the resolver.
+                update_payload = product_data.dict(
+                    exclude={'ingredients', 'recipe_base_ids', 'recipe_bases', 'controla_stock'},
+                    exclude_unset=True,
+                )
+                if (
+                    product_exists.get("is_resale")
+                    and "costo_percibido" in update_payload
+                ):
+                    await cost_resolution_service.sync_resale_mi_costo_to_ingredient(
+                        conn,
+                        tenant_id=tenant_id,
+                        product_id=product_id,
+                        costo_percibido=update_payload.get("costo_percibido"),
+                    )
 
                 # 2. Update recipe base associations if provided (Issue #517 — with quantity).
                 # Either of the two fields (recipe_bases / recipe_base_ids) being set means

--- a/tests/test_product_perceived_cost.py
+++ b/tests/test_product_perceived_cost.py
@@ -90,8 +90,9 @@ async def test_update_perceived_still_recalcs_real_not_perceived():
     update_sql = []
 
     conn = MagicMock()
-    conn.fetchrow = AsyncMock(return_value={"id": product_id, "name": "Test"})
+    conn.fetchrow = AsyncMock(return_value={"id": product_id, "name": "Test", "is_resale": False})
     conn.execute = AsyncMock(side_effect=lambda q, *a: update_sql.append(q))
+    conn.fetchval = AsyncMock(return_value=None)
     @asynccontextmanager
     async def _txn():
         yield

--- a/tests/test_product_resale_mi_costo_sync.py
+++ b/tests/test_product_resale_mi_costo_sync.py
@@ -1,0 +1,190 @@
+"""Resale Mi costo sync to warehouse seed when no purchases (#700)."""
+from contextlib import asynccontextmanager
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import Request
+
+from app.core.middleware import SessionContext
+from app.models.product import ProductUpdate
+from app.services import cost_resolution_service
+from app.services.products_service import update_product_with_recipe
+
+
+def _session():
+    return SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": uuid4(),
+        "email": "test@warocol.com",
+        "name": "Test",
+        "expires_at": None,
+        "is_active": True,
+    })
+
+
+@pytest.mark.asyncio
+async def test_ingredient_has_purchase_unit_cost_true_and_false():
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(side_effect=[True, False])
+    tenant_id = uuid4()
+    ingredient_id = uuid4()
+
+    assert await cost_resolution_service.ingredient_has_purchase_unit_cost(
+        conn, tenant_id=tenant_id, ingredient_id=ingredient_id,
+    ) is True
+    assert await cost_resolution_service.ingredient_has_purchase_unit_cost(
+        conn, tenant_id=tenant_id, ingredient_id=ingredient_id,
+    ) is False
+
+
+@pytest.mark.asyncio
+async def test_sync_resale_mi_costo_updates_ingredient_without_purchases():
+    conn = MagicMock()
+    ingredient_id = uuid4()
+    product_id = uuid4()
+    tenant_id = uuid4()
+    conn.fetchval = AsyncMock(side_effect=[ingredient_id, False])
+    conn.execute = AsyncMock()
+
+    updated = await cost_resolution_service.sync_resale_mi_costo_to_ingredient(
+        conn,
+        tenant_id=tenant_id,
+        product_id=product_id,
+        costo_percibido=Decimal("28"),
+    )
+
+    assert updated is True
+    conn.execute.assert_called_once()
+    sql, ing_id, cost, tid = conn.execute.call_args[0]
+    assert "UPDATE ingredients" in sql
+    assert "costo_unitario" in sql
+    assert ing_id == ingredient_id
+    assert cost == 28.0
+    assert tid == tenant_id
+
+
+@pytest.mark.asyncio
+async def test_sync_resale_mi_costo_skips_when_purchase_unit_cost_exists():
+    conn = MagicMock()
+    ingredient_id = uuid4()
+    conn.fetchval = AsyncMock(side_effect=[ingredient_id, True])
+    conn.execute = AsyncMock()
+
+    updated = await cost_resolution_service.sync_resale_mi_costo_to_ingredient(
+        conn,
+        tenant_id=uuid4(),
+        product_id=uuid4(),
+        costo_percibido=Decimal("28"),
+    )
+
+    assert updated is False
+    conn.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_resale_perceived_syncs_ingredient_then_recalcs():
+    request = MagicMock(spec=Request)
+    session = _session()
+    product_id = uuid4()
+    ingredient_id = uuid4()
+    execute_sql = []
+
+    async def _fetchrow(query, *args):
+        if "FROM product WHERE id" in query and "is_resale" in query:
+            return {"id": product_id, "name": "Club Colombia", "is_resale": True}
+        return None
+
+    async def _fetchval(query, *args):
+        if "JOIN product_recipes" in query:
+            return ingredient_id
+        if "tenant_purchase_items" in query:
+            return False
+        return None
+
+    async def _execute(query, *args):
+        execute_sql.append(query)
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=_fetchrow)
+    conn.fetchval = AsyncMock(side_effect=_fetchval)
+    conn.execute = AsyncMock(side_effect=_execute)
+
+    @asynccontextmanager
+    async def _txn():
+        yield
+
+    conn.transaction.return_value = _txn()
+
+    @asynccontextmanager
+    async def _db_ctx():
+        yield conn
+
+    product_data = ProductUpdate(costo_percibido=Decimal("28"))
+    mock_response = MagicMock()
+
+    with patch("app.services.products_service.require_valid_session", return_value=session), \
+         patch("app.services.products_service.get_db_connection", side_effect=_db_ctx), \
+         patch("app.services.products_service.menu_history_service.get_product_snapshot", AsyncMock(return_value=None)), \
+         patch("app.services.products_service.cost_resolution_service.product_has_any_recipe", AsyncMock(return_value=True)), \
+         patch("app.services.products_service.cost_resolution_service.persist_product_costo_calculado", AsyncMock()) as mock_persist, \
+         patch("app.services.products_service.get_product_by_id", AsyncMock(return_value=mock_response)):
+        await update_product_with_recipe(request, product_id, product_data)
+
+    assert any("costo_percibido" in q for q in execute_sql)
+    assert any("UPDATE ingredients" in q and "costo_unitario" in q for q in execute_sql)
+    mock_persist.assert_called_once()
+    assert mock_persist.call_args.kwargs["tracks_inventory"] is True
+
+
+@pytest.mark.asyncio
+async def test_update_resale_perceived_does_not_clobber_purchase_seed():
+    request = MagicMock(spec=Request)
+    session = _session()
+    product_id = uuid4()
+    ingredient_id = uuid4()
+    execute_sql = []
+
+    async def _fetchrow(query, *args):
+        if "FROM product WHERE id" in query and "is_resale" in query:
+            return {"id": product_id, "name": "Club Colombia", "is_resale": True}
+        return None
+
+    async def _fetchval(query, *args):
+        if "JOIN product_recipes" in query:
+            return ingredient_id
+        if "tenant_purchase_items" in query:
+            return True
+        return None
+
+    async def _execute(query, *args):
+        execute_sql.append(query)
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=_fetchrow)
+    conn.fetchval = AsyncMock(side_effect=_fetchval)
+    conn.execute = AsyncMock(side_effect=_execute)
+
+    @asynccontextmanager
+    async def _txn():
+        yield
+
+    conn.transaction.return_value = _txn()
+
+    @asynccontextmanager
+    async def _db_ctx():
+        yield conn
+
+    product_data = ProductUpdate(costo_percibido=Decimal("28"))
+
+    with patch("app.services.products_service.require_valid_session", return_value=session), \
+         patch("app.services.products_service.get_db_connection", side_effect=_db_ctx), \
+         patch("app.services.products_service.menu_history_service.get_product_snapshot", AsyncMock(return_value=None)), \
+         patch("app.services.products_service.cost_resolution_service.product_has_any_recipe", AsyncMock(return_value=True)), \
+         patch("app.services.products_service.cost_resolution_service.persist_product_costo_calculado", AsyncMock()), \
+         patch("app.services.products_service.get_product_by_id", AsyncMock(return_value=MagicMock())):
+        await update_product_with_recipe(request, product_id, product_data)
+
+    assert any("costo_percibido" in q for q in execute_sql)
+    assert not any("UPDATE ingredients" in q for q in execute_sql)


### PR DESCRIPTION
## Summary
- On resale product edit, sync `costo_percibido` → linked ingredient `costo_unitario` when no purchase unit cost exists
- Recalculate `costo_calculado` as before; purchase-driven costs are not overwritten
- Create path and non-resale products unchanged

Closes #700

## Test plan
- [ ] Edit resale Mi costo with no purchases → Costo real updates to match
- [ ] Edit Mi costo when ingredient has purchase unit_cost → real cost stays purchase-driven
- [ ] Non-resale product Mi costo edit still only updates operativo cost

## Validation evidence
```
$ pytest tests/test_product_resale_mi_costo_sync.py tests/test_product_perceived_cost.py::test_update_perceived_still_recalcs_real_not_perceived tests/test_product_perceived_cost.py::test_recalculate_ingredient_only_updates_real_cost tests/test_product_duplicate_name.py -q
10 passed in 0.14s
```

## wr-context
See `.wr/700.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)