### PR TITLE
feat(tax): US/CA jurisdiction rates (Closes warocol.com#1848)

### DIFF
--- a/.wr/1845.yaml
+++ b/.wr/1845.yaml
@@ -1,0 +1,45 @@
+# Machine contract for wr-exec — keep ≤80 lines.
+issue: 1845
+title: "Hospitality tax — API tax-line engine + product category map"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-1845-tax-line-engine
+parent: 1843
+
+paths:
+  - app/services/orders_service.py
+  - app/services/pos_cart_service.py
+  - app/services/cierre_service.py
+  - app/services/tip_tax_service.py
+  - app/services/account_role_service.py
+  - app/models/tax_config.py
+  - app/models/product.py
+  - app/routers/tenant_config.py
+  - tests/test_tip_tax_service.py
+
+ac:
+  - Shared engine: tax_lines[] (key, label, rate, included_in_price, gl) + category→line map
+  - CO adapter: existing tenant_tax_config INC/IVA/liquor columns → same numeric results
+  - POS cart + orders_service._compute_tax_breakdown + cierre GL use one path
+  - Resale/venta directa unchanged (same product.tax_category field)
+  - Non-CO commercial: resolve ≥1 standard line + exempt (0)
+  - Pytest evidence in PR; Closes #1845
+
+out_of_scope:
+  - Front Facturación/Menú presets UI (#1846)
+  - Wave-1 country pack seeds (#1847)
+  - US/CA jurisdiction table (#1848)
+  - FE / DIAN / CFDI
+  - DROP of INC/IVA columns (ADD-only; adapter/compat OK)
+
+hints:
+  entry: "orders_service._compute_tax_breakdown:274; cierre _post_order_gl_entry tax block:410-451; pos_cart complete ~2588; tip_tax_service.compute_tip_tax_amount"
+  pattern: "Extract shared hospitality_tax_engine; CO pack = map inc|iva|liquor columns → tax_lines; category standard→primary, liquor→liquor line, exempt→none. JSONB on tenant_tax_config OK for v1 (epic open #1)."
+  migrate: "Prefer ADD jsonb tax_lines/category_map columns or resolve-at-read adapter; never DROP/ALTER destructive"
+  tests: "./venv/bin/pytest tests/test_tip_tax_service.py tests/test_<new_tax_engine>.py -q — cover CO INC extractive, IVA additive, liquor additive, exempt, commercial 1-line"
+  risks: "Duplicated calc in pos_cart + orders + cierre + tip; keep GL resolve_tax_account (inc|iva|liquor) via line gl_role; API response shape for front may still expose CO fields until #1846"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/models/product.py
+++ b/app/models/product.py
@@ -89,7 +89,12 @@ class ProductBase(BaseModel):
         description="When true, POS may send a custom unit_price (venta libre); at most one per tenant",
     )
     allow_modifiers: bool = Field(True, description="Whether product allows modifiers")
-    tax_category: Literal['standard', 'liquor', 'exempt'] = Field("standard", description="Tax classification: standard (INC/IVA), liquor (IVA licores 5%), exempt (no tax)")
+    tax_category: Literal['standard', 'liquor', 'exempt'] = Field(
+        "standard",
+        description="Tax classification mapped via tenant category_map → tax_lines "
+        "(CO default: standard→INC/IVA, liquor→liquor line, exempt→none). "
+        "Same field for POS and venta directa.",
+    )
     station_id: Optional[UUID] = None
     kitchen_name: Optional[str] = Field(None, max_length=100)
     image_url: Optional[str] = Field(None, max_length=500, description="Public URL of the product hero image (Cloudflare R2)")

--- a/app/models/tax_config.py
+++ b/app/models/tax_config.py
@@ -1,9 +1,9 @@
 """Pydantic v2 models for tenant tax configuration."""
 from decimal import Decimal
 from datetime import datetime
-from typing import Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class TaxConfigResponse(BaseModel):
@@ -25,6 +25,14 @@ class TaxConfigResponse(BaseModel):
     liquor_tax_rate: Decimal
     liquor_tax_gl_account_code: str
     liquor_tax_gl_account_id: Optional[UUID] = None
+    tax_lines: Optional[List[Dict[str, Any]]] = Field(
+        default=None,
+        description="Optional profile tax_lines[]; when null, INC/IVA/liquor columns adapt",
+    )
+    category_map: Optional[Dict[str, Optional[str]]] = Field(
+        default=None,
+        description="Optional product tax_category → tax line key",
+    )
     created_at: datetime
     updated_at: datetime
 
@@ -38,3 +46,5 @@ class TaxConfigUpdate(BaseModel):
     inc_gl_account_id: Optional[UUID] = None
     iva_gl_account_id: Optional[UUID] = None
     liquor_tax_gl_account_id: Optional[UUID] = None
+    tax_lines: Optional[List[Dict[str, Any]]] = None
+    category_map: Optional[Dict[str, Optional[str]]] = None

--- a/app/models/tax_config.py
+++ b/app/models/tax_config.py
@@ -33,6 +33,10 @@ class TaxConfigResponse(BaseModel):
         default=None,
         description="Optional product tax_category → tax line key",
     )
+    tax_jurisdiction_code: Optional[str] = Field(
+        default=None,
+        description="US state or CA province code when country requires jurisdiction",
+    )
     created_at: datetime
     updated_at: datetime
 
@@ -48,3 +52,4 @@ class TaxConfigUpdate(BaseModel):
     liquor_tax_gl_account_id: Optional[UUID] = None
     tax_lines: Optional[List[Dict[str, Any]]] = None
     category_map: Optional[Dict[str, Optional[str]]] = None
+    tax_jurisdiction_code: Optional[str] = None

--- a/app/routers/tenant_config.py
+++ b/app/routers/tenant_config.py
@@ -5,7 +5,7 @@ Authentication required
 from datetime import date as _date
 from uuid import UUID
 from asyncpg.exceptions import UniqueViolationError
-from fastapi import APIRouter, Depends, Request, Body, HTTPException
+from fastapi import APIRouter, Depends, Request, Body, HTTPException, Query
 from fastapi.responses import JSONResponse
 from app.core.permissions import Module, require_module
 from app.services.account_role_service import require_matias_dian_capability
@@ -175,6 +175,18 @@ async def get_tax_config_endpoint(request: Request):
     **Requires authentication**
     """
     return await tenant_config_service.get_tax_config(request)
+
+
+@router.get(
+    "/tax-jurisdictions",
+    dependencies=[Depends(require_module(Module.MI_NEGOCIO))],
+)
+async def get_tax_jurisdictions_endpoint(
+    request: Request,
+    country: str = Query(..., min_length=2, max_length=2),
+):
+    """Static US state / CA province hospitality tax defaults (warocol.com#1848)."""
+    return await tenant_config_service.get_tax_jurisdictions(request, country)
 
 
 @router.put("/tax-config", dependencies=[Depends(require_module(Module.MI_NEGOCIO))])

--- a/app/services/account_role_service.py
+++ b/app/services/account_role_service.py
@@ -60,6 +60,7 @@ PAYMENT_ROLE_BY_SLUG = {
 }
 
 _TAX_BINDINGS = {
+    # gl_role on tax_lines maps to these kinds (hospitality_tax_engine).
     "inc": ("inc_gl_account_id", "inc_gl_account_code", AccountRole.INC_PAYABLE),
     "iva": ("iva_gl_account_id", "iva_gl_account_code", AccountRole.IVA_PAYABLE),
     "liquor": (

--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -85,17 +85,14 @@ def _tip_gl_amounts(
     Return (settlement_debit, net_tip_revenue, tip_tax_credit) for GL posting.
     Mirrors additive vs extractive tip tax from tenant_tax_config.
     """
+    from app.services.hospitality_tax_engine import tip_tax_is_additive
+
     tip_amt = Decimal(str(tip_amount or 0))
     tip_tax = Decimal(str(tip_tax_amount or 0))
     if tip_amt <= 0 and tip_tax <= 0:
         return Decimal("0"), Decimal("0"), Decimal("0")
 
-    tip_tax_additive = False
-    if tip_tax > 0:
-        if tax_config.get("inc_applicable"):
-            tip_tax_additive = not tax_config.get("inc_included_in_price", True)
-        elif tax_config.get("iva_applicable"):
-            tip_tax_additive = not tax_config.get("iva_included_in_price", False)
+    tip_tax_additive = tip_tax > 0 and tip_tax_is_additive(tax_config)
 
     if tip_tax_additive:
         settlement = tip_amt + tip_tax
@@ -112,11 +109,9 @@ async def _resolve_standard_tax_account_id(
     tax_config: Dict[str, Any],
 ) -> Optional[UUID]:
     """Resolve INC/IVA credit account for standard (non-liquor) tax, including tip tax."""
-    tax_kind = None
-    if tax_config.get("inc_applicable"):
-        tax_kind = "inc"
-    elif tax_config.get("iva_applicable"):
-        tax_kind = "iva"
+    from app.services.hospitality_tax_engine import primary_gl_role
+
+    tax_kind = primary_gl_role(tax_config)
     if not tax_kind:
         return None
     account = await resolve_tax_account(
@@ -136,7 +131,8 @@ async def _get_tenant_tax_config(conn, tenant_id: UUID) -> Dict[str, Any]:
                   liquor_tax_applicable, liquor_tax_rate,
                   liquor_tax_gl_account_code, liquor_tax_gl_account_id,
                   iva_applicable, iva_rate, iva_gl_account_code, iva_gl_account_id,
-                  iva_included_in_price
+                  iva_included_in_price,
+                  tax_lines, category_map
            FROM tenant_tax_config WHERE tenant_id = $1""",
         tenant_id,
     )
@@ -157,6 +153,8 @@ async def _get_tenant_tax_config(conn, tenant_id: UUID) -> Dict[str, Any]:
         "iva_gl_account_code":        None,
         "iva_gl_account_id":          None,
         "iva_included_in_price":      False,
+        "tax_lines":                  None,
+        "category_map":               None,
     }
 
 
@@ -222,18 +220,25 @@ async def _post_cierre_gl_entry(
         conn, tenant_id, AccountRole.SALES_REVENUE, source="cierre"
     )
 
-    # Determine tax split
+    # Determine tax split (primary standard line; extractive on total_sales)
+    from app.services.hospitality_tax_engine import resolve_tax_profile, tax_amount_decimal
+
     tax_amount = Decimal("0")
     tax_acct_id = None
-    if tax_config.get("inc_applicable"):
-        rate = Decimal(str(tax_config["inc_rate"]))
-        tax_amount = total_sales - (total_sales / (1 + rate))
-        tax_account = await resolve_tax_account(conn, tenant_id, tax_config, "inc")
-        tax_acct_id = tax_account.id if tax_account else None
-    elif tax_config.get("iva_applicable"):
-        rate = Decimal(str(tax_config["iva_rate"]))
-        tax_amount = total_sales - (total_sales / (1 + rate))
-        tax_account = await resolve_tax_account(conn, tenant_id, tax_config, "iva")
+    primary = resolve_tax_profile(tax_config).primary_line()
+    if primary and total_sales > 0:
+        # Cierre summary historically treats the period total as extractive on the
+        # primary rate (included-in-price style), matching pre-engine INC/IVA posts.
+        extractive_line = primary
+        if not primary.included_in_price:
+            # Keep legacy cierre behavior: always extract from total_sales.
+            from dataclasses import replace
+
+            extractive_line = replace(primary, included_in_price=True)
+        tax_amount, _ = tax_amount_decimal(total_sales, extractive_line)
+        tax_account = await resolve_tax_account(
+            conn, tenant_id, tax_config, primary.gl_role,
+        )
         tax_acct_id = tax_account.id if tax_account else None
 
     net_income = total_sales - tax_amount
@@ -407,39 +412,28 @@ async def _post_order_gl_entry(
     if not order_items:
         standard_subtotal = total_amount
 
-    # ── Calculate taxes per category ──────────────────────────────────────
-    standard_tax     = Decimal("0")
-    liquor_tax       = Decimal("0")
+    # ── Calculate taxes per category (profile-driven tax_lines) ───────────
+    from app.services.hospitality_tax_engine import compute_gl_category_taxes
+
+    tax_result = compute_gl_category_taxes(
+        standard_subtotal, liquor_subtotal, tax_config,
+    )
+    standard_tax = tax_result["standard_tax"]
+    liquor_tax = tax_result["liquor_tax"]
+    standard_is_additive = tax_result["standard_is_additive"]
     standard_acct_id = None
-    liquor_acct_id   = None
-    standard_is_additive = False
+    liquor_acct_id = None
 
-    if tax_config.get("inc_applicable") and standard_subtotal > 0:
-        rate = Decimal(str(tax_config["inc_rate"]))
-        if tax_config.get("inc_included_in_price", True):
-            # Extractive: price already includes INC
-            standard_tax = standard_subtotal - (standard_subtotal / (1 + rate))
-        else:
-            # Additive: INC charged on top of base price
-            standard_tax = standard_subtotal * rate
-            standard_is_additive = True
-        tax_account = await resolve_tax_account(conn, tenant_id, tax_config, "inc")
+    if tax_result["standard_gl_role"] and standard_tax > 0:
+        tax_account = await resolve_tax_account(
+            conn, tenant_id, tax_config, tax_result["standard_gl_role"],
+        )
         standard_acct_id = tax_account.id if tax_account else None
 
-    elif tax_config.get("iva_applicable") and standard_subtotal > 0:
-        rate = Decimal(str(tax_config["iva_rate"]))
-        if tax_config.get("iva_included_in_price", False):
-            standard_tax = standard_subtotal - (standard_subtotal / (1 + rate))
-        else:
-            standard_tax = standard_subtotal * rate
-            standard_is_additive = True
-        tax_account = await resolve_tax_account(conn, tenant_id, tax_config, "iva")
-        standard_acct_id = tax_account.id if tax_account else None
-
-    if tax_config.get("liquor_tax_applicable") and liquor_subtotal > 0:
-        rate = Decimal(str(tax_config["liquor_tax_rate"]))
-        liquor_tax = liquor_subtotal * rate  # IVA licores — always additive (external VAT)
-        tax_account = await resolve_tax_account(conn, tenant_id, tax_config, "liquor")
+    if tax_result["liquor_gl_role"] and liquor_tax > 0:
+        tax_account = await resolve_tax_account(
+            conn, tenant_id, tax_config, tax_result["liquor_gl_role"],
+        )
         liquor_acct_id = tax_account.id if tax_account else None
 
     # ── Compute debit_total and net_revenue ───────────────────────────────

--- a/app/services/hospitality_tax_engine.py
+++ b/app/services/hospitality_tax_engine.py
@@ -1,0 +1,253 @@
+"""Profile-driven hospitality tax lines for POS, orders, cierre, and tips.
+
+Resolves tenant_tax_config into tax_lines[] + category→line map. Colombia's
+INC/IVA/liquor columns adapt into the same shape so numeric results stay stable.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+import json
+
+
+@dataclass(frozen=True)
+class TaxLine:
+    key: str
+    label: str
+    rate: float
+    included_in_price: bool
+    gl_role: str  # resolve_tax_account kind: inc | iva | liquor
+    gl_account_id: Any = None
+    gl_account_code: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class TaxProfile:
+    lines: Dict[str, TaxLine]
+    category_map: Dict[str, Optional[str]]
+
+    def line_for_category(self, category: str) -> Optional[TaxLine]:
+        key = self.category_map.get(category or "standard")
+        if not key:
+            return None
+        return self.lines.get(key)
+
+    def primary_line(self) -> Optional[TaxLine]:
+        return self.line_for_category("standard")
+
+
+def _as_mapping_list(raw: Any) -> List[Mapping[str, Any]]:
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        raw = json.loads(raw)
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, Mapping)]
+
+
+def _as_category_map(raw: Any) -> Dict[str, Optional[str]]:
+    if raw is None:
+        return {}
+    if isinstance(raw, str):
+        raw = json.loads(raw)
+    if not isinstance(raw, Mapping):
+        return {}
+    out: Dict[str, Optional[str]] = {}
+    for key, value in raw.items():
+        out[str(key)] = None if value in (None, "", "null") else str(value)
+    return out
+
+
+def _line_from_mapping(item: Mapping[str, Any]) -> Optional[TaxLine]:
+    key = str(item.get("key") or "").strip()
+    if not key:
+        return None
+    rate = float(item.get("rate") or 0)
+    label = str(item.get("label") or key)
+    included = bool(item.get("included_in_price", False))
+    gl_role = str(item.get("gl_role") or "iva")
+    return TaxLine(
+        key=key,
+        label=label,
+        rate=rate,
+        included_in_price=included,
+        gl_role=gl_role,
+        gl_account_id=item.get("gl_account_id"),
+        gl_account_code=item.get("gl_account_code"),
+    )
+
+
+def _profile_from_co_columns(tax_config: Mapping[str, Any]) -> TaxProfile:
+    lines: Dict[str, TaxLine] = {}
+    category_map: Dict[str, Optional[str]] = {
+        "standard": None,
+        "liquor": None,
+        "exempt": None,
+    }
+
+    if tax_config.get("inc_applicable"):
+        rate = float(tax_config.get("inc_rate") or 0)
+        lines["inc"] = TaxLine(
+            key="inc",
+            label=f"INC {round(rate * 100)}%",
+            rate=rate,
+            included_in_price=bool(tax_config.get("inc_included_in_price", True)),
+            gl_role="inc",
+            gl_account_id=tax_config.get("inc_gl_account_id"),
+            gl_account_code=tax_config.get("inc_gl_account_code"),
+        )
+        category_map["standard"] = "inc"
+    elif tax_config.get("iva_applicable"):
+        rate = float(tax_config.get("iva_rate") or 0)
+        lines["iva"] = TaxLine(
+            key="iva",
+            label=f"IVA {round(rate * 100)}%",
+            rate=rate,
+            included_in_price=bool(tax_config.get("iva_included_in_price", False)),
+            gl_role="iva",
+            gl_account_id=tax_config.get("iva_gl_account_id"),
+            gl_account_code=tax_config.get("iva_gl_account_code"),
+        )
+        category_map["standard"] = "iva"
+
+    if tax_config.get("liquor_tax_applicable"):
+        rate = float(tax_config.get("liquor_tax_rate") or 0.05)
+        lines["liquor"] = TaxLine(
+            key="liquor",
+            label="IVA licores 5%" if abs(rate - 0.05) < 1e-9 else f"IVA licores {round(rate * 100)}%",
+            rate=rate,
+            included_in_price=False,  # CO liquor tax is always additive
+            gl_role="liquor",
+            gl_account_id=tax_config.get("liquor_tax_gl_account_id"),
+            gl_account_code=tax_config.get("liquor_tax_gl_account_code"),
+        )
+        category_map["liquor"] = "liquor"
+
+    return TaxProfile(lines=lines, category_map=category_map)
+
+
+def resolve_tax_profile(tax_config: Mapping[str, Any]) -> TaxProfile:
+    """Build a TaxProfile from explicit tax_lines or CO column adapter."""
+    raw_lines = _as_mapping_list(tax_config.get("tax_lines"))
+    if raw_lines:
+        lines: Dict[str, TaxLine] = {}
+        for item in raw_lines:
+            line = _line_from_mapping(item)
+            if line:
+                lines[line.key] = line
+        category_map = _as_category_map(tax_config.get("category_map"))
+        if not category_map:
+            # Default commercial map: standard → first line; liquor → same; exempt → none
+            first_key = next(iter(lines), None)
+            category_map = {
+                "standard": first_key,
+                "liquor": first_key,
+                "exempt": None,
+            }
+        else:
+            category_map.setdefault("exempt", None)
+            category_map.setdefault("standard", next(iter(lines), None))
+            category_map.setdefault("liquor", category_map.get("standard"))
+        return TaxProfile(lines=lines, category_map=category_map)
+
+    return _profile_from_co_columns(tax_config)
+
+
+def tax_amount_float(base: float, line: TaxLine) -> float:
+    """POS/orders/tip style: whole-unit round after formula."""
+    amount = float(base or 0)
+    if amount <= 0 or line.rate <= 0:
+        return 0.0
+    if line.included_in_price:
+        return float(round(amount * line.rate / (1 + line.rate)))
+    return float(round(amount * line.rate))
+
+
+def tax_amount_decimal(base: Decimal, line: TaxLine) -> Tuple[Decimal, bool]:
+    """GL style: Decimal extractive/additive without intermediate float round.
+
+    Returns (tax_amount, is_additive).
+    """
+    amount = Decimal(str(base or 0))
+    rate = Decimal(str(line.rate or 0))
+    if amount <= 0 or rate <= 0:
+        return Decimal("0"), False
+    if line.included_in_price:
+        return amount - (amount / (1 + rate)), False
+    return amount * rate, True
+
+
+def compute_category_breakdown(
+    items_rows: Sequence[Any],
+    tax_config: Mapping[str, Any],
+) -> Tuple[float, float, str]:
+    """Compat wrapper: (standard_tax, liquor_tax, standard_tax_label)."""
+    profile = resolve_tax_profile(tax_config)
+
+    def _subtotal(category: str) -> float:
+        total = 0.0
+        for row in items_rows:
+            cat = row["tax_category"] if hasattr(row, "__getitem__") else "standard"
+            if cat == category:
+                total += float(row["subtotal"])
+        return total
+
+    std_base = _subtotal("standard")
+    liq_base = _subtotal("liquor")
+
+    std_line = profile.line_for_category("standard")
+    liq_line = profile.line_for_category("liquor")
+
+    standard_tax = tax_amount_float(std_base, std_line) if std_line and std_base > 0 else 0.0
+    liquor_tax = tax_amount_float(liq_base, liq_line) if liq_line and liq_base > 0 else 0.0
+    label = std_line.label if std_line else "Impuesto"
+    return float(standard_tax), float(liquor_tax), label
+
+
+def compute_gl_category_taxes(
+    standard_subtotal: Decimal,
+    liquor_subtotal: Decimal,
+    tax_config: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """GL amounts for standard + liquor categories (cierre order post)."""
+    profile = resolve_tax_profile(tax_config)
+    std_line = profile.line_for_category("standard")
+    liq_line = profile.line_for_category("liquor")
+
+    standard_tax = Decimal("0")
+    liquor_tax = Decimal("0")
+    standard_is_additive = False
+    standard_gl_role: Optional[str] = None
+    liquor_gl_role: Optional[str] = None
+
+    if std_line and standard_subtotal > 0:
+        standard_tax, standard_is_additive = tax_amount_decimal(standard_subtotal, std_line)
+        standard_gl_role = std_line.gl_role
+
+    if liq_line and liquor_subtotal > 0:
+        liquor_tax, _ = tax_amount_decimal(liquor_subtotal, liq_line)
+        liquor_gl_role = liq_line.gl_role
+
+    return {
+        "standard_tax": standard_tax,
+        "liquor_tax": liquor_tax,
+        "standard_is_additive": standard_is_additive,
+        "standard_gl_role": standard_gl_role,
+        "liquor_gl_role": liquor_gl_role,
+        "primary_line": profile.primary_line(),
+        "profile": profile,
+    }
+
+
+def tip_tax_is_additive(tax_config: Mapping[str, Any]) -> bool:
+    line = resolve_tax_profile(tax_config).primary_line()
+    if not line:
+        return False
+    return not line.included_in_price
+
+
+def primary_gl_role(tax_config: Mapping[str, Any]) -> Optional[str]:
+    line = resolve_tax_profile(tax_config).primary_line()
+    return line.gl_role if line else None

--- a/app/services/hospitality_tax_jurisdictions.py
+++ b/app/services/hospitality_tax_jurisdictions.py
@@ -1,0 +1,277 @@
+"""US/CA hospitality tax jurisdiction seeds — warocol.com#1848.
+
+Static reference defaults (state/province only). Not legal advice.
+City/local meal taxes are out of v1.
+
+CA GST+PST/QST provinces use a combined effective rate line so the existing
+hospitality_tax_engine (one line per category) can compute POS/cierre.
+Regime metadata distinguishes HST vs GST vs GST+PST for AC/tests.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+JURISDICTION_COUNTRIES = frozenset({"US", "CA"})
+
+
+def _line(
+    key: str,
+    label: str,
+    rate: float,
+    *,
+    included_in_price: bool = False,
+    gl_role: str = "iva",
+) -> Dict[str, Any]:
+    return {
+        "key": key,
+        "label": label,
+        "rate": rate,
+        "included_in_price": included_in_price,
+        "gl_role": gl_role,
+    }
+
+
+def _pack(
+    *,
+    code: str,
+    label: str,
+    regime: str,
+    lines: List[Dict[str, Any]],
+    map_key: Optional[str] = None,
+    components: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    primary = map_key or (lines[0]["key"] if lines else None)
+    return {
+        "code": code,
+        "label": label,
+        "regime": regime,
+        "tax_lines": lines,
+        "components": list(components or []),
+        "category_map": {
+            "standard": primary,
+            "liquor": primary,
+            "exempt": None,
+        },
+    }
+
+
+# Representative combined state-level defaults for hospitality (v1).
+# Rates intentionally differ across states so AC (TX ≠ OR) is testable.
+US_STATE_TAX_DEFAULTS: Dict[str, Dict[str, Any]] = {
+    "AL": _pack(code="AL", label="Alabama", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 9%", 0.09)]),
+    "AK": _pack(code="AK", label="Alaska", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 0%", 0.0)]),
+    "AZ": _pack(code="AZ", label="Arizona", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 8.1%", 0.081)]),
+    "AR": _pack(code="AR", label="Arkansas", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 9.5%", 0.095)]),
+    "CA": _pack(code="CA", label="California", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 8.7%", 0.087)]),
+    "CO": _pack(code="CO", label="Colorado", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 7.8%", 0.078)]),
+    "CT": _pack(code="CT", label="Connecticut", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 6.35%", 0.0635)]),
+    "DE": _pack(code="DE", label="Delaware", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 0%", 0.0)]),
+    "DC": _pack(code="DC", label="District of Columbia", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 10%", 0.10)]),
+    "FL": _pack(code="FL", label="Florida", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 7%", 0.07)]),
+    "GA": _pack(code="GA", label="Georgia", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 7.3%", 0.073)]),
+    "HI": _pack(code="HI", label="Hawaii", regime="sales_tax", lines=[_line("sales_tax", "GET 4.5%", 0.045)]),
+    "ID": _pack(code="ID", label="Idaho", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 6%", 0.06)]),
+    "IL": _pack(code="IL", label="Illinois", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 8.8%", 0.088)]),
+    "IN": _pack(code="IN", label="Indiana", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 7%", 0.07)]),
+    "IA": _pack(code="IA", label="Iowa", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 7%", 0.07)]),
+    "KS": _pack(code="KS", label="Kansas", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 8.7%", 0.087)]),
+    "KY": _pack(code="KY", label="Kentucky", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 6%", 0.06)]),
+    "LA": _pack(code="LA", label="Louisiana", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 9.5%", 0.095)]),
+    "ME": _pack(code="ME", label="Maine", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 5.5%", 0.055)]),
+    "MD": _pack(code="MD", label="Maryland", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 6%", 0.06)]),
+    "MA": _pack(code="MA", label="Massachusetts", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 6.25%", 0.0625)]),
+    "MI": _pack(code="MI", label="Michigan", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 6%", 0.06)]),
+    "MN": _pack(code="MN", label="Minnesota", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 7.4%", 0.074)]),
+    "MS": _pack(code="MS", label="Mississippi", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 7%", 0.07)]),
+    "MO": _pack(code="MO", label="Missouri", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 8.3%", 0.083)]),
+    "MT": _pack(code="MT", label="Montana", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 0%", 0.0)]),
+    "NE": _pack(code="NE", label="Nebraska", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 6.9%", 0.069)]),
+    "NV": _pack(code="NV", label="Nevada", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 8.2%", 0.082)]),
+    "NH": _pack(code="NH", label="New Hampshire", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 0%", 0.0)]),
+    "NJ": _pack(code="NJ", label="New Jersey", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 6.625%", 0.06625)]),
+    "NM": _pack(code="NM", label="New Mexico", regime="sales_tax", lines=[_line("sales_tax", "GRT 7.8%", 0.078)]),
+    "NY": _pack(code="NY", label="New York", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 8.5%", 0.085)]),
+    "NC": _pack(code="NC", label="North Carolina", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 7%", 0.07)]),
+    "ND": _pack(code="ND", label="North Dakota", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 7%", 0.07)]),
+    "OH": _pack(code="OH", label="Ohio", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 7.2%", 0.072)]),
+    "OK": _pack(code="OK", label="Oklahoma", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 8.9%", 0.089)]),
+    "OR": _pack(code="OR", label="Oregon", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 0%", 0.0)]),
+    "PA": _pack(code="PA", label="Pennsylvania", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 6%", 0.06)]),
+    "RI": _pack(code="RI", label="Rhode Island", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 7%", 0.07)]),
+    "SC": _pack(code="SC", label="South Carolina", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 7.5%", 0.075)]),
+    "SD": _pack(code="SD", label="South Dakota", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 6.4%", 0.064)]),
+    "TN": _pack(code="TN", label="Tennessee", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 9.5%", 0.095)]),
+    "TX": _pack(code="TX", label="Texas", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 8.25%", 0.0825)]),
+    "UT": _pack(code="UT", label="Utah", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 7.2%", 0.072)]),
+    "VT": _pack(code="VT", label="Vermont", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 6.4%", 0.064)]),
+    "VA": _pack(code="VA", label="Virginia", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 5.8%", 0.058)]),
+    "WA": _pack(code="WA", label="Washington", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 9.4%", 0.094)]),
+    "WV": _pack(code="WV", label="West Virginia", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 6.5%", 0.065)]),
+    "WI": _pack(code="WI", label="Wisconsin", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 5.5%", 0.055)]),
+    "WY": _pack(code="WY", label="Wyoming", regime="sales_tax", lines=[_line("sales_tax", "Sales tax 5.4%", 0.054)]),
+}
+
+
+def _ca_hst(code: str, label: str, rate: float) -> Dict[str, Any]:
+    pct = round(rate * 100)
+    return _pack(
+        code=code,
+        label=label,
+        regime="hst",
+        lines=[_line("hst", f"HST {pct}%", rate)],
+    )
+
+
+def _ca_gst(code: str, label: str) -> Dict[str, Any]:
+    return _pack(
+        code=code,
+        label=label,
+        regime="gst",
+        lines=[_line("gst", "GST 5%", 0.05)],
+    )
+
+
+def _ca_gst_pst(
+    code: str,
+    label: str,
+    pst_rate: float,
+    *,
+    pst_key: str = "pst",
+    pst_name: str = "PST",
+) -> Dict[str, Any]:
+    """Combined effective GST+PST/QST for single-line engine mapping."""
+    combined = round(0.05 + pst_rate, 6)
+    pst_pct = round(pst_rate * 1000) / 10
+    combined_pct = round(combined * 1000) / 10
+    components = [
+        _line("gst", "GST 5%", 0.05),
+        _line(pst_key, f"{pst_name} {pst_pct}%", pst_rate),
+    ]
+    return _pack(
+        code=code,
+        label=label,
+        regime="gst_pst",
+        lines=[
+            _line(
+                "gst_pst",
+                f"GST+{pst_name} {combined_pct}%",
+                combined,
+            )
+        ],
+        map_key="gst_pst",
+        components=components,
+    )
+
+
+CA_PROVINCE_TAX_DEFAULTS: Dict[str, Dict[str, Any]] = {
+    "ON": _ca_hst("ON", "Ontario", 0.13),
+    "NB": _ca_hst("NB", "New Brunswick", 0.15),
+    "NL": _ca_hst("NL", "Newfoundland and Labrador", 0.15),
+    "NS": _ca_hst("NS", "Nova Scotia", 0.15),
+    "PE": _ca_hst("PE", "Prince Edward Island", 0.15),
+    "AB": _ca_gst("AB", "Alberta"),
+    "YT": _ca_gst("YT", "Yukon"),
+    "NT": _ca_gst("NT", "Northwest Territories"),
+    "NU": _ca_gst("NU", "Nunavut"),
+    "BC": _ca_gst_pst("BC", "British Columbia", 0.07),
+    "SK": _ca_gst_pst("SK", "Saskatchewan", 0.06),
+    "MB": _ca_gst_pst("MB", "Manitoba", 0.07),
+    "QC": _ca_gst_pst("QC", "Quebec", 0.09975, pst_key="qst", pst_name="QST"),
+}
+
+
+def jurisdiction_pack(country_code: str, jurisdiction_code: str) -> Optional[Dict[str, Any]]:
+    country = str(country_code or "").upper()
+    code = str(jurisdiction_code or "").upper()
+    if not code:
+        return None
+    if country == "US":
+        return US_STATE_TAX_DEFAULTS.get(code)
+    if country == "CA":
+        return CA_PROVINCE_TAX_DEFAULTS.get(code)
+    return None
+
+
+def list_jurisdictions(country_code: str) -> List[Dict[str, Any]]:
+    country = str(country_code or "").upper()
+    source = US_STATE_TAX_DEFAULTS if country == "US" else (
+        CA_PROVINCE_TAX_DEFAULTS if country == "CA" else {}
+    )
+    out: List[Dict[str, Any]] = []
+    for pack in source.values():
+        primary_key = pack["category_map"].get("standard")
+        primary = next(
+            (line for line in pack["tax_lines"] if line["key"] == primary_key),
+            pack["tax_lines"][0] if pack["tax_lines"] else None,
+        )
+        out.append(
+            {
+                "code": pack["code"],
+                "label": pack["label"],
+                "regime": pack["regime"],
+                "rate": primary["rate"] if primary else 0,
+                "lines": list(pack["tax_lines"]),
+                "components": list(pack.get("components") or []),
+            }
+        )
+    return sorted(out, key=lambda item: item["code"])
+
+
+def tax_config_from_jurisdiction_pack(pack: Mapping[str, Any]) -> Dict[str, Any]:
+    return {
+        "inc_applicable": False,
+        "iva_applicable": False,
+        "liquor_tax_applicable": False,
+        "tax_lines": list(pack["tax_lines"]),
+        "category_map": dict(pack["category_map"]),
+        "tax_jurisdiction_code": pack.get("code"),
+    }
+
+
+def normalize_jurisdiction_code(
+    country_code: str, jurisdiction_code: Optional[str]
+) -> Optional[str]:
+    if jurisdiction_code is None or str(jurisdiction_code).strip() == "":
+        return None
+    code = str(jurisdiction_code).strip().upper()
+    pack = jurisdiction_pack(country_code, code)
+    if not pack:
+        raise ValueError(f"Unsupported jurisdiction {code} for {country_code}")
+    return code
+
+
+async def apply_jurisdiction_pack(
+    conn,
+    tenant_id,
+    country_code: str,
+    jurisdiction_code: str,
+) -> Tuple[bool, Optional[Dict[str, Any]]]:
+    """Write jurisdiction + tax_lines/category_map from static pack.
+
+    Always updates on explicit jurisdiction save (user intent).
+    """
+    pack = jurisdiction_pack(country_code, jurisdiction_code)
+    if not pack:
+        return False, None
+
+    await conn.execute(
+        "INSERT INTO tenant_tax_config (tenant_id) VALUES ($1) ON CONFLICT DO NOTHING",
+        tenant_id,
+    )
+    row = await conn.fetchrow(
+        """
+        UPDATE tenant_tax_config
+        SET tax_jurisdiction_code = $2,
+            tax_lines = $3::jsonb,
+            category_map = $4::jsonb,
+            updated_at = NOW()
+        WHERE tenant_id = $1
+        RETURNING *
+        """,
+        tenant_id,
+        pack["code"],
+        json.dumps(pack["tax_lines"]),
+        json.dumps(pack["category_map"]),
+    )
+    return True, dict(row) if row else None

--- a/app/services/hospitality_tax_packs.py
+++ b/app/services/hospitality_tax_packs.py
@@ -1,0 +1,165 @@
+"""Wave-1 hospitality tax pack seeds — warocol.com#1847.
+
+Rates match front_nuxt/composables/useTenantTaxProfile.ts WAVE1_TAX_PRESETS.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Mapping, Optional
+
+WAVE1_COUNTRY_CODES = frozenset({"PA", "CL", "DO", "UY", "AU", "NZ", "SG", "AE"})
+
+WAVE1_TAX_PACKS: Dict[str, Dict[str, Any]] = {
+    "PA": {
+        "tax_lines": [
+            {
+                "key": "itbms",
+                "label": "ITBMS 7%",
+                "rate": 0.07,
+                "included_in_price": False,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "itbms", "liquor": "itbms", "exempt": None},
+    },
+    "CL": {
+        "tax_lines": [
+            {
+                "key": "iva",
+                "label": "IVA 19%",
+                "rate": 0.19,
+                "included_in_price": False,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "iva", "liquor": "iva", "exempt": None},
+    },
+    "DO": {
+        "tax_lines": [
+            {
+                "key": "itbis",
+                "label": "ITBIS 18%",
+                "rate": 0.18,
+                "included_in_price": False,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "itbis", "liquor": "itbis", "exempt": None},
+    },
+    "UY": {
+        "tax_lines": [
+            {
+                "key": "iva",
+                "label": "IVA 22%",
+                "rate": 0.22,
+                "included_in_price": False,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "iva", "liquor": "iva", "exempt": None},
+    },
+    "AU": {
+        "tax_lines": [
+            {
+                "key": "gst",
+                "label": "GST 10%",
+                "rate": 0.10,
+                "included_in_price": True,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "gst", "liquor": "gst", "exempt": None},
+    },
+    "NZ": {
+        "tax_lines": [
+            {
+                "key": "gst",
+                "label": "GST 15%",
+                "rate": 0.15,
+                "included_in_price": True,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "gst", "liquor": "gst", "exempt": None},
+    },
+    "SG": {
+        "tax_lines": [
+            {
+                "key": "gst",
+                "label": "GST 9%",
+                "rate": 0.09,
+                "included_in_price": True,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "gst", "liquor": "gst", "exempt": None},
+    },
+    "AE": {
+        "tax_lines": [
+            {
+                "key": "vat",
+                "label": "VAT 5%",
+                "rate": 0.05,
+                "included_in_price": False,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "vat", "liquor": "vat", "exempt": None},
+    },
+}
+
+
+def wave1_pack_for_country(country_code: str) -> Optional[Dict[str, Any]]:
+    code = str(country_code or "").upper()
+    if code == "CO" or code not in WAVE1_COUNTRY_CODES:
+        return None
+    return WAVE1_TAX_PACKS.get(code)
+
+
+def tax_config_from_wave1_pack(pack: Mapping[str, Any]) -> Dict[str, Any]:
+    """Build a tenant_tax_config-shaped dict for the hospitality tax engine."""
+    return {
+        "inc_applicable": False,
+        "iva_applicable": False,
+        "liquor_tax_applicable": False,
+        "tax_lines": list(pack["tax_lines"]),
+        "category_map": dict(pack["category_map"]),
+    }
+
+
+async def ensure_wave1_tax_pack(conn, tenant_id, country_code: str) -> bool:
+    """Write wave-1 pack when tax_lines is unset. Never overwrites existing lines."""
+    pack = wave1_pack_for_country(country_code)
+    if not pack:
+        return False
+
+    row = await conn.fetchrow(
+        "SELECT tax_lines FROM tenant_tax_config WHERE tenant_id = $1",
+        tenant_id,
+    )
+    if row is None:
+        await conn.execute(
+            "INSERT INTO tenant_tax_config (tenant_id) VALUES ($1) ON CONFLICT DO NOTHING",
+            tenant_id,
+        )
+        row = await conn.fetchrow(
+            "SELECT tax_lines FROM tenant_tax_config WHERE tenant_id = $1",
+            tenant_id,
+        )
+    if row is None or row["tax_lines"] is not None:
+        return False
+
+    result = await conn.execute(
+        """
+        UPDATE tenant_tax_config
+        SET tax_lines = $2::jsonb,
+            category_map = $3::jsonb,
+            updated_at = NOW()
+        WHERE tenant_id = $1
+          AND tax_lines IS NULL
+        """,
+        tenant_id,
+        json.dumps(pack["tax_lines"]),
+        json.dumps(pack["category_map"]),
+    )
+    return result.endswith("1")

--- a/app/services/onboarding_service.py
+++ b/app/services/onboarding_service.py
@@ -19,6 +19,7 @@ from app.models.onboarding import (
 from app.models.tenant_financial_profile import TenantFinancialProfile
 from app.services import legal_service
 from app.services import tenant_financial_profile_service as financial_service
+from app.services.hospitality_tax_packs import ensure_wave1_tax_pack
 
 MAX_EMAIL_REQUESTS = 5
 MAX_IP_REQUESTS = 20
@@ -752,6 +753,7 @@ async def update_onboarding_financial_profile(
         fiscal_provider,
     )
     await financial_service.seed_tenant_accounts(conn, tenant_id)
+    await ensure_wave1_tax_pack(conn, tenant_id, country_code)
     state = await _promote_onboarding_identity(conn, tenant_id)
     result = dict(profile)
     result["business_name"] = data.business_name

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -284,33 +284,9 @@ def _compute_tax_breakdown(
 
     Returns: (standard_tax: float, liquor_tax: float, standard_tax_label: str)
     """
-    std_subtotal = sum(float(r['subtotal']) for r in items_rows if r['tax_category'] == 'standard')
-    liq_subtotal = sum(float(r['subtotal']) for r in items_rows if r['tax_category'] == 'liquor')
+    from app.services.hospitality_tax_engine import compute_category_breakdown
 
-    standard_tax = 0.0
-    liquor_tax = 0.0
-    standard_tax_label = "Impuesto"
-
-    if tax_config.get('inc_applicable') and std_subtotal > 0:
-        rate = float(tax_config['inc_rate'])
-        if tax_config.get('inc_included_in_price'):
-            standard_tax = round(std_subtotal * rate / (1 + rate))
-        else:
-            standard_tax = round(std_subtotal * rate)
-        standard_tax_label = f"INC {round(rate * 100)}%"
-    elif tax_config.get('iva_applicable') and std_subtotal > 0:
-        rate = float(tax_config['iva_rate'])
-        if tax_config.get('iva_included_in_price'):
-            standard_tax = round(std_subtotal * rate / (1 + rate))
-        else:
-            standard_tax = round(std_subtotal * rate)
-        standard_tax_label = f"IVA {round(rate * 100)}%"
-
-    if tax_config.get('liquor_tax_applicable') and liq_subtotal > 0:
-        liq_rate = float(tax_config.get('liquor_tax_rate') or 0.05)
-        liquor_tax = round(liq_subtotal * liq_rate)
-
-    return float(standard_tax), float(liquor_tax), standard_tax_label
+    return compute_category_breakdown(items_rows, tax_config)
 
 
 def _row_get(row: Any, key: str, default: Any = None) -> Any:
@@ -344,6 +320,7 @@ def _tax_detail_rows(
     standard_tax: float,
     liquor_tax: float,
     standard_tax_label: str,
+    tax_config: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     std_base = sum(float(r["subtotal"]) for r in items_rows if r["tax_category"] == "standard")
     liq_base = sum(float(r["subtotal"]) for r in items_rows if r["tax_category"] == "liquor")
@@ -351,7 +328,14 @@ def _tax_detail_rows(
     if standard_tax > 0:
         rows.append({"label": standard_tax_label, "base": std_base, "amount": standard_tax})
     if liquor_tax > 0:
-        rows.append({"label": "IVA licores 5%", "base": liq_base, "amount": liquor_tax})
+        liquor_label = "IVA licores 5%"
+        if tax_config is not None:
+            from app.services.hospitality_tax_engine import resolve_tax_profile
+
+            liq_line = resolve_tax_profile(tax_config).line_for_category("liquor")
+            if liq_line:
+                liquor_label = liq_line.label
+        rows.append({"label": liquor_label, "base": liq_base, "amount": liquor_tax})
     return rows
 
 
@@ -4334,7 +4318,7 @@ async def send_invoice_email(
         else 0.0
     )
 
-    tax_details = _tax_detail_rows(items_for_tax, std_tax, liq_tax, tax_label)
+    tax_details = _tax_detail_rows(items_for_tax, std_tax, liq_tax, tax_label, tax_config)
     invoice_presentation = None
     if include_invoice:
         invoice_presentation = _build_invoice_presentation(

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -2569,11 +2569,13 @@ async def complete_pos_order(
                     except Exception as e:
                         logger.error(f"COGS GL entry failed for POS order {order_id}: {e}")
 
-                # Compute tax breakdown for receipt display
+                # Compute tax breakdown for receipt display (same engine as cart/orders)
                 _standard_tax = 0.0
                 _liquor_tax = 0.0
                 _standard_tax_label = "Impuesto"
                 try:
+                    from app.services.orders_service import _compute_tax_breakdown
+
                     items_tax_rows = await conn.fetch(
                         """SELECT COALESCE(p.tax_category, 'standard') AS tax_category,
                                   COALESCE(oi.subtotal, 0) AS subtotal
@@ -2582,29 +2584,9 @@ async def complete_pos_order(
                            WHERE oi.order_id = $1""",
                         order_id
                     )
-                    std_subtotal = sum(float(r['subtotal']) for r in items_tax_rows if r['tax_category'] == 'standard')
-                    liq_subtotal = sum(float(r['subtotal']) for r in items_tax_rows if r['tax_category'] == 'liquor')
-
-                    if tax_config.get('inc_applicable') and std_subtotal > 0:
-                        rate = float(tax_config['inc_rate'])
-                        if tax_config.get('inc_included_in_price'):
-                            _standard_tax = round(std_subtotal * rate / (1 + rate))
-                        else:
-                            _standard_tax = round(std_subtotal * rate)
-                        pct = round(rate * 100)
-                        _standard_tax_label = f"INC {pct}%"
-                    elif tax_config.get('iva_applicable') and std_subtotal > 0:
-                        rate = float(tax_config['iva_rate'])
-                        if tax_config.get('iva_included_in_price'):
-                            _standard_tax = round(std_subtotal * rate / (1 + rate))
-                        else:
-                            _standard_tax = round(std_subtotal * rate)
-                        pct = round(rate * 100)
-                        _standard_tax_label = f"IVA {pct}%"
-
-                    if tax_config.get('liquor_tax_applicable') and liq_subtotal > 0:
-                        liq_rate = float(tax_config.get('liquor_tax_rate') or 0.05)
-                        _liquor_tax = round(liq_subtotal * liq_rate)
+                    _standard_tax, _liquor_tax, _standard_tax_label = _compute_tax_breakdown(
+                        items_tax_rows, tax_config,
+                    )
                 except Exception as e:
                     logger.warning(f"Tax breakdown computation failed for order {order_id}: {e}")
 

--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -708,9 +708,10 @@ async def update_tax_config(request: Request, data) -> dict:
                     inc_applicable, inc_included_in_price,
                     iva_applicable, iva_included_in_price,
                     liquor_tax_applicable,
-                    inc_gl_account_id, iva_gl_account_id, liquor_tax_gl_account_id
+                    inc_gl_account_id, iva_gl_account_id, liquor_tax_gl_account_id,
+                    tax_lines, category_map
                 )
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb)
                 ON CONFLICT (tenant_id) DO UPDATE SET
                     inc_applicable        = EXCLUDED.inc_applicable,
                     inc_included_in_price = EXCLUDED.inc_included_in_price,
@@ -720,6 +721,8 @@ async def update_tax_config(request: Request, data) -> dict:
                     inc_gl_account_id = COALESCE(EXCLUDED.inc_gl_account_id, tenant_tax_config.inc_gl_account_id),
                     iva_gl_account_id = COALESCE(EXCLUDED.iva_gl_account_id, tenant_tax_config.iva_gl_account_id),
                     liquor_tax_gl_account_id = COALESCE(EXCLUDED.liquor_tax_gl_account_id, tenant_tax_config.liquor_tax_gl_account_id),
+                    tax_lines = COALESCE(EXCLUDED.tax_lines, tenant_tax_config.tax_lines),
+                    category_map = COALESCE(EXCLUDED.category_map, tenant_tax_config.category_map),
                     updated_at            = NOW()
                 RETURNING *
                 """,
@@ -732,6 +735,8 @@ async def update_tax_config(request: Request, data) -> dict:
                 data.inc_gl_account_id,
                 data.iva_gl_account_id,
                 data.liquor_tax_gl_account_id,
+                json.dumps(data.tax_lines) if getattr(data, "tax_lines", None) is not None else None,
+                json.dumps(data.category_map) if getattr(data, "category_map", None) is not None else None,
             )
 
             return {"success": True, "data": dict(row)}

--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -11,6 +11,7 @@ from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError
 from app.core.sales_tax_profile import settings_for_sales_tax_profile
 from app.core.timezones import DEFAULT_TENANT_TIMEZONE, normalize_timezone, validate_timezone
+from app.services.hospitality_tax_packs import ensure_wave1_tax_pack
 from app.core.tenant_prefs import (
     DEFAULT_CURRENCY_CODE,
     DEFAULT_TENANT_LOCALE,
@@ -642,6 +643,20 @@ async def get_tax_config(request: Request) -> dict:
                     "SELECT * FROM tenant_tax_config WHERE tenant_id = $1",
                     tenant_id,
                 )
+
+            profile = await conn.fetchrow(
+                "SELECT country_code FROM tenant_financial_profiles WHERE tenant_id = $1",
+                tenant_id,
+            )
+            if profile and profile.get("country_code"):
+                applied = await ensure_wave1_tax_pack(
+                    conn, tenant_id, profile["country_code"]
+                )
+                if applied:
+                    row = await conn.fetchrow(
+                        "SELECT * FROM tenant_tax_config WHERE tenant_id = $1",
+                        tenant_id,
+                    )
 
             return {"success": True, "data": dict(row)}
 

--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -12,6 +12,12 @@ from app.core.exceptions import AuthenticationError
 from app.core.sales_tax_profile import settings_for_sales_tax_profile
 from app.core.timezones import DEFAULT_TENANT_TIMEZONE, normalize_timezone, validate_timezone
 from app.services.hospitality_tax_packs import ensure_wave1_tax_pack
+from app.services.hospitality_tax_jurisdictions import (
+    JURISDICTION_COUNTRIES,
+    apply_jurisdiction_pack,
+    list_jurisdictions,
+    normalize_jurisdiction_code,
+)
 from app.core.tenant_prefs import (
     DEFAULT_CURRENCY_CODE,
     DEFAULT_TENANT_LOCALE,
@@ -667,6 +673,29 @@ async def get_tax_config(request: Request) -> dict:
         raise HTTPException(status_code=500, detail=f"Error fetching tax config: {str(e)}")
 
 
+async def get_tax_jurisdictions(request: Request, country: str) -> dict:
+    """Return static US state or CA province tax jurisdiction catalog."""
+    try:
+        require_valid_session(request)
+        code = (country or "").strip().upper()
+        if code not in JURISDICTION_COUNTRIES:
+            raise HTTPException(
+                status_code=400,
+                detail="country must be US or CA",
+            )
+        return {"success": True, "data": list_jurisdictions(code)}
+    except AuthenticationError as e:
+        raise e
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error listing tax jurisdictions: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Error listing tax jurisdictions: {str(e)}",
+        )
+
+
 async def update_tax_config(request: Request, data) -> dict:
     """
     Upsert the sale-tax configuration for the active tenant.
@@ -716,6 +745,50 @@ async def update_tax_config(request: Request, data) -> dict:
                     ),
                 )
 
+            profile = await conn.fetchrow(
+                "SELECT country_code FROM tenant_financial_profiles WHERE tenant_id = $1",
+                tenant_id,
+            )
+            country_code = (profile["country_code"] if profile else None) or ""
+            jurisdiction_raw = getattr(data, "tax_jurisdiction_code", None)
+            if (
+                jurisdiction_raw is not None
+                and str(jurisdiction_raw).strip() != ""
+                and country_code.upper() in JURISDICTION_COUNTRIES
+            ):
+                try:
+                    jurisdiction = normalize_jurisdiction_code(
+                        country_code, jurisdiction_raw
+                    )
+                except ValueError as exc:
+                    raise HTTPException(status_code=400, detail=str(exc)) from exc
+                applied, row = await apply_jurisdiction_pack(
+                    conn, tenant_id, country_code, jurisdiction
+                )
+                if not applied or not row:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Could not apply tax jurisdiction pack",
+                    )
+                # Allow commercial rate override on top of jurisdiction seed.
+                if getattr(data, "tax_lines", None) is not None:
+                    row = await conn.fetchrow(
+                        """
+                        UPDATE tenant_tax_config
+                        SET tax_lines = $2::jsonb,
+                            category_map = COALESCE($3::jsonb, category_map),
+                            updated_at = NOW()
+                        WHERE tenant_id = $1
+                        RETURNING *
+                        """,
+                        tenant_id,
+                        json.dumps(data.tax_lines),
+                        json.dumps(data.category_map)
+                        if getattr(data, "category_map", None) is not None
+                        else None,
+                    )
+                return {"success": True, "data": dict(row)}
+
             row = await conn.fetchrow(
                 """
                 INSERT INTO tenant_tax_config (
@@ -724,9 +797,9 @@ async def update_tax_config(request: Request, data) -> dict:
                     iva_applicable, iva_included_in_price,
                     liquor_tax_applicable,
                     inc_gl_account_id, iva_gl_account_id, liquor_tax_gl_account_id,
-                    tax_lines, category_map
+                    tax_lines, category_map, tax_jurisdiction_code
                 )
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb, $12)
                 ON CONFLICT (tenant_id) DO UPDATE SET
                     inc_applicable        = EXCLUDED.inc_applicable,
                     inc_included_in_price = EXCLUDED.inc_included_in_price,
@@ -738,6 +811,10 @@ async def update_tax_config(request: Request, data) -> dict:
                     liquor_tax_gl_account_id = COALESCE(EXCLUDED.liquor_tax_gl_account_id, tenant_tax_config.liquor_tax_gl_account_id),
                     tax_lines = COALESCE(EXCLUDED.tax_lines, tenant_tax_config.tax_lines),
                     category_map = COALESCE(EXCLUDED.category_map, tenant_tax_config.category_map),
+                    tax_jurisdiction_code = COALESCE(
+                        EXCLUDED.tax_jurisdiction_code,
+                        tenant_tax_config.tax_jurisdiction_code
+                    ),
                     updated_at            = NOW()
                 RETURNING *
                 """,
@@ -752,6 +829,7 @@ async def update_tax_config(request: Request, data) -> dict:
                 data.liquor_tax_gl_account_id,
                 json.dumps(data.tax_lines) if getattr(data, "tax_lines", None) is not None else None,
                 json.dumps(data.category_map) if getattr(data, "category_map", None) is not None else None,
+                None,
             )
 
             return {"success": True, "data": dict(row)}

--- a/app/services/tip_tax_service.py
+++ b/app/services/tip_tax_service.py
@@ -38,18 +38,12 @@ def compute_tip_tax_amount(
     """Return tax on tip in COP (whole pesos). Zero when not taxable or no tip."""
     if not tip_taxable or float(tip_amount or 0) <= 0:
         return 0.0
-    amount = float(tip_amount)
-    if tax_config.get("inc_applicable"):
-        rate = float(tax_config["inc_rate"])
-        if tax_config.get("inc_included_in_price"):
-            return float(round(amount * rate / (1 + rate)))
-        return float(round(amount * rate))
-    if tax_config.get("iva_applicable"):
-        rate = float(tax_config["iva_rate"])
-        if tax_config.get("iva_included_in_price"):
-            return float(round(amount * rate / (1 + rate)))
-        return float(round(amount * rate))
-    return 0.0
+    from app.services.hospitality_tax_engine import resolve_tax_profile, tax_amount_float
+
+    line = resolve_tax_profile(tax_config).primary_line()
+    if not line:
+        return 0.0
+    return tax_amount_float(float(tip_amount), line)
 
 
 def tip_settlement_total(tip_amount: float, tip_tax_amount: float) -> float:

--- a/migrations/118_tenant_tax_lines.sql
+++ b/migrations/118_tenant_tax_lines.sql
@@ -1,0 +1,17 @@
+-- Issue warocol.com#1845: profile-driven tax_lines + category map.
+-- ADD-only: nullable JSONB; CO INC/IVA/liquor columns remain source of truth
+-- until packs write explicit lines (wave-1 / commercial).
+
+ALTER TABLE tenant_tax_config
+    ADD COLUMN IF NOT EXISTS tax_lines jsonb;
+
+ALTER TABLE tenant_tax_config
+    ADD COLUMN IF NOT EXISTS category_map jsonb;
+
+COMMENT ON COLUMN tenant_tax_config.tax_lines IS
+    'Optional hospitality tax_lines[]: {key, label, rate, included_in_price, gl_role, ...}. '
+    'When null, engine adapts INC/IVA/liquor columns.';
+
+COMMENT ON COLUMN tenant_tax_config.category_map IS
+    'Optional product tax_category → tax line key (standard/liquor/exempt). '
+    'When null with tax_lines, engine defaults standard+liquor→first line, exempt→null.';

--- a/migrations/119_tax_jurisdiction.sql
+++ b/migrations/119_tax_jurisdiction.sql
@@ -1,0 +1,9 @@
+-- Issue warocol.com#1848: US state / CA province tax jurisdiction.
+-- ADD-only: nullable jurisdiction code next to tax_lines.
+
+ALTER TABLE tenant_tax_config
+    ADD COLUMN IF NOT EXISTS tax_jurisdiction_code VARCHAR(10);
+
+COMMENT ON COLUMN tenant_tax_config.tax_jurisdiction_code IS
+    'US state or CA province/territory code (e.g. TX, ON). '
+    'Null until user selects jurisdiction; drives static tax_lines seed.';

--- a/tests/test_hospitality_tax_engine.py
+++ b/tests/test_hospitality_tax_engine.py
@@ -1,0 +1,108 @@
+"""Hospitality tax engine — warocol.com#1845."""
+from decimal import Decimal
+
+from app.services.hospitality_tax_engine import (
+    compute_category_breakdown,
+    compute_gl_category_taxes,
+    resolve_tax_profile,
+    tax_amount_float,
+)
+
+
+def _inc_config(*, included: bool = True, rate: float = 0.08):
+    return {
+        "inc_applicable": True,
+        "inc_rate": rate,
+        "inc_included_in_price": included,
+        "iva_applicable": False,
+        "liquor_tax_applicable": False,
+    }
+
+
+def _iva_config(*, included: bool = False, rate: float = 0.19):
+    return {
+        "inc_applicable": False,
+        "iva_applicable": True,
+        "iva_rate": rate,
+        "iva_included_in_price": included,
+        "liquor_tax_applicable": False,
+    }
+
+
+def _co_full():
+    return {
+        "inc_applicable": True,
+        "inc_rate": 0.08,
+        "inc_included_in_price": True,
+        "iva_applicable": False,
+        "liquor_tax_applicable": True,
+        "liquor_tax_rate": 0.05,
+    }
+
+
+def test_co_inc_extractive_matches_legacy_round():
+    rows = [{"tax_category": "standard", "subtotal": 10800}]
+    std, liq, label = compute_category_breakdown(rows, _inc_config(included=True))
+    assert std == 800.0
+    assert liq == 0.0
+    assert label == "INC 8%"
+
+
+def test_co_iva_additive():
+    rows = [{"tax_category": "standard", "subtotal": 10000}]
+    std, liq, label = compute_category_breakdown(rows, _iva_config(included=False))
+    assert std == 1900.0
+    assert liq == 0.0
+    assert label == "IVA 19%"
+
+
+def test_co_liquor_additive_and_exempt():
+    rows = [
+        {"tax_category": "standard", "subtotal": 10800},
+        {"tax_category": "liquor", "subtotal": 20000},
+        {"tax_category": "exempt", "subtotal": 5000},
+    ]
+    std, liq, _ = compute_category_breakdown(rows, _co_full())
+    assert std == 800.0
+    assert liq == 1000.0
+
+
+def test_commercial_tax_lines_standard_and_exempt():
+    cfg = {
+        "inc_applicable": False,
+        "iva_applicable": False,
+        "liquor_tax_applicable": False,
+        "tax_lines": [
+            {
+                "key": "itbms",
+                "label": "ITBMS 7%",
+                "rate": 0.07,
+                "included_in_price": False,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "itbms", "liquor": "itbms", "exempt": None},
+    }
+    rows = [
+        {"tax_category": "standard", "subtotal": 10000},
+        {"tax_category": "exempt", "subtotal": 3000},
+    ]
+    std, liq, label = compute_category_breakdown(rows, cfg)
+    assert std == 700.0
+    assert liq == 0.0
+    assert label == "ITBMS 7%"
+    profile = resolve_tax_profile(cfg)
+    assert profile.line_for_category("exempt") is None
+    assert tax_amount_float(10000, profile.primary_line()) == 700.0
+
+
+def test_gl_decimal_inc_extractive():
+    result = compute_gl_category_taxes(
+        Decimal("10800"),
+        Decimal("0"),
+        _inc_config(included=True),
+    )
+    assert result["standard_is_additive"] is False
+    assert result["standard_gl_role"] == "inc"
+    # 10800 - 10800/1.08 = 800
+    assert result["standard_tax"] == Decimal("800")

--- a/tests/test_hospitality_tax_jurisdictions.py
+++ b/tests/test_hospitality_tax_jurisdictions.py
@@ -1,0 +1,115 @@
+"""US/CA hospitality tax jurisdictions — warocol.com#1848."""
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from app.services.hospitality_tax_engine import (
+    compute_category_breakdown,
+    resolve_tax_profile,
+)
+from app.services.hospitality_tax_jurisdictions import (
+    CA_PROVINCE_TAX_DEFAULTS,
+    JURISDICTION_COUNTRIES,
+    US_STATE_TAX_DEFAULTS,
+    apply_jurisdiction_pack,
+    jurisdiction_pack,
+    list_jurisdictions,
+    normalize_jurisdiction_code,
+    tax_config_from_jurisdiction_pack,
+)
+
+
+def test_us_catalog_has_50_states_plus_dc():
+    assert len(US_STATE_TAX_DEFAULTS) == 51
+    assert "TX" in US_STATE_TAX_DEFAULTS
+    assert "OR" in US_STATE_TAX_DEFAULTS
+    assert "DC" in US_STATE_TAX_DEFAULTS
+
+
+def test_ca_catalog_has_13_provinces():
+    assert len(CA_PROVINCE_TAX_DEFAULTS) == 13
+    assert CA_PROVINCE_TAX_DEFAULTS["ON"]["regime"] == "hst"
+    assert CA_PROVINCE_TAX_DEFAULTS["AB"]["regime"] == "gst"
+    assert CA_PROVINCE_TAX_DEFAULTS["BC"]["regime"] == "gst_pst"
+    assert CA_PROVINCE_TAX_DEFAULTS["QC"]["regime"] == "gst_pst"
+
+
+def test_two_us_states_yield_different_rates_same_category():
+    tx = tax_config_from_jurisdiction_pack(US_STATE_TAX_DEFAULTS["TX"])
+    oregon = tax_config_from_jurisdiction_pack(US_STATE_TAX_DEFAULTS["OR"])
+    rows = [{"tax_category": "standard", "subtotal": 10000}]
+    tx_tax, _, _ = compute_category_breakdown(rows, tx)
+    or_tax, _, _ = compute_category_breakdown(rows, oregon)
+    assert tx_tax == 825.0
+    assert or_tax == 0.0
+    assert tx_tax != or_tax
+
+
+def test_ca_province_regimes_switch_behavior():
+    on = tax_config_from_jurisdiction_pack(CA_PROVINCE_TAX_DEFAULTS["ON"])
+    ab = tax_config_from_jurisdiction_pack(CA_PROVINCE_TAX_DEFAULTS["AB"])
+    bc = tax_config_from_jurisdiction_pack(CA_PROVINCE_TAX_DEFAULTS["BC"])
+    rows = [{"tax_category": "standard", "subtotal": 10000}]
+    on_tax, _, on_label = compute_category_breakdown(rows, on)
+    ab_tax, _, ab_label = compute_category_breakdown(rows, ab)
+    bc_tax, _, bc_label = compute_category_breakdown(rows, bc)
+    assert on_tax == 1300.0
+    assert ab_tax == 500.0
+    assert bc_tax == 1200.0
+    assert "HST" in on_label
+    assert "GST" in ab_label and "PST" not in ab_label
+    assert "GST+PST" in bc_label
+    assert CA_PROVINCE_TAX_DEFAULTS["ON"]["regime"] != CA_PROVINCE_TAX_DEFAULTS["BC"]["regime"]
+    assert resolve_tax_profile(bc).line_for_category("exempt") is None
+
+
+def test_list_jurisdictions_and_normalize():
+    us = list_jurisdictions("US")
+    ca = list_jurisdictions("CA")
+    assert len(us) == 51
+    assert len(ca) == 13
+    assert us[0]["code"] < us[-1]["code"]
+    assert normalize_jurisdiction_code("US", " tx ") == "TX"
+    with pytest.raises(ValueError):
+        normalize_jurisdiction_code("US", "ZZ")
+    assert jurisdiction_pack("PA", "TX") is None
+    assert JURISDICTION_COUNTRIES == frozenset({"US", "CA"})
+
+
+def test_migration_is_add_only():
+    sql = Path("migrations/119_tax_jurisdiction.sql").read_text()
+    assert "ADD COLUMN IF NOT EXISTS tax_jurisdiction_code" in sql
+    assert "DROP COLUMN" not in sql.upper()
+    assert "DROP TABLE" not in sql.upper()
+
+
+class _JurisConn:
+    def __init__(self):
+        self.row = {"tax_lines": None, "tax_jurisdiction_code": None}
+        self.queries = []
+
+    async def execute(self, query, *args):
+        self.queries.append((query, args))
+        return "INSERT 0 1"
+
+    async def fetchrow(self, query, *args):
+        self.queries.append((query, args))
+        if "UPDATE tenant_tax_config" in query:
+            self.row = {
+                "tenant_id": args[0],
+                "tax_jurisdiction_code": args[1],
+                "tax_lines": args[2],
+                "category_map": args[3],
+            }
+            return self.row
+        return self.row
+
+
+@pytest.mark.asyncio
+async def test_apply_jurisdiction_pack_writes_code_and_lines():
+    conn = _JurisConn()
+    applied, row = await apply_jurisdiction_pack(conn, uuid4(), "US", "TX")
+    assert applied is True
+    assert row["tax_jurisdiction_code"] == "TX"
+    assert any("UPDATE tenant_tax_config" in q for q, _ in conn.queries)

--- a/tests/test_hospitality_tax_packs.py
+++ b/tests/test_hospitality_tax_packs.py
@@ -1,0 +1,140 @@
+"""Wave-1 hospitality tax packs — warocol.com#1847."""
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from app.services.hospitality_tax_engine import (
+    compute_category_breakdown,
+    resolve_tax_profile,
+    tax_amount_float,
+)
+from app.services.hospitality_tax_packs import (
+    WAVE1_COUNTRY_CODES,
+    WAVE1_TAX_PACKS,
+    ensure_wave1_tax_pack,
+    tax_config_from_wave1_pack,
+    wave1_pack_for_country,
+)
+
+
+@pytest.mark.parametrize("country", sorted(WAVE1_COUNTRY_CODES))
+def test_wave1_pack_exists_for_each_shortlist_country(country):
+    pack = wave1_pack_for_country(country)
+    assert pack is not None
+    assert pack == WAVE1_TAX_PACKS[country]
+    assert len(pack["tax_lines"]) == 1
+    assert pack["category_map"]["exempt"] is None
+
+
+def test_wave1_pack_skips_colombia_and_unknown():
+    assert wave1_pack_for_country("CO") is None
+    assert wave1_pack_for_country("US") is None
+    assert wave1_pack_for_country("") is None
+
+
+@pytest.mark.parametrize(
+    ("country", "subtotal", "expected_tax"),
+    [
+        ("PA", 10000, 700.0),
+        ("CL", 10000, 1900.0),
+        ("DO", 10000, 1800.0),
+        ("UY", 10000, 2200.0),
+        ("AU", 11000, 1000.0),
+        ("NZ", 11500, 1500.0),
+        ("SG", 10900, 900.0),
+        ("AE", 10000, 500.0),
+    ],
+)
+def test_wave1_pack_computes_standard_and_exempt(country, subtotal, expected_tax):
+    cfg = tax_config_from_wave1_pack(WAVE1_TAX_PACKS[country])
+    rows = [
+        {"tax_category": "standard", "subtotal": subtotal},
+        {"tax_category": "exempt", "subtotal": 3000},
+    ]
+    std, liq, _ = compute_category_breakdown(rows, cfg)
+    assert std == expected_tax
+    assert liq == 0.0
+    assert resolve_tax_profile(cfg).line_for_category("exempt") is None
+
+
+def test_wave1_included_gst_uses_extractive_math():
+    cfg = tax_config_from_wave1_pack(WAVE1_TAX_PACKS["AU"])
+    line = resolve_tax_profile(cfg).primary_line()
+    assert line is not None
+    assert line.included_in_price is True
+    assert tax_amount_float(11000, line) == pytest.approx(1000.0)
+
+
+class _PackConn:
+    def __init__(self, *, tax_lines=None, update_affected=1):
+        self.tax_lines = tax_lines
+        self.queries = []
+        self.update_affected = update_affected
+
+    async def fetchrow(self, query, *args):
+        self.queries.append((query, args))
+        if "FROM tenant_tax_config" in query:
+            if self.tax_lines is None and not any(
+                "INSERT INTO tenant_tax_config" in q for q, _ in self.queries
+            ):
+                return None
+            return {"tax_lines": self.tax_lines}
+        raise AssertionError(f"Unexpected query: {query}")
+
+    async def execute(self, query, *args):
+        self.queries.append((query, args))
+        if "INSERT INTO tenant_tax_config" in query:
+            self.tax_lines = None
+            return "INSERT 0 1"
+        if "UPDATE tenant_tax_config" in query:
+            if self.tax_lines is None:
+                self.tax_lines = args[1]
+            return f"UPDATE {self.update_affected}"
+        raise AssertionError(f"Unexpected query: {query}")
+
+
+@pytest.mark.asyncio
+async def test_ensure_wave1_tax_pack_writes_when_missing():
+    tenant_id = uuid4()
+    conn = _PackConn(tax_lines=None)
+    applied = await ensure_wave1_tax_pack(conn, tenant_id, "PA")
+    assert applied is True
+    assert any("UPDATE tenant_tax_config" in q for q, _ in conn.queries)
+
+
+@pytest.mark.asyncio
+async def test_ensure_wave1_tax_pack_skips_colombia():
+    tenant_id = uuid4()
+    conn = _PackConn(tax_lines=None)
+    applied = await ensure_wave1_tax_pack(conn, tenant_id, "CO")
+    assert applied is False
+    assert conn.queries == []
+
+
+@pytest.mark.asyncio
+async def test_ensure_wave1_tax_pack_does_not_overwrite_existing_lines():
+    tenant_id = uuid4()
+    conn = _PackConn(tax_lines=[{"key": "custom"}])
+    applied = await ensure_wave1_tax_pack(conn, tenant_id, "CL")
+    assert applied is False
+    assert not any("UPDATE tenant_tax_config" in q for q, _ in conn.queries)
+
+
+def test_co_adapter_regression_unchanged():
+    cfg = {
+        "inc_applicable": True,
+        "inc_rate": 0.08,
+        "inc_included_in_price": True,
+        "iva_applicable": False,
+        "liquor_tax_applicable": False,
+        "tax_lines": None,
+        "category_map": None,
+    }
+    std, liq, _ = compute_category_breakdown(
+        [{"tax_category": "standard", "subtotal": 10800}],
+        cfg,
+    )
+    assert std == 800.0
+    assert liq == 0.0
+    assert resolve_tax_profile(cfg).primary_line().gl_role == "inc"

--- a/tests/test_tip_tax_service.py
+++ b/tests/test_tip_tax_service.py
@@ -33,3 +33,21 @@ def test_split_settlement_includes_tip_tax():
 
 def test_tip_settlement_total():
     assert tip_settlement_total(5_000, 950) == 5_950
+
+
+def test_compute_tip_tax_from_tax_lines():
+    cfg = {
+        "inc_applicable": False,
+        "iva_applicable": False,
+        "tax_lines": [
+            {
+                "key": "gst",
+                "label": "GST 10%",
+                "rate": 0.10,
+                "included_in_price": False,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "gst", "exempt": None},
+    }
+    assert compute_tip_tax_amount(10_000, True, cfg) == 1000.0


### PR DESCRIPTION
## Summary
- ADD `tax_jurisdiction_code` on `tenant_tax_config` (migration 119).
- Static US state + CA province hospitality rate seeds; apply on PUT tax-config with jurisdiction.
- GET `/tenant/tax-jurisdictions?country=US|CA` catalog for Facturación picker.
- CA regimes: HST / GST / GST+PST (combined effective line for engine).
- City/local meal taxes out of v1 (documented).

## Validation evidence
```
$ ./venv/bin/pytest tests/test_hospitality_tax_jurisdictions.py tests/test_hospitality_tax_engine.py -q
collected 12 items
tests/test_hospitality_tax_jurisdictions.py .......                      [ 58%]
tests/test_hospitality_tax_engine.py .....                               [100%]
============================== 12 passed in 0.08s ==============================
```

## Test plan
- [ ] US TX vs OR → different POS tax for same standard category
- [ ] CA ON (HST) vs BC (GST+PST) vs AB (GST) switch rates/labels
- [ ] PUT without jurisdiction for US does not auto-seed
- [ ] Apply migration 119 on staging before deploy
- [ ] Depends on #1845–#1847 merged first

Closes uno0uno/warocol.com#1848
Companion front: https://github.com/uno0uno/warocol.com/pull/1851