### PR TITLE
fix(cost): convert recipe ml/gr to und before unit cost

### DIFF
--- a/.wr/702.yaml
+++ b/.wr/702.yaml
@@ -1,0 +1,39 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 702
+title: "fix cost: convert recipe ml/gr to und via unit_weight before multiplying unit cost"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-702-recipe-cost-unit-convert
+
+paths:
+  - app/services/cost_resolution_service.py
+  - tests/test_recipe_base_costs.py
+
+ac:
+  - Cost SQL converts recipe qty to stock unit via unit_weight (ml|gr ↔ und) before × unit cost
+  - Direct product_recipes and base_recipe_templates both convert
+  - 45 ml of 750 ml/und @ 350 → ~21 not 15750
+  - Same-unit lines unchanged; base multiplier still applies
+  - persist/recalc paths keep using calculated_product_cost_real
+
+out_of_scope:
+  - Resale 1:1 model changes
+  - Front UX warning
+  - Separate ml tequila SKU requirement
+
+hints:
+  entry: "app/services/cost_resolution_service.py LIST_COST_CTE_PREFIX + _CALCULATE_PRODUCT_COST_SQL"
+  pattern: "resolve_recipe_quantity_to_base_unit in ingredient_purchase_units_service.py"
+  tests: "pytest tests/test_recipe_base_costs.py -q"
+
+risk:
+  sensitive: false
+  areas: [costing]
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "ready-for-review + wr-review subagent"

--- a/app/services/cost_resolution_service.py
+++ b/app/services/cost_resolution_service.py
@@ -7,13 +7,105 @@ Priority for each ingredient unit cost:
   3. 0
 
 Product total = sum(direct product_recipes) + sum(product_base_recipes × base_recipe_templates).
+
+Recipe quantities are converted to the ingredient stock unit before multiplying cost
+(same rules as resolve_recipe_quantity_to_base_unit: ml|gr ↔ und via unit_weight_gr).
 """
 from decimal import Decimal
-from typing import Optional
+from typing import Any, Optional
 from uuid import UUID
 
+# Catalog purchase-style units → gr/ml (mirrors ingredient_purchase_units_service).
+_CATALOG_TO_BASE_FACTOR: dict[str, tuple[Decimal, str]] = {
+    "kg": (Decimal("1000"), "gr"),
+    "libra": (Decimal("500"), "gr"),
+    "arroba": (Decimal("12500"), "gr"),
+    "bulto_25kg": (Decimal("25000"), "gr"),
+    "lt": (Decimal("1000"), "ml"),
+    "botella": (Decimal("750"), "ml"),
+    "galon": (Decimal("3785"), "ml"),
+}
+
+
+def recipe_qty_to_stock_units(
+    quantity: Any,
+    recipe_unit: Optional[str],
+    stock_unit: Optional[str],
+    unit_weight_gr: Any = None,
+) -> Decimal:
+    """
+    Convert a recipe line quantity into the ingredient's stock unit for costing.
+
+    Mirrors resolve_recipe_quantity_to_base_unit (stock path) for the common cases.
+    """
+    qty = Decimal(str(quantity or 0))
+    ru = (recipe_unit or stock_unit or "").strip()
+    su = (stock_unit or "").strip()
+    if not su or ru == su or not ru:
+        return qty
+
+    weight = Decimal(str(unit_weight_gr)) if unit_weight_gr not in (None, "") else Decimal("0")
+
+    if su == "und" and ru in ("gr", "ml") and weight > 0:
+        return qty / weight
+    if ru == "und" and su in ("gr", "ml") and weight > 0:
+        return qty * weight
+
+    catalog = _CATALOG_TO_BASE_FACTOR.get(ru)
+    if catalog and su == "und" and weight > 0:
+        factor, base = catalog
+        if base in ("gr", "ml"):
+            return (qty * factor) / weight
+
+    return qty
+
+
+def _sql_recipe_qty_to_stock(qty_sql: str, unit_sql: str) -> str:
+    """
+    SQL expression: recipe qty in ingredient stock units (ingredients alias must be `i`).
+    """
+    return f"""(
+        CASE
+          WHEN COALESCE(NULLIF(TRIM({unit_sql}), ''), i.unit) IS NOT DISTINCT FROM i.unit
+            THEN ({qty_sql})::numeric
+          WHEN i.unit = 'und'
+               AND COALESCE(NULLIF(TRIM({unit_sql}), ''), '') IN ('gr', 'ml')
+               AND i.unit_weight_gr IS NOT NULL AND i.unit_weight_gr > 0
+            THEN ({qty_sql})::numeric / i.unit_weight_gr::numeric
+          WHEN COALESCE(NULLIF(TRIM({unit_sql}), ''), '') = 'und'
+               AND i.unit IN ('gr', 'ml')
+               AND i.unit_weight_gr IS NOT NULL AND i.unit_weight_gr > 0
+            THEN ({qty_sql})::numeric * i.unit_weight_gr::numeric
+          WHEN i.unit = 'und'
+               AND COALESCE(NULLIF(TRIM({unit_sql}), ''), '') = 'lt'
+               AND i.unit_weight_gr IS NOT NULL AND i.unit_weight_gr > 0
+            THEN (({qty_sql})::numeric * 1000) / i.unit_weight_gr::numeric
+          WHEN i.unit = 'und'
+               AND COALESCE(NULLIF(TRIM({unit_sql}), ''), '') = 'botella'
+               AND i.unit_weight_gr IS NOT NULL AND i.unit_weight_gr > 0
+            THEN (({qty_sql})::numeric * 750) / i.unit_weight_gr::numeric
+          WHEN i.unit = 'und'
+               AND COALESCE(NULLIF(TRIM({unit_sql}), ''), '') = 'galon'
+               AND i.unit_weight_gr IS NOT NULL AND i.unit_weight_gr > 0
+            THEN (({qty_sql})::numeric * 3785) / i.unit_weight_gr::numeric
+          WHEN i.unit = 'und'
+               AND COALESCE(NULLIF(TRIM({unit_sql}), ''), '') = 'kg'
+               AND i.unit_weight_gr IS NOT NULL AND i.unit_weight_gr > 0
+            THEN (({qty_sql})::numeric * 1000) / i.unit_weight_gr::numeric
+          WHEN i.unit = 'und'
+               AND COALESCE(NULLIF(TRIM({unit_sql}), ''), '') = 'libra'
+               AND i.unit_weight_gr IS NOT NULL AND i.unit_weight_gr > 0
+            THEN (({qty_sql})::numeric * 500) / i.unit_weight_gr::numeric
+          ELSE ({qty_sql})::numeric
+        END
+    )"""
+
+
+_DIRECT_QTY = _sql_recipe_qty_to_stock("pr.quantity", "pr.unit")
+_BASE_QTY = _sql_recipe_qty_to_stock("brt.base_quantity", "brt.unit")
+
 # Shared CTE for list queries — $1 must be tenant_id
-LIST_COST_CTE_PREFIX = """
+LIST_COST_CTE_PREFIX = f"""
     WITH latest_purchase_costs AS (
         SELECT DISTINCT ON (pi.ingredient_id)
             pi.ingredient_id,
@@ -29,7 +121,7 @@ LIST_COST_CTE_PREFIX = """
         SELECT
             pr.product_id,
             SUM(
-                pr.quantity * COALESCE(lpc.unit_cost, i.costo_unitario, 0)
+                {_DIRECT_QTY} * COALESCE(lpc.unit_cost, i.costo_unitario, 0)
             ) AS direct_cost
         FROM product_recipes pr
         JOIN ingredients i ON pr.ingredient_id = i.id
@@ -40,7 +132,7 @@ LIST_COST_CTE_PREFIX = """
         SELECT
             pbr.product_id,
             SUM(
-                pbr.quantity * brt.base_quantity * COALESCE(lpc.unit_cost, i.costo_unitario, 0)
+                pbr.quantity * {_BASE_QTY} * COALESCE(lpc.unit_cost, i.costo_unitario, 0)
             ) AS base_cost
         FROM product_base_recipes pbr
         JOIN base_recipe_templates brt ON pbr.product_base_type_id = brt.product_base_type_id
@@ -50,7 +142,7 @@ LIST_COST_CTE_PREFIX = """
     )
 """
 
-_CALCULATE_PRODUCT_COST_SQL = """
+_CALCULATE_PRODUCT_COST_SQL = f"""
     WITH latest_purchase_costs AS (
         SELECT DISTINCT ON (pi.ingredient_id)
             pi.ingredient_id,
@@ -64,7 +156,7 @@ _CALCULATE_PRODUCT_COST_SQL = """
     ),
     direct_cost AS (
         SELECT COALESCE(SUM(
-            pr.quantity * COALESCE(lpc.unit_cost, i.costo_unitario, 0)
+            {_DIRECT_QTY} * COALESCE(lpc.unit_cost, i.costo_unitario, 0)
         ), 0) AS amount
         FROM product_recipes pr
         JOIN ingredients i ON pr.ingredient_id = i.id
@@ -73,7 +165,7 @@ _CALCULATE_PRODUCT_COST_SQL = """
     ),
     base_cost AS (
         SELECT COALESCE(SUM(
-            pbr.quantity * brt.base_quantity * COALESCE(lpc.unit_cost, i.costo_unitario, 0)
+            pbr.quantity * {_BASE_QTY} * COALESCE(lpc.unit_cost, i.costo_unitario, 0)
         ), 0) AS amount
         FROM product_base_recipes pbr
         JOIN base_recipe_templates brt ON pbr.product_base_type_id = brt.product_base_type_id

--- a/tests/test_recipe_base_costs.py
+++ b/tests/test_recipe_base_costs.py
@@ -249,12 +249,45 @@ class TestUnifiedProductCostResolution:
 
         assert "i.costo_unitario" in LIST_COST_CTE_PREFIX
         assert "COALESCE(lpc.unit_cost, i.costo_unitario, 0)" in LIST_COST_CTE_PREFIX
+        assert "unit_weight_gr" in LIST_COST_CTE_PREFIX
+        assert "pr.unit" in LIST_COST_CTE_PREFIX
+        assert "brt.unit" in LIST_COST_CTE_PREFIX
 
     def test_direct_plus_base_recipe_total(self):
         """Product cost = direct ingredients + base template ingredients."""
         direct = Decimal("10") * Decimal("100")  # 1000
         base = Decimal("2") * Decimal("500") * Decimal("3")  # qty × base_qty × unit
         assert direct + base == Decimal("4000")
+
+    def test_resale_und_recipe_ml_converts_before_cost(self):
+        """45 ml of a 750 ml/und bottle at 350/und → 21, not 15750 (#702)."""
+        from app.services.cost_resolution_service import recipe_qty_to_stock_units
+
+        stock_qty = recipe_qty_to_stock_units(
+            Decimal("45"), "ml", "und", unit_weight_gr=Decimal("750")
+        )
+        cost = stock_qty * Decimal("350")
+        assert stock_qty == Decimal("45") / Decimal("750")
+        assert cost == Decimal("21")
+
+    def test_same_unit_ml_unchanged(self):
+        from app.services.cost_resolution_service import recipe_qty_to_stock_units
+
+        assert recipe_qty_to_stock_units(Decimal("45"), "ml", "ml") == Decimal("45")
+
+    def test_same_unit_und_unchanged(self):
+        from app.services.cost_resolution_service import recipe_qty_to_stock_units
+
+        assert recipe_qty_to_stock_units(Decimal("1"), "und", "und") == Decimal("1")
+
+    def test_base_multiplier_applies_after_unit_conversion(self):
+        from app.services.cost_resolution_service import recipe_qty_to_stock_units
+
+        per_base = recipe_qty_to_stock_units(
+            Decimal("45"), "ml", "und", unit_weight_gr=Decimal("750")
+        ) * Decimal("350")
+        multiplier = Decimal("2")
+        assert per_base * multiplier == Decimal("42")
 
     def test_purchase_wins_over_costo_unitario_for_line(self):
         purchase = Decimal("500")


### PR DESCRIPTION
## Summary
- Convert recipe quantities to ingredient stock units (`unit_weight` ml|gr ↔ und) before multiplying by purchase/`costo_unitario`
- Applies to direct menu recipe lines and recipe-base templates (list CTE + single-product calc)
- Fixes bottle-in-cocktail costing (`45 ml × 350` → `(45/750)×350 ≈ 21`)

Closes #702

## Test plan
- [ ] Save/recalc Margarita using resale tequila bottle at 45 ml → costo_calculado ~21 not 15750
- [ ] Same-unit ml and und recipe lines unchanged
- [ ] Base multiplier ×2 doubles converted cost

## Validation evidence
```
./venv/bin/pytest tests/test_recipe_base_costs.py -q --tb=short
→ 23 passed in 0.04s
```

## wr-context
See `.wr/702.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)