### PR TITLE
fix(recipe-bases): expose converted costo_linea with unit_weight

### DIFF
--- a/.wr/704.yaml
+++ b/.wr/704.yaml
@@ -1,0 +1,39 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 704
+title: "Recipe bases: convert ml/gr to und for line cost"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-704-recipe-base-line-cost
+
+paths:
+  - app/models/recipe_base.py
+  - app/services/recipe_bases_service.py
+  - tests/test_recipe_base_costs.py
+
+ac:
+  - Recipe-base ingredients expose stock_unit, unit_weight_*, and costo_linea
+  - costo_linea uses recipe_qty_to_stock_units × unit cost (45 ml / 750 @ 350 → ~21)
+  - Same-unit lines unchanged
+  - List/get/update/create responses include converted line cost
+  - Companion front: warocol.com#1748
+
+out_of_scope:
+  - Front /menu/recetas display
+  - Resale 1:1 model changes
+
+hints:
+  entry: "recipe_bases_service._recipe_base_ingredient_from_row + _RECIPE_BASE_INGREDIENT_SELECT"
+  pattern: "cost_resolution_service.recipe_qty_to_stock_units"
+  tests: "pytest tests/test_recipe_base_costs.py -q"
+
+risk:
+  sensitive: false
+  areas: [costing]
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "ready-for-review + wr-review; then /wr-fast #1748"

--- a/app/models/recipe_base.py
+++ b/app/models/recipe_base.py
@@ -35,6 +35,11 @@ class RecipeBaseIngredient(RecipeBaseIngredientBase):
     ingredient_name: Optional[str] = None
     costo_unitario: Optional[float] = 0
     controla_inventario: Optional[bool] = False
+    # Stock unit + weight for ml|gr ↔ und costing (#704); costo_linea is converted.
+    stock_unit: Optional[str] = None
+    unit_weight_gr: Optional[float] = None
+    unit_weight_unit: Optional[str] = None
+    costo_linea: Optional[float] = 0
 
     class Config:
         from_attributes = True

--- a/app/services/recipe_bases_service.py
+++ b/app/services/recipe_bases_service.py
@@ -20,9 +20,63 @@ from app.models.recipe_base import (
 from app.services import menu_history_service
 from app.services.ingredient_purchase_units_service import resolve_to_base_unit
 from app.services.billing_service import check_plan_quota_scoped
+from app.services.cost_resolution_service import recipe_qty_to_stock_units
+from decimal import Decimal
 
 logger = logging.getLogger(__name__)
 
+# Shared SELECT for recipe-base ingredient rows (cost + stock metadata for #704).
+_RECIPE_BASE_INGREDIENT_SELECT = """
+    SELECT
+        brt.id,
+        brt.product_base_type_id,
+        brt.ingredient_id,
+        brt.base_quantity,
+        brt.unit,
+        brt.is_required,
+        brt.notes,
+        brt.tenant_id,
+        brt.created_at,
+        brt.updated_at,
+        i.name as ingredient_name,
+        COALESCE(i.controla_inventario, false) as controla_inventario,
+        i.unit as stock_unit,
+        CAST(i.unit_weight_gr AS float) as unit_weight_gr,
+        i.unit_weight_unit,
+        COALESCE(
+            (SELECT pi.unit_cost
+             FROM tenant_purchase_items pi
+             JOIN tenant_purchases p ON pi.purchase_id = p.id
+             WHERE pi.ingredient_id = brt.ingredient_id
+             AND p.tenant_id = brt.tenant_id
+             AND pi.unit_cost IS NOT NULL
+             AND pi.unit_cost > 0
+             ORDER BY p.purchase_date DESC
+             LIMIT 1),
+            i.costo_unitario,
+            0
+        ) as costo_unitario
+    FROM base_recipe_templates brt
+    LEFT JOIN ingredients i ON brt.ingredient_id = i.id
+    WHERE brt.product_base_type_id = $1 AND brt.tenant_id = $2
+    ORDER BY brt.created_at
+"""
+
+
+def _recipe_base_ingredient_from_row(ing_row) -> RecipeBaseIngredient:
+    """Build RecipeBaseIngredient with converted costo_linea (#704)."""
+    data = dict(ing_row)
+    unit_cost = Decimal(str(data.get("costo_unitario") or 0))
+    stock_qty = recipe_qty_to_stock_units(
+        data.get("base_quantity") or 0,
+        data.get("unit"),
+        data.get("stock_unit"),
+        data.get("unit_weight_gr"),
+    )
+    data["costo_linea"] = float(stock_qty * unit_cost)
+    # Defaults when create path omits optional joins
+    data.setdefault("controla_inventario", False)
+    return RecipeBaseIngredient(**data)
 
 async def create_recipe_base_type(
     request: Request,
@@ -123,16 +177,31 @@ async def create_recipe_base_type(
                         tenant_id
                     )
 
-                    # Fetch ingredient name for the response
-                    name_query = """
-                        SELECT name FROM ingredients WHERE id = $1
+                    # Fetch ingredient cost/stock metadata for the response
+                    meta_query = """
+                        SELECT
+                            name,
+                            unit as stock_unit,
+                            CAST(unit_weight_gr AS float) as unit_weight_gr,
+                            unit_weight_unit,
+                            COALESCE(costo_unitario, 0) as costo_unitario,
+                            COALESCE(controla_inventario, false) as controla_inventario
+                        FROM ingredients WHERE id = $1
                     """
-                    ingredient_name_row = await conn.fetchrow(name_query, ingredient_data.ingredient_id)
+                    meta_row = await conn.fetchrow(meta_query, ingredient_data.ingredient_id)
 
                     ingredient_dict = dict(ingredient_row)
-                    ingredient_dict['ingredient_name'] = ingredient_name_row['name'] if ingredient_name_row else None
+                    if meta_row:
+                        ingredient_dict['ingredient_name'] = meta_row['name']
+                        ingredient_dict['stock_unit'] = meta_row['stock_unit']
+                        ingredient_dict['unit_weight_gr'] = meta_row['unit_weight_gr']
+                        ingredient_dict['unit_weight_unit'] = meta_row['unit_weight_unit']
+                        ingredient_dict['costo_unitario'] = float(meta_row['costo_unitario'] or 0)
+                        ingredient_dict['controla_inventario'] = meta_row['controla_inventario']
+                    else:
+                        ingredient_dict['ingredient_name'] = None
 
-                    ingredients.append(RecipeBaseIngredient(**ingredient_dict))
+                    ingredients.append(_recipe_base_ingredient_from_row(ingredient_dict))
 
             # Build response
             recipe_base_type = RecipeBaseType(
@@ -249,41 +318,13 @@ async def get_recipe_base_types_list(
                 # Optionally fetch ingredients
                 ingredients = []
                 if include_ingredients:
-                    ingredients_query = """
-                        SELECT
-                            brt.id,
-                            brt.product_base_type_id,
-                            brt.ingredient_id,
-                            brt.base_quantity,
-                            brt.unit,
-                            brt.is_required,
-                            brt.notes,
-                            brt.tenant_id,
-                            brt.created_at,
-                            brt.updated_at,
-                            i.name as ingredient_name,
-                            COALESCE(i.controla_inventario, false) as controla_inventario,
-                            COALESCE(
-                                (SELECT pi.unit_cost
-                                 FROM tenant_purchase_items pi
-                                 JOIN tenant_purchases p ON pi.purchase_id = p.id
-                                 WHERE pi.ingredient_id = brt.ingredient_id
-                                 AND p.tenant_id = brt.tenant_id
-                                 AND pi.unit_cost IS NOT NULL
-                                 AND pi.unit_cost > 0
-                                 ORDER BY p.purchase_date DESC
-                                 LIMIT 1),
-                                i.costo_unitario,
-                                0
-                            ) as costo_unitario
-                        FROM base_recipe_templates brt
-                        LEFT JOIN ingredients i ON brt.ingredient_id = i.id
-                        WHERE brt.product_base_type_id = $1 AND brt.tenant_id = $2
-                        ORDER BY brt.created_at
-                    """
-
-                    ingredient_rows = await conn.fetch(ingredients_query, row['id'], tenant_id)
-                    ingredients = [RecipeBaseIngredient(**dict(ing_row)) for ing_row in ingredient_rows]
+                    ingredient_rows = await conn.fetch(
+                        _RECIPE_BASE_INGREDIENT_SELECT, row['id'], tenant_id
+                    )
+                    ingredients = [
+                        _recipe_base_ingredient_from_row(ing_row)
+                        for ing_row in ingredient_rows
+                    ]
 
                 recipe_dict['ingredients'] = ingredients
                 recipe_base_types.append(RecipeBaseType(**recipe_dict))
@@ -341,41 +382,13 @@ async def get_recipe_base_type_by_id(
                 raise HTTPException(status_code=404, detail="Recipe base type not found")
 
             # Fetch ingredients
-            ingredients_query = """
-                SELECT
-                    brt.id,
-                    brt.product_base_type_id,
-                    brt.ingredient_id,
-                    brt.base_quantity,
-                    brt.unit,
-                    brt.is_required,
-                    brt.notes,
-                    brt.tenant_id,
-                    brt.created_at,
-                    brt.updated_at,
-                    i.name as ingredient_name,
-                    COALESCE(i.controla_inventario, false) as controla_inventario,
-                    COALESCE(
-                        (SELECT pi.unit_cost
-                         FROM tenant_purchase_items pi
-                         JOIN tenant_purchases p ON pi.purchase_id = p.id
-                         WHERE pi.ingredient_id = brt.ingredient_id
-                         AND p.tenant_id = brt.tenant_id
-                         AND pi.unit_cost IS NOT NULL
-                         AND pi.unit_cost > 0
-                         ORDER BY p.purchase_date DESC
-                         LIMIT 1),
-                        i.costo_unitario,
-                        0
-                    ) as costo_unitario
-                FROM base_recipe_templates brt
-                LEFT JOIN ingredients i ON brt.ingredient_id = i.id
-                WHERE brt.product_base_type_id = $1 AND brt.tenant_id = $2
-                ORDER BY brt.created_at
-            """
-
-            ingredient_rows = await conn.fetch(ingredients_query, recipe_base_id, tenant_id)
-            ingredients = [RecipeBaseIngredient(**dict(ing_row)) for ing_row in ingredient_rows]
+            ingredient_rows = await conn.fetch(
+                _RECIPE_BASE_INGREDIENT_SELECT, recipe_base_id, tenant_id
+            )
+            ingredients = [
+                _recipe_base_ingredient_from_row(ing_row)
+                for ing_row in ingredient_rows
+            ]
 
             recipe_dict = dict(row)
             recipe_dict['ingredients'] = ingredients
@@ -538,41 +551,13 @@ async def update_recipe_base_type(
                     )
 
             # Fetch ingredients
-            ingredients_query = """
-                SELECT
-                    brt.id,
-                    brt.product_base_type_id,
-                    brt.ingredient_id,
-                    brt.base_quantity,
-                    brt.unit,
-                    brt.is_required,
-                    brt.notes,
-                    brt.tenant_id,
-                    brt.created_at,
-                    brt.updated_at,
-                    i.name as ingredient_name,
-                    COALESCE(i.controla_inventario, false) as controla_inventario,
-                    COALESCE(
-                        (SELECT pi.unit_cost
-                         FROM tenant_purchase_items pi
-                         JOIN tenant_purchases p ON pi.purchase_id = p.id
-                         WHERE pi.ingredient_id = brt.ingredient_id
-                         AND p.tenant_id = brt.tenant_id
-                         AND pi.unit_cost IS NOT NULL
-                         AND pi.unit_cost > 0
-                         ORDER BY p.purchase_date DESC
-                         LIMIT 1),
-                        i.costo_unitario,
-                        0
-                    ) as costo_unitario
-                FROM base_recipe_templates brt
-                LEFT JOIN ingredients i ON brt.ingredient_id = i.id
-                WHERE brt.product_base_type_id = $1 AND brt.tenant_id = $2
-                ORDER BY brt.created_at
-            """
-
-            ingredient_rows = await conn.fetch(ingredients_query, recipe_base_id, tenant_id)
-            ingredients = [RecipeBaseIngredient(**dict(ing_row)) for ing_row in ingredient_rows]
+            ingredient_rows = await conn.fetch(
+                _RECIPE_BASE_INGREDIENT_SELECT, recipe_base_id, tenant_id
+            )
+            ingredients = [
+                _recipe_base_ingredient_from_row(ing_row)
+                for ing_row in ingredient_rows
+            ]
 
             recipe_dict = dict(row)
             recipe_dict['ingredients'] = ingredients

--- a/tests/test_recipe_base_costs.py
+++ b/tests/test_recipe_base_costs.py
@@ -289,6 +289,65 @@ class TestUnifiedProductCostResolution:
         multiplier = Decimal("2")
         assert per_base * multiplier == Decimal("42")
 
+    def test_recipe_base_ingredient_costo_linea_converts_ml_und(self):
+        """API recipe-base payload costo_linea uses unit_weight (#704)."""
+        from datetime import datetime, timezone
+        from uuid import uuid4
+        from app.services.recipe_bases_service import _recipe_base_ingredient_from_row
+
+        now = datetime.now(timezone.utc)
+        ing = _recipe_base_ingredient_from_row(
+            {
+                "id": uuid4(),
+                "product_base_type_id": uuid4(),
+                "ingredient_id": uuid4(),
+                "base_quantity": 45,
+                "unit": "ml",
+                "is_required": True,
+                "notes": None,
+                "tenant_id": uuid4(),
+                "created_at": now,
+                "updated_at": now,
+                "ingredient_name": "Tequila blanco botella 750 ml",
+                "controla_inventario": True,
+                "stock_unit": "und",
+                "unit_weight_gr": 750.0,
+                "unit_weight_unit": "ml",
+                "costo_unitario": 350.0,
+            }
+        )
+        assert ing.costo_linea == pytest.approx(21.0)
+        assert ing.stock_unit == "und"
+        assert ing.unit_weight_gr == 750.0
+
+    def test_recipe_base_ingredient_costo_linea_same_unit_ml(self):
+        from datetime import datetime, timezone
+        from uuid import uuid4
+        from app.services.recipe_bases_service import _recipe_base_ingredient_from_row
+
+        now = datetime.now(timezone.utc)
+        ing = _recipe_base_ingredient_from_row(
+            {
+                "id": uuid4(),
+                "product_base_type_id": uuid4(),
+                "ingredient_id": uuid4(),
+                "base_quantity": 20,
+                "unit": "ml",
+                "is_required": True,
+                "notes": None,
+                "tenant_id": uuid4(),
+                "created_at": now,
+                "updated_at": now,
+                "ingredient_name": "Triple sec",
+                "controla_inventario": True,
+                "stock_unit": "ml",
+                "unit_weight_gr": None,
+                "unit_weight_unit": None,
+                "costo_unitario": 0.25,
+            }
+        )
+        assert ing.costo_linea == pytest.approx(5.0)
+
     def test_purchase_wins_over_costo_unitario_for_line(self):
         purchase = Decimal("500")
         configured = Decimal("100")


### PR DESCRIPTION
## Summary
- Recipe-base ingredients now include `stock_unit`, `unit_weight_*`, and server `costo_linea`
- `costo_linea` uses the same ml|gr ↔ und conversion as #702 (`recipe_qty_to_stock_units`)
- Fixes API payload behind Base Margarita list cost (45 ml of 750 ml/und @ 350 → ~21)

Closes #704

Companion front: https://github.com/uno0uno/warocol.com/issues/1748

## Test plan
- [ ] GET recipe-bases?include_ingredients=true → Base Margarita tequila line `costo_linea` ≈ 21
- [ ] Same-unit ml lines: `costo_linea` = qty × unit cost
- [ ] Front #1748 can sum `costo_linea` on `/menu/recetas`

## Validation evidence
```
./venv/bin/pytest tests/test_recipe_base_costs.py -q --tb=short
→ 25 passed in 0.07s
```

## wr-context
See `.wr/704.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)