### PR TITLE
fix(accounting): seed tenant chart on financial profile + backfill

### DIFF
--- a/app/services/onboarding_service.py
+++ b/app/services/onboarding_service.py
@@ -751,6 +751,7 @@ async def update_onboarding_financial_profile(
         document_mode,
         fiscal_provider,
     )
+    await financial_service.seed_tenant_accounts(conn, tenant_id)
     state = await _promote_onboarding_identity(conn, tenant_id)
     result = dict(profile)
     result["business_name"] = data.business_name

--- a/app/services/tenant_financial_profile_service.py
+++ b/app/services/tenant_financial_profile_service.py
@@ -132,6 +132,11 @@ def _response(profile_row: Any, blockers: Any) -> TenantFinancialProfileResponse
     )
 
 
+async def seed_tenant_accounts(conn, tenant_id) -> None:
+    """Idempotent chart seed from tenant_financial_profiles.accounting_localization."""
+    await conn.execute("SELECT seed_tenant_accounts($1)", tenant_id)
+
+
 async def build_financial_response(
     conn, tenant_id, *, lock_tenant: bool = False
 ) -> TenantFinancialProfileResponse:
@@ -143,7 +148,9 @@ async def build_financial_response(
         if not tenant:
             raise HTTPException(status_code=404, detail="Tenant not found")
 
-    await conn.execute(_DEFAULT_PROFILE_INSERT, tenant_id)
+    insert_status = await conn.execute(_DEFAULT_PROFILE_INSERT, tenant_id)
+    if insert_status == "INSERT 0 1":
+        await seed_tenant_accounts(conn, tenant_id)
     suffix = " FOR UPDATE" if lock_tenant else ""
     profile = await conn.fetchrow(
         """
@@ -223,4 +230,5 @@ async def update_financial_profile(
                 document_mode,
                 fiscal_provider,
             )
+            await seed_tenant_accounts(conn, tenant_id)
             return _response(row, {"permanent_activity": False, "temporary_activity": False})

--- a/sql/20260724_backfill_seed_tenant_accounts.sql
+++ b/sql/20260724_backfill_seed_tenant_accounts.sql
@@ -1,0 +1,25 @@
+-- One-shot backfill: active tenants with a financial profile and zero tenant_accounts.
+-- Idempotent via seed_tenant_accounts (ON CONFLICT DO NOTHING).
+-- Safe to re-run.
+
+DO $$
+DECLARE
+    r RECORD;
+    seeded INT := 0;
+BEGIN
+    FOR r IN
+        SELECT t.id
+        FROM tenants t
+        JOIN tenant_financial_profiles tfp ON tfp.tenant_id = t.id
+        WHERE t.lifecycle_status = 'active'
+          AND NOT EXISTS (
+              SELECT 1 FROM tenant_accounts ta WHERE ta.tenant_id = t.id
+          )
+        ORDER BY t.created_at
+    LOOP
+        PERFORM seed_tenant_accounts(r.id);
+        seeded := seeded + 1;
+    END LOOP;
+
+    RAISE NOTICE 'seed_tenant_accounts backfill complete: % tenants', seeded;
+END $$;

--- a/tests/test_onboarding_country_terms.py
+++ b/tests/test_onboarding_country_terms.py
@@ -55,6 +55,7 @@ async def test_initial_selection_atomically_promotes_identity_to_billing_boundar
     ])
     conn.execute = AsyncMock(side_effect=[
         "UPDATE 1",
+        "SELECT 1",
         "UPDATE 1",
         "UPDATE 1",
     ])
@@ -82,8 +83,10 @@ async def test_initial_selection_atomically_promotes_identity_to_billing_boundar
     statements = [" ".join(call.args[0].split()) for call in conn.execute.await_args_list]
     assert "UPDATE tenants SET name" in statements[0]
     assert conn.execute.await_args_list[0].args[2] == "Cafe Central"
-    assert "SET role = 'superuser', is_active = true" in statements[1]
-    assert "SET lifecycle_status = 'active'" in statements[2]
+    assert "seed_tenant_accounts($1)" in statements[1]
+    assert conn.execute.await_args_list[1].args[1] == tenant_id
+    assert "SET role = 'superuser', is_active = true" in statements[2]
+    assert "SET lifecycle_status = 'active'" in statements[3]
 
 
 @pytest.mark.asyncio

--- a/tests/test_tenant_financial_profile.py
+++ b/tests/test_tenant_financial_profile.py
@@ -146,7 +146,23 @@ async def test_update_locks_tenant_and_derives_global_mode_server_side():
     assert result.capabilities.matias_dian is False
     lock_query = next(query for query, _ in conn.queries if "FROM tenants WHERE id" in query)
     assert "FOR UPDATE" in lock_query
-    assert all(args == (tenant_id,) for _, args in conn.queries[:-1])
+    seed_queries = [
+        (query, args)
+        for query, args in conn.queries
+        if "seed_tenant_accounts" in query
+    ]
+    assert len(seed_queries) == 2
+    assert all(args == (tenant_id,) for _, args in seed_queries)
+    update_query = next(
+        query for query, _ in conn.queries if "UPDATE tenant_financial_profiles" in query
+    )
+    assert "accounting_localization = $4" in update_query
+    non_update = [
+        args
+        for query, args in conn.queries
+        if "UPDATE tenant_financial_profiles" not in query
+    ]
+    assert all(args == (tenant_id,) for args in non_update)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Call `seed_tenant_accounts($tenant_id)` after onboarding financial-profile upsert and after financial-profile create/update localization writes.
- Add one-shot SQL backfill for active tenants with profile and zero `tenant_accounts` (already applied; 17 tenants seeded).
- Update targeted tests to expect seed on financial-profile paths.

Closes uno0uno/warocol.com#1773

## Test plan
- [x] `./venv/bin/pytest tests/test_onboarding_registration.py tests/test_onboarding_country_terms.py tests/test_tenant_financial_profile.py -q`
- [x] Backfill SQL against tunnel DB; verify `TEST-23-07-2026` has 20 hospitality accounts and `CASH`/`INVENTORY`/`ACCOUNTS_PAYABLE` resolve

## Validation evidence

### pytest
```
collected 31 items
tests/test_onboarding_registration.py ........
tests/test_onboarding_country_terms.py .............
tests/test_tenant_financial_profile.py ..........
============================== 31 passed in 0.18s ==============================
```

### backfill + role check
```
NOTICE:  seed_tenant_accounts backfill complete: 17 tenants
slug=onboarding-d24649926c6f4886 localization=WARO_HOSPITALITY_GLOBAL_V1 accounts=20
ACCOUNTS_PAYABLE 2000 | CASH 1000 | INVENTORY 1200
```

Made with [Cursor](https://cursor.com)