### PR TITLE
feat(tax): Wave 2 multi-rate packs (DE/NL)

### DIFF
--- a/app/services/hospitality_tax_packs.py
+++ b/app/services/hospitality_tax_packs.py
@@ -1,7 +1,7 @@
-"""Hospitality tax pack seeds — wave-1 (#1847) + wave-2 simple (#1862).
+"""Hospitality tax pack seeds — wave-1 (#1847) + wave-2 (#1862/#1863).
 
 Wave-1 rates match front_nuxt/composables/useTenantTaxProfile.ts WAVE1_TAX_PRESETS.
-Wave-2 simple rates: warocol.com#1860 epic research / #1862 delta.
+Wave-2 simple (#1862) and multi-rate DE/NL (#1863): warocol.com#1860 epic research.
 """
 from __future__ import annotations
 
@@ -13,6 +13,8 @@ WAVE1_COUNTRY_CODES = frozenset({"PA", "CL", "DO", "UY", "AU", "NZ", "SG", "AE"}
 WAVE2_SIMPLE_COUNTRY_CODES = frozenset(
     {"PE", "MX", "CR", "AR", "ES", "FR", "GB", "CN"}
 )
+
+WAVE2_MULTI_COUNTRY_CODES = frozenset({"DE", "NL"})
 
 WAVE1_TAX_PACKS: Dict[str, Dict[str, Any]] = {
     "PA": {
@@ -212,15 +214,68 @@ WAVE2_SIMPLE_TAX_PACKS: Dict[str, Dict[str, Any]] = {
     },
 }
 
-# Union for seed lookup (wave-1 + wave-2 simple). DE/NL stay in #1863.
+
+WAVE2_MULTI_TAX_PACKS: Dict[str, Dict[str, Any]] = {
+    # Commercial approx: food/soft → standard (reduced); alcohol → liquor (full).
+    "DE": {
+        "tax_lines": [
+            {
+                "key": "mwst_reduced",
+                "label": "MwSt 7%",
+                "rate": 0.07,
+                "included_in_price": False,
+                "gl_role": "iva",
+            },
+            {
+                "key": "mwst_standard",
+                "label": "MwSt 19%",
+                "rate": 0.19,
+                "included_in_price": False,
+                "gl_role": "iva",
+            },
+        ],
+        "category_map": {
+            "standard": "mwst_reduced",
+            "liquor": "mwst_standard",
+            "exempt": None,
+        },
+    },
+    "NL": {
+        "tax_lines": [
+            {
+                "key": "btw_reduced",
+                "label": "BTW 9%",
+                "rate": 0.09,
+                "included_in_price": False,
+                "gl_role": "iva",
+            },
+            {
+                "key": "btw_standard",
+                "label": "BTW 21%",
+                "rate": 0.21,
+                "included_in_price": False,
+                "gl_role": "iva",
+            },
+        ],
+        "category_map": {
+            "standard": "btw_reduced",
+            "liquor": "btw_standard",
+            "exempt": None,
+        },
+    },
+}
+
+# Union for seed lookup (wave-1 + wave-2 simple + DE/NL multi).
 COUNTRY_TAX_PACKS: Dict[str, Dict[str, Any]] = {
     **WAVE1_TAX_PACKS,
     **WAVE2_SIMPLE_TAX_PACKS,
+    **WAVE2_MULTI_TAX_PACKS,
 }
 SEEDED_COUNTRY_CODES = frozenset(COUNTRY_TAX_PACKS)
 
 
-def _one_rate_pack(pack: Mapping[str, Any]) -> Dict[str, Any]:
+def _copy_pack(pack: Mapping[str, Any]) -> Dict[str, Any]:
+    """Shallow-copy pack for callers (1-rate or multi-rate)."""
     return {
         "tax_lines": list(pack["tax_lines"]),
         "category_map": dict(pack["category_map"]),
@@ -228,12 +283,12 @@ def _one_rate_pack(pack: Mapping[str, Any]) -> Dict[str, Any]:
 
 
 def pack_for_country(country_code: str) -> Optional[Dict[str, Any]]:
-    """Return wave-1 or wave-2 simple pack, or None for CO / jurisdiction / unknown."""
+    """Return seeded country pack, or None for CO / jurisdiction / unknown."""
     code = str(country_code or "").upper()
     if code == "CO" or code not in SEEDED_COUNTRY_CODES:
         return None
     pack = COUNTRY_TAX_PACKS.get(code)
-    return _one_rate_pack(pack) if pack else None
+    return _copy_pack(pack) if pack else None
 
 
 def wave1_pack_for_country(country_code: str) -> Optional[Dict[str, Any]]:
@@ -242,7 +297,7 @@ def wave1_pack_for_country(country_code: str) -> Optional[Dict[str, Any]]:
     if code == "CO" or code not in WAVE1_COUNTRY_CODES:
         return None
     pack = WAVE1_TAX_PACKS.get(code)
-    return _one_rate_pack(pack) if pack else None
+    return _copy_pack(pack) if pack else None
 
 
 def tax_config_from_wave1_pack(pack: Mapping[str, Any]) -> Dict[str, Any]:

--- a/tests/test_hospitality_tax_packs.py
+++ b/tests/test_hospitality_tax_packs.py
@@ -1,4 +1,4 @@
-"""Hospitality tax packs — wave-1 (#1847) + wave-2 simple (#1862)."""
+"""Hospitality tax packs — wave-1 (#1847) + wave-2 simple/multi (#1862/#1863)."""
 from uuid import uuid4
 
 import pytest
@@ -11,6 +11,8 @@ from app.services.hospitality_tax_engine import (
 from app.services.hospitality_tax_packs import (
     WAVE1_COUNTRY_CODES,
     WAVE1_TAX_PACKS,
+    WAVE2_MULTI_COUNTRY_CODES,
+    WAVE2_MULTI_TAX_PACKS,
     WAVE2_SIMPLE_COUNTRY_CODES,
     WAVE2_SIMPLE_TAX_PACKS,
     ensure_country_tax_pack,
@@ -49,7 +51,6 @@ def test_wave1_pack_skips_colombia_and_unknown():
     assert wave1_pack_for_country("") is None
     assert pack_for_country("CO") is None
     assert pack_for_country("US") is None
-    assert pack_for_country("DE") is None  # multi-rate → #1863
 
 
 @pytest.mark.parametrize(
@@ -99,6 +100,41 @@ def test_wave2_simple_pack_computes_standard_and_exempt(country, subtotal, expec
     std, liq, _ = compute_category_breakdown(rows, cfg)
     assert std == expected_tax
     assert liq == 0.0
+    assert resolve_tax_profile(cfg).line_for_category("exempt") is None
+
+
+
+
+@pytest.mark.parametrize("country", sorted(WAVE2_MULTI_COUNTRY_CODES))
+def test_wave2_multi_pack_exists_for_each_country(country):
+    pack = pack_for_country(country)
+    assert pack is not None
+    assert pack == WAVE2_MULTI_TAX_PACKS[country]
+    assert len(pack["tax_lines"]) == 2
+    assert pack["category_map"]["exempt"] is None
+    assert pack["category_map"]["standard"] != pack["category_map"]["liquor"]
+    assert wave1_pack_for_country(country) is None
+
+
+@pytest.mark.parametrize(
+    ("country", "std_subtotal", "liq_subtotal", "expected_std", "expected_liq"),
+    [
+        ("DE", 10000, 10000, 700.0, 1900.0),
+        ("NL", 10000, 10000, 900.0, 2100.0),
+    ],
+)
+def test_wave2_multi_pack_computes_standard_and_liquor(
+    country, std_subtotal, liq_subtotal, expected_std, expected_liq
+):
+    cfg = tax_config_from_wave1_pack(WAVE2_MULTI_TAX_PACKS[country])
+    rows = [
+        {"tax_category": "standard", "subtotal": std_subtotal},
+        {"tax_category": "liquor", "subtotal": liq_subtotal},
+        {"tax_category": "exempt", "subtotal": 3000},
+    ]
+    std, liq, _ = compute_category_breakdown(rows, cfg)
+    assert std == expected_std
+    assert liq == expected_liq
     assert resolve_tax_profile(cfg).line_for_category("exempt") is None
 
 
@@ -184,6 +220,27 @@ async def test_ensure_country_tax_pack_does_not_overwrite_wave2():
     assert applied is False
     assert not any("UPDATE tenant_tax_config" in q for q, _ in conn.queries)
 
+
+
+
+@pytest.mark.asyncio
+async def test_ensure_country_tax_pack_writes_wave2_de():
+    tenant_id = uuid4()
+    conn = _PackConn(tax_lines=None)
+    applied = await ensure_country_tax_pack(conn, tenant_id, "DE")
+    assert applied is True
+    assert any("UPDATE tenant_tax_config" in q for q, _ in conn.queries)
+    update = next(args for q, args in conn.queries if "UPDATE tenant_tax_config" in q)
+    assert "mwst_reduced" in update[1] and "mwst_standard" in update[1]
+
+
+@pytest.mark.asyncio
+async def test_ensure_country_tax_pack_does_not_overwrite_wave2_multi():
+    tenant_id = uuid4()
+    conn = _PackConn(tax_lines=[{"key": "custom"}])
+    applied = await ensure_country_tax_pack(conn, tenant_id, "NL")
+    assert applied is False
+    assert not any("UPDATE tenant_tax_config" in q for q, _ in conn.queries)
 
 def test_co_adapter_regression_unchanged():
     cfg = {


### PR DESCRIPTION
## Summary
- Seed DE (MwSt 7% + 19%) and NL (BTW 9% + 21%) dual-line packs
- `standard` → reduced, `liquor` → full; exempt null
- Auto-seed via existing `ensure_country_tax_pack` when `tax_lines` is null

Closes uno0uno/warocol.com#1863

## Test plan
- [x] `./venv/bin/pytest tests/test_hospitality_tax_packs.py -q`
- [x] Dual-rate breakdown for DE/NL
- [x] Ensure write + no-overwrite for multi packs

## Validation evidence

```text
$ ./venv/bin/pytest tests/test_hospitality_tax_packs.py -q
collected 46 items
..............................................
============================== 46 passed in 0.08s ==============================
```

Made with [Cursor](https://cursor.com)