### PR TITLE
feat(billing): add starter recipe bases quota

### DIFF
--- a/.wr/1800.yaml
+++ b/.wr/1800.yaml
@@ -1,0 +1,43 @@
+issue: 1800
+title: "Add starter recipe_bases quota and gate Recetas Nuevo"
+repo: both
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: both
+branch: wr-1800-recipe-bases-quota
+
+paths:
+  - app/services/billing_service.py
+  - app/services/recipe_bases_service.py
+  - sql/20260724_starter_recipe_bases_quota.sql
+  - tests/test_quota_enforcement.py
+  - tests/test_billing_remaining_usage.py
+  - tests/test_billing_plan_quotas.py
+  - .wr/1800.yaml
+
+ac:
+  - "Starter recipe_bases limit is 5, counted from product_base_types"
+  - "Recipe base CREATE enforces the quota with a 429 quota_exceeded payload"
+  - "remaining-usage exposes recipe_bases"
+  - "Paid plans keep recipe_bases effectively unlimited"
+  - "Migration only merges recipe_bases into the starter plan quotas"
+
+out_of_scope:
+  - "Change menu_products, modifier_groups, recipe_lines_per_product or recipe_base_template_lines"
+  - "Add menu_categories (separate issue #1798)"
+
+hints:
+  entry: "billing_service.check_plan_quota_growth; recipe_bases_service.create_recipe_base_type"
+  pattern: "Existing menu_products and modifier_groups growth quotas"
+  tests: "./venv/bin/pytest tests/test_quota_enforcement.py tests/test_billing_remaining_usage.py tests/test_billing_plan_quotas.py -q"
+
+risk:
+  sensitive: false
+  areas:
+    - "API/front quota contract"
+
+skip:
+  audits: []
+
+next:
+  after_pr: "Merge API before companion front PR, then apply the SQL seed"

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -40,6 +40,7 @@ STARTER_OPERATIONAL_QUOTAS = {
     "menu_products": 10,
     "tenant_ingredients": 5,
     "modifier_groups": 2,
+    "recipe_bases": 5,
     "recipe_lines_per_product": 4,
     "modifier_options_per_group": 6,
     "recipe_base_template_lines": 4,
@@ -55,6 +56,7 @@ QUOTA_KEYS = (
     "menu_products",
     "tenant_ingredients",
     "modifier_groups",
+    "recipe_bases",
     "recipe_lines_per_product",
     "modifier_options_per_group",
     "recipe_base_template_lines",
@@ -70,6 +72,7 @@ BASE_OPERATIONAL_QUOTAS = {
     "menu_products": CATALOG_UNLIMITED,
     "tenant_ingredients": CATALOG_UNLIMITED,
     "modifier_groups": CATALOG_UNLIMITED,
+    "recipe_bases": CATALOG_UNLIMITED,
     "recipe_lines_per_product": 100,
     "modifier_options_per_group": 50,
     "recipe_base_template_lines": 75,
@@ -103,6 +106,7 @@ ENFORCEABLE_QUOTA_RESOURCES = {
     "menu_products",
     "tenant_ingredients",
     "modifier_groups",
+    "recipe_bases",
 }
 SCOPED_QUOTA_RESOURCES = {
     "recipe_lines_per_product",
@@ -880,6 +884,15 @@ async def _count_quota_resource_usage(
             """
             SELECT COUNT(*)
             FROM modifier_groups
+            WHERE tenant_id = $1
+            """,
+            tenant_id,
+        )
+    elif resource == "recipe_bases":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM product_base_types
             WHERE tenant_id = $1
             """,
             tenant_id,
@@ -1835,7 +1848,12 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
                 SELECT COUNT(*)
                 FROM modifier_groups mg
                 WHERE mg.tenant_id = $1
-            ) AS modifier_groups
+            ) AS modifier_groups,
+            (
+                SELECT COUNT(*)
+                FROM product_base_types pbt
+                WHERE pbt.tenant_id = $1
+            ) AS recipe_bases
     """, tenant_id, period_start, period_end, list(LEGACY_INTERNAL_TEAM_ROLES))
 
     def metric(used: int, quota: EffectiveQuota) -> Dict[str, Any]:
@@ -1904,6 +1922,10 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
             "modifier_groups": metric(
                 int(quota_counts["modifier_groups"] or 0),
                 effective_quotas["modifier_groups"],
+            ),
+            "recipe_bases": metric(
+                int(quota_counts["recipe_bases"] or 0),
+                effective_quotas["recipe_bases"],
             ),
         },
     }

--- a/app/services/recipe_bases_service.py
+++ b/app/services/recipe_bases_service.py
@@ -19,7 +19,7 @@ from app.models.recipe_base import (
 )
 from app.services import menu_history_service
 from app.services.ingredient_purchase_units_service import resolve_to_base_unit
-from app.services.billing_service import check_plan_quota_scoped
+from app.services.billing_service import check_plan_quota_growth, check_plan_quota_scoped
 from app.services.cost_resolution_service import recipe_qty_to_stock_units
 from decimal import Decimal
 
@@ -114,6 +114,7 @@ async def create_recipe_base_type(
                 )
 
         async with get_db_connection() as conn:
+            await check_plan_quota_growth(conn, tenant_id, "recipe_bases")
             # Insert product_base_type
             insert_base_query = """
                 INSERT INTO product_base_types (name, description, is_active, tenant_id)

--- a/sql/20260724_starter_recipe_bases_quota.sql
+++ b/sql/20260724_starter_recipe_bases_quota.sql
@@ -1,0 +1,15 @@
+-- warocol.com#1800: add a Starter recipe-bases growth cap.
+-- Non-destructive: merge only this catalog quota key into the Starter plan.
+
+UPDATE subscription_plans
+SET
+    features = jsonb_set(
+        COALESCE(features, '{}'::jsonb),
+        '{quotas}',
+        COALESCE(features->'quotas', '{}'::jsonb) || '{
+          "recipe_bases": 5
+        }'::jsonb,
+        true
+    ),
+    updated_at = now()
+WHERE slug = 'starter';

--- a/tests/test_billing_plan_quotas.py
+++ b/tests/test_billing_plan_quotas.py
@@ -104,6 +104,7 @@ async def test_remaining_usage_exposes_quota_usage_and_internal_roles_only():
                 "completed_online_orders_per_month": 28,
                 "menu_products": 9,
                 "modifier_groups": 1,
+                "recipe_bases": 2,
             },
         ]
     )
@@ -131,6 +132,8 @@ async def test_remaining_usage_exposes_quota_usage_and_internal_roles_only():
     }
     assert usage["quota_usage"]["modifier_groups"]["used"] == 1
     assert usage["quota_usage"]["modifier_groups"]["limit"] == 1_000_000
+    assert usage["quota_usage"]["recipe_bases"]["used"] == 2
+    assert usage["quota_usage"]["recipe_bases"]["limit"] == 1_000_000
 
     quota_query_args = conn.fetchrow.await_args_list[1].args
     assert quota_query_args[4] == list(LEGACY_INTERNAL_TEAM_ROLES)
@@ -164,6 +167,7 @@ async def test_remaining_usage_exposes_effective_quota_override_state():
                 "completed_online_orders_per_month": 28,
                 "menu_products": 0,
                 "modifier_groups": 0,
+                "recipe_bases": 0,
             },
         ]
     )
@@ -220,6 +224,7 @@ async def test_remaining_usage_exposes_disabled_override_as_unlimited():
                 "completed_online_orders_per_month": 301,
                 "menu_products": 0,
                 "modifier_groups": 0,
+                "recipe_bases": 0,
             },
         ]
     )

--- a/tests/test_billing_remaining_usage.py
+++ b/tests/test_billing_remaining_usage.py
@@ -36,6 +36,7 @@ def _quota_counts_row(**overrides):
         "completed_online_orders_per_month": 0,
         "menu_products": 0,
         "modifier_groups": 0,
+        "recipe_bases": 0,
     }
     base.update(overrides)
     return base
@@ -74,6 +75,7 @@ async def test_remaining_usage_non_fe_plan_reports_zero_invoice_quota():
     }
     assert result["quota_usage"]["menu_products"]["limit"] == 1_000_000
     assert result["quota_usage"]["modifier_groups"]["limit"] == 1_000_000
+    assert result["quota_usage"]["recipe_bases"]["limit"] == 1_000_000
     subscription_query = conn.fetchrow.await_args_list[0].args[0]
     assert "su.period_start <= now()" in subscription_query
     assert "su.period_end > now()" in subscription_query
@@ -201,6 +203,7 @@ async def test_remaining_usage_starter_without_subscription_exposes_catalog_quot
                     "quotas": {
                         "menu_products": 10,
                         "modifier_groups": 2,
+                        "recipe_bases": 5,
                         "admin_users": 1,
                         "active_sessions_per_admin_user": 1,
                         "active_kitchens": 0,
@@ -223,6 +226,7 @@ async def test_remaining_usage_starter_without_subscription_exposes_catalog_quot
                 "completed_online_orders_per_month": 5,
                 "menu_products": 10,
                 "modifier_groups": 2,
+                "recipe_bases": 5,
             },
         ]
     )
@@ -242,3 +246,5 @@ async def test_remaining_usage_starter_without_subscription_exposes_catalog_quot
     }
     assert usage["quota_usage"]["modifier_groups"]["used"] == 2
     assert usage["quota_usage"]["modifier_groups"]["remaining"] == 0
+    assert usage["quota_usage"]["recipe_bases"]["used"] == 5
+    assert usage["quota_usage"]["recipe_bases"]["remaining"] == 0

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -861,6 +861,30 @@ async def test_starter_modifier_groups_quota_blocks_at_limit():
 
 
 @pytest.mark.asyncio
+async def test_starter_recipe_bases_quota_allows_below_limit():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_starter_plan_row("recipe_bases", 5))
+    conn.fetchval = AsyncMock(return_value=4)
+
+    await billing_service.check_plan_quota_growth(conn, tenant_id, "recipe_bases")
+
+
+@pytest.mark.asyncio
+async def test_starter_recipe_bases_quota_blocks_at_limit():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_starter_plan_row("recipe_bases", 5))
+    conn.fetchval = AsyncMock(return_value=5)
+
+    with pytest.raises(APIError) as exc:
+        await billing_service.check_plan_quota_growth(conn, tenant_id, "recipe_bases")
+
+    assert exc.value.status_code == 429
+    assert exc.value.details["resource"] == "recipe_bases"
+
+
+@pytest.mark.asyncio
 async def test_scoped_recipe_base_template_lines_quota_blocks_over_limit():
     tenant_id = uuid4()
     base_type_id = uuid4()


### PR DESCRIPTION
## Summary
- Adds a Starter `recipe_bases` growth quota of 5, counted from `product_base_types`.
- Enforces it on recipe base CREATE and exposes `recipe_bases` in remaining usage.

Refs uno0uno/warocol.com#1800

## Test plan
- [ ] Confirm Starter recipe base CREATE is allowed at 4 and blocked at 5.
- [ ] Confirm paid plans still report `recipe_bases` as unlimited.
- [ ] Apply `sql/20260724_starter_recipe_bases_quota.sql` after merge.

## Validation evidence
```text
./venv/bin/pytest tests/test_quota_enforcement.py tests/test_billing_remaining_usage.py tests/test_billing_plan_quotas.py -q
============================== 51 passed in 0.22s ==============================
```

## wr-context
See `.wr/1800.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)