### PR TITLE
fix(finanzas): hospitality chart roles + expense maps + hard-lock

### DIFF
--- a/app/services/tenant_financial_profile_service.py
+++ b/app/services/tenant_financial_profile_service.py
@@ -23,6 +23,7 @@ from app.models.tenant_financial_profile import (
 
 PERMANENT_REASON = "PERMANENT_FINANCIAL_ACTIVITY"
 TEMPORARY_REASON = "TEMPORARY_OPERATIONAL_ACTIVITY"
+CONFIGURED_REASON = "FINANCIAL_PROFILE_CONFIGURED"
 
 _DEFAULT_PROFILE_INSERT = """
     INSERT INTO tenant_financial_profiles (
@@ -180,7 +181,6 @@ async def update_financial_profile(
     country_code, currency_code = validate_country_currency_pair(
         data.country_code, data.base_currency_code
     )
-    accounting_localization, document_mode, fiscal_provider = _financial_mode(country_code)
 
     async with get_db_connection() as conn:
         async with conn.transaction():
@@ -191,36 +191,24 @@ async def update_financial_profile(
             )
             if same_pair:
                 return current
-            if not current.eligibility.eligible:
-                raise HTTPException(
-                    status_code=409,
-                    detail={
-                        "code": "FINANCIAL_PROFILE_LOCKED",
-                        "lock_type": current.eligibility.lock_type,
-                        "reason_codes": current.eligibility.reason_codes,
-                    },
-                )
 
-            row = await conn.fetchrow(
-                """
-                UPDATE tenant_financial_profiles
-                SET country_code = $2,
-                    base_currency_code = $3,
-                    accounting_localization = $4,
-                    document_mode = $5,
-                    fiscal_provider = $6,
-                    selection_revision = selection_revision + 1,
-                    updated_at = NOW()
-                WHERE tenant_id = $1
-                RETURNING tenant_id, country_code, base_currency_code,
-                          accounting_localization, document_mode, fiscal_provider,
-                          selection_revision, created_at, updated_at
-                """,
-                tenant_id,
-                country_code,
-                currency_code,
-                accounting_localization,
-                document_mode,
-                fiscal_provider,
+            # Country/currency are immutable after first configure (onboarding /
+            # default profile). Stronger than activity-only eligibility locks.
+            lock_type = (
+                current.eligibility.lock_type
+                if not current.eligibility.eligible
+                else "configured"
             )
-            return _response(row, {"permanent_activity": False, "temporary_activity": False})
+            reason_codes = (
+                current.eligibility.reason_codes
+                if not current.eligibility.eligible
+                else [CONFIGURED_REASON]
+            )
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "FINANCIAL_PROFILE_LOCKED",
+                    "lock_type": lock_type,
+                    "reason_codes": reason_codes,
+                },
+            )

--- a/migrations/104_accounting_localizations.sql
+++ b/migrations/104_accounting_localizations.sql
@@ -145,9 +145,11 @@ INSERT INTO account_templates (
     ('WARO_HOSPITALITY_GLOBAL_V1', '4',    'Revenue',                    '4', 'income',    'credit', 1, NULL, false, NULL, true),
     ('WARO_HOSPITALITY_GLOBAL_V1', '40',   'Operating revenue',          '4', 'income',    'credit', 2, '4',  false, NULL, true),
     ('WARO_HOSPITALITY_GLOBAL_V1', '4000', 'Sales revenue',              '4', 'income',    'credit', 4, '40', true,  NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '4010', 'Other income',               '4', 'income',    'credit', 4, '40', true,  NULL, true),
     ('WARO_HOSPITALITY_GLOBAL_V1', '5',    'Expenses',                   '5', 'expense',   'debit',  1, NULL, false, NULL, true),
     ('WARO_HOSPITALITY_GLOBAL_V1', '50',   'Operating expenses',         '5', 'expense',   'debit',  2, '5',  false, NULL, true),
     ('WARO_HOSPITALITY_GLOBAL_V1', '5000', 'Payroll expense',            '5', 'expense',   'debit',  4, '50', true,  NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '5100', 'Bank fees expense',          '5', 'expense',   'debit',  4, '50', true,  NULL, true),
     ('WARO_HOSPITALITY_GLOBAL_V1', '6',    'Cost of goods sold',         '6', 'cogs',      'debit',  1, NULL, false, NULL, true),
     ('WARO_HOSPITALITY_GLOBAL_V1', '60',   'Cost of goods sold details', '6', 'cogs',      'debit',  2, '6',  false, NULL, true),
     ('WARO_HOSPITALITY_GLOBAL_V1', '6000', 'Cost of goods sold',         '6', 'cogs',      'debit',  4, '60', true,  NULL, true)
@@ -175,7 +177,8 @@ CREATE TABLE IF NOT EXISTS account_template_role_defaults (
     role VARCHAR(40) NOT NULL CHECK (role IN (
         'CASH', 'BANK', 'ACCOUNTS_RECEIVABLE', 'INVENTORY',
         'ACCOUNTS_PAYABLE', 'SALES_REVENUE', 'TAX_PAYABLE', 'COGS',
-        'PAYROLL_EXPENSE', 'CUSTOMER_ADVANCES'
+        'PAYROLL_EXPENSE', 'CUSTOMER_ADVANCES',
+        'BANK_FEES_EXPENSE', 'OTHER_INCOME'
     )),
     account_template_id UUID NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -218,7 +221,9 @@ WITH role_codes(role, code) AS (
         ('TAX_PAYABLE', '2100'),
         ('CUSTOMER_ADVANCES', '2200'),
         ('SALES_REVENUE', '4000'),
+        ('OTHER_INCOME', '4010'),
         ('PAYROLL_EXPENSE', '5000'),
+        ('BANK_FEES_EXPENSE', '5100'),
         ('COGS', '6000')
 )
 INSERT INTO account_template_role_defaults (localization_id, role, account_template_id)

--- a/migrations/117_hospitality_finanzas_roles_expense_maps.sql
+++ b/migrations/117_hospitality_finanzas_roles_expense_maps.sql
@@ -109,7 +109,10 @@ BEGIN
             (p_tenant_id, 'INSURANCE',    '5000', '1000', '1010'),
             (p_tenant_id, 'CAPITAL',      '5000', '1000', '2000'),
             (p_tenant_id, 'CONTINGENCY',  '5000', '1000', '1010')
-        ON CONFLICT (tenant_id, category_code) DO NOTHING;
+        ON CONFLICT (tenant_id, category_code) DO UPDATE SET
+            debit_account_code = EXCLUDED.debit_account_code,
+            credit_cash_account_code = EXCLUDED.credit_cash_account_code,
+            credit_default_account_code = EXCLUDED.credit_default_account_code;
     ELSIF p_localization_id = 'WARO_CO_PUC_V1' THEN
         INSERT INTO expense_category_gl_mappings (
             tenant_id, category_code,

--- a/migrations/117_hospitality_finanzas_roles_expense_maps.sql
+++ b/migrations/117_hospitality_finanzas_roles_expense_maps.sql
@@ -1,0 +1,165 @@
+-- Issue warocol.com#1776: hospitality Finanzas roles + expense GL maps.
+-- ADD-only: new template accounts/role defaults, extend seed_tenant_accounts,
+-- backfill existing hospitality tenants.
+
+BEGIN;
+
+INSERT INTO account_templates (
+    localization_id, code, standard_name, account_class, account_type,
+    normal_balance, level, parent_code, is_detail, niif_group, is_active
+) VALUES
+    ('WARO_HOSPITALITY_GLOBAL_V1', '4010', 'Other income',      '4', 'income',  'credit', 4, '40', true, NULL, true),
+    ('WARO_HOSPITALITY_GLOBAL_V1', '5100', 'Bank fees expense', '5', 'expense', 'debit',  4, '50', true, NULL, true)
+ON CONFLICT (localization_id, code) DO UPDATE SET
+    standard_name = EXCLUDED.standard_name,
+    account_class = EXCLUDED.account_class,
+    account_type = EXCLUDED.account_type,
+    normal_balance = EXCLUDED.normal_balance,
+    level = EXCLUDED.level,
+    parent_code = EXCLUDED.parent_code,
+    is_detail = EXCLUDED.is_detail,
+    niif_group = EXCLUDED.niif_group,
+    is_active = EXCLUDED.is_active;
+
+UPDATE account_templates child
+SET parent_template_id = parent.id
+FROM account_templates parent
+WHERE parent.localization_id = child.localization_id
+  AND parent.code = child.parent_code
+  AND child.localization_id = 'WARO_HOSPITALITY_GLOBAL_V1'
+  AND child.code IN ('4010', '5100')
+  AND child.parent_template_id IS DISTINCT FROM parent.id;
+
+WITH role_codes(role, code) AS (
+    VALUES
+        ('OTHER_INCOME', '4010'),
+        ('BANK_FEES_EXPENSE', '5100')
+)
+INSERT INTO account_template_role_defaults (localization_id, role, account_template_id)
+SELECT 'WARO_HOSPITALITY_GLOBAL_V1', role_codes.role, templates.id
+FROM role_codes
+JOIN account_templates templates
+  ON templates.localization_id = 'WARO_HOSPITALITY_GLOBAL_V1'
+ AND templates.code = role_codes.code
+ON CONFLICT (localization_id, role) DO UPDATE
+SET account_template_id = EXCLUDED.account_template_id;
+
+CREATE OR REPLACE FUNCTION seed_tenant_accounts(
+    p_tenant_id UUID,
+    p_localization_id VARCHAR(50)
+)
+RETURNS VOID AS $$
+DECLARE
+    v_profile_localization VARCHAR(50);
+BEGIN
+    SELECT accounting_localization
+    INTO v_profile_localization
+    FROM tenant_financial_profiles
+    WHERE tenant_id = p_tenant_id;
+
+    IF v_profile_localization IS NULL THEN
+        RAISE EXCEPTION 'Tenant % has no financial profile', p_tenant_id;
+    END IF;
+
+    IF v_profile_localization <> p_localization_id THEN
+        RAISE EXCEPTION 'Localization % does not match tenant % profile %',
+            p_localization_id, p_tenant_id, v_profile_localization;
+    END IF;
+
+    INSERT INTO tenant_accounts (
+        tenant_id, template_id, code, name,
+        account_class, account_type, normal_balance,
+        level, is_detail, is_system, is_active
+    )
+    SELECT
+        p_tenant_id, templates.id, templates.code, templates.standard_name,
+        templates.account_class, templates.account_type, templates.normal_balance,
+        templates.level, templates.is_detail, true, true
+    FROM account_templates templates
+    WHERE templates.localization_id = p_localization_id
+      AND templates.is_active = true
+    ON CONFLICT (tenant_id, code) DO NOTHING;
+
+    UPDATE tenant_accounts child_account
+    SET parent_id = parent_account.id
+    FROM account_templates child_template
+    JOIN account_templates parent_template
+      ON parent_template.localization_id = child_template.localization_id
+     AND parent_template.id = child_template.parent_template_id
+    JOIN tenant_accounts parent_account
+      ON parent_account.tenant_id = p_tenant_id
+     AND parent_account.code = parent_template.code
+    WHERE child_account.tenant_id = p_tenant_id
+      AND child_account.template_id = child_template.id
+      AND child_template.localization_id = p_localization_id
+      AND child_account.parent_id IS DISTINCT FROM parent_account.id;
+
+    IF p_localization_id = 'WARO_HOSPITALITY_GLOBAL_V1' THEN
+        INSERT INTO expense_category_gl_mappings (
+            tenant_id, category_code,
+            debit_account_code, credit_cash_account_code, credit_default_account_code
+        ) VALUES
+            (p_tenant_id, 'SUPPLIES',     '6000', '1000', '2000'),
+            (p_tenant_id, 'PAYROLL',      '5000', '1000', '1010'),
+            (p_tenant_id, 'RENT',         '5000', '1000', '2000'),
+            (p_tenant_id, 'UTILITIES',    '5000', '1000', '1010'),
+            (p_tenant_id, 'MAINTENANCE',  '5000', '1000', '2000'),
+            (p_tenant_id, 'MARKETING',    '5000', '1000', '1010'),
+            (p_tenant_id, 'PROFESSIONAL', '5000', '1000', '1010'),
+            (p_tenant_id, 'INSURANCE',    '5000', '1000', '1010'),
+            (p_tenant_id, 'CAPITAL',      '5000', '1000', '2000'),
+            (p_tenant_id, 'CONTINGENCY',  '5000', '1000', '1010')
+        ON CONFLICT (tenant_id, category_code) DO NOTHING;
+    ELSIF p_localization_id = 'WARO_CO_PUC_V1' THEN
+        INSERT INTO expense_category_gl_mappings (
+            tenant_id, category_code,
+            debit_account_code, credit_cash_account_code, credit_default_account_code
+        ) VALUES
+            (p_tenant_id, 'SUPPLIES',     '6135', '1105', '2205'),
+            (p_tenant_id, 'PAYROLL',      '5105', '1105', '2335'),
+            (p_tenant_id, 'RENT',         '5140', '1105', '2205'),
+            (p_tenant_id, 'UTILITIES',    '5135', '1105', '2335'),
+            (p_tenant_id, 'MAINTENANCE',  '5145', '1105', '2205'),
+            (p_tenant_id, 'MARKETING',    '5195', '1105', '2335'),
+            (p_tenant_id, 'PROFESSIONAL', '5195', '1105', '2335'),
+            (p_tenant_id, 'INSURANCE',    '5195', '1105', '2335'),
+            (p_tenant_id, 'CAPITAL',      '5195', '1105', '2205'),
+            (p_tenant_id, 'CONTINGENCY',  '5195', '1105', '2335')
+        ON CONFLICT (tenant_id, category_code) DO NOTHING;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION seed_tenant_accounts(p_tenant_id UUID)
+RETURNS VOID AS $$
+DECLARE
+    v_localization_id VARCHAR(50);
+BEGIN
+    SELECT accounting_localization
+    INTO v_localization_id
+    FROM tenant_financial_profiles
+    WHERE tenant_id = p_tenant_id;
+
+    IF v_localization_id IS NULL THEN
+        RAISE EXCEPTION 'Tenant % has no financial profile', p_tenant_id;
+    END IF;
+
+    PERFORM seed_tenant_accounts(p_tenant_id, v_localization_id);
+END;
+$$ LANGUAGE plpgsql;
+
+-- Backfill new accounts + role-mapped expense maps for existing hospitality tenants.
+DO $$
+DECLARE
+    t_id UUID;
+BEGIN
+    FOR t_id IN
+        SELECT tenant_id
+        FROM tenant_financial_profiles
+        WHERE accounting_localization = 'WARO_HOSPITALITY_GLOBAL_V1'
+    LOOP
+        PERFORM seed_tenant_accounts(t_id, 'WARO_HOSPITALITY_GLOBAL_V1');
+    END LOOP;
+END $$;
+
+COMMIT;

--- a/tests/sql/accounting_localizations.sql
+++ b/tests/sql/accounting_localizations.sql
@@ -54,8 +54,8 @@ BEGIN
     END IF;
 
     IF (SELECT COUNT(*) FROM account_template_role_defaults
-        WHERE localization_id = 'WARO_HOSPITALITY_GLOBAL_V1') <> 10 THEN
-        RAISE EXCEPTION 'Global must have ten semantic defaults';
+        WHERE localization_id = 'WARO_HOSPITALITY_GLOBAL_V1') <> 12 THEN
+        RAISE EXCEPTION 'Global must have twelve semantic defaults';
     END IF;
 END $$;
 

--- a/tests/test_accounting_localizations.py
+++ b/tests/test_accounting_localizations.py
@@ -38,7 +38,9 @@ def test_global_chart_is_managerial_and_contains_only_generic_role_accounts():
         ("2100", "Tax payable"),
         ("2200", "Customer advances"),
         ("4000", "Sales revenue"),
+        ("4010", "Other income"),
         ("5000", "Payroll expense"),
+        ("5100", "Bank fees expense"),
         ("6000", "Cost of goods sold"),
     ):
         assert f"'{code}', '{name}'" in MIGRATION_104
@@ -60,6 +62,8 @@ def test_semantic_roles_are_scoped_and_co_tax_stays_specific():
         "COGS",
         "PAYROLL_EXPENSE",
         "CUSTOMER_ADVANCES",
+        "BANK_FEES_EXPENSE",
+        "OTHER_INCOME",
     )
     for role in roles:
         assert f"'{role}'" in MIGRATION_104
@@ -67,6 +71,8 @@ def test_semantic_roles_are_scoped_and_co_tax_stays_specific():
     co_roles = co_roles.split("WITH role_codes(role, code) AS (", 1)[0]
     assert "('TAX_PAYABLE'" not in co_roles
     assert "('CUSTOMER_ADVANCES', '2810')" in co_roles
+    assert "('BANK_FEES_EXPENSE', '5100')" in MIGRATION_104
+    assert "('OTHER_INCOME', '4010')" in MIGRATION_104
 
 
 def test_seed_function_requires_profile_localization_and_is_tenant_scoped():
@@ -76,6 +82,17 @@ def test_seed_function_requires_profile_localization_and_is_tenant_scoped():
     assert "ON CONFLICT (tenant_id, code) DO NOTHING" in MIGRATION_104
     assert "parent_template.id = child_template.parent_template_id" in MIGRATION_104
     assert "parent_account.tenant_id = p_tenant_id" in MIGRATION_104
+
+
+def test_migration_117_extends_seed_with_hospitality_expense_maps():
+    migration_117 = (ROOT / "migrations/117_hospitality_finanzas_roles_expense_maps.sql").read_text()
+    assert "BANK_FEES_EXPENSE" in migration_117
+    assert "OTHER_INCOME" in migration_117
+    assert "expense_category_gl_mappings" in migration_117
+    assert "'SUPPLIES'" in migration_117 and "'6000'" in migration_117 and "'1000'" in migration_117
+    assert "WARO_CO_PUC_V1" in migration_117
+    assert "DELETE FROM" not in migration_117
+    assert "DROP TABLE" not in migration_117
 
 
 def test_historical_bootstrap_conflicts_are_localization_aware():

--- a/tests/test_accounting_localizations.py
+++ b/tests/test_accounting_localizations.py
@@ -90,6 +90,7 @@ def test_migration_117_extends_seed_with_hospitality_expense_maps():
     assert "OTHER_INCOME" in migration_117
     assert "expense_category_gl_mappings" in migration_117
     assert "'SUPPLIES'" in migration_117 and "'6000'" in migration_117 and "'1000'" in migration_117
+    assert "DO UPDATE SET" in migration_117
     assert "WARO_CO_PUC_V1" in migration_117
     assert "DELETE FROM" not in migration_117
     assert "DROP TABLE" not in migration_117

--- a/tests/test_tenant_financial_profile.py
+++ b/tests/test_tenant_financial_profile.py
@@ -126,27 +126,35 @@ def test_temporary_activity_uses_distinct_reversible_lock():
 
 
 @pytest.mark.asyncio
-async def test_update_locks_tenant_and_derives_global_mode_server_side():
+async def test_update_rejects_country_change_when_eligible_hard_lock():
     tenant_id = uuid4()
-    conn = FakeConn(tenant_id, update_row=_profile(tenant_id, "US", "USD"))
+    conn = FakeConn(tenant_id)
     request = object()
     session = SimpleNamespace(tenant_id=tenant_id)
 
     with patch.object(service, "require_valid_session", return_value=session), patch.object(
         service, "get_db_connection", side_effect=_db_context(conn)
     ):
-        result = await service.update_financial_profile(
-            request,
-            TenantFinancialProfileUpdate(country_code="US", base_currency_code="USD"),
-        )
+        with pytest.raises(HTTPException) as exc:
+            await service.update_financial_profile(
+                request,
+                TenantFinancialProfileUpdate(country_code="US", base_currency_code="USD"),
+            )
 
-    assert result.profile.accounting_localization == "WARO_HOSPITALITY_GLOBAL_V1"
-    assert result.profile.document_mode == "waro_commercial"
-    assert result.profile.fiscal_provider is None
-    assert result.capabilities.matias_dian is False
-    lock_query = next(query for query, _ in conn.queries if "FROM tenants WHERE id" in query)
-    assert "FOR UPDATE" in lock_query
-    assert all(args == (tenant_id,) for _, args in conn.queries[:-1])
+    assert exc.value.status_code == 409
+    assert exc.value.detail["code"] == "FINANCIAL_PROFILE_LOCKED"
+    assert exc.value.detail["lock_type"] == "configured"
+    assert exc.value.detail["reason_codes"] == [service.CONFIGURED_REASON]
+    assert not any("UPDATE tenant_financial_profiles" in q for q, _ in conn.queries)
+
+
+@pytest.mark.asyncio
+async def test_financial_mode_derives_hospitality_for_non_co():
+    localization, document_mode, fiscal_provider = service._financial_mode("US")
+    assert localization == "WARO_HOSPITALITY_GLOBAL_V1"
+    assert document_mode == "waro_commercial"
+    assert fiscal_provider is None
+    assert service._financial_mode("CO") == ("WARO_CO_PUC_V1", "fiscal_integrated", "matias")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add hospitality `BANK_FEES_EXPENSE` / `OTHER_INCOME` accounts + role defaults (104 + migration 117)
- Extend `seed_tenant_accounts` to upsert localization-aware `expense_category_gl_mappings` and backfill hospitality tenants
- Hard-lock country/currency after configure (409 `FINANCIAL_PROFILE_LOCKED` / `configured`)

Refs uno0uno/warocol.com#1776

## Test plan
- [ ] Apply migration 117 on staging/prod path
- [ ] Seeded MX: arqueo reconciliation + gasto GL without `ACCOUNT_ROLE_MISSING` / silent CO codes
- [ ] PUT financial-profile with different country → 409; same pair → 200
- [ ] CO PUC mappings unchanged

## Validation evidence
```text
$ ./venv/bin/pytest tests/test_tenant_financial_profile.py tests/test_accounting_localizations.py -q
18 passed in 0.11s
```


Made with [Cursor](https://cursor.com)