### PR TITLE
fix(purchases): Contado requires payment method on direct purchases

### DIFF
--- a/.wr/1759.yaml
+++ b/.wr/1759.yaml
@@ -1,0 +1,43 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1759
+title: "Compras directas: Contado must require payment method (else Crédito)"
+repo: both
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: both
+branch: wr-1759-contado-requires-payment
+
+paths:
+  - pages/abastecimiento/compras-directas/crear.vue
+  - pages/abastecimiento/compras-directas/[id]/editar.vue
+  - ../api_warocol.com/app/services/direct_purchase_service.py
+  - ../api_warocol.com/app/models/purchase.py
+  - ../api_warocol.com/app/routers/purchases.py
+  - ../api_warocol.com/tests/test_direct_purchase_payment_type.py
+
+ac:
+  - Create/edit: contado requires payment method before submit
+  - Sin pago aun only with credito (or deferred); clearing method on contado → credito
+  - OCR/default unpaid → credito
+  - API POST/PUT rejects contado without payment_method with 400
+  - Contado+method paid path; credito+empty pending payment
+
+out_of_scope:
+  - ACCOUNT_ROLE_MISSING / ACCOUNTS_PAYABLE provisioning
+  - GL posting changes
+  - DIAN XML import
+
+hints:
+  entry: "assert_contado_requires_payment_method + crear/editar validateForm"
+  pattern: "direct_purchase_service create/update payment_method gates status paid"
+  tests: "python3 -m pytest tests/test_direct_purchase_payment_type.py -q"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "merge API then front; manual Contado+method and Credito+Sin pago"

--- a/app/models/purchase.py
+++ b/app/models/purchase.py
@@ -488,6 +488,7 @@ class DirectPurchaseUpdate(BaseModel):
     purchase_date: Optional[str] = None
     notes: Optional[str] = None
     invoice_number: Optional[str] = None
+    payment_type: Optional[str] = Field(None, description="Payment type: contado, credito, contraentrega")
     payment_method: Optional[str] = None
     payment_method_id: Optional[str] = None
     payment_reference: Optional[str] = None

--- a/app/routers/purchases.py
+++ b/app/routers/purchases.py
@@ -298,6 +298,7 @@ async def update_direct_purchase_endpoint(
         purchase_date=purchase_data.purchase_date,
         notes=purchase_data.notes,
         invoice_number=purchase_data.invoice_number,
+        payment_type=purchase_data.payment_type,
         payment_method=purchase_data.payment_method,
         payment_method_id=purchase_data.payment_method_id,
         payment_reference=purchase_data.payment_reference,

--- a/app/services/direct_purchase_service.py
+++ b/app/services/direct_purchase_service.py
@@ -143,6 +143,22 @@ from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 
+CONTADO_REQUIRES_PAYMENT_METHOD_DETAIL = (
+    "Contado requires a payment method. Use credito when payment is not registered yet."
+)
+
+
+def assert_contado_requires_payment_method(
+    payment_type: Optional[str],
+    payment_method: Optional[str],
+) -> None:
+    """Contado = paid now; unpaid purchases must use credito (or other deferred type)."""
+    if (payment_type or "").strip().lower() != "contado":
+        return
+    if payment_method and str(payment_method).strip():
+        return
+    raise HTTPException(status_code=400, detail=CONTADO_REQUIRES_PAYMENT_METHOD_DETAIL)
+
 
 async def _normalize_direct_purchase_payment(
     conn,
@@ -413,6 +429,8 @@ async def create_direct_purchase(
         if not items or len(items) == 0:
             raise HTTPException(status_code=400, detail="At least one item is required")
 
+        assert_contado_requires_payment_method(payment_type, payment_method)
+
         async with get_db_connection() as conn:
             timezone_name = await resolve_tenant_timezone(conn, tenant_id)
             async with conn.transaction():
@@ -424,6 +442,7 @@ async def create_direct_purchase(
                     payment_method,
                     payment_method_id,
                 )
+                assert_contado_requires_payment_method(payment_type, payment_method)
 
                 # 2. Calculate totals from items
                 total_amount = _calculate_direct_purchase_total(items)
@@ -1094,6 +1113,7 @@ async def update_direct_purchase(
     purchase_date: Optional[str] = None,
     notes: Optional[str] = None,
     invoice_number: Optional[str] = None,
+    payment_type: Optional[str] = None,
     payment_method: Optional[str] = None,
     payment_method_id: Optional[str] = None,
     payment_reference: Optional[str] = None,
@@ -1129,7 +1149,7 @@ async def update_direct_purchase(
             async with conn.transaction():
                 # 1. Get existing purchase and verify ownership
                 existing_purchase = await conn.fetchrow("""
-                    SELECT id, status, purchase_number, tenant_id
+                    SELECT id, status, purchase_number, tenant_id, payment_type
                     FROM tenant_purchases
                     WHERE id = $1 AND tenant_id = $2 AND is_direct_entry = TRUE
                 """, purchase_id, tenant_id)
@@ -1138,6 +1158,12 @@ async def update_direct_purchase(
                     raise HTTPException(status_code=404, detail="Compra directa no encontrada")
 
                 purchase_number = existing_purchase['purchase_number']
+                effective_payment_type = (
+                    payment_type
+                    if payment_type is not None
+                    else existing_purchase["payment_type"]
+                )
+                assert_contado_requires_payment_method(effective_payment_type, payment_method)
 
                 # 2. Get existing items WITH ingredient names for audit trail
                 existing_items = await conn.fetch("""
@@ -1451,6 +1477,7 @@ async def update_direct_purchase(
                     payment_method,
                     payment_method_id,
                 )
+                assert_contado_requires_payment_method(effective_payment_type, payment_method)
 
                 # 9. Update purchase record
                 await conn.execute("""
@@ -1459,6 +1486,7 @@ async def update_direct_purchase(
                         total_amount = $1,
                         notes = $2,
                         invoice_number = $3,
+                        payment_type = COALESCE($13, payment_type),
                         payment_method = $4,
                         payment_method_id = $5::uuid,
                         payment_reference = $6,
@@ -1481,7 +1509,8 @@ async def update_direct_purchase(
                     new_status,
                     bool(payment_method and payment_amount and current_status != 'paid'),
                     purchase_id,
-                    _parse_date(purchase_date)
+                    _parse_date(purchase_date),
+                    payment_type,
                 )
 
                 # 10. Create status history if status changed

--- a/tests/test_direct_purchase_payment_type.py
+++ b/tests/test_direct_purchase_payment_type.py
@@ -1,0 +1,30 @@
+"""Contado requires payment method on direct purchases (#1759)."""
+import pytest
+from fastapi import HTTPException
+
+from app.services.direct_purchase_service import (
+    CONTADO_REQUIRES_PAYMENT_METHOD_DETAIL,
+    assert_contado_requires_payment_method,
+)
+
+
+def test_contado_without_method_raises_400():
+    with pytest.raises(HTTPException) as exc:
+        assert_contado_requires_payment_method("contado", None)
+    assert exc.value.status_code == 400
+    assert exc.value.detail == CONTADO_REQUIRES_PAYMENT_METHOD_DETAIL
+
+
+def test_contado_with_empty_method_raises_400():
+    with pytest.raises(HTTPException) as exc:
+        assert_contado_requires_payment_method("contado", "  ")
+    assert exc.value.status_code == 400
+
+
+def test_contado_with_method_ok():
+    assert_contado_requires_payment_method("contado", "cash")
+
+
+def test_credito_without_method_ok():
+    assert_contado_requires_payment_method("credito", None)
+    assert_contado_requires_payment_method("contraentrega", "")


### PR DESCRIPTION
## Summary
- Reject `payment_type=contado` without `payment_method` on direct purchase create/update (HTTP 400)
- Allow unpaid purchases via `credito` / deferred types
- Unit tests for the Contado payment-method guard

Companion front PR: warocol.com (same branch name). Related to uno0uno/warocol.com#1759

## Test plan
- [ ] POST `/suppliers/purchases/direct` with contado + no method → 400
- [ ] POST with credito + no method → allowed (subject to other rules)
- [ ] PUT clearing method on contado purchase → 400; switching to credito → OK

## Validation evidence
```
cd api_warocol.com && pytest tests/test_direct_purchase_payment_type.py -q --tb=short
....
4 passed in 0.02s
```

## wr-context
See `.wr/1759.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)