### PR TITLE
feat(tax): commercial tax enable/disable API + engine

### DIFF
--- a/app/models/tax_config.py
+++ b/app/models/tax_config.py
@@ -37,6 +37,10 @@ class TaxConfigResponse(BaseModel):
         default=None,
         description="US state or CA province code when country requires jurisdiction",
     )
+    commercial_tax_applicable: bool = Field(
+        default=False,
+        description="When tax_lines present: apply commercial tax in POS/Menú if true",
+    )
     created_at: datetime
     updated_at: datetime
 
@@ -53,3 +57,7 @@ class TaxConfigUpdate(BaseModel):
     tax_lines: Optional[List[Dict[str, Any]]] = None
     category_map: Optional[Dict[str, Optional[str]]] = None
     tax_jurisdiction_code: Optional[str] = None
+    commercial_tax_applicable: Optional[bool] = Field(
+        default=None,
+        description="Commercial on/off; omit on CO-only updates to leave unchanged",
+    )

--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -132,7 +132,7 @@ async def _get_tenant_tax_config(conn, tenant_id: UUID) -> Dict[str, Any]:
                   liquor_tax_gl_account_code, liquor_tax_gl_account_id,
                   iva_applicable, iva_rate, iva_gl_account_code, iva_gl_account_id,
                   iva_included_in_price,
-                  tax_lines, category_map
+                  tax_lines, category_map, commercial_tax_applicable
            FROM tenant_tax_config WHERE tenant_id = $1""",
         tenant_id,
     )
@@ -155,6 +155,7 @@ async def _get_tenant_tax_config(conn, tenant_id: UUID) -> Dict[str, Any]:
         "iva_included_in_price":      False,
         "tax_lines":                  None,
         "category_map":               None,
+        "commercial_tax_applicable":  False,
     }
 
 

--- a/app/services/hospitality_tax_engine.py
+++ b/app/services/hospitality_tax_engine.py
@@ -132,6 +132,12 @@ def resolve_tax_profile(tax_config: Mapping[str, Any]) -> TaxProfile:
     """Build a TaxProfile from explicit tax_lines or CO column adapter."""
     raw_lines = _as_mapping_list(tax_config.get("tax_lines"))
     if raw_lines:
+        # Commercial disable: keep stored lines in DB but apply no tax (#1868).
+        if tax_config.get("commercial_tax_applicable") is False:
+            return TaxProfile(
+                lines={},
+                category_map={"standard": None, "liquor": None, "exempt": None},
+            )
         lines: Dict[str, TaxLine] = {}
         for item in raw_lines:
             line = _line_from_mapping(item)

--- a/app/services/hospitality_tax_jurisdictions.py
+++ b/app/services/hospitality_tax_jurisdictions.py
@@ -265,6 +265,7 @@ async def apply_jurisdiction_pack(
         SET tax_jurisdiction_code = $2,
             tax_lines = $3::jsonb,
             category_map = $4::jsonb,
+            commercial_tax_applicable = true,
             updated_at = NOW()
         WHERE tenant_id = $1
         RETURNING *

--- a/app/services/hospitality_tax_packs.py
+++ b/app/services/hospitality_tax_packs.py
@@ -306,6 +306,7 @@ def tax_config_from_wave1_pack(pack: Mapping[str, Any]) -> Dict[str, Any]:
         "inc_applicable": False,
         "iva_applicable": False,
         "liquor_tax_applicable": False,
+        "commercial_tax_applicable": True,
         "tax_lines": list(pack["tax_lines"]),
         "category_map": dict(pack["category_map"]),
     }
@@ -338,6 +339,7 @@ async def ensure_country_tax_pack(conn, tenant_id, country_code: str) -> bool:
         UPDATE tenant_tax_config
         SET tax_lines = $2::jsonb,
             category_map = $3::jsonb,
+            commercial_tax_applicable = true,
             updated_at = NOW()
         WHERE tenant_id = $1
           AND tax_lines IS NULL

--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -772,11 +772,13 @@ async def update_tax_config(request: Request, data) -> dict:
                     )
                 # Allow commercial rate override on top of jurisdiction seed.
                 if getattr(data, "tax_lines", None) is not None:
+                    commercial_flag = getattr(data, "commercial_tax_applicable", None)
                     row = await conn.fetchrow(
                         """
                         UPDATE tenant_tax_config
                         SET tax_lines = $2::jsonb,
                             category_map = COALESCE($3::jsonb, category_map),
+                            commercial_tax_applicable = COALESCE($4, commercial_tax_applicable),
                             updated_at = NOW()
                         WHERE tenant_id = $1
                         RETURNING *
@@ -786,9 +788,23 @@ async def update_tax_config(request: Request, data) -> dict:
                         json.dumps(data.category_map)
                         if getattr(data, "category_map", None) is not None
                         else None,
+                        commercial_flag,
+                    )
+                elif getattr(data, "commercial_tax_applicable", None) is not None:
+                    row = await conn.fetchrow(
+                        """
+                        UPDATE tenant_tax_config
+                        SET commercial_tax_applicable = $2,
+                            updated_at = NOW()
+                        WHERE tenant_id = $1
+                        RETURNING *
+                        """,
+                        tenant_id,
+                        data.commercial_tax_applicable,
                     )
                 return {"success": True, "data": dict(row)}
 
+            commercial_flag = getattr(data, "commercial_tax_applicable", None)
             row = await conn.fetchrow(
                 """
                 INSERT INTO tenant_tax_config (
@@ -797,9 +813,10 @@ async def update_tax_config(request: Request, data) -> dict:
                     iva_applicable, iva_included_in_price,
                     liquor_tax_applicable,
                     inc_gl_account_id, iva_gl_account_id, liquor_tax_gl_account_id,
-                    tax_lines, category_map, tax_jurisdiction_code
+                    tax_lines, category_map, tax_jurisdiction_code,
+                    commercial_tax_applicable
                 )
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb, $12)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb, $12, COALESCE($13, false))
                 ON CONFLICT (tenant_id) DO UPDATE SET
                     inc_applicable        = EXCLUDED.inc_applicable,
                     inc_included_in_price = EXCLUDED.inc_included_in_price,
@@ -814,6 +831,10 @@ async def update_tax_config(request: Request, data) -> dict:
                     tax_jurisdiction_code = COALESCE(
                         EXCLUDED.tax_jurisdiction_code,
                         tenant_tax_config.tax_jurisdiction_code
+                    ),
+                    commercial_tax_applicable = COALESCE(
+                        EXCLUDED.commercial_tax_applicable,
+                        tenant_tax_config.commercial_tax_applicable
                     ),
                     updated_at            = NOW()
                 RETURNING *
@@ -830,6 +851,7 @@ async def update_tax_config(request: Request, data) -> dict:
                 json.dumps(data.tax_lines) if getattr(data, "tax_lines", None) is not None else None,
                 json.dumps(data.category_map) if getattr(data, "category_map", None) is not None else None,
                 None,
+                commercial_flag,
             )
 
             return {"success": True, "data": dict(row)}

--- a/sql/20260728_commercial_tax_applicable.sql
+++ b/sql/20260728_commercial_tax_applicable.sql
@@ -1,0 +1,14 @@
+-- warocol.com#1868 — commercial tax enable/disable flag (ADD only).
+ALTER TABLE tenant_tax_config
+    ADD COLUMN IF NOT EXISTS commercial_tax_applicable boolean NOT NULL DEFAULT false;
+
+-- Backfill: enabled when any tax_lines entry has rate > 0.
+UPDATE tenant_tax_config
+SET commercial_tax_applicable = true
+WHERE commercial_tax_applicable = false
+  AND tax_lines IS NOT NULL
+  AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(tax_lines) AS elem
+      WHERE COALESCE((elem->>'rate')::numeric, 0) > 0
+  );

--- a/tests/test_hospitality_tax_engine.py
+++ b/tests/test_hospitality_tax_engine.py
@@ -72,6 +72,7 @@ def test_commercial_tax_lines_standard_and_exempt():
         "inc_applicable": False,
         "iva_applicable": False,
         "liquor_tax_applicable": False,
+        "commercial_tax_applicable": True,
         "tax_lines": [
             {
                 "key": "itbms",
@@ -94,6 +95,48 @@ def test_commercial_tax_lines_standard_and_exempt():
     profile = resolve_tax_profile(cfg)
     assert profile.line_for_category("exempt") is None
     assert tax_amount_float(10000, profile.primary_line()) == 700.0
+
+
+def test_commercial_tax_disabled_keeps_lines_but_applies_zero():
+    """warocol.com#1868 — flag false → empty profile; tax_lines still on config."""
+    cfg = {
+        "inc_applicable": False,
+        "iva_applicable": False,
+        "liquor_tax_applicable": False,
+        "commercial_tax_applicable": False,
+        "tax_lines": [
+            {
+                "key": "iva",
+                "label": "IVA 16%",
+                "rate": 0.16,
+                "included_in_price": False,
+                "gl_role": "iva",
+            }
+        ],
+        "category_map": {"standard": "iva", "liquor": "iva", "exempt": None},
+    }
+    rows = [{"tax_category": "standard", "subtotal": 10000}]
+    std, liq, label = compute_category_breakdown(rows, cfg)
+    assert std == 0.0
+    assert liq == 0.0
+    profile = resolve_tax_profile(cfg)
+    assert profile.lines == {}
+    assert profile.primary_line() is None
+    # Re-enable restores prior rates without re-seeding.
+    cfg["commercial_tax_applicable"] = True
+    std_on, _, label_on = compute_category_breakdown(rows, cfg)
+    assert std_on == 1600.0
+    assert label_on == "IVA 16%"
+
+
+def test_co_path_ignores_commercial_flag_when_tax_lines_null():
+    cfg = _inc_config(included=True)
+    cfg["commercial_tax_applicable"] = False
+    cfg["tax_lines"] = None
+    rows = [{"tax_category": "standard", "subtotal": 10800}]
+    std, liq, label = compute_category_breakdown(rows, cfg)
+    assert std == 800.0
+    assert label == "INC 8%"
 
 
 def test_gl_decimal_inc_extractive():

--- a/tests/test_hospitality_tax_packs.py
+++ b/tests/test_hospitality_tax_packs.py
@@ -190,8 +190,22 @@ async def test_ensure_country_tax_pack_writes_wave2_mx():
     applied = await ensure_country_tax_pack(conn, tenant_id, "MX")
     assert applied is True
     assert any("UPDATE tenant_tax_config" in q for q, _ in conn.queries)
-    update = next(args for q, args in conn.queries if "UPDATE tenant_tax_config" in q)
+    update_q, update = next(
+        (q, args) for q, args in conn.queries if "UPDATE tenant_tax_config" in q
+    )
     assert '"IVA 16%"' in update[1] or "0.16" in update[1]
+    assert "commercial_tax_applicable = true" in update_q
+
+
+@pytest.mark.asyncio
+async def test_ensure_country_tax_pack_sets_applicable_true_on_seed():
+    tenant_id = uuid4()
+    conn = _PackConn(tax_lines=None)
+    await ensure_country_tax_pack(conn, tenant_id, "PE")
+    update_q, _ = next(
+        (q, args) for q, args in conn.queries if "UPDATE tenant_tax_config" in q
+    )
+    assert "commercial_tax_applicable = true" in update_q
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- ADD `commercial_tax_applicable` on `tenant_tax_config` with backfill for rate &gt; 0 packs
- Engine returns empty profile when flag is false but `tax_lines` remain stored
- Seed + US/CA jurisdiction pack set flag true; GET/PUT expose and persist the field

Closes uno0uno/warocol.com#1868

## Test plan
- [x] `./venv/bin/pytest tests/test_hospitality_tax_engine.py tests/test_hospitality_tax_packs.py -q`
- [x] `./venv/bin/pytest tests/test_hospitality_tax_jurisdictions.py -q`
- [ ] Apply `sql/20260728_commercial_tax_applicable.sql` on target DB before deploy

## Validation evidence

```text
$ ./venv/bin/pytest tests/test_hospitality_tax_engine.py tests/test_hospitality_tax_packs.py -q
collected 54 items
......................................................
============================== 54 passed in 0.13s ==============================

$ ./venv/bin/pytest tests/test_hospitality_tax_jurisdictions.py -q
collected 8 items
........
============================== 8 passed in 0.03s ===============================
```

Made with [Cursor](https://cursor.com)