### PR TITLE
fix(orders): track POS receipts and allow ventas email without invoice

### DIFF
--- a/.wr/1769.yaml
+++ b/.wr/1769.yaml
@@ -1,0 +1,39 @@
+# Machine contract for wr-fast — keep ≤80 lines.
+issue: 1769
+title: "Sale detail + POS: resend order email and unify delivery history"
+repo: both
+repo_remote: uno0uno/warocol.com + uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA
+stack: both
+branch: wr-1769-order-email-history
+
+paths:
+  - api_warocol.com/app/services/orders_service.py
+  - api_warocol.com/app/routers/pos_cart.py
+  - api_warocol.com/app/services/pos_cart_service.py
+  - api_warocol.com/tests/test_invoice_send_email.py
+  - api_warocol.com/tests/test_pos_receipt_email_tracking.py
+  - front_nuxt/pages/ventas/[id].vue
+  - front_nuxt/pages/pos/checkout.vue
+  - front_nuxt/components/ventas/InvoiceEmailModal.vue
+
+ac:
+  - Completed /ventas/[id]: Enviar + Ver historial without accepted DIAN invoice (receipt send)
+  - Accepted invoice: keep invoice email + attachments; resend appends history row
+  - POS /receipt-email with order_id → invoice_email_deliveries (+ pixel) like send_invoice_email
+  - Complete-order fire-and-forget with receipt_email + _order_id also tracks (fail-open)
+  - Historial shows POS + ventas deliveries; empty only if never tracked
+  - Tests: invoice send/history still pass; receipt-without-invoice + POS delivery when order_id
+
+out_of_scope:
+  - Backfill old untracked POS emails
+  - Inventing DIAN invoices
+  - SES template redesign
+
+hints:
+  entry: "orders_service.send_invoice_email; pos_cart SendReceiptRequest + /receipt-email; pos_cart_service complete receipt; ventas/[id] CTA gate"
+  pattern: "Mirror create_pending_delivery + mark_sent/failed + tracking_pixel_url from send_invoice_email (~4377); POS currently skips this"
+  tests: "./venv/bin/pytest tests/test_invoice_send_email.py tests/test_pos_receipt_email_tracking.py -q"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/routers/pos_cart.py
+++ b/app/routers/pos_cart.py
@@ -9,8 +9,10 @@ from datetime import date, datetime
 from pydantic import BaseModel, EmailStr, Field
 from app.services import pos_cart_service
 from app.services.email_helpers import send_pos_receipt_email
+from app.services import invoice_email_tracking_service
 from app.core.middleware import require_valid_session
 from app.core.permissions import Module, require_module
+from app.database import get_db_connection
 
 router = APIRouter(prefix="/pos/cart", tags=["POS Cart"])
 
@@ -304,6 +306,10 @@ async def fire_pos_cart(request: Request, cart_id: UUID):
 class SendReceiptRequest(BaseModel):
     email: EmailStr = Field(..., description="Customer email to send receipt to")
     order_number: int
+    order_id: Optional[UUID] = Field(
+        None,
+        description="Order UUID — when set, registers invoice_email_deliveries for Ver historial (warocol.com#1769).",
+    )
     total_amount: float
     payment_method: str
     items: List[Dict[str, Any]] = Field(default_factory=list)
@@ -363,8 +369,42 @@ async def send_receipt_email(request: Request, receipt_data: SendReceiptRequest)
     """
     Send a POS receipt email on demand.
     Used when the cashier types a customer email in the success modal after order completion.
+
+    When order_id is provided and belongs to the session tenant, registers the
+    send in invoice_email_deliveries (same table as ventas Ver historial).
+    Tracking is fail-open: email still sends if the insert fails.
     """
     session = require_valid_session(request)
+    tenant_id = session.tenant_id if session else None
+
+    delivery_id = None
+    pixel_url = None
+    tracked_order_id = receipt_data.order_id
+    if tracked_order_id and tenant_id:
+        try:
+            async with get_db_connection(use_transaction=False) as conn:
+                owned = await conn.fetchrow(
+                    "SELECT id FROM orders WHERE id = $1 AND tenant_id = $2",
+                    tracked_order_id,
+                    tenant_id,
+                )
+            if owned:
+                tracking_token = invoice_email_tracking_service.generate_tracking_token()
+                tracking_token_hash = invoice_email_tracking_service.hash_tracking_token(
+                    tracking_token
+                )
+                delivery_id = await invoice_email_tracking_service.create_pending_delivery(
+                    tenant_id=tenant_id,
+                    order_id=tracked_order_id,
+                    recipient_email=str(receipt_data.email),
+                    tracking_token_hash=tracking_token_hash,
+                )
+                if delivery_id is not None:
+                    pixel_url = invoice_email_tracking_service.build_pixel_url(tracking_token)
+        except Exception:
+            delivery_id = None
+            pixel_url = None
+
     success = await send_pos_receipt_email(
         customer_email=receipt_data.email,
         order_number=receipt_data.order_number,
@@ -372,7 +412,7 @@ async def send_receipt_email(request: Request, receipt_data: SendReceiptRequest)
         payment_method=receipt_data.payment_method,
         items=receipt_data.items,
         order_date=datetime.utcnow(),
-        tenant_id=str(session.tenant_id) if session and session.tenant_id else None,
+        tenant_id=str(tenant_id) if tenant_id else None,
         business_name=receipt_data.business_name,
         business_address=receipt_data.business_address,
         business_city=receipt_data.business_city,
@@ -389,7 +429,17 @@ async def send_receipt_email(request: Request, receipt_data: SendReceiptRequest)
         promo_savings=receipt_data.promo_savings,
         promo_breakdown=receipt_data.promo_breakdown,
         waro_redemption_summary=receipt_data.waro_redemption_summary,
+        tracking_pixel_url=pixel_url,
     )
+
+    if delivery_id is not None:
+        if success:
+            await invoice_email_tracking_service.mark_delivery_sent(delivery_id)
+        else:
+            await invoice_email_tracking_service.mark_delivery_failed(
+                delivery_id, failure_code="ses_rejected"
+            )
+
     return {"success": success}
 
 

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -4202,16 +4202,17 @@ async def send_invoice_email(
     recipient_email: str,
 ) -> Dict[str, Any]:
     """
-    Send the WARO-branded receipt email for an order's accepted invoice (warocol.com#603).
+    Send the WARO-branded receipt/invoice email for an order (warocol.com#603, #1769).
 
-    Loads the order header + items + invoice + tenant business profile from DB
-    (single connection, sequential reads), validates the invoice is accepted,
-    then dispatches the existing `send_pos_receipt_email` helper which handles
-    SES + template + optional PDF/XML attachment.
+    Loads the order header + items + optional invoice + tenant business profile
+    from DB, then dispatches `send_pos_receipt_email` (SES + template).
+
+    When an accepted electronic invoice exists, includes invoice fields and
+    optional PDF/XML attachments. Otherwise sends a receipt-style email so
+    cashiers can resend from `/ventas/[id]` without DIAN acceptance.
 
     Raises:
         HTTPException 404 — order not found for the session tenant
-        HTTPException 422 — no invoice / invoice not accepted
         HTTPException 502 — SES rejected the send
     """
     session_context = require_valid_session(request)
@@ -4238,8 +4239,8 @@ async def send_invoice_email(
         if not order_row:
             raise HTTPException(status_code=404, detail="Order not found")
 
-        # 2. Invoice header — must exist and be accepted. PDF attachment is optional:
-        # accepted Matias invoices may exist before the local R2 PDF key is stored.
+        # 2. Invoice header — optional. Accepted invoices get FE attachments;
+        # missing / non-accepted still allow a receipt-style resend (#1769).
         invoice_row = await conn.fetchrow(
             """SELECT prefix, invoice_number, cufe, status, r2_pdf_key, r2_xml_key,
                       emitted_at, created_at
@@ -4249,16 +4250,7 @@ async def send_invoice_email(
                LIMIT 1""",
             order_id, tenant_id,
         )
-        if not invoice_row:
-            raise HTTPException(
-                status_code=422,
-                detail="Esta orden no tiene factura electrónica. Emitila antes de enviarla.",
-            )
-        if invoice_row['status'] != 'accepted':
-            raise HTTPException(
-                status_code=422,
-                detail="La factura debe estar aceptada por DIAN para poder enviarla por correo.",
-            )
+        include_invoice = bool(invoice_row and invoice_row['status'] == 'accepted')
 
         # 3. Tax breakdown — net line base matches GL / cierre_service.
         tax_config = await _get_tenant_tax_config(conn, tenant_id)
@@ -4317,17 +4309,19 @@ async def send_invoice_email(
             tenant_id,
         )
 
-        resolution_row = await conn.fetchrow(
-            """SELECT resolution_number, prefix, date_from, date_to,
-                      from_number, to_number
-               FROM dian_resolutions
-               WHERE tenant_id = $1
-                 AND prefix = $2
-                 AND is_active = true
-               ORDER BY created_at DESC
-               LIMIT 1""",
-            tenant_id, invoice_row['prefix'],
-        )
+        resolution_row = None
+        if include_invoice:
+            resolution_row = await conn.fetchrow(
+                """SELECT resolution_number, prefix, date_from, date_to,
+                          from_number, to_number
+                   FROM dian_resolutions
+                   WHERE tenant_id = $1
+                     AND prefix = $2
+                     AND is_active = true
+                   ORDER BY created_at DESC
+                   LIMIT 1""",
+                tenant_id, invoice_row['prefix'],
+            )
 
     discount_amount = float(order_row['discount_amount']) if order_row['discount_amount'] is not None else 0.0
     promo_savings = float(promo_summary["promo_savings"])
@@ -4341,35 +4335,37 @@ async def send_invoice_email(
     )
 
     tax_details = _tax_detail_rows(items_for_tax, std_tax, liq_tax, tax_label)
-    invoice_presentation = _build_invoice_presentation(
-        invoice_row,
-        order_row,
-        profile_row,
-        resolution_row,
-        tax_details,
-        serialize_datetimes=False,
-        provider="matias",
-    )
+    invoice_presentation = None
+    if include_invoice:
+        invoice_presentation = _build_invoice_presentation(
+            invoice_row,
+            order_row,
+            profile_row,
+            resolution_row,
+            tax_details,
+            serialize_datetimes=False,
+            provider="matias",
+        )
 
     # FE email: subject/header prefer tenant fiscal name (emisor), not product brand.
-    issuer_name = (invoice_presentation.get("issuer") or {}).get("name")
+    issuer_name = (invoice_presentation or {}).get("issuer", {}).get("name") if invoice_presentation else None
     email_business_name = commercial_header_name(
         fiscal_row=profile_row,
         public_profile=profile_row,
         prefer_fiscal=True,
-    ) or issuer_name
+    ) or issuer_name or (_row_get(profile_row, "display_name") if profile_row else None)
     email_address = (
-        (invoice_presentation.get("issuer") or {}).get("address")
-        or (_row_get(profile_row, "address") if profile_row else None)
-    )
+        ((invoice_presentation or {}).get("issuer") or {}).get("address")
+        if invoice_presentation else None
+    ) or (_row_get(profile_row, "address") if profile_row else None)
     email_city = (
-        (invoice_presentation.get("issuer") or {}).get("city")
-        or (_row_get(profile_row, "city") if profile_row else None)
-    )
+        ((invoice_presentation or {}).get("issuer") or {}).get("city")
+        if invoice_presentation else None
+    ) or (_row_get(profile_row, "city") if profile_row else None)
     email_phone = (
-        (invoice_presentation.get("issuer") or {}).get("phone")
-        or (_row_get(profile_row, "phone_number") if profile_row else None)
-    )
+        ((invoice_presentation or {}).get("issuer") or {}).get("phone")
+        if invoice_presentation else None
+    ) or (_row_get(profile_row, "phone_number") if profile_row else None)
 
     # api-warolabs#657: persist the attempt before SES. Raw token goes only
     # into the pixel URL; the DB stores its SHA-256 hash. Fail-open: when
@@ -4408,20 +4404,24 @@ async def send_invoice_email(
         promo_savings=promo_savings,
         promo_breakdown=promo_breakdown,
         waro_redemption_summary=waro_summary,
-        invoice_prefix=invoice_row['prefix'],
-        invoice_number=int(invoice_row['invoice_number']),
-        invoice_cufe=invoice_row['cufe'],
+        invoice_prefix=invoice_row['prefix'] if include_invoice else None,
+        invoice_number=int(invoice_row['invoice_number']) if include_invoice else None,
+        invoice_cufe=invoice_row['cufe'] if include_invoice else None,
         invoice_presentation=invoice_presentation,
         return_details=True,
         tracking_pixel_url=pixel_url,
     )
     if isinstance(send_result, dict):
         success = bool(send_result.get("success"))
-        attachment_status = send_result.get("attachments") or _invoice_attachment_flags(invoice_row)
+        attachment_status = send_result.get("attachments") or (
+            _invoice_attachment_flags(invoice_row) if include_invoice else {"pdf": False, "xml": False}
+        )
         attachment_warnings = send_result.get("attachment_warnings") or []
     else:
         success = bool(send_result)
-        attachment_status = _invoice_attachment_flags(invoice_row)
+        attachment_status = (
+            _invoice_attachment_flags(invoice_row) if include_invoice else {"pdf": False, "xml": False}
+        )
         attachment_warnings = []
 
     if not success:

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -15,6 +15,7 @@ from app.core.timezones import get_zoneinfo, local_date_for_tenant, resolve_tena
 from app.services.waros_service import evaluate_and_award
 from app.services.orders_service import _get_order_waro_redemption_summary
 from app.services.email_helpers import send_pos_receipt_email
+from app.services import invoice_email_tracking_service
 from app.services.cierre_service import (
     _get_tenant_tax_config,
     _post_order_gl_entry,
@@ -1787,6 +1788,81 @@ async def void_order_payment(
         raise APIError(f"Error al anular el pago: {e}", status_code=500)
 
 
+async def _send_tracked_pos_receipt_email(
+    *,
+    customer_email: str,
+    order_id: UUID,
+    tenant_id: UUID,
+    order_number: int,
+    total_amount: float,
+    payment_method: str,
+    items: List[dict],
+    order_date: Any,
+    business_name: Optional[str],
+    business_address: Optional[str],
+    business_city: Optional[str],
+    business_phone: Optional[str],
+    discount_amount: float,
+    subtotal: float,
+    promo_savings: float,
+    promo_breakdown: List[dict],
+    waro_redemption_summary: Optional[Dict[str, Any]],
+    tip_amount: float,
+) -> bool:
+    """Fire-and-forget receipt send with optional delivery tracking (#1769). Fail-open."""
+    delivery_id = None
+    pixel_url = None
+    try:
+        tracking_token = invoice_email_tracking_service.generate_tracking_token()
+        tracking_token_hash = invoice_email_tracking_service.hash_tracking_token(tracking_token)
+        delivery_id = await invoice_email_tracking_service.create_pending_delivery(
+            tenant_id=tenant_id,
+            order_id=order_id,
+            recipient_email=customer_email,
+            tracking_token_hash=tracking_token_hash,
+        )
+        if delivery_id is not None:
+            pixel_url = invoice_email_tracking_service.build_pixel_url(tracking_token)
+    except Exception as track_err:
+        logger.warning(f"POS receipt tracking skipped for order {order_id}: {track_err}")
+        delivery_id = None
+        pixel_url = None
+
+    success = await send_pos_receipt_email(
+        customer_email=customer_email,
+        order_number=order_number,
+        total_amount=total_amount,
+        payment_method=payment_method,
+        items=items,
+        order_date=order_date,
+        tenant_id=str(tenant_id),
+        business_name=business_name,
+        business_address=business_address,
+        business_city=business_city,
+        business_phone=business_phone,
+        discount_amount=discount_amount,
+        subtotal=subtotal,
+        promo_savings=promo_savings,
+        promo_breakdown=promo_breakdown,
+        waro_redemption_summary=waro_redemption_summary,
+        tip_amount=tip_amount,
+        tracking_pixel_url=pixel_url,
+    )
+
+    if delivery_id is not None:
+        try:
+            if success:
+                await invoice_email_tracking_service.mark_delivery_sent(delivery_id)
+            else:
+                await invoice_email_tracking_service.mark_delivery_failed(
+                    delivery_id, failure_code="ses_rejected"
+                )
+        except Exception as mark_err:
+            logger.warning(f"POS receipt delivery status update failed: {mark_err}")
+
+    return bool(success)
+
+
 async def complete_pos_order(
     request: Request,
     cart_id: UUID,
@@ -2625,14 +2701,15 @@ async def complete_pos_order(
                     else 0.0
                 )
                 asyncio.create_task(
-                    send_pos_receipt_email(
+                    _send_tracked_pos_receipt_email(
                         customer_email=receipt_email,
+                        order_id=_order_id,
+                        tenant_id=_tenant_id,
                         order_number=_order_number,
                         total_amount=_total_amount,
                         payment_method=payment_method,
                         items=_items,
                         order_date=_order_date,
-                        tenant_id=str(_tenant_id),
                         business_name=_business_name,
                         business_address=_business_address,
                         business_city=_business_city,

--- a/tests/test_invoice_send_email.py
+++ b/tests/test_invoice_send_email.py
@@ -222,47 +222,75 @@ async def test_send_invoice_email_blocks_cross_tenant():
     helper_mock.assert_not_awaited()
 
 
-# ── No invoice on the order ──────────────────────────────────────────────────
+# ── No invoice on the order → receipt-style send (#1769) ─────────────────────
 
 @pytest.mark.asyncio
-async def test_send_invoice_email_rejects_when_no_invoice():
-    """Order exists but has no electronic_invoices row → 422, no helper call."""
+async def test_send_invoice_email_allows_when_no_invoice():
+    """Order exists but has no electronic_invoices row → receipt email still sends."""
     request = MagicMock()
-    helper_mock = AsyncMock(return_value=True)
+    helper_mock = AsyncMock(return_value={
+        'success': True,
+        'attachments': {'pdf': False, 'xml': False},
+        'attachment_warnings': [],
+    })
 
-    with _patch_session(), _patch_db(fetchrow=[_order_row(), None], fetch=[]), patch(
+    fetchrow = [_order_row(), None, _waro_inferred_row(), _profile_row()]
+    fetch = [
+        [],  # tax items
+        [],  # promo summary
+        [],  # waro redemption
+        [{'id': uuid4(), 'quantity': 1, 'subtotal': 200.0, 'product_name': 'tomate barranca'}],
+        [],  # modifiers
+    ]
+
+    with _patch_session(), _patch_db(fetchrow=fetchrow, fetch=fetch), _patch_tax(), patch(
         'app.services.orders_service.send_pos_receipt_email',
         new=helper_mock,
     ):
-        with pytest.raises(HTTPException) as exc_info:
-            await orders_service.send_invoice_email(request, _ORDER_ID, _RECIPIENT)
+        result = await orders_service.send_invoice_email(request, _ORDER_ID, _RECIPIENT)
 
-    assert exc_info.value.status_code == 422
-    assert 'no tiene factura' in exc_info.value.detail.lower()
-    helper_mock.assert_not_awaited()
+    assert result['success'] is True
+    assert result['sent_to'] == _RECIPIENT
+    assert result['attachments'] == {'pdf': False, 'xml': False}
+    helper_mock.assert_awaited_once()
+    kwargs = helper_mock.await_args.kwargs
+    assert kwargs['invoice_prefix'] is None
+    assert kwargs['invoice_number'] is None
+    assert kwargs['invoice_cufe'] is None
+    assert kwargs['invoice_presentation'] is None
 
 
-# ── Invoice not accepted ─────────────────────────────────────────────────────
+# ── Invoice not accepted → receipt-style send (#1769) ────────────────────────
 
 @pytest.mark.asyncio
-async def test_send_invoice_email_rejects_non_accepted():
-    """Invoice exists but status != 'accepted' → 422."""
+async def test_send_invoice_email_allows_non_accepted_as_receipt():
+    """Invoice exists but status != 'accepted' → receipt send without FE attachments."""
     request = MagicMock()
-    helper_mock = AsyncMock(return_value=True)
+    helper_mock = AsyncMock(return_value={
+        'success': True,
+        'attachments': {'pdf': False, 'xml': False},
+        'attachment_warnings': [],
+    })
 
-    with _patch_session(), _patch_db(
-        fetchrow=[_order_row(), _invoice_row(status='rejected')],
-        fetch=[],
-    ), patch(
+    fetchrow = [_order_row(), _invoice_row(status='rejected'), _waro_inferred_row(), _profile_row()]
+    fetch = [
+        [],
+        [],
+        [],
+        [{'id': uuid4(), 'quantity': 1, 'subtotal': 200.0, 'product_name': 'tomate barranca'}],
+        [],
+    ]
+
+    with _patch_session(), _patch_db(fetchrow=fetchrow, fetch=fetch), _patch_tax(), patch(
         'app.services.orders_service.send_pos_receipt_email',
         new=helper_mock,
     ):
-        with pytest.raises(HTTPException) as exc_info:
-            await orders_service.send_invoice_email(request, _ORDER_ID, _RECIPIENT)
+        result = await orders_service.send_invoice_email(request, _ORDER_ID, _RECIPIENT)
 
-    assert exc_info.value.status_code == 422
-    assert 'aceptada' in exc_info.value.detail.lower()
-    helper_mock.assert_not_awaited()
+    assert result['success'] is True
+    kwargs = helper_mock.await_args.kwargs
+    assert kwargs['invoice_prefix'] is None
+    assert kwargs['invoice_presentation'] is None
 
 
 # ── Missing PDF (r2_pdf_key is null) ─────────────────────────────────────────

--- a/tests/test_pos_receipt_email_tracking.py
+++ b/tests/test_pos_receipt_email_tracking.py
@@ -1,0 +1,108 @@
+"""POS receipt-email tracking registration (warocol.com#1769)."""
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import Request
+
+from app.routers import pos_cart as pos_cart_router
+
+
+_TENANT_ID = UUID("93b3e582-34fa-44a6-8d0f-bf82a3608727")
+_ORDER_ID = uuid4()
+_DELIVERY_ID = uuid4()
+
+
+class _OwnedConnCtx:
+    def __init__(self, owned_row):
+        self._owned = owned_row
+
+    async def __aenter__(self):
+        conn = MagicMock()
+        conn.fetchrow = AsyncMock(return_value=self._owned)
+        return conn
+
+    async def __aexit__(self, *_):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_receipt_email_registers_delivery_when_order_id_owned():
+    request = MagicMock(spec=Request)
+    session = MagicMock()
+    session.tenant_id = _TENANT_ID
+
+    body = pos_cart_router.SendReceiptRequest(
+        email="cashier@example.com",
+        order_number=42,
+        order_id=_ORDER_ID,
+        total_amount=1000.0,
+        payment_method="cash",
+        items=[],
+    )
+
+    with (
+        patch("app.routers.pos_cart.require_valid_session", return_value=session),
+        patch(
+            "app.routers.pos_cart.get_db_connection",
+            lambda *a, **k: _OwnedConnCtx({"id": _ORDER_ID}),
+        ),
+        patch(
+            "app.routers.pos_cart.invoice_email_tracking_service.create_pending_delivery",
+            new=AsyncMock(return_value=_DELIVERY_ID),
+        ) as create_pending,
+        patch(
+            "app.routers.pos_cart.invoice_email_tracking_service.mark_delivery_sent",
+            new=AsyncMock(),
+        ) as mark_sent,
+        patch(
+            "app.routers.pos_cart.invoice_email_tracking_service.mark_delivery_failed",
+            new=AsyncMock(),
+        ) as mark_failed,
+        patch(
+            "app.routers.pos_cart.send_pos_receipt_email",
+            new=AsyncMock(return_value=True),
+        ) as send_mock,
+    ):
+        result = await pos_cart_router.send_receipt_email(request, body)
+
+    assert result == {"success": True}
+    create_pending.assert_awaited_once()
+    assert create_pending.await_args.kwargs["order_id"] == _ORDER_ID
+    assert create_pending.await_args.kwargs["tenant_id"] == _TENANT_ID
+    send_mock.assert_awaited_once()
+    assert send_mock.await_args.kwargs["tracking_pixel_url"]
+    mark_sent.assert_awaited_once_with(_DELIVERY_ID)
+    mark_failed.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_receipt_email_skips_tracking_without_order_id():
+    request = MagicMock(spec=Request)
+    session = MagicMock()
+    session.tenant_id = _TENANT_ID
+
+    body = pos_cart_router.SendReceiptRequest(
+        email="cashier@example.com",
+        order_number=42,
+        total_amount=1000.0,
+        payment_method="cash",
+        items=[],
+    )
+
+    with (
+        patch("app.routers.pos_cart.require_valid_session", return_value=session),
+        patch(
+            "app.routers.pos_cart.invoice_email_tracking_service.create_pending_delivery",
+            new=AsyncMock(),
+        ) as create_pending,
+        patch(
+            "app.routers.pos_cart.send_pos_receipt_email",
+            new=AsyncMock(return_value=True),
+        ) as send_mock,
+    ):
+        result = await pos_cart_router.send_receipt_email(request, body)
+
+    assert result == {"success": True}
+    create_pending.assert_not_awaited()
+    assert send_mock.await_args.kwargs.get("tracking_pixel_url") is None


### PR DESCRIPTION
## Summary
- `send_invoice_email` sends a receipt-style email when there is no accepted DIAN invoice (still tracks deliveries).
- POS `/receipt-email` accepts `order_id` and registers `invoice_email_deliveries` (+ pixel); complete-order fire-and-forget uses the same tracking (fail-open).

Related to uno0uno/warocol.com#1769  
Companion front: https://github.com/uno0uno/warocol.com/pull/1770

## Test plan
- [ ] POS success → send receipt → Ver historial on `/ventas/[id]` shows the row
- [ ] Completed sale without invoice → Enviar por correo works
- [ ] Accepted invoice → send still attaches PDF when available; resend appends history

## Validation evidence
```
./venv/bin/pytest tests/test_invoice_send_email.py tests/test_pos_receipt_email_tracking.py -q
============================= test session starts ==============================
collected 9 items
tests/test_invoice_send_email.py .......                                 [ 77%]
tests/test_pos_receipt_email_tracking.py ..                              [100%]
============================== 9 passed in 1.56s ===============================
```

## wr-context
See `.wr/1769.yaml` on this branch (LLM contract).