### PR TITLE
feat(billing): expose scoped line/option limits in remaining-usage

### DIFF
--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -1949,6 +1949,16 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
                 int(quota_counts["recipe_bases"] or 0),
                 effective_quotas["recipe_bases"],
             ),
+            # Scoped caps: limit is plan-level; used is always 0 here (count is
+            # per product/group). Front compares local editor counts to limit.
+            "recipe_lines_per_product": metric(
+                0,
+                effective_quotas["recipe_lines_per_product"],
+            ),
+            "modifier_options_per_group": metric(
+                0,
+                effective_quotas["modifier_options_per_group"],
+            ),
         },
     }
 

--- a/tests/test_billing_remaining_usage.py
+++ b/tests/test_billing_remaining_usage.py
@@ -78,6 +78,10 @@ async def test_remaining_usage_non_fe_plan_reports_zero_invoice_quota():
     assert result["quota_usage"]["menu_categories"]["limit"] == 1_000_000
     assert result["quota_usage"]["modifier_groups"]["limit"] == 1_000_000
     assert result["quota_usage"]["recipe_bases"]["limit"] == 1_000_000
+    assert result["quota_usage"]["recipe_lines_per_product"]["used"] == 0
+    assert result["quota_usage"]["recipe_lines_per_product"]["limit"] == 100
+    assert result["quota_usage"]["modifier_options_per_group"]["used"] == 0
+    assert result["quota_usage"]["modifier_options_per_group"]["limit"] == 50
     subscription_query = conn.fetchrow.await_args_list[0].args[0]
     assert "su.period_start <= now()" in subscription_query
     assert "su.period_end > now()" in subscription_query
@@ -254,3 +258,12 @@ async def test_remaining_usage_starter_without_subscription_exposes_catalog_quot
     assert usage["quota_usage"]["modifier_groups"]["remaining"] == 0
     assert usage["quota_usage"]["recipe_bases"]["used"] == 5
     assert usage["quota_usage"]["recipe_bases"]["remaining"] == 0
+    assert usage["quota_usage"]["recipe_lines_per_product"] == {
+        "used": 0,
+        "limit": 4,
+        "remaining": 4,
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+    }
+    assert usage["quota_usage"]["modifier_options_per_group"]["limit"] == 6
+    assert usage["quota_usage"]["modifier_options_per_group"]["used"] == 0


### PR DESCRIPTION
## Summary
- Expose `recipe_lines_per_product` and `modifier_options_per_group` plan limits in `remaining-usage.quota_usage` (`used` is always 0; count is per product/group).
- Enables front editors to gate add-line / add-option before save (warocol.com#1808).

Supports [warocol.com#1808](https://github.com/uno0uno/warocol.com/issues/1808)

## Test plan
- [x] `./venv/bin/python -m pytest tests/test_billing_remaining_usage.py -q`
- [ ] Deploy API before front PR that depends on these keys

## Validation evidence
```
./venv/bin/python -m pytest tests/test_billing_remaining_usage.py -q
tests/test_billing_remaining_usage.py .......                            [100%]
7 passed in 0.04s
```

## wr-context
Companion to front `.wr/1808.yaml`.

Made with [Cursor](https://cursor.com)