### PR TITLE
fix(inventory): backfill missing stock-0 rows for tenant ingredients

### DIFF
--- a/.wr/716.yaml
+++ b/.wr/716.yaml
@@ -1,0 +1,40 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 716
+title: "Close warehouse-article create gaps: backfill stock-0 inventory + regression guards"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-716-inventory-seed-backfill
+
+paths:
+  - sql/20260724_backfill_tenant_inventory_zero.sql
+  - tests/test_tenant_inventory_seed_guards.py
+  - tests/test_ingredients.py
+  - app/services/ingredients_service.py
+
+ac:
+  - Backfill tenant_inventory 0/0 for tenant ingredients missing a row
+  - Regression: create_tenant_ingredient seeds stock 0
+  - Regression: auto_resale + convert_to_resale call create_tenant_ingredient
+  - Entry-point matrix documented; AI global path does not seed tenant inventory
+
+out_of_scope:
+  - Front UI changes
+  - Rewriting purchase/POS inventory inserts
+  - Merging warocol.com#1782 front PR
+
+hints:
+  entry: "create_tenant_ingredient + sql backfill"
+  pattern: "sql/20260724_backfill_seed_tenant_accounts.sql style; seed already on wr-1782"
+  tests: "./venv/bin/pytest tests/test_tenant_inventory_seed_guards.py tests/test_ingredients.py::TestVariantPurchaseUnitInheritance::test_create_tenant_ingredient_seeds_zero_inventory -q"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "Run backfill SQL on prod after merge; stack on / merge after #715"

--- a/sql/20260724_backfill_tenant_inventory_zero.sql
+++ b/sql/20260724_backfill_tenant_inventory_zero.sql
@@ -1,0 +1,16 @@
+-- One-shot backfill: tenant-scoped warehouse articles missing tenant_inventory.
+-- Seeds stock 0 / min 0 so they appear on /abastecimiento/stock after #1782 list change.
+-- Idempotent via ON CONFLICT DO NOTHING. Safe to re-run.
+-- Does NOT touch global ingredients (tenant_id IS NULL).
+
+INSERT INTO tenant_inventory (tenant_id, ingredient_id, current_stock, minimum_stock)
+SELECT i.tenant_id, i.id, 0, 0
+FROM ingredients i
+WHERE i.tenant_id IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1
+      FROM tenant_inventory ti
+      WHERE ti.tenant_id = i.tenant_id
+        AND ti.ingredient_id = i.id
+  )
+ON CONFLICT (tenant_id, ingredient_id) DO NOTHING;

--- a/tests/test_tenant_inventory_seed_guards.py
+++ b/tests/test_tenant_inventory_seed_guards.py
@@ -1,0 +1,56 @@
+"""
+Guards for warehouse-article → stock-0 inventory seeding (#716).
+
+Entry-point matrix (all tenant creates must go through create_tenant_ingredient):
+- Catálogo / IngredientePropioPanel → POST /api/suppliers/ingredients
+- Recipe / product / modifier searchers → InlineCatalogCreateShell → same panel
+- Compra directa → InlineCatalogCreateShell → same panel
+- Resale 1:1 → products_service create + convert_to_resale → create_tenant_ingredient
+
+Out of scope: AI/admin global ingredients (tenant_id IS NULL).
+"""
+from pathlib import Path
+
+BACKFILL_SQL = Path("sql/20260724_backfill_tenant_inventory_zero.sql").read_text()
+INGREDIENTS_SERVICE = Path("app/services/ingredients_service.py").read_text()
+PRODUCTS_SERVICE = Path("app/services/products_service.py").read_text()
+
+
+def test_backfill_sql_is_scoped_idempotent_and_non_destructive():
+    assert "INSERT INTO tenant_inventory" in BACKFILL_SQL
+    assert "i.tenant_id IS NOT NULL" in BACKFILL_SQL
+    assert "NOT EXISTS" in BACKFILL_SQL
+    assert "ON CONFLICT (tenant_id, ingredient_id) DO NOTHING" in BACKFILL_SQL
+    assert "DROP" not in BACKFILL_SQL.upper()
+    assert "DELETE" not in BACKFILL_SQL.upper()
+    assert "current_stock" in BACKFILL_SQL and "minimum_stock" in BACKFILL_SQL
+
+
+def test_create_tenant_ingredient_source_seeds_zero_inventory():
+    assert "async def create_tenant_ingredient" in INGREDIENTS_SERVICE
+    seed_idx = INGREDIENTS_SERVICE.index(
+        "INSERT INTO tenant_inventory (tenant_id, ingredient_id, current_stock, minimum_stock)"
+    )
+    create_idx = INGREDIENTS_SERVICE.index("async def create_tenant_ingredient")
+    update_idx = INGREDIENTS_SERVICE.index("async def update_tenant_ingredient")
+    assert create_idx < seed_idx < update_idx
+    assert "ON CONFLICT (tenant_id, ingredient_id) DO NOTHING" in INGREDIENTS_SERVICE[seed_idx:seed_idx + 400]
+
+
+def test_auto_resale_and_convert_call_create_tenant_ingredient():
+    assert "from app.services.ingredients_service import create_tenant_ingredient" in PRODUCTS_SERVICE
+    assert PRODUCTS_SERVICE.count("await create_tenant_ingredient(") >= 2
+    assert "async def convert_product_to_resale" in PRODUCTS_SERVICE
+    convert_idx = PRODUCTS_SERVICE.index("async def convert_product_to_resale")
+    assert "await create_tenant_ingredient(" in PRODUCTS_SERVICE[convert_idx:]
+
+
+def test_ai_global_ingredient_insert_does_not_seed_tenant_inventory():
+    """AI path inserts global ingredients (tenant_id NULL) without tenant_inventory."""
+    assert "async def create_ai_ingredient" in INGREDIENTS_SERVICE
+    ai_idx = INGREDIENTS_SERVICE.index("async def create_ai_ingredient")
+    # No tenant_inventory insert inside the AI create function body
+    next_def = INGREDIENTS_SERVICE.find("\nasync def ", ai_idx + 1)
+    ai_body = INGREDIENTS_SERVICE[ai_idx:next_def if next_def != -1 else None]
+    assert "VALUES ($1, $2, NULL, TRUE, NOW())" in ai_body
+    assert "INSERT INTO tenant_inventory" not in ai_body


### PR DESCRIPTION
## Summary
- Idempotent SQL backfill for tenant ingredients missing `tenant_inventory` (stock 0 / min 0)
- Source guards: `create_tenant_ingredient` seeds inventory; auto_resale + convert call it; AI global path does not
- Documents entry-point matrix (catalog / recipes / products / modifiers / compra directa / resale)

Closes #716

## Test plan
- [ ] Run `sql/20260724_backfill_tenant_inventory_zero.sql` on staging/prod after merge
- [ ] Spot-check a legacy tenant ingredient without inventory appears on stock at 0
- [ ] Create via compra directa / recipe searcher still lands on stock at 0 (via #715 seed)

## Validation evidence
```
./venv/bin/pytest tests/test_tenant_inventory_seed_guards.py tests/test_ingredients.py::TestVariantPurchaseUnitInheritance::test_create_tenant_ingredient_seeds_zero_inventory -q
============================== 5 passed in 0.04s ===============================
```

## wr-context
See `.wr/716.yaml` on this branch (LLM contract).

Stacked on `wr-1782-stock-zero-badges` (#715). Retarget base to `main` after #715 merges.

Made with [Cursor](https://cursor.com)