### PR TITLE
feat(billing): expose tenant_ingredients in remaining-usage

### DIFF
--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -1864,6 +1864,12 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
             ) AS menu_categories,
             (
                 SELECT COUNT(*)
+                FROM ingredients i
+                WHERE i.tenant_id = $1
+                  AND i.is_active = TRUE
+            ) AS tenant_ingredients,
+            (
+                SELECT COUNT(*)
                 FROM modifier_groups mg
                 WHERE mg.tenant_id = $1
             ) AS modifier_groups,
@@ -1940,6 +1946,10 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
             "menu_categories": metric(
                 int(quota_counts["menu_categories"] or 0),
                 effective_quotas["menu_categories"],
+            ),
+            "tenant_ingredients": metric(
+                int(quota_counts["tenant_ingredients"] or 0),
+                effective_quotas["tenant_ingredients"],
             ),
             "modifier_groups": metric(
                 int(quota_counts["modifier_groups"] or 0),

--- a/tests/test_billing_remaining_usage.py
+++ b/tests/test_billing_remaining_usage.py
@@ -36,6 +36,7 @@ def _quota_counts_row(**overrides):
         "completed_online_orders_per_month": 0,
         "menu_products": 0,
         "menu_categories": 0,
+        "tenant_ingredients": 0,
         "modifier_groups": 0,
         "recipe_bases": 0,
     }
@@ -209,6 +210,7 @@ async def test_remaining_usage_starter_without_subscription_exposes_catalog_quot
                     "quotas": {
                         "menu_products": 10,
                         "menu_categories": 5,
+                        "tenant_ingredients": 5,
                         "modifier_groups": 4,
                         "recipe_bases": 5,
                         "admin_users": 1,
@@ -233,6 +235,7 @@ async def test_remaining_usage_starter_without_subscription_exposes_catalog_quot
                 "completed_online_orders_per_month": 5,
                 "menu_products": 10,
                 "menu_categories": 5,
+                "tenant_ingredients": 5,
                 "modifier_groups": 4,
                 "recipe_bases": 5,
             },
@@ -254,6 +257,9 @@ async def test_remaining_usage_starter_without_subscription_exposes_catalog_quot
     }
     assert usage["quota_usage"]["menu_categories"]["used"] == 5
     assert usage["quota_usage"]["menu_categories"]["remaining"] == 0
+    assert usage["quota_usage"]["tenant_ingredients"]["used"] == 5
+    assert usage["quota_usage"]["tenant_ingredients"]["limit"] == 5
+    assert usage["quota_usage"]["tenant_ingredients"]["remaining"] == 0
     assert usage["quota_usage"]["modifier_groups"]["used"] == 4
     assert usage["quota_usage"]["modifier_groups"]["remaining"] == 0
     assert usage["quota_usage"]["recipe_bases"]["used"] == 5


### PR DESCRIPTION
## Summary
- Add `tenant_ingredients` (active ingredient count) to the `get_remaining_billing_usage` SQL and `quota_usage` payload, with its plan limit.
- Enables the front warehouse catalog to open the Mi Plan quota modal *before* create (pre-click parity with menu catalog). Create enforcement (429) was already in place.

Companion front issue: uno0uno/warocol.com#1814

## Test plan
- [x] `pytest tests/test_billing_remaining_usage.py -q`

## Validation evidence
```
$ python -m pytest tests/test_billing_remaining_usage.py -q
tests/test_billing_remaining_usage.py .......                            [100%]
7 passed in 0.06s
```

Made with [Cursor](https://cursor.com)