### PR TITLE
feat(billing): add starter menu category quota

### DIFF
--- a/.wr/1798.yaml
+++ b/.wr/1798.yaml
@@ -1,0 +1,43 @@
+issue: 1798
+title: "Add menu_categories quota and raise Starter modifier groups"
+repo: both
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: both
+branch: wr-1798-menu-categories-quota
+
+paths:
+  - app/services/billing_service.py
+  - app/routers/categories.py
+  - sql/20260724_starter_menu_categories_quota.sql
+  - tests/test_quota_enforcement.py
+  - tests/test_billing_remaining_usage.py
+  - tests/test_billing_plan_quotas.py
+  - .wr/1798.yaml
+
+ac:
+  - "Starter menu_categories limit is 5 and category CREATE enforces it"
+  - "Starter modifier_groups limit is 4"
+  - "remaining-usage exposes menu_categories"
+  - "Paid plans retain effectively unlimited catalog quotas"
+  - "Migration only merges the two Starter quota values"
+
+out_of_scope:
+  - "Change menu_products or modifier_options_per_group"
+  - "Add a recipe count quota"
+
+hints:
+  entry: "billing_service.check_plan_quota_growth; categories.create_category_endpoint"
+  pattern: "Existing menu_products and modifier_groups growth quotas"
+  tests: "./venv/bin/pytest tests/test_quota_enforcement.py tests/test_billing_remaining_usage.py tests/test_billing_plan_quotas.py -q"
+
+risk:
+  sensitive: false
+  areas:
+    - "API/front quota contract"
+
+skip:
+  audits: []
+
+next:
+  after_pr: "Merge API before companion front PR"

--- a/app/routers/categories.py
+++ b/app/routers/categories.py
@@ -15,6 +15,7 @@ from app.models.category import (
     ReorderOnlineMenuCategoriesRequest,
 )
 from app.services import categories_service
+from app.services.billing_service import check_plan_quota_growth
 
 router = APIRouter()
 
@@ -87,12 +88,14 @@ async def create_category_endpoint(request: Request, payload: CategoryCreate):
 
     try:
         async with get_db_connection() as conn:
-            row = await conn.fetchrow(
-                insert_query,
-                payload.name.strip(),
-                (payload.description.strip() if payload.description else None),
-                tenant_id,
-            )
+            async with conn.transaction():
+                await check_plan_quota_growth(conn, tenant_id, "menu_categories")
+                row = await conn.fetchrow(
+                    insert_query,
+                    payload.name.strip(),
+                    (payload.description.strip() if payload.description else None),
+                    tenant_id,
+                )
     except asyncpg.UniqueViolationError:
         raise HTTPException(
             status_code=409,

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -38,8 +38,9 @@ STARTER_OPERATIONAL_QUOTAS = {
     "completed_online_orders_per_month": 30,
     "electronic_invoices_per_period": 0,
     "menu_products": 10,
+    "menu_categories": 5,
     "tenant_ingredients": 5,
-    "modifier_groups": 2,
+    "modifier_groups": 4,
     "recipe_lines_per_product": 4,
     "modifier_options_per_group": 6,
     "recipe_base_template_lines": 4,
@@ -53,6 +54,7 @@ QUOTA_KEYS = (
     "completed_online_orders_per_month",
     "electronic_invoices_per_period",
     "menu_products",
+    "menu_categories",
     "tenant_ingredients",
     "modifier_groups",
     "recipe_lines_per_product",
@@ -68,6 +70,7 @@ BASE_OPERATIONAL_QUOTAS = {
     "active_qr_tables": 20,
     "completed_online_orders_per_month": 300,
     "menu_products": CATALOG_UNLIMITED,
+    "menu_categories": CATALOG_UNLIMITED,
     "tenant_ingredients": CATALOG_UNLIMITED,
     "modifier_groups": CATALOG_UNLIMITED,
     "recipe_lines_per_product": 100,
@@ -101,6 +104,7 @@ ENFORCEABLE_QUOTA_RESOURCES = {
     "active_tables_including_bar",
     "active_qr_tables",
     "menu_products",
+    "menu_categories",
     "tenant_ingredients",
     "modifier_groups",
 }
@@ -861,6 +865,15 @@ async def _count_quota_resource_usage(
             """
             SELECT COUNT(*)
             FROM product
+            WHERE tenant_id = $1
+            """,
+            tenant_id,
+        )
+    elif resource == "menu_categories":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM categories
             WHERE tenant_id = $1
             """,
             tenant_id,
@@ -1833,6 +1846,11 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
             ) AS menu_products,
             (
                 SELECT COUNT(*)
+                FROM categories c
+                WHERE c.tenant_id = $1
+            ) AS menu_categories,
+            (
+                SELECT COUNT(*)
                 FROM modifier_groups mg
                 WHERE mg.tenant_id = $1
             ) AS modifier_groups
@@ -1900,6 +1918,10 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
             "menu_products": metric(
                 int(quota_counts["menu_products"] or 0),
                 effective_quotas["menu_products"],
+            ),
+            "menu_categories": metric(
+                int(quota_counts["menu_categories"] or 0),
+                effective_quotas["menu_categories"],
             ),
             "modifier_groups": metric(
                 int(quota_counts["modifier_groups"] or 0),

--- a/sql/20260724_starter_menu_categories_quota.sql
+++ b/sql/20260724_starter_menu_categories_quota.sql
@@ -1,0 +1,16 @@
+-- warocol.com#1798: add a Starter category cap and raise modifier groups.
+-- Non-destructive: merge only these catalog quota keys into the Starter plan.
+
+UPDATE subscription_plans
+SET
+    features = jsonb_set(
+        COALESCE(features, '{}'::jsonb),
+        '{quotas}',
+        COALESCE(features->'quotas', '{}'::jsonb) || '{
+          "menu_categories": 5,
+          "modifier_groups": 4
+        }'::jsonb,
+        true
+    ),
+    updated_at = now()
+WHERE slug = 'starter';

--- a/tests/test_billing_plan_quotas.py
+++ b/tests/test_billing_plan_quotas.py
@@ -103,6 +103,7 @@ async def test_remaining_usage_exposes_quota_usage_and_internal_roles_only():
                 "active_qr_tables": 6,
                 "completed_online_orders_per_month": 28,
                 "menu_products": 9,
+                "menu_categories": 3,
                 "modifier_groups": 1,
             },
         ]
@@ -129,6 +130,8 @@ async def test_remaining_usage_exposes_quota_usage_and_internal_roles_only():
         "period_start": period_start.isoformat(),
         "period_end": period_end.isoformat(),
     }
+    assert usage["quota_usage"]["menu_categories"]["used"] == 3
+    assert usage["quota_usage"]["menu_categories"]["limit"] == 1_000_000
     assert usage["quota_usage"]["modifier_groups"]["used"] == 1
     assert usage["quota_usage"]["modifier_groups"]["limit"] == 1_000_000
 
@@ -163,6 +166,7 @@ async def test_remaining_usage_exposes_effective_quota_override_state():
                 "active_qr_tables": 6,
                 "completed_online_orders_per_month": 28,
                 "menu_products": 0,
+                "menu_categories": 0,
                 "modifier_groups": 0,
             },
         ]
@@ -219,6 +223,7 @@ async def test_remaining_usage_exposes_disabled_override_as_unlimited():
                 "active_qr_tables": 6,
                 "completed_online_orders_per_month": 301,
                 "menu_products": 0,
+                "menu_categories": 0,
                 "modifier_groups": 0,
             },
         ]

--- a/tests/test_billing_remaining_usage.py
+++ b/tests/test_billing_remaining_usage.py
@@ -35,6 +35,7 @@ def _quota_counts_row(**overrides):
         "active_qr_tables": 0,
         "completed_online_orders_per_month": 0,
         "menu_products": 0,
+        "menu_categories": 0,
         "modifier_groups": 0,
     }
     base.update(overrides)
@@ -73,6 +74,7 @@ async def test_remaining_usage_non_fe_plan_reports_zero_invoice_quota():
         "period_end": "2026-07-01T00:00:00+00:00",
     }
     assert result["quota_usage"]["menu_products"]["limit"] == 1_000_000
+    assert result["quota_usage"]["menu_categories"]["limit"] == 1_000_000
     assert result["quota_usage"]["modifier_groups"]["limit"] == 1_000_000
     subscription_query = conn.fetchrow.await_args_list[0].args[0]
     assert "su.period_start <= now()" in subscription_query
@@ -200,7 +202,8 @@ async def test_remaining_usage_starter_without_subscription_exposes_catalog_quot
                 "plan_features": {
                     "quotas": {
                         "menu_products": 10,
-                        "modifier_groups": 2,
+                        "menu_categories": 5,
+                        "modifier_groups": 4,
                         "admin_users": 1,
                         "active_sessions_per_admin_user": 1,
                         "active_kitchens": 0,
@@ -222,7 +225,8 @@ async def test_remaining_usage_starter_without_subscription_exposes_catalog_quot
                 "active_qr_tables": 0,
                 "completed_online_orders_per_month": 5,
                 "menu_products": 10,
-                "modifier_groups": 2,
+                "menu_categories": 5,
+                "modifier_groups": 4,
             },
         ]
     )
@@ -240,5 +244,7 @@ async def test_remaining_usage_starter_without_subscription_exposes_catalog_quot
         "period_start": period_start.isoformat(),
         "period_end": period_end.isoformat(),
     }
-    assert usage["quota_usage"]["modifier_groups"]["used"] == 2
+    assert usage["quota_usage"]["menu_categories"]["used"] == 5
+    assert usage["quota_usage"]["menu_categories"]["remaining"] == 0
+    assert usage["quota_usage"]["modifier_groups"]["used"] == 4
     assert usage["quota_usage"]["modifier_groups"]["remaining"] == 0

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -738,6 +738,34 @@ async def test_starter_menu_products_quota_blocks_at_limit():
 
 
 @pytest.mark.asyncio
+async def test_starter_menu_categories_quota_allows_below_limit():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_starter_plan_row("menu_categories", 5))
+    conn.fetchval = AsyncMock(return_value=4)
+
+    await billing_service.check_plan_quota_growth(
+        conn, tenant_id, "menu_categories"
+    )
+
+
+@pytest.mark.asyncio
+async def test_starter_menu_categories_quota_blocks_at_limit():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_starter_plan_row("menu_categories", 5))
+    conn.fetchval = AsyncMock(return_value=5)
+
+    with pytest.raises(APIError) as exc:
+        await billing_service.check_plan_quota_growth(
+            conn, tenant_id, "menu_categories"
+        )
+
+    assert exc.value.status_code == 429
+    assert exc.value.details["resource"] == "menu_categories"
+
+
+@pytest.mark.asyncio
 async def test_starter_tenant_ingredients_quota_blocks_at_limit():
     tenant_id = uuid4()
     conn = MagicMock()
@@ -851,13 +879,25 @@ async def test_assert_starter_toggle_rejects_tables_enabled():
 async def test_starter_modifier_groups_quota_blocks_at_limit():
     tenant_id = uuid4()
     conn = MagicMock()
-    conn.fetchrow = AsyncMock(return_value=_starter_plan_row("modifier_groups", 2))
-    conn.fetchval = AsyncMock(return_value=2)
+    conn.fetchrow = AsyncMock(return_value=_starter_plan_row("modifier_groups", 4))
+    conn.fetchval = AsyncMock(return_value=4)
 
     with pytest.raises(APIError) as exc:
         await billing_service.check_plan_quota_growth(conn, tenant_id, "modifier_groups")
 
     assert exc.value.details["resource"] == "modifier_groups"
+
+
+@pytest.mark.asyncio
+async def test_starter_modifier_groups_quota_allows_below_limit():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_starter_plan_row("modifier_groups", 4))
+    conn.fetchval = AsyncMock(return_value=3)
+
+    await billing_service.check_plan_quota_growth(
+        conn, tenant_id, "modifier_groups"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds a Starter `menu_categories` growth quota of 5 and raises `modifier_groups` from 2 to 4.
- Enforces the new category cap on CREATE and exposes `menu_categories` in remaining usage.

Refs uno0uno/warocol.com#1798

## Test plan
- [ ] Confirm Starter category CREATE is allowed at 4 and blocked at 5.
- [ ] Confirm Starter modifier groups are allowed at 3 and blocked at 4.
- [ ] Confirm paid plans still report catalog quotas as unlimited.

## Validation evidence
```text
./venv/bin/pytest tests/test_quota_enforcement.py tests/test_billing_remaining_usage.py tests/test_billing_plan_quotas.py tests/test_categories.py -q
======================== 70 passed, 2 skipped in 2.62s =========================
```

## wr-context
See `.wr/1798.yaml` on this branch (LLM contract).