### PR TITLE
fix(gates): type Request on matias_dian + colombia_payroll deps to stop 422

### DIFF
--- a/.wr/725.yaml
+++ b/.wr/725.yaml
@@ -1,0 +1,41 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 725
+title: "fix(gates): type Request on matias_dian + colombia_payroll deps to stop 422"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-725-request-type-gates
+
+paths:
+  - app/services/account_role_service.py
+  - tests/test_account_role_resolution.py
+  - .wr/725.yaml
+
+ac:
+  - Annotate request: Request on require_matias_dian_capability and require_colombia_payroll_capability
+  - DIAN GETs no longer 422 for missing ?request=
+  - /api/salaries/employees, /pila, /pila/pending no longer 422 for missing ?request=
+  - CO tenants reach handlers (or 409 when capability off)
+  - Regression test: untyped dep → 422; typed Request → 200
+
+out_of_scope:
+  - Front changes
+  - Quota/limit gates
+  - Changing 409 capability semantics
+  - GTM/setTimeout Chrome violations
+
+hints:
+  entry: "require_matias_dian_capability / require_colombia_payroll_capability"
+  pattern: "app/core/permissions.py require_module uses request: Request"
+  tests: "./venv/bin/pytest tests/test_account_role_resolution.py -q"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "deploy API; verify Facturación + Equipo/Salarios in browser"

--- a/app/services/account_role_service.py
+++ b/app/services/account_role_service.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
+from fastapi import Request
+
 from app.core.exceptions import APIError
 from app.core.middleware import require_valid_session
 from app.database import get_db_connection
@@ -320,7 +322,7 @@ async def ensure_colombia_payroll(conn, tenant_id: UUID) -> None:
         )
 
 
-async def require_colombia_payroll_capability(request) -> None:
+async def require_colombia_payroll_capability(request: Request) -> None:
     session = require_valid_session(request)
     if not session.tenant_id:
         raise APIError("Tenant ID is required", status_code=401)
@@ -346,7 +348,7 @@ async def ensure_matias_dian(conn, tenant_id: UUID) -> None:
         )
 
 
-async def require_matias_dian_capability(request) -> None:
+async def require_matias_dian_capability(request: Request) -> None:
     session = require_valid_session(request)
     if not session.tenant_id:
         raise APIError("Tenant ID is required", status_code=401)

--- a/tests/test_account_role_resolution.py
+++ b/tests/test_account_role_resolution.py
@@ -151,6 +151,39 @@ async def test_matias_dian_gate_allows_colombia_profile():
     conn.fetchval.assert_awaited_once()
 
 
+def test_capability_deps_request_annotation_avoids_fastapi_query_422():
+    """Bare `request` is treated as a required query param → 422 (#725)."""
+    from fastapi import Depends, FastAPI, Request
+    from fastapi.testclient import TestClient
+
+    async def untyped_request_dep(request):
+        return None
+
+    async def typed_request_dep(request: Request):
+        return None
+
+    app = FastAPI()
+
+    @app.get("/untyped", dependencies=[Depends(untyped_request_dep)])
+    async def untyped_route():
+        return {"ok": True}
+
+    @app.get("/typed", dependencies=[Depends(typed_request_dep)])
+    async def typed_route():
+        return {"ok": True}
+
+    client = TestClient(app)
+    bad = client.get("/untyped")
+    assert bad.status_code == 422
+    assert any(
+        err.get("loc") == ["query", "request"] for err in bad.json().get("detail", [])
+    )
+
+    good = client.get("/typed")
+    assert good.status_code == 200
+    assert good.json() == {"ok": True}
+
+
 @pytest.mark.asyncio
 async def test_global_pl_does_not_query_or_include_colombia_payroll():
     conn = MagicMock()


### PR DESCRIPTION
## Summary
- Annotate `request: Request` on `require_matias_dian_capability` and `require_colombia_payroll_capability`
- Stops FastAPI 422 (`query.request` Field required) on DIAN GETs and all `/api/salaries/*` routes
- Adds regression test for untyped vs typed Request dependency

Closes #725

## Test plan
- [ ] Facturación: dian-resolutions / gaps-summary / facturacion-status no longer 422
- [ ] Equipo → Salarios: `/api/salaries/employees`, `/pila`, `/pila/pending` no longer 422
- [ ] Non-CO tenant still gets 409 capability codes when gates apply

## Validation evidence
```text
./venv/bin/pytest tests/test_account_role_resolution.py -q

============================= test session starts ==============================
collected 10 items
tests/test_account_role_resolution.py ..........                         [100%]
============================== 10 passed in 0.05s ==============================
```

## wr-context
See `.wr/725.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)