### PR TITLE
feat(billing): expose starter catalog quotas in remaining-usage

### DIFF
--- a/.wr/1796.yaml
+++ b/.wr/1796.yaml
@@ -1,0 +1,49 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1796
+title: "fix(menu): block Nuevo CTAs and redirect create routes when catalog quotas are exhausted"
+repo: both
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-1796-menu-catalog-quota-gate
+
+paths:
+  - app/services/billing_service.py
+  - tests/test_billing_remaining_usage.py
+  - tests/test_billing_plan_quotas.py
+  - composables/useBilling.ts
+  - composables/useMenuCatalogQuotaGate.ts
+  - pages/menu/productos/index.vue
+  - pages/menu/productos/crear.vue
+  - pages/menu/modificadores/index.vue
+  - pages/menu/modificadores/crear.vue
+  - pages/menu/recetas/index.vue
+  - pages/menu/recetas/crear.vue
+  - pages/menu/categorias/index.vue
+
+ac:
+  - remaining-usage works for Starter without subscription and exposes menu_products + modifier_groups
+  - Nuevo CTAs disabled in Recetas/Productos/Modificadores/Categorías when catalog create exhausted
+  - create routes redirect to list when quota exhausted
+  - paid plans unaffected; list/edit remain available
+  - API CREATE 429 remains as backstop
+
+out_of_scope:
+  - new DB quotas for Recetas/Categorías counts
+  - blocking Menú sub-nav tabs
+  - deleting over-quota rows
+
+hints:
+  entry: "get_remaining_billing_usage + useMenuCatalogQuotaGate"
+  pattern: "pages/equipo/miembros/index.vue disabled invite CTA"
+  tests: "pytest tests/test_billing_remaining_usage.py tests/test_billing_plan_quotas.py"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "merge API first, then front; restart uvicorn"

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -1677,11 +1677,13 @@ async def get_tenant_subscription(conn, tenant_id: UUID) -> Dict[str, Any]:
 
 async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
     """
-    Return current-period remaining usage for scans and electronic invoices.
+    Return current-period remaining usage for scans, electronic invoices, and
+    operational/catalog quotas.
 
-    The measurement window is the tenant subscription period. Electronic invoice
-    quota is only exposed for the paid FE plan; other plans intentionally report
-    0/0/0 to avoid implying an included entitlement.
+    Paid tenants use the subscription period. Starter tenants without a
+    subscription row use the calendar month and the active `starter` plan
+    catalog (warocol.com#1796). Electronic invoice quota is only exposed for
+    the paid FE plan; other plans intentionally report 0/0/0.
     """
     row = await conn.fetchrow("""
         SELECT
@@ -1701,7 +1703,33 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
         WHERE ts.tenant_id = $1
     """, tenant_id)
     if row is None:
-        raise HTTPException(status_code=404, detail="Subscription not found")
+        effective_slug = await get_effective_plan_slug(conn, tenant_id)
+        if effective_slug != STARTER_PLAN_SLUG:
+            raise HTTPException(status_code=404, detail="Subscription not found")
+        row = await conn.fetchrow(
+            """
+            SELECT
+                date_trunc('month', now()) AS current_period_start,
+                date_trunc('month', now()) + interval '1 month' AS current_period_end,
+                sp.slug AS plan_slug,
+                sp.features AS plan_features,
+                sp.scan_limit AS plan_scan_limit,
+                COALESCE(su.scans_used, 0) AS scans_used,
+                COALESCE(su.scans_limit, sp.scan_limit) AS scans_limit
+            FROM subscription_plans sp
+            LEFT JOIN scan_usage su
+                ON su.tenant_id = $1
+               AND su.period_start <= now()
+               AND su.period_end > now()
+            WHERE sp.slug = $2
+              AND sp.is_active = true
+            LIMIT 1
+            """,
+            tenant_id,
+            STARTER_PLAN_SLUG,
+        )
+        if row is None:
+            raise HTTPException(status_code=404, detail="Subscription not found")
 
     period_start = row["current_period_start"]
     period_end = row["current_period_end"]
@@ -1797,7 +1825,17 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
                   AND o.status = 'completed'
                   AND o.order_date >= $2
                   AND o.order_date < $3
-            ) AS completed_online_orders_per_month
+            ) AS completed_online_orders_per_month,
+            (
+                SELECT COUNT(*)
+                FROM product p
+                WHERE p.tenant_id = $1
+            ) AS menu_products,
+            (
+                SELECT COUNT(*)
+                FROM modifier_groups mg
+                WHERE mg.tenant_id = $1
+            ) AS modifier_groups
     """, tenant_id, period_start, period_end, list(LEGACY_INTERNAL_TEAM_ROLES))
 
     def metric(used: int, quota: EffectiveQuota) -> Dict[str, Any]:
@@ -1858,6 +1896,14 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
             "electronic_invoices_per_period": metric(
                 invoice_used,
                 effective_quotas["electronic_invoices_per_period"],
+            ),
+            "menu_products": metric(
+                int(quota_counts["menu_products"] or 0),
+                effective_quotas["menu_products"],
+            ),
+            "modifier_groups": metric(
+                int(quota_counts["modifier_groups"] or 0),
+                effective_quotas["modifier_groups"],
             ),
         },
     }

--- a/tests/test_billing_plan_quotas.py
+++ b/tests/test_billing_plan_quotas.py
@@ -102,6 +102,8 @@ async def test_remaining_usage_exposes_quota_usage_and_internal_roles_only():
                 "active_tables_including_bar": 7,
                 "active_qr_tables": 6,
                 "completed_online_orders_per_month": 28,
+                "menu_products": 9,
+                "modifier_groups": 1,
             },
         ]
     )
@@ -120,6 +122,15 @@ async def test_remaining_usage_exposes_quota_usage_and_internal_roles_only():
     assert usage["quota_usage"]["completed_online_orders_per_month"]["used"] == 28
     assert usage["quota_usage"]["electronic_invoices_per_period"]["used"] == 12
     assert usage["quota_usage"]["electronic_invoices_per_period"]["limit"] == 200
+    assert usage["quota_usage"]["menu_products"] == {
+        "used": 9,
+        "limit": 1_000_000,
+        "remaining": 1_000_000 - 9,
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+    }
+    assert usage["quota_usage"]["modifier_groups"]["used"] == 1
+    assert usage["quota_usage"]["modifier_groups"]["limit"] == 1_000_000
 
     quota_query_args = conn.fetchrow.await_args_list[1].args
     assert quota_query_args[4] == list(LEGACY_INTERNAL_TEAM_ROLES)
@@ -151,6 +162,8 @@ async def test_remaining_usage_exposes_effective_quota_override_state():
                 "active_tables_including_bar": 7,
                 "active_qr_tables": 6,
                 "completed_online_orders_per_month": 28,
+                "menu_products": 0,
+                "modifier_groups": 0,
             },
         ]
     )
@@ -205,6 +218,8 @@ async def test_remaining_usage_exposes_disabled_override_as_unlimited():
                 "active_tables_including_bar": 7,
                 "active_qr_tables": 6,
                 "completed_online_orders_per_month": 301,
+                "menu_products": 0,
+                "modifier_groups": 0,
             },
         ]
     )

--- a/tests/test_billing_remaining_usage.py
+++ b/tests/test_billing_remaining_usage.py
@@ -26,14 +26,35 @@ def _subscription_row(
     }
 
 
+def _quota_counts_row(**overrides):
+    base = {
+        "admin_users": 0,
+        "active_sessions_per_admin_user": 0,
+        "active_kitchens": 0,
+        "active_tables_including_bar": 0,
+        "active_qr_tables": 0,
+        "completed_online_orders_per_month": 0,
+        "menu_products": 0,
+        "modifier_groups": 0,
+    }
+    base.update(overrides)
+    return base
+
+
+def _mock_remaining_usage_conn(subscription_row, *, invoice_used=0):
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[subscription_row, _quota_counts_row()])
+    conn.fetchval = AsyncMock(return_value=invoice_used)
+    conn.fetch = AsyncMock(return_value=[])
+    return conn
+
+
 @pytest.mark.asyncio
 async def test_remaining_usage_non_fe_plan_reports_zero_invoice_quota():
     tenant_id = uuid4()
-    conn = MagicMock()
-    conn.fetchrow = AsyncMock(
-        return_value=_subscription_row(plan_slug="pro", scans_used=12, scans_limit=500)
+    conn = _mock_remaining_usage_conn(
+        _subscription_row(plan_slug="pro", scans_used=12, scans_limit=500)
     )
-    conn.fetchval = AsyncMock()
 
     result = await billing_service.get_remaining_billing_usage(conn, tenant_id)
 
@@ -51,7 +72,9 @@ async def test_remaining_usage_non_fe_plan_reports_zero_invoice_quota():
         "period_start": "2026-06-01T00:00:00+00:00",
         "period_end": "2026-07-01T00:00:00+00:00",
     }
-    subscription_query = conn.fetchrow.await_args.args[0]
+    assert result["quota_usage"]["menu_products"]["limit"] == 1_000_000
+    assert result["quota_usage"]["modifier_groups"]["limit"] == 1_000_000
+    subscription_query = conn.fetchrow.await_args_list[0].args[0]
     assert "su.period_start <= now()" in subscription_query
     assert "su.period_end > now()" in subscription_query
     assert "sp.features AS plan_features" in subscription_query
@@ -61,14 +84,12 @@ async def test_remaining_usage_non_fe_plan_reports_zero_invoice_quota():
 @pytest.mark.asyncio
 async def test_remaining_usage_non_fe_plan_ignores_invoice_feature_metadata():
     tenant_id = uuid4()
-    conn = MagicMock()
-    conn.fetchrow = AsyncMock(
-        return_value=_subscription_row(
+    conn = _mock_remaining_usage_conn(
+        _subscription_row(
             plan_slug="pro",
             plan_features={"electronic_invoice_limit": 200},
         )
     )
-    conn.fetchval = AsyncMock()
 
     result = await billing_service.get_remaining_billing_usage(conn, tenant_id)
 
@@ -81,16 +102,15 @@ async def test_remaining_usage_non_fe_plan_ignores_invoice_feature_metadata():
 @pytest.mark.asyncio
 async def test_remaining_usage_fe_plan_counts_accepted_invoices_in_period():
     tenant_id = uuid4()
-    conn = MagicMock()
-    conn.fetchrow = AsyncMock(
-        return_value=_subscription_row(
+    conn = _mock_remaining_usage_conn(
+        _subscription_row(
             plan_slug="facturacion-electronica",
             plan_features={"electronic_invoice_limit": 200},
             scans_used=20,
             scans_limit=500,
-        )
+        ),
+        invoice_used=37,
     )
-    conn.fetchval = AsyncMock(return_value=37)
 
     result = await billing_service.get_remaining_billing_usage(conn, tenant_id)
 
@@ -116,14 +136,13 @@ async def test_remaining_usage_fe_plan_counts_accepted_invoices_in_period():
 @pytest.mark.asyncio
 async def test_remaining_usage_fe_plan_reads_numeric_invoice_limit_from_features():
     tenant_id = uuid4()
-    conn = MagicMock()
-    conn.fetchrow = AsyncMock(
-        return_value=_subscription_row(
+    conn = _mock_remaining_usage_conn(
+        _subscription_row(
             plan_slug="facturacion-electronica",
             plan_features={"electronic_invoice_limit": "150"},
-        )
+        ),
+        invoice_used=12,
     )
-    conn.fetchval = AsyncMock(return_value=12)
 
     result = await billing_service.get_remaining_billing_usage(conn, tenant_id)
 
@@ -135,16 +154,15 @@ async def test_remaining_usage_fe_plan_reads_numeric_invoice_limit_from_features
 @pytest.mark.asyncio
 async def test_remaining_usage_caps_remaining_at_zero():
     tenant_id = uuid4()
-    conn = MagicMock()
-    conn.fetchrow = AsyncMock(
-        return_value=_subscription_row(
+    conn = _mock_remaining_usage_conn(
+        _subscription_row(
             plan_slug="facturacion-electronica",
             plan_features={"electronic_invoice_limit": 200},
             scans_used=550,
             scans_limit=500,
-        )
+        ),
+        invoice_used=220,
     )
-    conn.fetchval = AsyncMock(return_value=220)
 
     result = await billing_service.get_remaining_billing_usage(conn, tenant_id)
 
@@ -156,9 +174,71 @@ async def test_remaining_usage_caps_remaining_at_zero():
 async def test_remaining_usage_missing_subscription_mirrors_subscription_endpoint():
     conn = MagicMock()
     conn.fetchrow = AsyncMock(return_value=None)
+    conn.fetchval = AsyncMock(return_value="payment_pending")
 
     with pytest.raises(HTTPException) as exc:
         await billing_service.get_remaining_billing_usage(conn, uuid4())
 
     assert exc.value.status_code == 404
     assert exc.value.detail == "Subscription not found"
+
+
+@pytest.mark.asyncio
+async def test_remaining_usage_starter_without_subscription_exposes_catalog_quotas():
+    tenant_id = uuid4()
+    period_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    period_end = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            None,  # no tenant_subscriptions row
+            None,  # get_effective_plan_slug paid lookup
+            {
+                "current_period_start": period_start,
+                "current_period_end": period_end,
+                "plan_slug": "starter",
+                "plan_features": {
+                    "quotas": {
+                        "menu_products": 10,
+                        "modifier_groups": 2,
+                        "admin_users": 1,
+                        "active_sessions_per_admin_user": 1,
+                        "active_kitchens": 0,
+                        "active_tables_including_bar": 0,
+                        "active_qr_tables": 0,
+                        "completed_online_orders_per_month": 30,
+                        "electronic_invoices_per_period": 0,
+                    }
+                },
+                "plan_scan_limit": 10,
+                "scans_used": 3,
+                "scans_limit": 10,
+            },
+            {
+                "admin_users": 1,
+                "active_sessions_per_admin_user": 1,
+                "active_kitchens": 0,
+                "active_tables_including_bar": 0,
+                "active_qr_tables": 0,
+                "completed_online_orders_per_month": 5,
+                "menu_products": 10,
+                "modifier_groups": 2,
+            },
+        ]
+    )
+    conn.fetchval = AsyncMock(return_value="starter_active")
+    conn.fetch = AsyncMock(return_value=[])
+
+    usage = await billing_service.get_remaining_billing_usage(conn, tenant_id)
+
+    assert usage["scan_usage"]["used"] == 3
+    assert usage["scan_usage"]["limit"] == 10
+    assert usage["quota_usage"]["menu_products"] == {
+        "used": 10,
+        "limit": 10,
+        "remaining": 0,
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+    }
+    assert usage["quota_usage"]["modifier_groups"]["used"] == 2
+    assert usage["quota_usage"]["modifier_groups"]["remaining"] == 0


### PR DESCRIPTION
## Summary
- `/billing/remaining-usage` works for Starter tenants without `tenant_subscriptions` (calendar month + starter plan).
- Exposes `menu_products` and `modifier_groups` in `quota_usage` for Menú create gating.

Companion front PR: uno0uno/warocol.com (same branch name).

Closes uno0uno/warocol.com#1796 (API half)

## Test plan
- [ ] Starter tenant without subscription: GET `/billing/remaining-usage` returns 200 with menu_products/modifier_groups
- [ ] Paid Pro/FE still return subscription-period usage

## Validation evidence
```
cd api_warocol.com && ./venv/bin/pytest tests/test_billing_remaining_usage.py tests/test_billing_plan_quotas.py -q --tb=line
============================== 13 passed in 0.09s ==============================
```

## wr-context
See `.wr/1796.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)