### PR TITLE
fix(inventory): include zero-stock items in stock list

### DIFF
--- a/.wr/1782.yaml
+++ b/.wr/1782.yaml
@@ -1,0 +1,39 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1782
+title: "Improve abastecimiento stock list: show zero-stock items and named status badges"
+repo: both
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: both
+branch: wr-1782-stock-zero-badges
+
+paths:
+  - app/services/inventory_service.py
+  - app/services/ingredients_service.py
+  - app/routers/inventory.py
+  - tests/test_inventory.py
+
+ac:
+  - Include current_stock = 0 in stock list
+  - Status zero + filter zero; critical alias for negative
+  - Create tenant ingredient seeds tenant_inventory at 0
+  - Stats include zero_count; total_ingredients counts all rows
+
+out_of_scope:
+  - Front badge/i18n (companion PR on warocol.com)
+  - Destructive migrations
+
+hints:
+  entry: "_get_inventory_stock_for_tenant + create_tenant_ingredient"
+  pattern: "inventory_service CASE/WHERE; ingredients_service INSERT tenant_inventory"
+  tests: "./venv/bin/pytest tests/test_inventory.py::test_inventory_stock_includes_zero_and_filters_zero_status tests/test_inventory.py::test_inventory_stock_core_uses_explicit_tenant_without_session -q"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "merge before or with front PR #1782"

--- a/app/routers/inventory.py
+++ b/app/routers/inventory.py
@@ -18,7 +18,7 @@ async def get_inventory_stock(
     limit: int = Query(250, ge=1, le=500, description="Items per page"),
     offset: int = Query(0, ge=0, description="Number of items to skip"),
     search: Optional[str] = Query(None, description="Search by ingredient name"),
-    status_filter: Optional[str] = Query('all', description="Filter by status: low, critical, ok, all"),
+    status_filter: Optional[str] = Query('all', description="Filter by status: low, critical, zero, ok, all"),
     category: Optional[str] = Query(None, description="Filter by ingredient category"),
     unit: Optional[str] = Query(None, description="Filter by ingredient unit"),
     sort_field: str = Query("current_stock", description="Field to sort by"),

--- a/app/services/ingredients_service.py
+++ b/app/services/ingredients_service.py
@@ -607,6 +607,17 @@ async def create_tenant_ingredient(
     elif parent_uuid:
         await _copy_parent_purchase_units(conn, parent_uuid, ingredient_uuid)
 
+    # Ensure the article appears on stock list at 0 before any movement/adjustment.
+    await conn.execute(
+        """
+        INSERT INTO tenant_inventory (tenant_id, ingredient_id, current_stock, minimum_stock)
+        VALUES ($1, $2, 0, 0)
+        ON CONFLICT (tenant_id, ingredient_id) DO NOTHING
+        """,
+        tenant_id,
+        ingredient_uuid,
+    )
+
     return result
 
 

--- a/app/services/inventory_service.py
+++ b/app/services/inventory_service.py
@@ -40,7 +40,7 @@ async def _get_inventory_stock_for_tenant(
     limit: int = 250,
     offset: int = 0,
     search: Optional[str] = None,
-    status_filter: Optional[str] = None,  # 'low', 'critical', 'ok', 'all'
+    status_filter: Optional[str] = None,  # 'low', 'critical'/'negative', 'ok', 'zero', 'all'
     category: Optional[str] = None,
     unit: Optional[str] = None,
     sort_field: str = "current_stock",
@@ -54,7 +54,7 @@ async def _get_inventory_stock_for_tenant(
         limit: Number of records to return
         offset: Number of records to skip
         search: Search term for ingredient name
-        status_filter: Filter by stock status (low, critical, ok, all)
+        status_filter: Filter by stock status (low, critical/negative, ok, zero, all)
         category: Filter by ingredient category
         unit: Filter by ingredient unit
         sort_field: Field to sort by
@@ -98,6 +98,7 @@ async def _get_inventory_stock_for_tenant(
                     ti.fecha_vencimiento,
                     CASE
                         WHEN ti.current_stock < 0 THEN 'negative'
+                        WHEN ti.current_stock = 0 THEN 'zero'
                         WHEN ti.current_stock > 0 AND ti.current_stock <= ti.minimum_stock THEN 'low'
                         ELSE 'ok'
                     END as status,
@@ -111,14 +112,14 @@ async def _get_inventory_stock_for_tenant(
                 FROM tenant_inventory ti
                 JOIN ingredients i ON ti.ingredient_id = i.id
                 LEFT JOIN latest_costs lc ON lc.ingredient_id = ti.ingredient_id
-                WHERE ti.tenant_id = $1 AND ti.current_stock != 0
+                WHERE ti.tenant_id = $1
             """
 
             count_query = """
                 SELECT COUNT(*) as total
                 FROM tenant_inventory ti
                 JOIN ingredients i ON ti.ingredient_id = i.id
-                WHERE ti.tenant_id = $1 AND ti.current_stock != 0
+                WHERE ti.tenant_id = $1
             """
 
             params = [tenant_id]
@@ -133,9 +134,12 @@ async def _get_inventory_stock_for_tenant(
 
             # Add status filter
             if status_filter and status_filter != 'all':
-                if status_filter == 'negative':
+                if status_filter in ('negative', 'critical'):
                     base_query += " AND ti.current_stock < 0"
                     count_query += " AND ti.current_stock < 0"
+                elif status_filter == 'zero':
+                    base_query += " AND ti.current_stock = 0"
+                    count_query += " AND ti.current_stock = 0"
                 elif status_filter == 'low':
                     base_query += " AND ti.current_stock > 0 AND ti.current_stock <= ti.minimum_stock"
                     count_query += " AND ti.current_stock > 0 AND ti.current_stock <= ti.minimum_stock"
@@ -179,8 +183,9 @@ async def _get_inventory_stock_for_tenant(
             # Get stats using CTE join (avoids correlated subquery per row)
             stats_query = cost_cte + """
                 SELECT
-                    COUNT(*) FILTER (WHERE ti.current_stock != 0) as total_ingredients,
+                    COUNT(*) as total_ingredients,
                     COUNT(*) FILTER (WHERE ti.current_stock < 0) as critical_count,
+                    COUNT(*) FILTER (WHERE ti.current_stock = 0) as zero_count,
                     COUNT(*) FILTER (WHERE ti.current_stock > 0 AND ti.current_stock <= ti.minimum_stock) as low_stock_count,
                     COUNT(*) FILTER (WHERE ti.current_stock > ti.minimum_stock) as ok_count,
                     SUM(ti.current_stock * COALESCE(lc.cost_per_unit, 0)) as total_inventory_value
@@ -199,7 +204,6 @@ async def _get_inventory_stock_for_tenant(
                             FROM tenant_inventory ti
                             JOIN ingredients i ON ti.ingredient_id = i.id
                             WHERE ti.tenant_id = $1
-                              AND ti.current_stock != 0
                               AND i.category IS NOT NULL
                         ) categories
                     ), ARRAY[]::text[]) AS categories,
@@ -210,7 +214,6 @@ async def _get_inventory_stock_for_tenant(
                             FROM tenant_inventory ti
                             JOIN ingredients i ON ti.ingredient_id = i.id
                             WHERE ti.tenant_id = $1
-                              AND ti.current_stock != 0
                               AND i.unit IS NOT NULL
                         ) units
                     ), ARRAY[]::text[]) AS units
@@ -248,6 +251,7 @@ async def _get_inventory_stock_for_tenant(
                 "stats": {
                     "total_ingredients": stats['total_ingredients'],
                     "critical_count": stats['critical_count'],
+                    "zero_count": stats['zero_count'],
                     "low_stock_count": stats['low_stock_count'],
                     "ok_count": stats['ok_count'],
                     "total_inventory_value": _json_decimal(stats['total_inventory_value'], _MONEY_JSON_SCALE, 0)
@@ -271,7 +275,7 @@ async def get_inventory_stock(
     limit: int = 250,
     offset: int = 0,
     search: Optional[str] = None,
-    status_filter: Optional[str] = None,  # 'low', 'critical', 'ok', 'all'
+    status_filter: Optional[str] = None,  # 'low', 'critical'/'negative', 'ok', 'zero', 'all'
     category: Optional[str] = None,
     unit: Optional[str] = None,
     sort_field: str = "current_stock",

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -6,7 +6,7 @@ Endpoints tested:
 - type×unit validation (create_tenant_ingredient)
 """
 import pytest
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 from fastapi import HTTPException
@@ -220,15 +220,21 @@ class TestVariantPurchaseUnitInheritance:
             parent_id=str(parent_id),
         )
 
-        result = await create_tenant_ingredient(conn, tenant_id, data)
+        with patch("app.services.ingredients_service.check_plan_quota_growth", new_callable=AsyncMock):
+            result = await create_tenant_ingredient(conn, tenant_id, data)
 
         assert result["parent_id"] == str(parent_id)
         conn.fetch.assert_awaited_once()
         assert conn.fetch.await_args.args[1] == parent_id
-        conn.execute.assert_awaited_once()
-        insert_args = conn.execute.await_args.args
-        assert insert_args[1] == ingredient_id
-        assert insert_args[2] == "kg"
+        execute_sqls = [call.args[0] for call in conn.execute.await_args_list]
+        assert any("ingredient_purchase_units" in sql for sql in execute_sqls)
+        assert any("tenant_inventory" in sql for sql in execute_sqls)
+        purchase_call = next(
+            call for call in conn.execute.await_args_list
+            if "ingredient_purchase_units" in call.args[0]
+        )
+        assert purchase_call.args[1] == ingredient_id
+        assert purchase_call.args[2] == "kg"
 
     @pytest.mark.asyncio
     async def test_create_variant_parent_without_purchase_units(self):
@@ -263,10 +269,13 @@ class TestVariantPurchaseUnitInheritance:
             parent_id=str(parent_id),
         )
 
-        await create_tenant_ingredient(conn, tenant_id, data)
+        with patch("app.services.ingredients_service.check_plan_quota_growth", new_callable=AsyncMock):
+            await create_tenant_ingredient(conn, tenant_id, data)
 
         conn.fetch.assert_awaited_once()
-        conn.execute.assert_not_awaited()
+        execute_sqls = [call.args[0] for call in conn.execute.await_args_list]
+        assert not any("ingredient_purchase_units" in sql for sql in execute_sqls)
+        assert any("tenant_inventory" in sql for sql in execute_sqls)
 
     @pytest.mark.asyncio
     async def test_create_variant_explicit_purchase_units_skip_inheritance(self):
@@ -302,11 +311,51 @@ class TestVariantPurchaseUnitInheritance:
             purchase_units=[PurchaseUnitInput(purchase_unit="libra", is_default=True)],
         )
 
-        await create_tenant_ingredient(conn, tenant_id, data)
+        with patch("app.services.ingredients_service.check_plan_quota_growth", new_callable=AsyncMock):
+            await create_tenant_ingredient(conn, tenant_id, data)
 
         conn.fetch.assert_not_awaited()
-        conn.execute.assert_awaited_once()
-        assert conn.execute.await_args.args[2] == "libra"
+        execute_sqls = [call.args[0] for call in conn.execute.await_args_list]
+        assert any("tenant_inventory" in sql for sql in execute_sqls)
+        purchase_call = next(
+            call for call in conn.execute.await_args_list
+            if "ingredient_purchase_units" in call.args[0]
+        )
+        assert purchase_call.args[2] == "libra"
+
+    @pytest.mark.asyncio
+    async def test_create_tenant_ingredient_seeds_zero_inventory(self):
+        tenant_id = uuid4()
+        ingredient_id = uuid4()
+        conn = AsyncMock()
+        conn.fetchrow = AsyncMock(
+            return_value={
+                "id": str(ingredient_id),
+                "name": "Sal",
+                "unit": "gr",
+                "type": "food",
+                "category": None,
+                "warehouse_category_id": None,
+                "costo_unitario": None,
+                "parent_id": None,
+                "tenant_id": str(tenant_id),
+                "is_resale": False,
+                "unit_weight_gr": None,
+                "unit_weight_unit": "gr",
+                "created_at": None,
+            }
+        )
+        data = TenantIngredientCreate(name="Sal", unit="gr", type="food")
+
+        with patch("app.services.ingredients_service.check_plan_quota_growth", new_callable=AsyncMock):
+            await create_tenant_ingredient(conn, tenant_id, data)
+
+        inventory_call = next(
+            call for call in conn.execute.await_args_list
+            if "tenant_inventory" in call.args[0]
+        )
+        assert inventory_call.args[1] == tenant_id
+        assert inventory_call.args[2] == ingredient_id
 
 
 class TestIngredientCategorySearch:

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -88,6 +88,7 @@ async def test_inventory_stock_core_uses_explicit_tenant_without_session():
             {
                 "total_ingredients": 1,
                 "critical_count": 0,
+                "zero_count": 0,
                 "low_stock_count": 0,
                 "ok_count": 1,
                 "total_inventory_value": "1253.125",
@@ -115,6 +116,61 @@ async def test_inventory_stock_core_uses_explicit_tenant_without_session():
     assert result["data"][0]["ingredient_name"] == "Tomate"
     assert conn.fetch_calls[0][1][0] == tenant_id
     assert conn.fetch_calls[0][1][-2:] == (10, 5)
+    assert "current_stock != 0" not in conn.fetch_calls[0][0]
+
+
+@pytest.mark.asyncio
+async def test_inventory_stock_includes_zero_and_filters_zero_status():
+    tenant_id = "tenant-zero-stock"
+    ingredient_id = uuid4()
+    conn = _FakeInventoryConnection(
+        fetch_rows=[
+            {
+                "id": uuid4(),
+                "ingredient_id": ingredient_id,
+                "ingredient_name": "Sal",
+                "unit": "gr",
+                "category": "Guarniciones",
+                "current_stock": "0",
+                "minimum_stock": "0",
+                "maximum_stock": None,
+                "last_updated": datetime(2026, 1, 1, 12, 0),
+                "location": None,
+                "lote_actual": None,
+                "fecha_vencimiento": None,
+                "status": "zero",
+                "stock_percentage": None,
+                "unit_cost": None,
+                "total_value": "0",
+            }
+        ],
+        fetchrow_rows=[
+            {"total": 1},
+            {
+                "total_ingredients": 1,
+                "critical_count": 0,
+                "zero_count": 1,
+                "low_stock_count": 0,
+                "ok_count": 0,
+                "total_inventory_value": "0",
+            },
+            {"categories": ["Guarniciones"], "units": ["gr"]},
+        ],
+    )
+
+    with patch("app.services.inventory_service.require_valid_session", side_effect=AssertionError), \
+         patch("app.services.inventory_service.get_db_connection", return_value=conn):
+        result = await _get_inventory_stock_for_tenant(
+            tenant_id,
+            status_filter="zero",
+        )
+
+    query = conn.fetch_calls[0][0]
+    assert "current_stock != 0" not in query
+    assert "ti.current_stock = 0" in query
+    assert result["data"][0]["status"] == "zero"
+    assert result["data"][0]["current_stock"] == 0.0
+    assert result["stats"]["zero_count"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Include `current_stock = 0` in `/inventory/stock` with status `zero` and filter support
- Seed `tenant_inventory` at 0 when creating a warehouse article so it appears immediately
- Stats: count all rows + `zero_count`

Closes uno0uno/warocol.com#1782

## Test plan
- [ ] Create warehouse article → appears on `/abastecimiento/stock` at 0
- [ ] Filter Estado → Sin stock / zero
- [ ] Non-zero filters still work

## Validation evidence
```
./venv/bin/pytest tests/test_inventory.py::test_inventory_stock_core_uses_explicit_tenant_without_session tests/test_inventory.py::test_inventory_stock_includes_zero_and_filters_zero_status -q
============================== 2 passed in 0.03s ===============================
```

## wr-context
See `.wr/1782.yaml` on this branch (LLM contract).

Companion front PR: warocol.com (same branch name).

Made with [Cursor](https://cursor.com)