### PR TITLE
feat(tax): hospitality tax_lines engine (Closes warocol.com#1845)

### DIFF
--- a/.wr/1845.yaml
+++ b/.wr/1845.yaml
@@ -1,0 +1,45 @@
+# Machine contract for wr-exec — keep ≤80 lines.
+issue: 1845
+title: "Hospitality tax — API tax-line engine + product category map"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-1845-tax-line-engine
+parent: 1843
+
+paths:
+  - app/services/orders_service.py
+  - app/services/pos_cart_service.py
+  - app/services/cierre_service.py
+  - app/services/tip_tax_service.py
+  - app/services/account_role_service.py
+  - app/models/tax_config.py
+  - app/models/product.py
+  - app/routers/tenant_config.py
+  - tests/test_tip_tax_service.py
+
+ac:
+  - Shared engine: tax_lines[] (key, label, rate, included_in_price, gl) + category→line map
+  - CO adapter: existing tenant_tax_config INC/IVA/liquor columns → same numeric results
+  - POS cart + orders_service._compute_tax_breakdown + cierre GL use one path
+  - Resale/venta directa unchanged (same product.tax_category field)
+  - Non-CO commercial: resolve ≥1 standard line + exempt (0)
+  - Pytest evidence in PR; Closes #1845
+
+out_of_scope:
+  - Front Facturación/Menú presets UI (#1846)
+  - Wave-1 country pack seeds (#1847)
+  - US/CA jurisdiction table (#1848)
+  - FE / DIAN / CFDI
+  - DROP of INC/IVA columns (ADD-only; adapter/compat OK)
+
+hints:
+  entry: "orders_service._compute_tax_breakdown:274; cierre _post_order_gl_entry tax block:410-451; pos_cart complete ~2588; tip_tax_service.compute_tip_tax_amount"
+  pattern: "Extract shared hospitality_tax_engine; CO pack = map inc|iva|liquor columns → tax_lines; category standard→primary, liquor→liquor line, exempt→none. JSONB on tenant_tax_config OK for v1 (epic open #1)."
+  migrate: "Prefer ADD jsonb tax_lines/category_map columns or resolve-at-read adapter; never DROP/ALTER destructive"
+  tests: "./venv/bin/pytest tests/test_tip_tax_service.py tests/test_<new_tax_engine>.py -q — cover CO INC extractive, IVA additive, liquor additive, exempt, commercial 1-line"
+  risks: "Duplicated calc in pos_cart + orders + cierre + tip; keep GL resolve_tax_account (inc|iva|liquor) via line gl_role; API response shape for front may still expose CO fields until #1846"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/models/product.py
+++ b/app/models/product.py
@@ -89,7 +89,12 @@ class ProductBase(BaseModel):
         description="When true, POS may send a custom unit_price (venta libre); at most one per tenant",
     )
     allow_modifiers: bool = Field(True, description="Whether product allows modifiers")
-    tax_category: Literal['standard', 'liquor', 'exempt'] = Field("standard", description="Tax classification: standard (INC/IVA), liquor (IVA licores 5%), exempt (no tax)")
+    tax_category: Literal['standard', 'liquor', 'exempt'] = Field(
+        "standard",
+        description="Tax classification mapped via tenant category_map → tax_lines "
+        "(CO default: standard→INC/IVA, liquor→liquor line, exempt→none). "
+        "Same field for POS and venta directa.",
+    )
     station_id: Optional[UUID] = None
     kitchen_name: Optional[str] = Field(None, max_length=100)
     image_url: Optional[str] = Field(None, max_length=500, description="Public URL of the product hero image (Cloudflare R2)")

--- a/app/models/tax_config.py
+++ b/app/models/tax_config.py
@@ -1,9 +1,9 @@
 """Pydantic v2 models for tenant tax configuration."""
 from decimal import Decimal
 from datetime import datetime
-from typing import Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class TaxConfigResponse(BaseModel):
@@ -25,6 +25,14 @@ class TaxConfigResponse(BaseModel):
     liquor_tax_rate: Decimal
     liquor_tax_gl_account_code: str
     liquor_tax_gl_account_id: Optional[UUID] = None
+    tax_lines: Optional[List[Dict[str, Any]]] = Field(
+        default=None,
+        description="Optional profile tax_lines[]; when null, INC/IVA/liquor columns adapt",
+    )
+    category_map: Optional[Dict[str, Optional[str]]] = Field(
+        default=None,
+        description="Optional product tax_category → tax line key",
+    )
     created_at: datetime
     updated_at: datetime
 
@@ -38,3 +46,5 @@ class TaxConfigUpdate(BaseModel):
     inc_gl_account_id: Optional[UUID] = None
     iva_gl_account_id: Optional[UUID] = None
     liquor_tax_gl_account_id: Optional[UUID] = None
+    tax_lines: Optional[List[Dict[str, Any]]] = None
+    category_map: Optional[Dict[str, Optional[str]]] = None

--- a/app/services/account_role_service.py
+++ b/app/services/account_role_service.py
@@ -60,6 +60,7 @@ PAYMENT_ROLE_BY_SLUG = {
 }
 
 _TAX_BINDINGS = {
+    # gl_role on tax_lines maps to these kinds (hospitality_tax_engine).
     "inc": ("inc_gl_account_id", "inc_gl_account_code", AccountRole.INC_PAYABLE),
     "iva": ("iva_gl_account_id", "iva_gl_account_code", AccountRole.IVA_PAYABLE),
     "liquor": (

--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -85,17 +85,14 @@ def _tip_gl_amounts(
     Return (settlement_debit, net_tip_revenue, tip_tax_credit) for GL posting.
     Mirrors additive vs extractive tip tax from tenant_tax_config.
     """
+    from app.services.hospitality_tax_engine import tip_tax_is_additive
+
     tip_amt = Decimal(str(tip_amount or 0))
     tip_tax = Decimal(str(tip_tax_amount or 0))
     if tip_amt <= 0 and tip_tax <= 0:
         return Decimal("0"), Decimal("0"), Decimal("0")
 
-    tip_tax_additive = False
-    if tip_tax > 0:
-        if tax_config.get("inc_applicable"):
-            tip_tax_additive = not tax_config.get("inc_included_in_price", True)
-        elif tax_config.get("iva_applicable"):
-            tip_tax_additive = not tax_config.get("iva_included_in_price", False)
+    tip_tax_additive = tip_tax > 0 and tip_tax_is_additive(tax_config)
 
     if tip_tax_additive:
         settlement = tip_amt + tip_tax
@@ -112,11 +109,9 @@ async def _resolve_standard_tax_account_id(
     tax_config: Dict[str, Any],
 ) -> Optional[UUID]:
     """Resolve INC/IVA credit account for standard (non-liquor) tax, including tip tax."""
-    tax_kind = None
-    if tax_config.get("inc_applicable"):
-        tax_kind = "inc"
-    elif tax_config.get("iva_applicable"):
-        tax_kind = "iva"
+    from app.services.hospitality_tax_engine import primary_gl_role
+
+    tax_kind = primary_gl_role(tax_config)
     if not tax_kind:
         return None
     account = await resolve_tax_account(
@@ -136,7 +131,8 @@ async def _get_tenant_tax_config(conn, tenant_id: UUID) -> Dict[str, Any]:
                   liquor_tax_applicable, liquor_tax_rate,
                   liquor_tax_gl_account_code, liquor_tax_gl_account_id,
                   iva_applicable, iva_rate, iva_gl_account_code, iva_gl_account_id,
-                  iva_included_in_price
+                  iva_included_in_price,
+                  tax_lines, category_map
            FROM tenant_tax_config WHERE tenant_id = $1""",
         tenant_id,
     )
@@ -157,6 +153,8 @@ async def _get_tenant_tax_config(conn, tenant_id: UUID) -> Dict[str, Any]:
         "iva_gl_account_code":        None,
         "iva_gl_account_id":          None,
         "iva_included_in_price":      False,
+        "tax_lines":                  None,
+        "category_map":               None,
     }
 
 
@@ -222,18 +220,25 @@ async def _post_cierre_gl_entry(
         conn, tenant_id, AccountRole.SALES_REVENUE, source="cierre"
     )
 
-    # Determine tax split
+    # Determine tax split (primary standard line; extractive on total_sales)
+    from app.services.hospitality_tax_engine import resolve_tax_profile, tax_amount_decimal
+
     tax_amount = Decimal("0")
     tax_acct_id = None
-    if tax_config.get("inc_applicable"):
-        rate = Decimal(str(tax_config["inc_rate"]))
-        tax_amount = total_sales - (total_sales / (1 + rate))
-        tax_account = await resolve_tax_account(conn, tenant_id, tax_config, "inc")
-        tax_acct_id = tax_account.id if tax_account else None
-    elif tax_config.get("iva_applicable"):
-        rate = Decimal(str(tax_config["iva_rate"]))
-        tax_amount = total_sales - (total_sales / (1 + rate))
-        tax_account = await resolve_tax_account(conn, tenant_id, tax_config, "iva")
+    primary = resolve_tax_profile(tax_config).primary_line()
+    if primary and total_sales > 0:
+        # Cierre summary historically treats the period total as extractive on the
+        # primary rate (included-in-price style), matching pre-engine INC/IVA posts.
+        extractive_line = primary
+        if not primary.included_in_price:
+            # Keep legacy cierre behavior: always extract from total_sales.
+            from dataclasses import replace
+
+            extractive_line = replace(primary, included_in_price=True)
+        tax_amount, _ = tax_amount_decimal(total_sales, extractive_line)
+        tax_account = await resolve_tax_account(
+            conn, tenant_id, tax_config, primary.gl_role,
+        )
         tax_acct_id = tax_account.id if tax_account else None
 
     net_income = total_sales - tax_amount
@@ -407,39 +412,28 @@ async def _post_order_gl_entry(
     if not order_items:
         standard_subtotal = total_amount
 
-    # ── Calculate taxes per category ──────────────────────────────────────
-    standard_tax     = Decimal("0")
-    liquor_tax       = Decimal("0")
+    # ── Calculate taxes per category (profile-driven tax_lines) ───────────
+    from app.services.hospitality_tax_engine import compute_gl_category_taxes
+
+    tax_result = compute_gl_category_taxes(
+        standard_subtotal, liquor_subtotal, tax_config,
+    )
+    standard_tax = tax_result["standard_tax"]
+    liquor_tax = tax_result["liquor_tax"]
+    standard_is_additive = tax_result["standard_is_additive"]
     standard_acct_id = None
-    liquor_acct_id   = None
-    standard_is_additive = False
+    liquor_acct_id = None
 
-    if tax_config.get("inc_applicable") and standard_subtotal > 0:
-        rate = Decimal(str(tax_config["inc_rate"]))
-        if tax_config.get("inc_included_in_price", True):
-            # Extractive: price already includes INC
-            standard_tax = standard_subtotal - (standard_subtotal / (1 + rate))
-        else:
-            # Additive: INC charged on top of base price
-            standard_tax = standard_subtotal * rate
-            standard_is_additive = True
-        tax_account = await resolve_tax_account(conn, tenant_id, tax_config, "inc")
+    if tax_result["standard_gl_role"] and standard_tax > 0:
+        tax_account = await resolve_tax_account(
+            conn, tenant_id, tax_config, tax_result["standard_gl_role"],
+        )
         standard_acct_id = tax_account.id if tax_account else None
 
-    elif tax_config.get("iva_applicable") and standard_subtotal > 0:
-        rate = Decimal(str(tax_config["iva_rate"]))
-        if tax_config.get("iva_included_in_price", False):
-            standard_tax = standard_subtotal - (standard_subtotal / (1 + rate))
-        else:
-            standard_tax = standard_subtotal * rate
-            standard_is_additive = True
-        tax_account = await resolve_tax_account(conn, tenant_id, tax_config, "iva")
-        standard_acct_id = tax_account.id if tax_account else None
-
-    if tax_config.get("liquor_tax_applicable") and liquor_subtotal > 0:
-        rate = Decimal(str(tax_config["liquor_tax_rate"]))
-        liquor_tax = liquor_subtotal * rate  # IVA licores — always additive (external VAT)
-        tax_account = await resolve_tax_account(conn, tenant_id, tax_config, "liquor")
+    if tax_result["liquor_gl_role"] and liquor_tax > 0:
+        tax_account = await resolve_tax_account(
+            conn, tenant_id, tax_config, tax_result["liquor_gl_role"],
+        )
         liquor_acct_id = tax_account.id if tax_account else None
 
     # ── Compute debit_total and net_revenue ───────────────────────────────

--- a/app/services/hospitality_tax_engine.py
+++ b/app/services/hospitality_tax_engine.py
@@ -1,0 +1,253 @@
+"""Profile-driven hospitality tax lines for POS, orders, cierre, and tips.
+
+Resolves tenant_tax_config into tax_lines[] + category→line map. Colombia's
+INC/IVA/liquor columns adapt into the same shape so numeric results stay stable.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+import json
+
+
+@dataclass(frozen=True)
+class TaxLine:
+    key: str
+    label: str
+    rate: float
+    included_in_price: bool
+    gl_role: str  # resolve_tax_account kind: inc | iva | liquor
+    gl_account_id: Any = None
+    gl_account_code: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class TaxProfile:
+    lines: Dict[str, TaxLine]
+    category_map: Dict[str, Optional[str]]
+
+    def line_for_category(self, category: str) -> Optional[TaxLine]:
+        key = self.category_map.get(category or "standard")
+        if not key:
+            return None
+        return self.lines.get(key)
+
+    def primary_line(self) -> Optional[TaxLine]:
+        return self.line_for_category("standard")
+
+
+def _as_mapping_list(raw: Any) -> List[Mapping[str, Any]]:
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        raw = json.loads(raw)
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, Mapping)]
+
+
+def _as_category_map(raw: Any) -> Dict[str, Optional[str]]:
+    if raw is None:
+        return {}
+    if isinstance(raw, str):
+        raw = json.loads(raw)
+    if not isinstance(raw, Mapping):
+        return {}
+    out: Dict[str, Optional[str]] = {}
+    for key, value in raw.items():
+        out[str(key)] = None if value in (None, "", "null") else str(value)
+    return out
+
+
+def _line_from_mapping(item: Mapping[str, Any]) -> Optional[TaxLine]:
+    key = str(item.get("key") or "").strip()
+    if not key:
+        return None
+    rate = float(item.get("rate") or 0)
+    label = str(item.get("label") or key)
+    included = bool(item.get("included_in_price", False))
+    gl_role = str(item.get("gl_role") or "iva")
+    return TaxLine(
+        key=key,
+        label=label,
+        rate=rate,
+        included_in_price=included,
+        gl_role=gl_role,
+        gl_account_id=item.get("gl_account_id"),
+        gl_account_code=item.get("gl_account_code"),
+    )
+
+
+def _profile_from_co_columns(tax_config: Mapping[str, Any]) -> TaxProfile:
+    lines: Dict[str, TaxLine] = {}
+    category_map: Dict[str, Optional[str]] = {
+        "standard": None,
+        "liquor": None,
+        "exempt": None,
+    }
+
+    if tax_config.get("inc_applicable"):
+        rate = float(tax_config.get("inc_rate") or 0)
+        lines["inc"] = TaxLine(
+            key="inc",
+            label=f"INC {round(rate * 100)}%",
+            rate=rate,
+            included_in_price=bool(tax_config.get("inc_included_in_price", True)),
+            gl_role="inc",
+            gl_account_id=tax_config.get("inc_gl_account_id"),
+            gl_account_code=tax_config.get("inc_gl_account_code"),
+        )
+        category_map["standard"] = "inc"
+    elif tax_config.get("iva_applicable"):
+        rate = float(tax_config.get("iva_rate") or 0)
+        lines["iva"] = TaxLine(
+            key="iva",
+            label=f"IVA {round(rate * 100)}%",
+            rate=rate,
+            included_in_price=bool(tax_config.get("iva_included_in_price", False)),
+            gl_role="iva",
+            gl_account_id=tax_config.get("iva_gl_account_id"),
+            gl_account_code=tax_config.get("iva_gl_account_code"),
+        )
+        category_map["standard"] = "iva"
+
+    if tax_config.get("liquor_tax_applicable"):
+        rate = float(tax_config.get("liquor_tax_rate") or 0.05)
+        lines["liquor"] = TaxLine(
+            key="liquor",
+            label="IVA licores 5%" if abs(rate - 0.05) < 1e-9 else f"IVA licores {round(rate * 100)}%",
+            rate=rate,
+            included_in_price=False,  # CO liquor tax is always additive
+            gl_role="liquor",
+            gl_account_id=tax_config.get("liquor_tax_gl_account_id"),
+            gl_account_code=tax_config.get("liquor_tax_gl_account_code"),
+        )
+        category_map["liquor"] = "liquor"
+
+    return TaxProfile(lines=lines, category_map=category_map)
+
+
+def resolve_tax_profile(tax_config: Mapping[str, Any]) -> TaxProfile:
+    """Build a TaxProfile from explicit tax_lines or CO column adapter."""
+    raw_lines = _as_mapping_list(tax_config.get("tax_lines"))
+    if raw_lines:
+        lines: Dict[str, TaxLine] = {}
+        for item in raw_lines:
+            line = _line_from_mapping(item)
+            if line:
+                lines[line.key] = line
+        category_map = _as_category_map(tax_config.get("category_map"))
+        if not category_map:
+            # Default commercial map: standard → first line; liquor → same; exempt → none
+            first_key = next(iter(lines), None)
+            category_map = {
+                "standard": first_key,
+                "liquor": first_key,
+                "exempt": None,
+            }
+        else:
+            category_map.setdefault("exempt", None)
+            category_map.setdefault("standard", next(iter(lines), None))
+            category_map.setdefault("liquor", category_map.get("standard"))
+        return TaxProfile(lines=lines, category_map=category_map)
+
+    return _profile_from_co_columns(tax_config)
+
+
+def tax_amount_float(base: float, line: TaxLine) -> float:
+    """POS/orders/tip style: whole-unit round after formula."""
+    amount = float(base or 0)
+    if amount <= 0 or line.rate <= 0:
+        return 0.0
+    if line.included_in_price:
+        return float(round(amount * line.rate / (1 + line.rate)))
+    return float(round(amount * line.rate))
+
+
+def tax_amount_decimal(base: Decimal, line: TaxLine) -> Tuple[Decimal, bool]:
+    """GL style: Decimal extractive/additive without intermediate float round.
+
+    Returns (tax_amount, is_additive).
+    """
+    amount = Decimal(str(base or 0))
+    rate = Decimal(str(line.rate or 0))
+    if amount <= 0 or rate <= 0:
+        return Decimal("0"), False
+    if line.included_in_price:
+        return amount - (amount / (1 + rate)), False
+    return amount * rate, True
+
+
+def compute_category_breakdown(
+    items_rows: Sequence[Any],
+    tax_config: Mapping[str, Any],
+) -> Tuple[float, float, str]:
+    """Compat wrapper: (standard_tax, liquor_tax, standard_tax_label)."""
+    profile = resolve_tax_profile(tax_config)
+
+    def _subtotal(category: str) -> float:
+        total = 0.0
+        for row in items_rows:
+            cat = row["tax_category"] if hasattr(row, "__getitem__") else "standard"
+            if cat == category:
+                total += float(row["subtotal"])
+        return total
+
+    std_base = _subtotal("standard")
+    liq_base = _subtotal("liquor")
+
+    std_line = profile.line_for_category("standard")
+    liq_line = profile.line_for_category("liquor")
+
+    standard_tax = tax_amount_float(std_base, std_line) if std_line and std_base > 0 else 0.0
+    liquor_tax = tax_amount_float(liq_base, liq_line) if liq_line and liq_base > 0 else 0.0
+    label = std_line.label if std_line else "Impuesto"
+    return float(standard_tax), float(liquor_tax), label
+
+
+def compute_gl_category_taxes(
+    standard_subtotal: Decimal,
+    liquor_subtotal: Decimal,
+    tax_config: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """GL amounts for standard + liquor categories (cierre order post)."""
+    profile = resolve_tax_profile(tax_config)
+    std_line = profile.line_for_category("standard")
+    liq_line = profile.line_for_category("liquor")
+
+    standard_tax = Decimal("0")
+    liquor_tax = Decimal("0")
+    standard_is_additive = False
+    standard_gl_role: Optional[str] = None
+    liquor_gl_role: Optional[str] = None
+
+    if std_line and standard_subtotal > 0:
+        standard_tax, standard_is_additive = tax_amount_decimal(standard_subtotal, std_line)
+        standard_gl_role = std_line.gl_role
+
+    if liq_line and liquor_subtotal > 0:
+        liquor_tax, _ = tax_amount_decimal(liquor_subtotal, liq_line)
+        liquor_gl_role = liq_line.gl_role
+
+    return {
+        "standard_tax": standard_tax,
+        "liquor_tax": liquor_tax,
+        "standard_is_additive": standard_is_additive,
+        "standard_gl_role": standard_gl_role,
+        "liquor_gl_role": liquor_gl_role,
+        "primary_line": profile.primary_line(),
+        "profile": profile,
+    }
+
+
+def tip_tax_is_additive(tax_config: Mapping[str, Any]) -> bool:
+    line = resolve_tax_profile(tax_config).primary_line()
+    if not line:
+        return False
+    return not line.included_in_price
+
+
+def primary_gl_role(tax_config: Mapping[str, Any]) -> Optional[str]:
+    line = resolve_tax_profile(tax_config).primary_line()
+    return line.gl_role if line else None

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -284,33 +284,9 @@ def _compute_tax_breakdown(
 
     Returns: (standard_tax: float, liquor_tax: float, standard_tax_label: str)
     """
-    std_subtotal = sum(float(r['subtotal']) for r in items_rows if r['tax_category'] == 'standard')
-    liq_subtotal = sum(float(r['subtotal']) for r in items_rows if r['tax_category'] == 'liquor')
+    from app.services.hospitality_tax_engine import compute_category_breakdown
 
-    standard_tax = 0.0
-    liquor_tax = 0.0
-    standard_tax_label = "Impuesto"
-
-    if tax_config.get('inc_applicable') and std_subtotal > 0:
-        rate = float(tax_config['inc_rate'])
-        if tax_config.get('inc_included_in_price'):
-            standard_tax = round(std_subtotal * rate / (1 + rate))
-        else:
-            standard_tax = round(std_subtotal * rate)
-        standard_tax_label = f"INC {round(rate * 100)}%"
-    elif tax_config.get('iva_applicable') and std_subtotal > 0:
-        rate = float(tax_config['iva_rate'])
-        if tax_config.get('iva_included_in_price'):
-            standard_tax = round(std_subtotal * rate / (1 + rate))
-        else:
-            standard_tax = round(std_subtotal * rate)
-        standard_tax_label = f"IVA {round(rate * 100)}%"
-
-    if tax_config.get('liquor_tax_applicable') and liq_subtotal > 0:
-        liq_rate = float(tax_config.get('liquor_tax_rate') or 0.05)
-        liquor_tax = round(liq_subtotal * liq_rate)
-
-    return float(standard_tax), float(liquor_tax), standard_tax_label
+    return compute_category_breakdown(items_rows, tax_config)
 
 
 def _row_get(row: Any, key: str, default: Any = None) -> Any:
@@ -344,6 +320,7 @@ def _tax_detail_rows(
     standard_tax: float,
     liquor_tax: float,
     standard_tax_label: str,
+    tax_config: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     std_base = sum(float(r["subtotal"]) for r in items_rows if r["tax_category"] == "standard")
     liq_base = sum(float(r["subtotal"]) for r in items_rows if r["tax_category"] == "liquor")
@@ -351,7 +328,14 @@ def _tax_detail_rows(
     if standard_tax > 0:
         rows.append({"label": standard_tax_label, "base": std_base, "amount": standard_tax})
     if liquor_tax > 0:
-        rows.append({"label": "IVA licores 5%", "base": liq_base, "amount": liquor_tax})
+        liquor_label = "IVA licores 5%"
+        if tax_config is not None:
+            from app.services.hospitality_tax_engine import resolve_tax_profile
+
+            liq_line = resolve_tax_profile(tax_config).line_for_category("liquor")
+            if liq_line:
+                liquor_label = liq_line.label
+        rows.append({"label": liquor_label, "base": liq_base, "amount": liquor_tax})
     return rows
 
 
@@ -4334,7 +4318,7 @@ async def send_invoice_email(
         else 0.0
     )
 
-    tax_details = _tax_detail_rows(items_for_tax, std_tax, liq_tax, tax_label)
+    tax_details = _tax_detail_rows(items_for_tax, std_tax, liq_tax, tax_label, tax_config)
     invoice_presentation = None
     if include_invoice:
         invoice_presentation = _build_invoice_presentation(

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -2569,11 +2569,13 @@ async def complete_pos_order(
                     except Exception as e:
                         logger.error(f"COGS GL entry failed for POS order {order_id}: {e}")
 
-                # Compute tax breakdown for receipt display
+                # Compute tax breakdown for receipt display (same engine as cart/orders)
                 _standard_tax = 0.0
                 _liquor_tax = 0.0
                 _standard_tax_label = "Impuesto"
                 try:
+                    from app.services.orders_service import _compute_tax_breakdown
+
                     items_tax_rows = await conn.fetch(
                         """SELECT COALESCE(p.tax_category, 'standard') AS tax_category,
                                   COALESCE(oi.subtotal, 0) AS subtotal
@@ -2582,29 +2584,9 @@ async def complete_pos_order(
                            WHERE oi.order_id = $1""",
                         order_id
                     )
-                    std_subtotal = sum(float(r['subtotal']) for r in items_tax_rows if r['tax_category'] == 'standard')
-                    liq_subtotal = sum(float(r['subtotal']) for r in items_tax_rows if r['tax_category'] == 'liquor')
-
-                    if tax_config.get('inc_applicable') and std_subtotal > 0:
-                        rate = float(tax_config['inc_rate'])
-                        if tax_config.get('inc_included_in_price'):
-                            _standard_tax = round(std_subtotal * rate / (1 + rate))
-                        else:
-                            _standard_tax = round(std_subtotal * rate)
-                        pct = round(rate * 100)
-                        _standard_tax_label = f"INC {pct}%"
-                    elif tax_config.get('iva_applicable') and std_subtotal > 0:
-                        rate = float(tax_config['iva_rate'])
-                        if tax_config.get('iva_included_in_price'):
-                            _standard_tax = round(std_subtotal * rate / (1 + rate))
-                        else:
-                            _standard_tax = round(std_subtotal * rate)
-                        pct = round(rate * 100)
-                        _standard_tax_label = f"IVA {pct}%"
-
-                    if tax_config.get('liquor_tax_applicable') and liq_subtotal > 0:
-                        liq_rate = float(tax_config.get('liquor_tax_rate') or 0.05)
-                        _liquor_tax = round(liq_subtotal * liq_rate)
+                    _standard_tax, _liquor_tax, _standard_tax_label = _compute_tax_breakdown(
+                        items_tax_rows, tax_config,
+                    )
                 except Exception as e:
                     logger.warning(f"Tax breakdown computation failed for order {order_id}: {e}")
 

--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -708,9 +708,10 @@ async def update_tax_config(request: Request, data) -> dict:
                     inc_applicable, inc_included_in_price,
                     iva_applicable, iva_included_in_price,
                     liquor_tax_applicable,
-                    inc_gl_account_id, iva_gl_account_id, liquor_tax_gl_account_id
+                    inc_gl_account_id, iva_gl_account_id, liquor_tax_gl_account_id,
+                    tax_lines, category_map
                 )
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb)
                 ON CONFLICT (tenant_id) DO UPDATE SET
                     inc_applicable        = EXCLUDED.inc_applicable,
                     inc_included_in_price = EXCLUDED.inc_included_in_price,
@@ -720,6 +721,8 @@ async def update_tax_config(request: Request, data) -> dict:
                     inc_gl_account_id = COALESCE(EXCLUDED.inc_gl_account_id, tenant_tax_config.inc_gl_account_id),
                     iva_gl_account_id = COALESCE(EXCLUDED.iva_gl_account_id, tenant_tax_config.iva_gl_account_id),
                     liquor_tax_gl_account_id = COALESCE(EXCLUDED.liquor_tax_gl_account_id, tenant_tax_config.liquor_tax_gl_account_id),
+                    tax_lines = COALESCE(EXCLUDED.tax_lines, tenant_tax_config.tax_lines),
+                    category_map = COALESCE(EXCLUDED.category_map, tenant_tax_config.category_map),
                     updated_at            = NOW()
                 RETURNING *
                 """,
@@ -732,6 +735,8 @@ async def update_tax_config(request: Request, data) -> dict:
                 data.inc_gl_account_id,
                 data.iva_gl_account_id,
                 data.liquor_tax_gl_account_id,
+                json.dumps(data.tax_lines) if getattr(data, "tax_lines", None) is not None else None,
+                json.dumps(data.category_map) if getattr(data, "category_map", None) is not None else None,
             )
 
             return {"success": True, "data": dict(row)}

--- a/app/services/tip_tax_service.py
+++ b/app/services/tip_tax_service.py
@@ -38,18 +38,12 @@ def compute_tip_tax_amount(
     """Return tax on tip in COP (whole pesos). Zero when not taxable or no tip."""
     if not tip_taxable or float(tip_amount or 0) <= 0:
         return 0.0
-    amount = float(tip_amount)
-    if tax_config.get("inc_applicable"):
-        rate = float(tax_config["inc_rate"])
-        if tax_config.get("inc_included_in_price"):
-            return float(round(amount * rate / (1 + rate)))
-        return float(round(amount * rate))
-    if tax_config.get("iva_applicable"):
-        rate = float(tax_config["iva_rate"])
-        if tax_config.get("iva_included_in_price"):
-            return float(round(amount * rate / (1 + rate)))
-        return float(round(amount * rate))
-    return 0.0
+    from app.services.hospitality_tax_engine import resolve_tax_profile, tax_amount_float
+
+    line = resolve_tax_profile(tax_config).primary_line()
+    if not line:
+        return 0.0
+    return tax_amount_float(float(tip_amount), line)
 
 
 def tip_settlement_total(tip_amount: float, tip_tax_amount: float) -> float:

--- a/migrations/118_tenant_tax_lines.sql
+++ b/migrations/118_tenant_tax_lines.sql
@@ -1,0 +1,17 @@
+-- Issue warocol.com#1845: profile-driven tax_lines + category map.
+-- ADD-only: nullable JSONB; CO INC/IVA/liquor columns remain source of truth
+-- until packs write explicit lines (wave-1 / commercial).
+
+ALTER TABLE tenant_tax_config
+    ADD COLUMN IF NOT EXISTS tax_lines jsonb;
+
+ALTER TABLE tenant_tax_config
+    ADD COLUMN IF NOT EXISTS category_map jsonb;
+
+COMMENT ON COLUMN tenant_tax_config.tax_lines IS
+    'Optional hospitality tax_lines[]: {key, label, rate, included_in_price, gl_role, ...}. '
+    'When null, engine adapts INC/IVA/liquor columns.';
+
+COMMENT ON COLUMN tenant_tax_config.category_map IS
+    'Optional product tax_category → tax line key (standard/liquor/exempt). '
+    'When null with tax_lines, engine defaults standard+liquor→first line, exempt→null.';

--- a/tests/test_hospitality_tax_engine.py
+++ b/tests/test_hospitality_tax_engine.py
@@ -1,0 +1,108 @@
+"""Hospitality tax engine — warocol.com#1845."""
+from decimal import Decimal
+
+from app.services.hospitality_tax_engine import (
+    compute_category_breakdown,
+    compute_gl_category_taxes,
+    resolve_tax_profile,
+    tax_amount_float,
+)
+
+
+def _inc_config(*, included: bool = True, rate: float = 0.08):
+    return {
+        "inc_applicable": True,
+        "inc_rate": rate,
+        "inc_included_in_price": included,
+        "iva_applicable": False,
+        "liquor_tax_applicable": False,
+    }
+
+
+def _iva_config(*, included: bool = False, rate: float = 0.19):
+    return {
+        "inc_applicable": False,
+        "iva_applicable": True,
+        "iva_rate": rate,
+        "iva_included_in_price": included,
+        "liquor_tax_applicable": False,
+    }
+
+
+def _co_full():
+    return {
+        "inc_applicable": True,
+        "inc_rate": 0.08,
+        "inc_included_in_price": True,
+        "iva_applicable": False,
+        "liquor_tax_applicable": True,
+        "liquor_tax_rate": 0.05,
+    }
+
+
+def test_co_inc_extractive_matches_legacy_round():
+    rows = [{"tax_category": "standard", "subtotal": 10800}]
+    std, liq, label = compute_category_breakdown(rows, _inc_config(included=True))
+    assert std == 800.0
+    assert liq == 0.0
+    assert label == "INC 8%"
+
+
+def test_co_iva_additive():
+    rows = [{"tax_category": "standard", "subtotal": 10000}]
+    std, liq, label = compute_category_breakdown(rows, _iva_config(included=False))
+    assert std == 1900.0
+    assert liq == 0.0
+    assert label == "IVA 19%"
+
+
+def test_co_liquor_additive_and_exempt():
+    rows = [
+        {"tax_category": "standard", "subtotal": 10800},
+        {"tax_category": "liquor", "subtotal": 20000},
+        {"tax_category": "exempt", "subtotal": 5000},
+    ]
+    std, liq, _ = compute_category_breakdown(rows, _co_full())
+    assert std == 800.0
+    assert liq == 1000.0
+
+
+def test_commercial_tax_lines_standard_and_exempt():
+    cfg = {
+        "inc_applicable": False,
+        "iva_applicable": False,
+        "liquor_tax_applicable": False,
+        "tax_lines": [
+            {
+                "key": "itbms",
+                "label": "ITBMS 7%",
+                "rate": 0.07,
+                "included_in_price": False,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "itbms", "liquor": "itbms", "exempt": None},
+    }
+    rows = [
+        {"tax_category": "standard", "subtotal": 10000},
+        {"tax_category": "exempt", "subtotal": 3000},
+    ]
+    std, liq, label = compute_category_breakdown(rows, cfg)
+    assert std == 700.0
+    assert liq == 0.0
+    assert label == "ITBMS 7%"
+    profile = resolve_tax_profile(cfg)
+    assert profile.line_for_category("exempt") is None
+    assert tax_amount_float(10000, profile.primary_line()) == 700.0
+
+
+def test_gl_decimal_inc_extractive():
+    result = compute_gl_category_taxes(
+        Decimal("10800"),
+        Decimal("0"),
+        _inc_config(included=True),
+    )
+    assert result["standard_is_additive"] is False
+    assert result["standard_gl_role"] == "inc"
+    # 10800 - 10800/1.08 = 800
+    assert result["standard_tax"] == Decimal("800")

--- a/tests/test_tip_tax_service.py
+++ b/tests/test_tip_tax_service.py
@@ -33,3 +33,21 @@ def test_split_settlement_includes_tip_tax():
 
 def test_tip_settlement_total():
     assert tip_settlement_total(5_000, 950) == 5_950
+
+
+def test_compute_tip_tax_from_tax_lines():
+    cfg = {
+        "inc_applicable": False,
+        "iva_applicable": False,
+        "tax_lines": [
+            {
+                "key": "gst",
+                "label": "GST 10%",
+                "rate": 0.10,
+                "included_in_price": False,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "gst", "exempt": None},
+    }
+    assert compute_tip_tax_amount(10_000, True, cfg) == 1000.0


### PR DESCRIPTION
## Summary
- Shared `hospitality_tax_engine` resolves `tax_lines[]` + category map; CO INC/IVA/liquor columns adapt without behavior change.
- POS cart, orders breakdown, tip tax, and cierre GL posts use the same path; venta directa keeps `product.tax_category`.
- ADD-only migration `118_tenant_tax_lines.sql` for nullable `tax_lines` / `category_map` JSONB.

Closes uno0uno/warocol.com#1845

## Validation evidence
```text
$ ./venv/bin/pytest tests/test_tip_tax_service.py tests/test_hospitality_tax_engine.py -q
============================= test session starts ==============================
collected 11 items
tests/test_tip_tax_service.py ......                                     [ 54%]
tests/test_hospitality_tax_engine.py .....                               [100%]
============================== 11 passed in 0.05s ==============================
```

## Test plan
- [ ] CO INC extractive + liquor additive receipt/GL unchanged on a CO tenant
- [ ] Commercial tenant with `tax_lines` standard + exempt resolves rates
- [ ] Tip gravada follows primary line included/additive mode
- [ ] Apply migration 118 on staging before deploy


Made with [Cursor](https://cursor.com)