### PR TITLE
feat(billing): show all modules on Starter/trial plan

### DIFF
--- a/.wr/1781.yaml
+++ b/.wr/1781.yaml
@@ -1,0 +1,36 @@
+# Machine contract for wr-fast — keep ≤80 lines.
+issue: 1781
+title: "feat(billing): show all modules on Starter/trial plan"
+github_issue: uno0uno/warocol.com#1781
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-1781-starter-all-modules
+
+paths:
+  - app/services/billing_service.py
+  - tests/test_me_access.py
+
+ac:
+  - Starter owner /me/access includes pos ventas menu operaciones abastecimiento analitica finanzas integraciones equipo facturacion mi_negocio mi_plan
+  - Role intersection unchanged (cashier POS-only)
+  - Starter toggles/quotas unchanged
+  - #1772 country gates unchanged (no edits to payroll/matias middleware)
+  - pytest test_me_access green
+
+out_of_scope:
+  - Front nav changes
+  - Unlocking Starter operation toggles
+  - MX Matias/DIAN or payroll localization
+  - Reversing #1773–#1776
+
+hints:
+  entry: "STARTER_PLAN_MODULE_VALUES billing_service.py:257-265 — add analitica finanzas integraciones equipo facturacion"
+  pattern: "me.py:_intersect_plan_modules and permissions.py:372 already consume the frozenset — no duplicate lists"
+  tests: "./venv/bin/pytest tests/test_me_access.py -q"
+  update_test: "test_starter_owner_excludes_finanzas_and_facturacion → assert modules present; rename accordingly"
+  risks: "permissions require_module also uses STARTER_PLAN_MODULE_VALUES — expanding allow-list opens API routes for those modules on starter (intended)"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -260,6 +260,11 @@ STARTER_PLAN_MODULE_VALUES = frozenset({
     "menu",
     "operaciones",
     "abastecimiento",
+    "analitica",
+    "finanzas",
+    "integraciones",
+    "equipo",
+    "facturacion",
     "mi_negocio",
     "mi_plan",
 })

--- a/tests/test_me_access.py
+++ b/tests/test_me_access.py
@@ -132,7 +132,8 @@ def test_starter_owner_includes_all_product_modules():
 
 
 @pytest.mark.parametrize("role", ["cashier", "employee"])
-def test_cashier_and_legacy_employee_return_pos_only(role):
+@pytest.mark.parametrize("plan_slug", ["pro", "starter"])
+def test_cashier_and_legacy_employee_return_pos_only(role, plan_slug):
     """Cashier and legacy employee see only [pos] per DEFAULT_ROLE_MODULES."""
     session = _build_session(role=role)
     app = FastAPI()
@@ -144,7 +145,7 @@ def test_cashier_and_legacy_employee_return_pos_only(role):
          patch("app.routers.me.require_valid_session", return_value=session), \
          patch("app.core.permissions.get_db_connection", side_effect=_mock_db_ctx("disabled")), \
          patch("app.routers.me.get_db_connection", side_effect=_mock_db_ctx("disabled")), \
-         patch("app.routers.me.get_effective_plan_slug", new=AsyncMock(return_value="pro")), \
+         patch("app.routers.me.get_effective_plan_slug", new=AsyncMock(return_value=plan_slug)), \
          patch(
              "app.routers.me.get_kali_access_features",
              new=AsyncMock(return_value={"kali_enabled": False}),
@@ -159,6 +160,7 @@ def test_cashier_and_legacy_employee_return_pos_only(role):
     assert response.status_code == 200
     body = response.json()
     assert body["role"] == role
+    assert body["plan_slug"] == plan_slug
     assert body["modules"] == ["pos"]
     assert body["features"]["kali_enabled"] is False
 

--- a/tests/test_me_access.py
+++ b/tests/test_me_access.py
@@ -92,8 +92,8 @@ def test_owner_returns_all_modules():
     assert body["features"]["kali_enabled"] is True
 
 
-def test_starter_owner_excludes_finanzas_and_facturacion():
-    """Starter plan intersects owner modules — paid-only modules hidden."""
+def test_starter_owner_includes_all_product_modules():
+    """Starter plan still intersects role modules, but no longer hides product modules."""
     session = _build_session(role="owner")
     app = FastAPI()
     app.include_router(me_router, prefix="/me")
@@ -113,10 +113,21 @@ def test_starter_owner_excludes_finanzas_and_facturacion():
     assert response.status_code == 200
     body = response.json()
     assert body["plan_slug"] == "starter"
-    assert "finanzas" not in body["modules"]
-    assert "facturacion" not in body["modules"]
-    assert "equipo" not in body["modules"]
-    assert "pos" in body["modules"]
+    for module in (
+        "pos",
+        "ventas",
+        "menu",
+        "operaciones",
+        "abastecimiento",
+        "analitica",
+        "finanzas",
+        "integraciones",
+        "equipo",
+        "facturacion",
+        "mi_negocio",
+        "mi_plan",
+    ):
+        assert module in body["modules"]
     assert body["features"]["kali_enabled"] is False
 
 

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -913,7 +913,7 @@ async def test_default_scan_limit_for_starter_is_ten():
 
 
 @pytest.mark.asyncio
-async def test_require_module_blocks_finanzas_for_starter_plan():
+async def test_require_module_allows_finanzas_for_starter_plan():
     from app.core.permissions import Module, require_module
 
     session = SimpleNamespace(
@@ -931,11 +931,12 @@ async def test_require_module_blocks_finanzas_for_starter_plan():
              "app.services.billing_service.get_effective_plan_slug",
              new=AsyncMock(return_value="starter"),
          ), \
+         patch(
+             "app.core.permissions.get_enforcement_mode",
+             new=AsyncMock(return_value="disabled"),
+         ), \
          patch("app.core.permissions.get_db_connection") as db_ctx:
         db_ctx.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
         db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
-        with pytest.raises(HTTPException) as exc:
-            await dep(request)
+        await dep(request)
 
-    assert exc.value.status_code == 403
-    assert "Starter" in exc.value.detail


### PR DESCRIPTION
## Summary
- Expand `STARTER_PLAN_MODULE_VALUES` with analitica, finanzas, integraciones, equipo, facturacion
- Update `/me/access` Starter owner test to assert full product module set
- Leaves #1772 country capability gates and Starter toggles unchanged

Closes uno0uno/warocol.com#1781

## Test plan
- [ ] Starter MX trial: sidebar shows Equipo, Facturación, Finanzas, Analítica, Integraciones
- [ ] Cashier on Starter still POS-only
- [ ] Non-CO: Equipo hides salarios/nómina; Facturación hides Matias/DIAN
- [ ] Starter still blocks locked operation toggles

## Validation evidence
```text
$ ./venv/bin/pytest tests/test_me_access.py -q
9 passed in 0.18s
```

## wr-context
See `.wr/1781.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)