### PR TITLE
feat(tax): Wave 2 simple 1-rate hospitality packs

### DIFF
--- a/app/services/hospitality_tax_packs.py
+++ b/app/services/hospitality_tax_packs.py
@@ -1,6 +1,7 @@
-"""Wave-1 hospitality tax pack seeds — warocol.com#1847.
+"""Hospitality tax pack seeds — wave-1 (#1847) + wave-2 simple (#1862).
 
-Rates match front_nuxt/composables/useTenantTaxProfile.ts WAVE1_TAX_PRESETS.
+Wave-1 rates match front_nuxt/composables/useTenantTaxProfile.ts WAVE1_TAX_PRESETS.
+Wave-2 simple rates: warocol.com#1860 epic research / #1862 delta.
 """
 from __future__ import annotations
 
@@ -8,6 +9,10 @@ import json
 from typing import Any, Dict, Mapping, Optional
 
 WAVE1_COUNTRY_CODES = frozenset({"PA", "CL", "DO", "UY", "AU", "NZ", "SG", "AE"})
+
+WAVE2_SIMPLE_COUNTRY_CODES = frozenset(
+    {"PE", "MX", "CR", "AR", "ES", "FR", "GB", "CN"}
+)
 
 WAVE1_TAX_PACKS: Dict[str, Dict[str, Any]] = {
     "PA": {
@@ -108,12 +113,136 @@ WAVE1_TAX_PACKS: Dict[str, Dict[str, Any]] = {
     },
 }
 
+WAVE2_SIMPLE_TAX_PACKS: Dict[str, Dict[str, Any]] = {
+    "PE": {
+        "tax_lines": [
+            {
+                "key": "igv",
+                "label": "IGV 18%",
+                "rate": 0.18,
+                "included_in_price": False,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "igv", "liquor": "igv", "exempt": None},
+    },
+    "MX": {
+        "tax_lines": [
+            {
+                "key": "iva",
+                "label": "IVA 16%",
+                "rate": 0.16,
+                "included_in_price": False,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "iva", "liquor": "iva", "exempt": None},
+    },
+    "CR": {
+        "tax_lines": [
+            {
+                "key": "iva",
+                "label": "IVA 13%",
+                "rate": 0.13,
+                "included_in_price": False,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "iva", "liquor": "iva", "exempt": None},
+    },
+    "AR": {
+        "tax_lines": [
+            {
+                "key": "iva",
+                "label": "IVA 21%",
+                "rate": 0.21,
+                "included_in_price": False,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "iva", "liquor": "iva", "exempt": None},
+    },
+    "ES": {
+        "tax_lines": [
+            {
+                "key": "iva",
+                "label": "IVA 10%",
+                "rate": 0.10,
+                "included_in_price": False,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "iva", "liquor": "iva", "exempt": None},
+    },
+    "FR": {
+        "tax_lines": [
+            {
+                "key": "tva",
+                "label": "TVA 10%",
+                "rate": 0.10,
+                "included_in_price": False,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "tva", "liquor": "tva", "exempt": None},
+    },
+    "GB": {
+        "tax_lines": [
+            {
+                "key": "vat",
+                "label": "VAT 20%",
+                "rate": 0.20,
+                "included_in_price": False,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "vat", "liquor": "vat", "exempt": None},
+    },
+    "CN": {
+        "tax_lines": [
+            {
+                "key": "vat",
+                "label": "VAT 6%",
+                "rate": 0.06,
+                "included_in_price": False,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "vat", "liquor": "vat", "exempt": None},
+    },
+}
+
+# Union for seed lookup (wave-1 + wave-2 simple). DE/NL stay in #1863.
+COUNTRY_TAX_PACKS: Dict[str, Dict[str, Any]] = {
+    **WAVE1_TAX_PACKS,
+    **WAVE2_SIMPLE_TAX_PACKS,
+}
+SEEDED_COUNTRY_CODES = frozenset(COUNTRY_TAX_PACKS)
+
+
+def _one_rate_pack(pack: Mapping[str, Any]) -> Dict[str, Any]:
+    return {
+        "tax_lines": list(pack["tax_lines"]),
+        "category_map": dict(pack["category_map"]),
+    }
+
+
+def pack_for_country(country_code: str) -> Optional[Dict[str, Any]]:
+    """Return wave-1 or wave-2 simple pack, or None for CO / jurisdiction / unknown."""
+    code = str(country_code or "").upper()
+    if code == "CO" or code not in SEEDED_COUNTRY_CODES:
+        return None
+    pack = COUNTRY_TAX_PACKS.get(code)
+    return _one_rate_pack(pack) if pack else None
+
 
 def wave1_pack_for_country(country_code: str) -> Optional[Dict[str, Any]]:
+    """Wave-1-only lookup (tests / callers that must not see wave-2)."""
     code = str(country_code or "").upper()
     if code == "CO" or code not in WAVE1_COUNTRY_CODES:
         return None
-    return WAVE1_TAX_PACKS.get(code)
+    pack = WAVE1_TAX_PACKS.get(code)
+    return _one_rate_pack(pack) if pack else None
 
 
 def tax_config_from_wave1_pack(pack: Mapping[str, Any]) -> Dict[str, Any]:
@@ -127,9 +256,9 @@ def tax_config_from_wave1_pack(pack: Mapping[str, Any]) -> Dict[str, Any]:
     }
 
 
-async def ensure_wave1_tax_pack(conn, tenant_id, country_code: str) -> bool:
-    """Write wave-1 pack when tax_lines is unset. Never overwrites existing lines."""
-    pack = wave1_pack_for_country(country_code)
+async def ensure_country_tax_pack(conn, tenant_id, country_code: str) -> bool:
+    """Write seeded pack when tax_lines is unset. Never overwrites existing lines."""
+    pack = pack_for_country(country_code)
     if not pack:
         return False
 
@@ -163,3 +292,8 @@ async def ensure_wave1_tax_pack(conn, tenant_id, country_code: str) -> bool:
         json.dumps(pack["category_map"]),
     )
     return result.endswith("1")
+
+
+async def ensure_wave1_tax_pack(conn, tenant_id, country_code: str) -> bool:
+    """Alias kept for existing call sites (onboarding + tax-config GET)."""
+    return await ensure_country_tax_pack(conn, tenant_id, country_code)

--- a/tests/test_hospitality_tax_packs.py
+++ b/tests/test_hospitality_tax_packs.py
@@ -1,5 +1,4 @@
-"""Wave-1 hospitality tax packs — warocol.com#1847."""
-from decimal import Decimal
+"""Hospitality tax packs — wave-1 (#1847) + wave-2 simple (#1862)."""
 from uuid import uuid4
 
 import pytest
@@ -12,7 +11,11 @@ from app.services.hospitality_tax_engine import (
 from app.services.hospitality_tax_packs import (
     WAVE1_COUNTRY_CODES,
     WAVE1_TAX_PACKS,
+    WAVE2_SIMPLE_COUNTRY_CODES,
+    WAVE2_SIMPLE_TAX_PACKS,
+    ensure_country_tax_pack,
     ensure_wave1_tax_pack,
+    pack_for_country,
     tax_config_from_wave1_pack,
     wave1_pack_for_country,
 )
@@ -27,10 +30,26 @@ def test_wave1_pack_exists_for_each_shortlist_country(country):
     assert pack["category_map"]["exempt"] is None
 
 
+@pytest.mark.parametrize("country", sorted(WAVE2_SIMPLE_COUNTRY_CODES))
+def test_wave2_simple_pack_exists_for_each_country(country):
+    pack = pack_for_country(country)
+    assert pack is not None
+    assert pack == WAVE2_SIMPLE_TAX_PACKS[country]
+    assert len(pack["tax_lines"]) == 1
+    assert pack["category_map"]["exempt"] is None
+    assert pack["category_map"]["standard"] == pack["tax_lines"][0]["key"]
+    assert pack["category_map"]["liquor"] == pack["tax_lines"][0]["key"]
+    # wave1-only helper must not surface wave-2
+    assert wave1_pack_for_country(country) is None
+
+
 def test_wave1_pack_skips_colombia_and_unknown():
     assert wave1_pack_for_country("CO") is None
     assert wave1_pack_for_country("US") is None
     assert wave1_pack_for_country("") is None
+    assert pack_for_country("CO") is None
+    assert pack_for_country("US") is None
+    assert pack_for_country("DE") is None  # multi-rate → #1863
 
 
 @pytest.mark.parametrize(
@@ -48,6 +67,31 @@ def test_wave1_pack_skips_colombia_and_unknown():
 )
 def test_wave1_pack_computes_standard_and_exempt(country, subtotal, expected_tax):
     cfg = tax_config_from_wave1_pack(WAVE1_TAX_PACKS[country])
+    rows = [
+        {"tax_category": "standard", "subtotal": subtotal},
+        {"tax_category": "exempt", "subtotal": 3000},
+    ]
+    std, liq, _ = compute_category_breakdown(rows, cfg)
+    assert std == expected_tax
+    assert liq == 0.0
+    assert resolve_tax_profile(cfg).line_for_category("exempt") is None
+
+
+@pytest.mark.parametrize(
+    ("country", "subtotal", "expected_tax"),
+    [
+        ("PE", 10000, 1800.0),
+        ("MX", 10000, 1600.0),
+        ("CR", 10000, 1300.0),
+        ("AR", 10000, 2100.0),
+        ("ES", 10000, 1000.0),
+        ("FR", 10000, 1000.0),
+        ("GB", 10000, 2000.0),
+        ("CN", 10000, 600.0),
+    ],
+)
+def test_wave2_simple_pack_computes_standard_and_exempt(country, subtotal, expected_tax):
+    cfg = tax_config_from_wave1_pack(WAVE2_SIMPLE_TAX_PACKS[country])
     rows = [
         {"tax_category": "standard", "subtotal": subtotal},
         {"tax_category": "exempt", "subtotal": 3000},
@@ -104,6 +148,17 @@ async def test_ensure_wave1_tax_pack_writes_when_missing():
 
 
 @pytest.mark.asyncio
+async def test_ensure_country_tax_pack_writes_wave2_mx():
+    tenant_id = uuid4()
+    conn = _PackConn(tax_lines=None)
+    applied = await ensure_country_tax_pack(conn, tenant_id, "MX")
+    assert applied is True
+    assert any("UPDATE tenant_tax_config" in q for q, _ in conn.queries)
+    update = next(args for q, args in conn.queries if "UPDATE tenant_tax_config" in q)
+    assert '"IVA 16%"' in update[1] or "0.16" in update[1]
+
+
+@pytest.mark.asyncio
 async def test_ensure_wave1_tax_pack_skips_colombia():
     tenant_id = uuid4()
     conn = _PackConn(tax_lines=None)
@@ -117,6 +172,15 @@ async def test_ensure_wave1_tax_pack_does_not_overwrite_existing_lines():
     tenant_id = uuid4()
     conn = _PackConn(tax_lines=[{"key": "custom"}])
     applied = await ensure_wave1_tax_pack(conn, tenant_id, "CL")
+    assert applied is False
+    assert not any("UPDATE tenant_tax_config" in q for q, _ in conn.queries)
+
+
+@pytest.mark.asyncio
+async def test_ensure_country_tax_pack_does_not_overwrite_wave2():
+    tenant_id = uuid4()
+    conn = _PackConn(tax_lines=[{"key": "custom"}])
+    applied = await ensure_country_tax_pack(conn, tenant_id, "MX")
     assert applied is False
     assert not any("UPDATE tenant_tax_config" in q for q, _ in conn.queries)
 


### PR DESCRIPTION
## Summary
- Seed 8 one-rate packs: PE, MX, CR, AR, ES, FR, GB, CN (std+liq → primary; exempt null)
- `ensure_wave1_tax_pack` aliases `ensure_country_tax_pack` so existing onboarding / tax-config hooks auto-seed wave-2 when `tax_lines` is null
- Never overwrites existing lines; CO / wave-1 / US-CA untouched

Closes uno0uno/warocol.com#1862

## Test plan
- [x] `./venv/bin/pytest tests/test_hospitality_tax_packs.py -q`
- [x] Wave-2 engine: standard rate + exempt=0 for all 8
- [x] MX ensure write + no-overwrite

## Validation evidence

```text
$ ./venv/bin/pytest tests/test_hospitality_tax_packs.py -q
collected 40 items
........................................
============================== 40 passed in 0.06s ==============================
```

Made with [Cursor](https://cursor.com)