### PR TITLE
feat(billing): Finanzas operational quotas (Trial)

### DIFF
--- a/app/services/accounting_service.py
+++ b/app/services/accounting_service.py
@@ -42,6 +42,7 @@ from app.services.account_role_service import (
     resolve_account,
     set_role_override,
 )
+from app.services.billing_service import check_plan_quota_period
 
 logger = logging.getLogger(__name__)
 
@@ -602,6 +603,11 @@ async def create_journal_entry(request: Request, body: JournalEntryCreate) -> Jo
                 source_module = body.source_module or 'manual'
                 source_id = body.source_id
                 pending_review = bool(body.pending_review)
+
+                if source_module in ('manual', 'manual_balance_adjustment'):
+                    await check_plan_quota_period(
+                        conn, tenant_id, "manual_journal_entries_per_period"
+                    )
 
                 entry_row = await conn.fetchrow(
                     """INSERT INTO tenant_journal_entries

--- a/app/services/accounting_service.py
+++ b/app/services/accounting_service.py
@@ -46,6 +46,9 @@ from app.services.billing_service import check_plan_quota_period
 
 logger = logging.getLogger(__name__)
 
+# Public POST /journal-entries only; auto GL uses other insert paths.
+MANUAL_JOURNAL_SOURCE_MODULES = frozenset({"manual", "manual_balance_adjustment"})
+
 VALID_ACCOUNT_TYPES = ['asset', 'liability', 'equity', 'income', 'expense', 'cogs']
 VALID_NORMAL_BALANCES = ['debit', 'credit']
 
@@ -597,17 +600,21 @@ async def create_journal_entry(request: Request, body: JournalEntryCreate) -> Jo
                 raise ValidationError("Una o más cuentas no pertenecen al tenant actual")
 
             async with conn.transaction():
-                # Issue #531 — accept caller-supplied source_module/source_id
-                # (e.g. 'manual_balance_adjustment' for the "Actualizar saldo
-                # real" flow) and the pending_review annotation flag.
+                # Public create path is manual-only. Auto GL posts use other
+                # service helpers and must not come through this endpoint with
+                # a forged source_module (warocol.com#1835 review).
                 source_module = body.source_module or 'manual'
+                if source_module not in MANUAL_JOURNAL_SOURCE_MODULES:
+                    raise ValidationError(
+                        "Los asientos creados desde esta API solo admiten "
+                        "source_module 'manual' o 'manual_balance_adjustment'."
+                    )
                 source_id = body.source_id
                 pending_review = bool(body.pending_review)
 
-                if source_module in ('manual', 'manual_balance_adjustment'):
-                    await check_plan_quota_period(
-                        conn, tenant_id, "manual_journal_entries_per_period"
-                    )
+                await check_plan_quota_period(
+                    conn, tenant_id, "manual_journal_entries_per_period"
+                )
 
                 entry_row = await conn.fetchrow(
                     """INSERT INTO tenant_journal_entries

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -43,6 +43,13 @@ STARTER_OPERATIONAL_QUOTAS = {
     "tenant_suppliers": 3,
     "direct_purchases_per_period": 15,
     "stock_adjustments_per_period": 20,
+    "cash_closes_per_period": 30,
+    "active_open_cash_shifts": 1,
+    "expenses_per_period": 30,
+    "supplier_payments_per_period": 30,
+    "payment_methods": 5,
+    "accounting_period_closes_per_period": 3,
+    "manual_journal_entries_per_period": 30,
     "modifier_groups": 4,
     "recipe_bases": 5,
     "recipe_lines_per_product": 4,
@@ -63,6 +70,13 @@ QUOTA_KEYS = (
     "tenant_suppliers",
     "direct_purchases_per_period",
     "stock_adjustments_per_period",
+    "cash_closes_per_period",
+    "active_open_cash_shifts",
+    "expenses_per_period",
+    "supplier_payments_per_period",
+    "payment_methods",
+    "accounting_period_closes_per_period",
+    "manual_journal_entries_per_period",
     "modifier_groups",
     "recipe_bases",
     "recipe_lines_per_product",
@@ -83,6 +97,13 @@ BASE_OPERATIONAL_QUOTAS = {
     "tenant_suppliers": CATALOG_UNLIMITED,
     "direct_purchases_per_period": CATALOG_UNLIMITED,
     "stock_adjustments_per_period": CATALOG_UNLIMITED,
+    "cash_closes_per_period": CATALOG_UNLIMITED,
+    "active_open_cash_shifts": CATALOG_UNLIMITED,
+    "expenses_per_period": CATALOG_UNLIMITED,
+    "supplier_payments_per_period": CATALOG_UNLIMITED,
+    "payment_methods": CATALOG_UNLIMITED,
+    "accounting_period_closes_per_period": CATALOG_UNLIMITED,
+    "manual_journal_entries_per_period": CATALOG_UNLIMITED,
     "modifier_groups": CATALOG_UNLIMITED,
     "recipe_bases": CATALOG_UNLIMITED,
     "recipe_lines_per_product": 100,
@@ -119,12 +140,19 @@ ENFORCEABLE_QUOTA_RESOURCES = {
     "menu_categories",
     "tenant_ingredients",
     "tenant_suppliers",
+    "active_open_cash_shifts",
+    "payment_methods",
     "modifier_groups",
     "recipe_bases",
 }
 PERIOD_QUOTA_RESOURCES = {
     "direct_purchases_per_period",
     "stock_adjustments_per_period",
+    "cash_closes_per_period",
+    "expenses_per_period",
+    "supplier_payments_per_period",
+    "accounting_period_closes_per_period",
+    "manual_journal_entries_per_period",
 }
 SCOPED_QUOTA_RESOURCES = {
     "recipe_lines_per_product",
@@ -601,6 +629,85 @@ async def _count_period_quota_usage(
             WHERE tenant_id = $1
               AND movement_type = 'adjustment'
               AND COALESCE(reference_table, '') <> 'tenant_purchases'
+              AND created_at >= $2
+              AND created_at < $3
+            """,
+            tenant_id,
+            period_start,
+            period_end,
+        )
+    elif resource == "cash_closes_per_period":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM accounting_period
+            WHERE tenant_id = $1
+              AND closed_at >= $2
+              AND closed_at < $3
+            """,
+            tenant_id,
+            period_start,
+            period_end,
+        )
+    elif resource == "expenses_per_period":
+        value = await conn.fetchval(
+            """
+            SELECT
+                (
+                    SELECT COUNT(*)
+                    FROM tenant_expenses
+                    WHERE tenant_id = $1
+                      AND created_at >= $2
+                      AND created_at < $3
+                )
+                +
+                (
+                    SELECT COUNT(*)
+                    FROM recurring_expense_instances
+                    WHERE tenant_id = $1
+                      AND created_at >= $2
+                      AND created_at < $3
+                )
+            """,
+            tenant_id,
+            period_start,
+            period_end,
+        )
+    elif resource == "supplier_payments_per_period":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM tenant_purchases
+            WHERE tenant_id = $1
+              AND paid_at IS NOT NULL
+              AND paid_at >= $2
+              AND paid_at < $3
+            """,
+            tenant_id,
+            period_start,
+            period_end,
+        )
+    elif resource == "accounting_period_closes_per_period":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM tenant_monthly_periods
+            WHERE tenant_id = $1
+              AND status = 'closed'
+              AND closed_at >= $2
+              AND closed_at < $3
+            """,
+            tenant_id,
+            period_start,
+            period_end,
+        )
+    elif resource == "manual_journal_entries_per_period":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM tenant_journal_entries
+            WHERE tenant_id = $1
+              AND source_module IN ('manual', 'manual_balance_adjustment')
               AND created_at >= $2
               AND created_at < $3
             """,
@@ -1097,6 +1204,26 @@ async def _count_quota_resource_usage(
             """
             SELECT COUNT(*)
             FROM tenant_suppliers
+            WHERE tenant_id = $1
+              AND is_active = TRUE
+            """,
+            tenant_id,
+        )
+    elif resource == "active_open_cash_shifts":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM cash_shift_openings
+            WHERE tenant_id = $1
+              AND status = 'open'
+            """,
+            tenant_id,
+        )
+    elif resource == "payment_methods":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM payment_methods
             WHERE tenant_id = $1
               AND is_active = TRUE
             """,
@@ -2103,6 +2230,67 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
             ) AS stock_adjustments_per_period,
             (
                 SELECT COUNT(*)
+                FROM accounting_period ap
+                WHERE ap.tenant_id = $1
+                  AND ap.closed_at >= $2
+                  AND ap.closed_at < $3
+            ) AS cash_closes_per_period,
+            (
+                SELECT COUNT(*)
+                FROM cash_shift_openings cso
+                WHERE cso.tenant_id = $1
+                  AND cso.status = 'open'
+            ) AS active_open_cash_shifts,
+            (
+                SELECT
+                    (
+                        SELECT COUNT(*)
+                        FROM tenant_expenses te
+                        WHERE te.tenant_id = $1
+                          AND te.created_at >= $2
+                          AND te.created_at < $3
+                    )
+                    +
+                    (
+                        SELECT COUNT(*)
+                        FROM recurring_expense_instances rei
+                        WHERE rei.tenant_id = $1
+                          AND rei.created_at >= $2
+                          AND rei.created_at < $3
+                    )
+            ) AS expenses_per_period,
+            (
+                SELECT COUNT(*)
+                FROM tenant_purchases tp_paid
+                WHERE tp_paid.tenant_id = $1
+                  AND tp_paid.paid_at IS NOT NULL
+                  AND tp_paid.paid_at >= $2
+                  AND tp_paid.paid_at < $3
+            ) AS supplier_payments_per_period,
+            (
+                SELECT COUNT(*)
+                FROM payment_methods pm
+                WHERE pm.tenant_id = $1
+                  AND pm.is_active = TRUE
+            ) AS payment_methods,
+            (
+                SELECT COUNT(*)
+                FROM tenant_monthly_periods tmp
+                WHERE tmp.tenant_id = $1
+                  AND tmp.status = 'closed'
+                  AND tmp.closed_at >= $2
+                  AND tmp.closed_at < $3
+            ) AS accounting_period_closes_per_period,
+            (
+                SELECT COUNT(*)
+                FROM tenant_journal_entries tje
+                WHERE tje.tenant_id = $1
+                  AND tje.source_module IN ('manual', 'manual_balance_adjustment')
+                  AND tje.created_at >= $2
+                  AND tje.created_at < $3
+            ) AS manual_journal_entries_per_period,
+            (
+                SELECT COUNT(*)
                 FROM modifier_groups mg
                 WHERE mg.tenant_id = $1
             ) AS modifier_groups,
@@ -2195,6 +2383,34 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
             "stock_adjustments_per_period": metric(
                 int(quota_counts["stock_adjustments_per_period"] or 0),
                 effective_quotas["stock_adjustments_per_period"],
+            ),
+            "cash_closes_per_period": metric(
+                int(quota_counts["cash_closes_per_period"] or 0),
+                effective_quotas["cash_closes_per_period"],
+            ),
+            "active_open_cash_shifts": metric(
+                int(quota_counts["active_open_cash_shifts"] or 0),
+                effective_quotas["active_open_cash_shifts"],
+            ),
+            "expenses_per_period": metric(
+                int(quota_counts["expenses_per_period"] or 0),
+                effective_quotas["expenses_per_period"],
+            ),
+            "supplier_payments_per_period": metric(
+                int(quota_counts["supplier_payments_per_period"] or 0),
+                effective_quotas["supplier_payments_per_period"],
+            ),
+            "payment_methods": metric(
+                int(quota_counts["payment_methods"] or 0),
+                effective_quotas["payment_methods"],
+            ),
+            "accounting_period_closes_per_period": metric(
+                int(quota_counts["accounting_period_closes_per_period"] or 0),
+                effective_quotas["accounting_period_closes_per_period"],
+            ),
+            "manual_journal_entries_per_period": metric(
+                int(quota_counts["manual_journal_entries_per_period"] or 0),
+                effective_quotas["manual_journal_entries_per_period"],
             ),
             "modifier_groups": metric(
                 int(quota_counts["modifier_groups"] or 0),

--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -28,6 +28,7 @@ from app.models.cierre import (
     CierreReconciliationResolve,
     OpenShiftCreate,
 )
+from app.services.billing_service import check_plan_quota_growth, check_plan_quota_period
 from app.services.tip_tax_service import tip_settlement_total
 from app.services.account_role_service import (
     AccountRole,
@@ -2194,6 +2195,8 @@ async def open_shift(request: Request, body: OpenShiftCreate) -> dict:
                     status_code=409,
                 )
 
+            await check_plan_quota_growth(conn, tenant_id, "active_open_cash_shifts")
+
             breakdown_json = (
                 json.dumps(body.opening_breakdown)
                 if body.opening_breakdown is not None
@@ -2489,6 +2492,8 @@ async def create_cierre(request: Request, body: CierreCreate) -> dict:
                     "Ya existe un cierre para este período o uno que se superpone.",
                     status_code=409,
                 )
+
+            await check_plan_quota_period(conn, tenant_id, "cash_closes_per_period")
 
             open_shift = await _fetch_open_shift_for_window(
                 conn, tenant_id, eff_start, eff_end, timezone_name,
@@ -3572,6 +3577,10 @@ async def close_monthly_period(
                     f"El período {year}-{month:02d} ya está cerrado.",
                     status_code=409,
                 )
+
+            await check_plan_quota_period(
+                conn, tenant_id, "accounting_period_closes_per_period"
+            )
 
             if existing:
                 row = await conn.fetchrow(

--- a/app/services/expenses_service.py
+++ b/app/services/expenses_service.py
@@ -7,7 +7,7 @@ from datetime import date, datetime
 from fastapi import Request, Response, HTTPException, UploadFile
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
-from app.core.exceptions import AuthenticationError
+from app.core.exceptions import AuthenticationError, APIError
 from app.models.expense import (
     Expense,
     ExpenseCreate,
@@ -22,6 +22,7 @@ from app.models.expense import (
     ChangeType,
     InstanceStatus
 )
+from app.services.billing_service import check_plan_quota_period
 from app.services.purchase_tracking_service import upload_purchase_attachments
 from app.services.aws_s3_service import AWSS3Service
 
@@ -728,6 +729,8 @@ async def create_expense(
             if not category_exists:
                 raise HTTPException(status_code=400, detail="Invalid expense category")
 
+            await check_plan_quota_period(conn, tenant_id, "expenses_per_period")
+
             # Generate expense number inside the same connection
             expense_number = await get_next_expense_number(conn, tenant_id)
 
@@ -880,6 +883,8 @@ async def create_expense(
 
     except AuthenticationError:
         raise
+    except APIError:
+        raise
     except HTTPException:
         raise
     except Exception as e:
@@ -933,6 +938,8 @@ async def create_expense_json(
                 expense_data.payment_method,
                 expense_data.payment_method_id,
             )
+
+            await check_plan_quota_period(conn, tenant_id, "expenses_per_period")
 
             # Generate expense number inside the same connection
             expense_number = await get_next_expense_number(conn, tenant_id)
@@ -1047,6 +1054,8 @@ async def create_expense_json(
             return ExpenseResponse(data=expense)
 
     except AuthenticationError:
+        raise
+    except APIError:
         raise
     except HTTPException:
         raise
@@ -2068,6 +2077,8 @@ async def create_recurring_instance(
             # Use expense amount if not provided
             instance_amount = amount if amount is not None else float(expense['amount'])
 
+            await check_plan_quota_period(conn, tenant_id, "expenses_per_period")
+
             # Insert instance
             instance_id = await conn.fetchval("""
                 INSERT INTO recurring_expense_instances (
@@ -2182,6 +2193,8 @@ async def create_recurring_instance(
             }
 
     except AuthenticationError:
+        raise
+    except APIError:
         raise
     except HTTPException:
         raise
@@ -2368,6 +2381,8 @@ async def create_recurring_instance_json(
             # Use expense amount if not provided
             instance_amount = instance_data.amount if instance_data.amount is not None else float(expense['amount'])
 
+            await check_plan_quota_period(conn, tenant_id, "expenses_per_period")
+
             # Insert instance. Retrying the same recurring period returns the
             # existing row instead of surfacing a duplicate-key failure.
             instance_id = await conn.fetchval("""
@@ -2409,6 +2424,8 @@ async def create_recurring_instance_json(
             return _format_recurring_instance_response(instance_row)
 
     except AuthenticationError:
+        raise
+    except APIError:
         raise
     except HTTPException:
         raise

--- a/app/services/payment_method_service.py
+++ b/app/services/payment_method_service.py
@@ -306,7 +306,7 @@ async def patch_method(request: Request, method_id: UUID, body: PatchMethodReque
 
     async with get_db_connection(use_transaction=True) as conn:
         existing = await conn.fetchrow(
-            "SELECT id, tenant_id FROM payment_methods WHERE id = $1 AND tenant_id = $2",
+            "SELECT id, tenant_id, is_active FROM payment_methods WHERE id = $1 AND tenant_id = $2",
             method_id,
             tenant_id,
         )
@@ -322,6 +322,8 @@ async def patch_method(request: Request, method_id: UUID, body: PatchMethodReque
             params.append(body.name)
             idx += 1
         if body.isActive is not None:
+            if body.isActive is True and not existing["is_active"]:
+                await check_plan_quota_growth(conn, tenant_id, "payment_methods")
             updates.append(f"is_active = ${idx}")
             params.append(body.isActive)
             idx += 1

--- a/app/services/payment_method_service.py
+++ b/app/services/payment_method_service.py
@@ -15,6 +15,7 @@ from app.models.payment_method import (
     CreateMethodRequest,
     PatchMethodRequest,
 )
+from app.services.billing_service import check_plan_quota_growth
 
 logger = logging.getLogger(__name__)
 
@@ -258,6 +259,8 @@ async def create_method(request: Request, body: CreateMethodRequest) -> dict:
                 "Cannot add methods to the Efectivo group. "
                 "Cash is a single built-in payment method."
             )
+
+        await check_plan_quota_growth(conn, tenant_id, "payment_methods")
 
         try:
             # Issue #533 — accept gl_account_code on creation so the auto-create

--- a/app/services/purchase_tracking_service.py
+++ b/app/services/purchase_tracking_service.py
@@ -10,7 +10,7 @@ from decimal import Decimal
 from fastapi import Request, Response, HTTPException, UploadFile
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
-from app.core.exceptions import AuthenticationError
+from app.core.exceptions import AuthenticationError, APIError
 from app.services.aws_s3_service import AWSS3Service
 from app.core.timezones import local_date_for_tenant, resolve_tenant_timezone
 from app.services.account_role_service import (
@@ -19,6 +19,7 @@ from app.services.account_role_service import (
     resolve_account,
     resolve_payment_account,
 )
+from app.services.billing_service import check_plan_quota_period
 import logging
 
 logger = logging.getLogger(__name__)
@@ -1425,6 +1426,10 @@ async def transition_to_paid(
                     payment_method_id,
                 )
 
+                await check_plan_quota_period(
+                    conn, tenant_id, "supplier_payments_per_period"
+                )
+
                 # Update purchase
                 await conn.execute("""
                     UPDATE tenant_purchases
@@ -1519,6 +1524,8 @@ async def transition_to_paid(
     except MissingAccountRoleError:
         raise
     except AuthenticationError:
+        raise
+    except APIError:
         raise
     except HTTPException:
         raise

--- a/tests/test_billing_remaining_usage.py
+++ b/tests/test_billing_remaining_usage.py
@@ -40,6 +40,13 @@ def _quota_counts_row(**overrides):
         "tenant_suppliers": 0,
         "direct_purchases_per_period": 0,
         "stock_adjustments_per_period": 0,
+        "cash_closes_per_period": 0,
+        "active_open_cash_shifts": 0,
+        "expenses_per_period": 0,
+        "supplier_payments_per_period": 0,
+        "payment_methods": 0,
+        "accounting_period_closes_per_period": 0,
+        "manual_journal_entries_per_period": 0,
         "modifier_groups": 0,
         "recipe_bases": 0,
     }
@@ -245,6 +252,13 @@ async def test_remaining_usage_starter_without_subscription_exposes_catalog_quot
                 "tenant_suppliers": 3,
                 "direct_purchases_per_period": 15,
                 "stock_adjustments_per_period": 20,
+                "cash_closes_per_period": 30,
+                "active_open_cash_shifts": 1,
+                "expenses_per_period": 30,
+                "supplier_payments_per_period": 30,
+                "payment_methods": 5,
+                "accounting_period_closes_per_period": 3,
+                "manual_journal_entries_per_period": 30,
                 "modifier_groups": 4,
                 "recipe_bases": 5,
             },
@@ -282,6 +296,15 @@ async def test_remaining_usage_starter_without_subscription_exposes_catalog_quot
     assert usage["quota_usage"]["stock_adjustments_per_period"]["used"] == 20
     assert usage["quota_usage"]["stock_adjustments_per_period"]["limit"] == 20
     assert usage["quota_usage"]["stock_adjustments_per_period"]["remaining"] == 0
+    assert usage["quota_usage"]["cash_closes_per_period"]["limit"] == 30
+    assert usage["quota_usage"]["cash_closes_per_period"]["used"] == 30
+    assert usage["quota_usage"]["cash_closes_per_period"]["remaining"] == 0
+    assert usage["quota_usage"]["active_open_cash_shifts"]["limit"] == 1
+    assert usage["quota_usage"]["expenses_per_period"]["limit"] == 30
+    assert usage["quota_usage"]["supplier_payments_per_period"]["limit"] == 30
+    assert usage["quota_usage"]["payment_methods"]["limit"] == 5
+    assert usage["quota_usage"]["accounting_period_closes_per_period"]["limit"] == 3
+    assert usage["quota_usage"]["manual_journal_entries_per_period"]["limit"] == 30
     assert usage["quota_usage"]["modifier_groups"]["used"] == 4
     assert usage["quota_usage"]["modifier_groups"]["remaining"] == 0
     assert usage["quota_usage"]["recipe_bases"]["used"] == 5
@@ -302,3 +325,8 @@ async def test_remaining_usage_starter_without_subscription_exposes_catalog_quot
     assert "movement_type = 'adjustment'" in counts_query
     assert "tenant_ingredient_movements" in counts_query
     assert "COALESCE(tim.reference_table, '') <> 'tenant_purchases'" in counts_query
+    assert "accounting_period" in counts_query
+    assert "cash_shift_openings" in counts_query
+    assert "recurring_expense_instances" in counts_query
+    assert "manual_balance_adjustment" in counts_query
+    assert "tenant_monthly_periods" in counts_query

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -1284,3 +1284,14 @@ async def test_accounting_period_closes_period_quota_blocks_at_limit():
 
     assert exc.value.details["resource"] == "accounting_period_closes_per_period"
     assert "FROM tenant_monthly_periods" in conn.fetchval.await_args.args[0]
+
+
+def test_manual_journal_allowed_source_modules_match_count_filter():
+    """Public JE create whitelist must stay aligned with period count SQL."""
+    from app.services.accounting_service import MANUAL_JOURNAL_SOURCE_MODULES
+
+    assert MANUAL_JOURNAL_SOURCE_MODULES == frozenset(
+        {"manual", "manual_balance_adjustment"}
+    )
+    assert "system" not in MANUAL_JOURNAL_SOURCE_MODULES
+    assert "orden" not in MANUAL_JOURNAL_SOURCE_MODULES

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -1133,3 +1133,154 @@ async def test_stock_adjustments_period_quota_allows_below_limit():
     await billing_service.check_plan_quota_period(
         conn, tenant_id, "stock_adjustments_per_period"
     )
+
+
+@pytest.mark.asyncio
+async def test_cash_closes_period_quota_blocks_at_limit():
+    tenant_id = uuid4()
+    period_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    period_end = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value=_period_plan_row(
+            "cash_closes_per_period", 30, period_start=period_start, period_end=period_end
+        )
+    )
+    conn.fetchval = AsyncMock(return_value=30)
+
+    with pytest.raises(APIError) as exc:
+        await billing_service.check_plan_quota_period(
+            conn, tenant_id, "cash_closes_per_period"
+        )
+
+    assert exc.value.status_code == 429
+    assert exc.value.details["resource"] == "cash_closes_per_period"
+    assert "FROM accounting_period" in conn.fetchval.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_manual_journal_entries_period_quota_filters_source_module():
+    tenant_id = uuid4()
+    period_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    period_end = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value=_period_plan_row(
+            "manual_journal_entries_per_period",
+            30,
+            period_start=period_start,
+            period_end=period_end,
+        )
+    )
+    conn.fetchval = AsyncMock(return_value=30)
+
+    with pytest.raises(APIError) as exc:
+        await billing_service.check_plan_quota_period(
+            conn, tenant_id, "manual_journal_entries_per_period"
+        )
+
+    assert exc.value.status_code == 429
+    sql = conn.fetchval.await_args.args[0]
+    assert "FROM tenant_journal_entries" in sql
+    assert "manual_balance_adjustment" in sql
+    assert "source_module IN" in sql
+
+
+@pytest.mark.asyncio
+async def test_expenses_period_quota_counts_expenses_and_instances():
+    tenant_id = uuid4()
+    period_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    period_end = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value=_period_plan_row(
+            "expenses_per_period", 30, period_start=period_start, period_end=period_end
+        )
+    )
+    conn.fetchval = AsyncMock(return_value=30)
+
+    with pytest.raises(APIError):
+        await billing_service.check_plan_quota_period(
+            conn, tenant_id, "expenses_per_period"
+        )
+
+    sql = conn.fetchval.await_args.args[0]
+    assert "FROM tenant_expenses" in sql
+    assert "FROM recurring_expense_instances" in sql
+
+
+@pytest.mark.asyncio
+async def test_active_open_cash_shifts_growth_quota_blocks_at_limit():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_starter_plan_row("active_open_cash_shifts", 1))
+    conn.fetchval = AsyncMock(return_value=1)
+
+    with pytest.raises(APIError) as exc:
+        await billing_service.check_plan_quota_growth(
+            conn, tenant_id, "active_open_cash_shifts"
+        )
+
+    assert exc.value.status_code == 429
+    assert exc.value.details["resource"] == "active_open_cash_shifts"
+    assert "FROM cash_shift_openings" in conn.fetchval.await_args.args[0]
+    assert "status = 'open'" in conn.fetchval.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_payment_methods_growth_quota_allows_below_limit():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_starter_plan_row("payment_methods", 5))
+    conn.fetchval = AsyncMock(return_value=4)
+
+    await billing_service.check_plan_quota_growth(conn, tenant_id, "payment_methods")
+
+
+@pytest.mark.asyncio
+async def test_supplier_payments_period_quota_uses_paid_at():
+    tenant_id = uuid4()
+    period_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    period_end = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value=_period_plan_row(
+            "supplier_payments_per_period",
+            30,
+            period_start=period_start,
+            period_end=period_end,
+        )
+    )
+    conn.fetchval = AsyncMock(return_value=29)
+
+    await billing_service.check_plan_quota_period(
+        conn, tenant_id, "supplier_payments_per_period"
+    )
+    sql = conn.fetchval.await_args.args[0]
+    assert "paid_at" in sql
+    assert "FROM tenant_purchases" in sql
+
+
+@pytest.mark.asyncio
+async def test_accounting_period_closes_period_quota_blocks_at_limit():
+    tenant_id = uuid4()
+    period_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    period_end = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value=_period_plan_row(
+            "accounting_period_closes_per_period",
+            3,
+            period_start=period_start,
+            period_end=period_end,
+        )
+    )
+    conn.fetchval = AsyncMock(return_value=3)
+
+    with pytest.raises(APIError) as exc:
+        await billing_service.check_plan_quota_period(
+            conn, tenant_id, "accounting_period_closes_per_period"
+        )
+
+    assert exc.value.details["resource"] == "accounting_period_closes_per_period"
+    assert "FROM tenant_monthly_periods" in conn.fetchval.await_args.args[0]


### PR DESCRIPTION
## Summary
- Add Trial Finanzas quota keys (cash closes, open shifts, expenses, supplier payments, payment methods, accounting month closes, manual journal entries).
- Enforce on create paths; expose metrics in `remaining-usage`.
- Manual JE count filters `source_module IN ('manual','manual_balance_adjustment')` so auto GL does not consume the cap.

## Test plan
- [x] `./venv/bin/pytest tests/test_quota_enforcement.py tests/test_billing_remaining_usage.py -q`
- [ ] Smoke: Starter tenant at cap gets 429 on cierre Z / expense create / manual asiento

## Validation evidence
```text
collected 61 items
tests/test_quota_enforcement.py ........................................ [ 65%]
..............                                                           [ 88%]
tests/test_billing_remaining_usage.py .......                            [100%]
============================== 61 passed in 0.14s ==============================
```

Closes uno0uno/warocol.com#1835
Epic: uno0uno/warocol.com#1834

Made with [Cursor](https://cursor.com)