### PR TITLE
fix(facturacion): gate DIAN/Matias APIs behind matias_dian

### DIFF
--- a/app/routers/tenant_config.py
+++ b/app/routers/tenant_config.py
@@ -8,6 +8,7 @@ from asyncpg.exceptions import UniqueViolationError
 from fastapi import APIRouter, Depends, Request, Body, HTTPException
 from fastapi.responses import JSONResponse
 from app.core.permissions import Module, require_module
+from app.services.account_role_service import require_matias_dian_capability
 from app.services import tenant_config_service
 from app.models.tenant_public_profile import (
     TenantPublicProfileCreate,
@@ -416,7 +417,13 @@ async def update_fiscal_data(request: Request, data: dict = Body(...)):
     return {'success': True, 'message': 'Datos fiscales actualizados'}
 
 
-@router.get("/dian-resolutions", dependencies=[Depends(require_module(Module.MI_NEGOCIO))])
+_dian_matias_deps = [
+    Depends(require_module(Module.MI_NEGOCIO)),
+    Depends(require_matias_dian_capability),
+]
+
+
+@router.get("/dian-resolutions", dependencies=_dian_matias_deps)
 async def get_dian_resolutions(request: Request):
     """
     Get all DIAN resolutions for the active tenant.
@@ -463,7 +470,7 @@ async def get_dian_resolutions(request: Request):
     return {'success': True, 'data': resolutions}
 
 
-@router.post("/dian-resolutions", dependencies=[Depends(require_module(Module.MI_NEGOCIO))])
+@router.post("/dian-resolutions", dependencies=_dian_matias_deps)
 async def create_dian_resolution(request: Request, data: dict = Body(...)):
     """Create a new DIAN resolution for the active tenant."""
     from app.core.middleware import require_valid_session
@@ -548,7 +555,7 @@ async def create_dian_resolution(request: Request, data: dict = Body(...)):
     return {'success': True, 'data': {'id': str(row_id)}, 'message': 'Resolución creada'}
 
 
-@router.put("/dian-resolutions/{resolution_id}", dependencies=[Depends(require_module(Module.MI_NEGOCIO))])
+@router.put("/dian-resolutions/{resolution_id}", dependencies=_dian_matias_deps)
 async def update_dian_resolution(request: Request, resolution_id: str, data: dict = Body(...)):
     """Update an existing DIAN resolution."""
     from app.core.middleware import require_valid_session
@@ -632,7 +639,7 @@ async def update_dian_resolution(request: Request, resolution_id: str, data: dic
     return {'success': True, 'message': 'Resolución actualizada'}
 
 
-@router.patch("/dian-resolutions/{resolution_id}/toggle", dependencies=[Depends(require_module(Module.MI_NEGOCIO))])
+@router.patch("/dian-resolutions/{resolution_id}/toggle", dependencies=_dian_matias_deps)
 async def toggle_dian_resolution(request: Request, resolution_id: str):
     """Toggle is_active for a DIAN resolution."""
     from app.core.middleware import require_valid_session
@@ -659,7 +666,7 @@ async def toggle_dian_resolution(request: Request, resolution_id: str):
     return {'success': True, 'data': {'is_active': new_state}}
 
 
-@router.get("/dian-resolutions/gaps", dependencies=[Depends(require_module(Module.MI_NEGOCIO))])
+@router.get("/dian-resolutions/gaps", dependencies=_dian_matias_deps)
 async def list_dian_sequence_gaps(
     request: Request,
     resolution_id: Optional[str] = None,
@@ -735,7 +742,7 @@ async def list_dian_sequence_gaps(
     }
 
 
-@router.get("/dian-resolutions/gaps-summary", dependencies=[Depends(require_module(Module.MI_NEGOCIO))])
+@router.get("/dian-resolutions/gaps-summary", dependencies=_dian_matias_deps)
 async def dian_gaps_summary(request: Request):
     """Aggregate gap counts for the active tenant (warocol.com#592).
 
@@ -771,7 +778,7 @@ async def dian_gaps_summary(request: Request):
     }
 
 
-@router.get("/facturacion-status", dependencies=[Depends(require_module(Module.MI_NEGOCIO))])
+@router.get("/facturacion-status", dependencies=_dian_matias_deps)
 async def get_facturacion_status(request: Request):
     """
     Get Matias API connection status and last emitted document.

--- a/app/services/account_role_service.py
+++ b/app/services/account_role_service.py
@@ -328,6 +328,32 @@ async def require_colombia_payroll_capability(request) -> None:
         await ensure_colombia_payroll(conn, session.tenant_id)
 
 
+async def ensure_matias_dian(conn, tenant_id: UUID) -> None:
+    """Fail closed when capabilities.matias_dian is off (non-CO profiles)."""
+    enabled = await conn.fetchval(
+        """
+        SELECT country_code = 'CO'
+        FROM tenant_financial_profiles
+        WHERE tenant_id = $1
+        """,
+        tenant_id,
+    )
+    if not enabled:
+        raise APIError(
+            "La facturacion electronica Matias/DIAN no esta disponible para este perfil financiero",
+            status_code=409,
+            details={"code": "MATIAS_DIAN_NOT_AVAILABLE"},
+        )
+
+
+async def require_matias_dian_capability(request) -> None:
+    session = require_valid_session(request)
+    if not session.tenant_id:
+        raise APIError("Tenant ID is required", status_code=401)
+    async with get_db_connection() as conn:
+        await ensure_matias_dian(conn, session.tenant_id)
+
+
 async def list_role_bindings(conn, tenant_id: UUID) -> List[Dict[str, Any]]:
     rows = await conn.fetch(
         """

--- a/tests/test_account_role_resolution.py
+++ b/tests/test_account_role_resolution.py
@@ -14,6 +14,7 @@ from app.services.account_role_service import (
     AccountRole,
     MissingAccountRoleError,
     ensure_colombia_payroll,
+    ensure_matias_dian,
     resolve_account,
     resolve_payment_account,
 )
@@ -127,6 +128,27 @@ async def test_colombia_payroll_gate_rejects_global_profile():
 
     assert exc.value.status_code == 409
     assert exc.value.details["code"] == "COLOMBIA_PAYROLL_NOT_AVAILABLE"
+
+
+@pytest.mark.asyncio
+async def test_matias_dian_gate_rejects_global_profile():
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=False)
+
+    with pytest.raises(APIError) as exc:
+        await ensure_matias_dian(conn, uuid4())
+
+    assert exc.value.status_code == 409
+    assert exc.value.details["code"] == "MATIAS_DIAN_NOT_AVAILABLE"
+
+
+@pytest.mark.asyncio
+async def test_matias_dian_gate_allows_colombia_profile():
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=True)
+
+    await ensure_matias_dian(conn, uuid4())
+    conn.fetchval.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `ensure_matias_dian` / `require_matias_dian_capability` (409 `MATIAS_DIAN_NOT_AVAILABLE`)
- Apply to `dian-resolutions*` and `facturacion-status` (module + capability)
- Emit paths keep `require_invoicing_ready` (already blocks non-CO)

Refs uno0uno/warocol.com#1775 (epic #1772 batch 3)

## Test plan
- [x] `./venv/bin/pytest tests/test_account_role_resolution.py -k matias_dian -q`
- [ ] MX tenant: DIAN resolution endpoints 409
- [ ] CO tenant: DIAN endpoints unchanged

## Validation evidence
```
============================= test session starts ==============================
collected 9 items / 7 deselected / 2 selected
tests/test_account_role_resolution.py ..                                 [100%]
======================= 2 passed, 7 deselected in 0.03s ========================
```

Made with [Cursor](https://cursor.com)