### PR TITLE
fix(customers): prefer Genérico for phone 0000000000

### DIFF
--- a/.wr/1767.yaml
+++ b/.wr/1767.yaml
@@ -1,0 +1,31 @@
+# Machine contract for wr-fast — keep ≤80 lines.
+issue: 1767
+title: "POS checkout: Genérico resolution, create loader dots, compact customer card"
+repo: both
+repo_remote: uno0uno/warocol.com + uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA
+stack: both
+branch: wr-1767-pos-generico-loader-card
+
+paths:
+  - api_warocol.com/app/services/customers_service.py
+  - api_warocol.com/tests/test_anonymous_customer_resolution.py
+  - front_nuxt/components/pos/CustomerIdentificationModal.vue
+  - front_nuxt/pages/pos/checkout.vue
+
+ac:
+  - Identify modal create/save uses UiLoadingDots (not CommonsTheCustomLoader)
+  - Phone 0000000000 lookup prefers Genérico (generico@warocol.com / name Genérico)
+  - Checkout Datos del cliente card denser L→R; keep Cambiar + wallet
+
+out_of_scope:
+  - Merging duplicate 0000000000 profiles in DB
+  - Changing shared Genérico email data
+
+hints:
+  entry: "search-or-create + search_by_phone — customers_service.py"
+  pattern: "ORDER BY email/name rank then created_at; rank_anonymous_phone_profile for unit tests"
+  tests: "./venv/bin/pytest tests/test_anonymous_customer_resolution.py -q"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/services/customers_service.py
+++ b/app/services/customers_service.py
@@ -24,8 +24,38 @@ from app.models.customer import (
 from uuid import UUID
 import json
 import logging
+import unicodedata
 
 logger = logging.getLogger(__name__)
+
+ANONYMOUS_PHONE = "0000000000"
+GENERIC_CUSTOMER_EMAIL = "generico@warocol.com"
+
+
+def _fold_ascii(value: str) -> str:
+    normalized = unicodedata.normalize("NFD", value.strip().lower())
+    return "".join(c for c in normalized if unicodedata.category(c) != "Mn")
+
+
+def rank_anonymous_phone_profile(name: str | None, email: str | None) -> int:
+    """Lower rank wins. Prefer shared Genérico over other profiles with phone 0000000000."""
+    email_l = (email or "").strip().lower()
+    if email_l == GENERIC_CUSTOMER_EMAIL:
+        return 0
+    if _fold_ascii(name or "") == "generico":
+        return 1
+    return 2
+
+
+_PROFILE_PHONE_ORDER_SQL = """
+ORDER BY
+  CASE
+    WHEN lower(trim(coalesce(email, ''))) = 'generico@warocol.com' THEN 0
+    WHEN lower(trim(coalesce(name, ''))) IN ('genérico', 'generico') THEN 1
+    ELSE 2
+  END,
+  created_at ASC NULLS LAST
+"""
 
 
 async def get_customer_by_id(
@@ -142,6 +172,13 @@ async def search_or_create_customer(
             """
             if is_email_input:
                 search_query = base_select + " WHERE lower(trim(email)) = $1 LIMIT 1"
+            elif phone_number == ANONYMOUS_PHONE:
+                search_query = (
+                    base_select
+                    + " WHERE phone_number = $1 "
+                    + _PROFILE_PHONE_ORDER_SQL
+                    + " LIMIT 1"
+                )
             else:
                 search_query = base_select + " WHERE phone_number = $1 LIMIT 1"
 
@@ -301,7 +338,26 @@ async def search_customer_by_phone(
         phone_number = phone_number.strip().replace(' ', '').replace('-', '')
 
         async with get_db_connection() as conn:
-            query = """
+            if phone_number == ANONYMOUS_PHONE:
+                query = f"""
+                SELECT
+                    p.id,
+                    p.phone_number,
+                    p.name,
+                    p.email,
+                    p.fiscal_id_type,
+                    p.fiscal_id,
+                    p.fiscal_business_name,
+                    p.fiscal_email,
+                    p.created_at,
+                    p.updated_at
+                FROM profile p
+                WHERE p.phone_number = $1
+                {_PROFILE_PHONE_ORDER_SQL}
+                LIMIT 1
+                """
+            else:
+                query = """
                 SELECT
                     p.id,
                     p.phone_number,
@@ -316,7 +372,7 @@ async def search_customer_by_phone(
                 FROM profile p
                 WHERE p.phone_number = $1
                 LIMIT 1
-            """
+                """
 
             result = await conn.fetchrow(query, phone_number)
 

--- a/tests/test_anonymous_customer_resolution.py
+++ b/tests/test_anonymous_customer_resolution.py
@@ -1,0 +1,20 @@
+"""Prefer Genérico profile when multiple rows share phone 0000000000 (#1767)."""
+from app.services.customers_service import rank_anonymous_phone_profile
+
+
+def test_rank_prefers_generico_email():
+    wrong = rank_anonymous_phone_profile("Dianeska Perez", "dp224916@gmail.com")
+    good = rank_anonymous_phone_profile("Genérico", "generico@warocol.com")
+    assert good < wrong
+
+
+def test_rank_prefers_generico_name_without_email_match():
+    wrong = rank_anonymous_phone_profile("Dianeska Perez", "dp224916@gmail.com")
+    by_name = rank_anonymous_phone_profile("Generico", "other@example.com")
+    assert by_name < wrong
+
+
+def test_rank_generico_email_beats_name_only():
+    by_email = rank_anonymous_phone_profile("Someone", "generico@warocol.com")
+    by_name = rank_anonymous_phone_profile("Genérico", "x@y.com")
+    assert by_email < by_name


### PR DESCRIPTION
## Summary
- When looking up phone `0000000000`, prefer the shared Genérico profile (`generico@warocol.com` / name Genérico) over other profiles that share the same phone.
- Applied in search-or-create and search-by-phone; unit tests cover the ranking helper.

Related to uno0uno/warocol.com#1767  
Companion front: https://github.com/uno0uno/warocol.com/pull/1768

## Test plan
- [ ] `./venv/bin/pytest tests/test_anonymous_customer_resolution.py -q`
- [ ] POS identify with no data / Genérico resolves to Genérico, not another walk-in with the same phone

## wr-context
See `.wr/1767.yaml` on this branch (LLM contract).