### PR TITLE
feat(tax): menu category tax map + resolve (#1883)

### DIFF
--- a/app/models/product.py
+++ b/app/models/product.py
@@ -93,7 +93,15 @@ class ProductBase(BaseModel):
         "standard",
         description="Tax classification mapped via tenant category_map → tax_lines "
         "(CO default: standard→INC/IVA, liquor→liquor line, exempt→none). "
-        "Same field for POS and venta directa.",
+        "Same field for POS and venta directa. Kept for CO/legacy dual-read.",
+    )
+    tax_resolution: Literal['inherit', 'exempt', 'line'] = Field(
+        "inherit",
+        description="Commercial override: inherit from menu category map, force exempt, or force a tax line",
+    )
+    tax_line_key: Optional[str] = Field(
+        None,
+        description="Tax line key when tax_resolution=line; ignored otherwise",
     )
     station_id: Optional[UUID] = None
     kitchen_name: Optional[str] = Field(None, max_length=100)
@@ -209,6 +217,14 @@ class ProductUpdate(BaseModel):
     open_priced: Optional[bool] = None
     allow_modifiers: Optional[bool] = None
     tax_category: Optional[Literal['standard', 'liquor', 'exempt']] = Field(None, description="Tax classification: standard, liquor, exempt")
+    tax_resolution: Optional[Literal['inherit', 'exempt', 'line']] = Field(
+        None,
+        description="Commercial override mode; omit to leave unchanged",
+    )
+    tax_line_key: Optional[str] = Field(
+        None,
+        description="Tax line key when tax_resolution=line; null clears when resolution set",
+    )
     ingredients: Optional[List[RecipeIngredientBase]] = Field(None, description="Updated recipe ingredients")
     station_id: Optional[UUID] = None
     kitchen_name: Optional[str] = Field(None, max_length=100)

--- a/app/models/tax_config.py
+++ b/app/models/tax_config.py
@@ -33,6 +33,14 @@ class TaxConfigResponse(BaseModel):
         default=None,
         description="Optional product tax_category → tax line key",
     )
+    menu_category_line_map: Optional[Dict[str, Optional[str]]] = Field(
+        default=None,
+        description="Menu category UUID → tax line key (commercial)",
+    )
+    exempt_menu_category_ids: Optional[List[UUID]] = Field(
+        default=None,
+        description="Menu category UUIDs with no tax (commercial)",
+    )
     tax_jurisdiction_code: Optional[str] = Field(
         default=None,
         description="US state or CA province code when country requires jurisdiction",
@@ -56,6 +64,14 @@ class TaxConfigUpdate(BaseModel):
     liquor_tax_gl_account_id: Optional[UUID] = None
     tax_lines: Optional[List[Dict[str, Any]]] = None
     category_map: Optional[Dict[str, Optional[str]]] = None
+    menu_category_line_map: Optional[Dict[str, Optional[str]]] = Field(
+        default=None,
+        description="Omit to leave unchanged; {} clears all menu-category mappings",
+    )
+    exempt_menu_category_ids: Optional[List[UUID]] = Field(
+        default=None,
+        description="Omit to leave unchanged; [] clears exempt set",
+    )
     tax_jurisdiction_code: Optional[str] = None
     commercial_tax_applicable: Optional[bool] = Field(
         default=None,

--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -388,6 +388,9 @@ async def _post_order_gl_entry(
     order_items = await conn.fetch(
         """SELECT
                COALESCE(oi.net_total, oi.subtotal, 0) AS subtotal,
+               COALESCE(p.category_id, pv_p.category_id) AS category_id,
+               COALESCE(p.tax_resolution, pv_p.tax_resolution, 'inherit') AS tax_resolution,
+               COALESCE(p.tax_line_key, pv_p.tax_line_key) AS tax_line_key,
                COALESCE(p.tax_category, pv_p.tax_category, 'standard') AS tax_category
            FROM order_items oi
            LEFT JOIN product p ON p.id = oi.product_id
@@ -398,10 +401,21 @@ async def _post_order_gl_entry(
     )
 
     # ── Accumulate subtotals per tax category ─────────────────────────────
+    from app.services.hospitality_tax_engine import (
+        compute_gl_category_taxes,
+        resolve_effective_tax_category,
+    )
+
     standard_subtotal = Decimal("0")
     liquor_subtotal   = Decimal("0")
     for item in order_items:
-        cat = item["tax_category"] or "standard"
+        cat = resolve_effective_tax_category(
+            tax_config,
+            category_id=item["category_id"],
+            tax_resolution=item["tax_resolution"] or "inherit",
+            tax_line_key=item["tax_line_key"],
+            tax_category=item["tax_category"] or "standard",
+        )
         sub = Decimal(str(item["subtotal"]))
         if cat == "liquor":
             liquor_subtotal += sub
@@ -414,8 +428,6 @@ async def _post_order_gl_entry(
         standard_subtotal = total_amount
 
     # ── Calculate taxes per category (profile-driven tax_lines) ───────────
-    from app.services.hospitality_tax_engine import compute_gl_category_taxes
-
     tax_result = compute_gl_category_taxes(
         standard_subtotal, liquor_subtotal, tax_config,
     )

--- a/app/services/hospitality_tax_engine.py
+++ b/app/services/hospitality_tax_engine.py
@@ -60,6 +60,120 @@ def _as_category_map(raw: Any) -> Dict[str, Optional[str]]:
     return out
 
 
+def _as_menu_category_line_map(raw: Any) -> Dict[str, Optional[str]]:
+    """Menu category UUID string → tax line key (same shape as category_map)."""
+    return _as_category_map(raw)
+
+
+def _as_uuid_str_set(raw: Any) -> set[str]:
+    if raw is None:
+        return set()
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except (TypeError, ValueError):
+            return {raw.strip()} if raw.strip() else set()
+    if not isinstance(raw, (list, tuple, set)):
+        return set()
+    out: set[str] = set()
+    for item in raw:
+        if item is None:
+            continue
+        s = str(item).strip()
+        if s:
+            out.add(s)
+    return out
+
+
+def _row_field(row: Any, key: str, default: Any = None) -> Any:
+    if row is None:
+        return default
+    if hasattr(row, "get"):
+        return row.get(key, default)
+    try:
+        return row[key]
+    except (KeyError, IndexError, TypeError):
+        return default
+
+
+def resolve_product_tax_line(
+    tax_config: Mapping[str, Any],
+    *,
+    category_id: Any = None,
+    tax_resolution: Optional[str] = "inherit",
+    tax_line_key: Optional[str] = None,
+    tax_category: Optional[str] = "standard",
+) -> Optional[TaxLine]:
+    """Epic #1881 order: override → exempt set → menu map → primary.
+
+    CO / column-only configs ignore menu maps and use legacy tax_category.
+    Empty menu map + empty exempt set dual-reads legacy tax_category so
+    existing standard/liquor POS keeps working until maps are configured.
+    """
+    profile = resolve_tax_profile(tax_config)
+    legacy_category = tax_category or "standard"
+
+    # No commercial tax_lines → CO adapter; ignore menu maps.
+    if not _as_mapping_list(tax_config.get("tax_lines")):
+        return profile.line_for_category(legacy_category)
+
+    # commercial_tax_applicable=false yields empty profile.lines
+    if not profile.lines:
+        return None
+
+    resolution = (tax_resolution or "inherit").strip().lower()
+    if resolution == "exempt":
+        return None
+    if resolution == "line":
+        key = (tax_line_key or "").strip()
+        return profile.lines.get(key) if key else None
+
+    # inherit
+    cat_id = str(category_id).strip() if category_id is not None else ""
+    exempt_ids = _as_uuid_str_set(tax_config.get("exempt_menu_category_ids"))
+    if cat_id and cat_id in exempt_ids:
+        return None
+
+    menu_map = _as_menu_category_line_map(tax_config.get("menu_category_line_map"))
+    if cat_id and cat_id in menu_map:
+        key = menu_map[cat_id]
+        if not key:
+            return None
+        return profile.lines.get(key)
+
+    # Dual-read: no menu maps configured yet → legacy fiscal tags.
+    if not menu_map and not exempt_ids:
+        return profile.line_for_category(legacy_category)
+
+    # Unmapped menu category → primary line.
+    return profile.primary_line()
+
+
+def resolve_effective_tax_category(
+    tax_config: Mapping[str, Any],
+    *,
+    category_id: Any = None,
+    tax_resolution: Optional[str] = "inherit",
+    tax_line_key: Optional[str] = None,
+    tax_category: Optional[str] = "standard",
+) -> str:
+    """Map resolved line → standard|liquor|exempt for legacy POS/GL buckets."""
+    line = resolve_product_tax_line(
+        tax_config,
+        category_id=category_id,
+        tax_resolution=tax_resolution,
+        tax_line_key=tax_line_key,
+        tax_category=tax_category,
+    )
+    if line is None:
+        return "exempt"
+    profile = resolve_tax_profile(tax_config)
+    liquor_key = profile.category_map.get("liquor")
+    if liquor_key and line.key == liquor_key:
+        return "liquor"
+    return "standard"
+
+
 def _line_from_mapping(item: Mapping[str, Any]) -> Optional[TaxLine]:
     key = str(item.get("key") or "").strip()
     if not key:
@@ -189,15 +303,27 @@ def compute_category_breakdown(
     items_rows: Sequence[Any],
     tax_config: Mapping[str, Any],
 ) -> Tuple[float, float, str]:
-    """Compat wrapper: (standard_tax, liquor_tax, standard_tax_label)."""
+    """Compat wrapper: (standard_tax, liquor_tax, standard_tax_label).
+
+    Dual-reads menu-category maps + product override when present on rows;
+    otherwise uses legacy tax_category.
+    """
     profile = resolve_tax_profile(tax_config)
+
+    def _effective_cat(row: Any) -> str:
+        return resolve_effective_tax_category(
+            tax_config,
+            category_id=_row_field(row, "category_id"),
+            tax_resolution=_row_field(row, "tax_resolution") or "inherit",
+            tax_line_key=_row_field(row, "tax_line_key"),
+            tax_category=_row_field(row, "tax_category") or "standard",
+        )
 
     def _subtotal(category: str) -> float:
         total = 0.0
         for row in items_rows:
-            cat = row["tax_category"] if hasattr(row, "__getitem__") else "standard"
-            if cat == category:
-                total += float(row["subtotal"])
+            if _effective_cat(row) == category:
+                total += float(_row_field(row, "subtotal") or 0)
         return total
 
     std_base = _subtotal("standard")

--- a/app/services/products_service.py
+++ b/app/services/products_service.py
@@ -209,9 +209,10 @@ async def create_product_with_recipe(
                         name, description, price, category_id, product_base_type_id, preparation_time,
                         controla_stock, is_available, is_available_online, is_available_table_qr,
                         is_combo, is_resale, open_priced, allow_modifiers,
-                        tax_category, tenant_id, station_id, kitchen_name, image_url, costo_percibido
+                        tax_category, tax_resolution, tax_line_key,
+                        tenant_id, station_id, kitchen_name, image_url, costo_percibido
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
                     RETURNING id, created_at, updated_at
                 """
                 product_result = await conn.fetchrow(
@@ -231,6 +232,8 @@ async def create_product_with_recipe(
                     product_data.open_priced,
                     product_data.allow_modifiers,
                     product_data.tax_category,
+                    getattr(product_data, "tax_resolution", None) or "inherit",
+                    getattr(product_data, "tax_line_key", None),
                     tenant_id,
                     product_data.station_id,
                     product_data.kitchen_name,
@@ -376,6 +379,8 @@ async def get_product_by_id(
                     p.open_priced,
                     p.allow_modifiers,
                     p.tax_category,
+                    p.tax_resolution,
+                    p.tax_line_key,
                     p.costo_calculado,
                     p.costo_percibido,
                     p.precio_sugerido,
@@ -634,6 +639,8 @@ async def get_products_list(
                     p.open_priced,
                     p.allow_modifiers,
                     p.tax_category,
+                    p.tax_resolution,
+                    p.tax_line_key,
                     COALESCE(dc.direct_cost, 0) + COALESCE(bc.base_cost, 0) as costo_calculado,
                     p.costo_percibido,
                     p.precio_sugerido,
@@ -1208,7 +1215,7 @@ async def update_product_with_recipe(
                 # Fields where None is a valid "clear this value" intent (#465).
                 # Without this, the loop below silently drops attempts to remove
                 # an image when the user clicks "Eliminar imagen" in the form.
-                NULLABLE_FIELDS = {'image_url', 'costo_percibido'}
+                NULLABLE_FIELDS = {'image_url', 'costo_percibido', 'tax_line_key'}
                 for field, value in product_data.dict(exclude={'ingredients', 'recipe_base_ids', 'recipe_bases', 'controla_stock'}, exclude_unset=True).items():
                     if value is None and field not in NULLABLE_FIELDS:
                         continue

--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 from decimal import Decimal
 from typing import Any, Dict, List, Mapping, Optional, Literal
+from uuid import UUID
 from fastapi import Request, HTTPException
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
@@ -627,21 +628,33 @@ async def upload_tenant_image(
 def decode_tax_config_jsonb(data: Mapping[str, Any]) -> Dict[str, Any]:
     """Decode asyncpg jsonb strings so clients get objects, not raw JSON text."""
     out = dict(data)
-    for key in ("tax_lines", "category_map"):
+    for key in ("tax_lines", "category_map", "menu_category_line_map"):
         val = out.get(key)
         if isinstance(val, str):
             try:
                 out[key] = json.loads(val)
             except (TypeError, ValueError):
                 pass
+    exempt = out.get("exempt_menu_category_ids")
+    if isinstance(exempt, str):
+        try:
+            exempt = json.loads(exempt)
+        except (TypeError, ValueError):
+            exempt = None
+    if isinstance(exempt, (list, tuple)):
+        out["exempt_menu_category_ids"] = [str(x) for x in exempt if x is not None]
+    elif exempt is None:
+        out.setdefault("exempt_menu_category_ids", [])
     return out
 
 
 def validate_tax_matrix_payload(
     tax_lines: Optional[List[Any]],
     category_map: Optional[Mapping[str, Any]],
+    menu_category_line_map: Optional[Mapping[str, Any]] = None,
+    exempt_menu_category_ids: Optional[List[Any]] = None,
 ) -> None:
-    """Validate commercial matrix rates and category_map line references."""
+    """Validate commercial matrix rates and category/menu map line references."""
     line_keys: set[str] = set()
     if tax_lines is not None:
         if not isinstance(tax_lines, list):
@@ -667,21 +680,80 @@ def validate_tax_matrix_payload(
     if category_map is not None:
         if not isinstance(category_map, Mapping):
             raise HTTPException(status_code=400, detail="category_map must be an object")
-        if tax_lines is None:
-            return
-        for cat, ref in category_map.items():
-            if ref in (None, "", "null"):
-                continue
-            ref_key = str(ref)
-            if ref_key not in line_keys:
+        if tax_lines is not None:
+            for cat, ref in category_map.items():
+                if ref in (None, "", "null"):
+                    continue
+                ref_key = str(ref)
+                if ref_key not in line_keys:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=(
+                            f"category_map['{cat}'] references unknown tax line key "
+                            f"'{ref_key}'"
+                        ),
+                    )
+
+    if menu_category_line_map is not None:
+        if not isinstance(menu_category_line_map, Mapping):
+            raise HTTPException(
+                status_code=400, detail="menu_category_line_map must be an object"
+            )
+        for cat_id, ref in menu_category_line_map.items():
+            cat_str = str(cat_id).strip()
+            if not cat_str:
                 raise HTTPException(
                     status_code=400,
-                    detail=(
-                        f"category_map['{cat}'] references unknown tax line key "
-                        f"'{ref_key}'"
-                    ),
+                    detail="menu_category_line_map keys must be category UUIDs",
                 )
+            try:
+                UUID(cat_str)
+            except (TypeError, ValueError) as exc:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"menu_category_line_map key '{cat_str}' is not a valid UUID",
+                ) from exc
+            if ref in (None, "", "null"):
+                continue
+            if tax_lines is not None:
+                ref_key = str(ref)
+                if ref_key not in line_keys:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=(
+                            f"menu_category_line_map['{cat_str}'] references unknown "
+                            f"tax line key '{ref_key}'"
+                        ),
+                    )
 
+    if exempt_menu_category_ids is not None:
+        if not isinstance(exempt_menu_category_ids, list):
+            raise HTTPException(
+                status_code=400, detail="exempt_menu_category_ids must be a list"
+            )
+        for item in exempt_menu_category_ids:
+            try:
+                UUID(str(item))
+            except (TypeError, ValueError) as exc:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"exempt_menu_category_ids entry '{item}' is not a valid UUID",
+                ) from exc
+
+
+def _encode_menu_category_line_map(raw: Optional[Mapping[str, Any]]) -> Optional[str]:
+    if raw is None:
+        return None
+    out: Dict[str, Optional[str]] = {}
+    for key, value in raw.items():
+        out[str(key)] = None if value in (None, "", "null") else str(value)
+    return json.dumps(out)
+
+
+def _encode_exempt_menu_category_ids(raw: Optional[List[Any]]) -> Optional[List[UUID]]:
+    if raw is None:
+        return None
+    return [UUID(str(x)) for x in raw]
 
 def validate_co_rate_fields(data: Any) -> None:
     """Validate optional CO column rates when present on TaxConfigUpdate."""
@@ -794,11 +866,20 @@ async def update_tax_config(request: Request, data) -> dict:
 
         tax_lines = getattr(data, "tax_lines", None)
         category_map = getattr(data, "category_map", None)
-        validate_tax_matrix_payload(tax_lines, category_map)
+        menu_category_line_map = getattr(data, "menu_category_line_map", None)
+        exempt_menu_category_ids = getattr(data, "exempt_menu_category_ids", None)
+        validate_tax_matrix_payload(
+            tax_lines,
+            category_map,
+            menu_category_line_map,
+            exempt_menu_category_ids,
+        )
         validate_co_rate_fields(data)
         iva_rate = _optional_co_rate(data, "iva_rate")
         inc_rate = _optional_co_rate(data, "inc_rate")
         liquor_tax_rate = _optional_co_rate(data, "liquor_tax_rate")
+        menu_map_json = _encode_menu_category_line_map(menu_category_line_map)
+        exempt_ids_pg = _encode_exempt_menu_category_ids(exempt_menu_category_ids)
 
         async with get_db_connection() as conn:
             fiscal_row = await conn.fetchrow(
@@ -860,22 +941,26 @@ async def update_tax_config(request: Request, data) -> dict:
                         detail="Could not apply tax jurisdiction pack",
                     )
                 # Allow commercial rate override on top of jurisdiction seed.
-                if tax_lines is not None:
+                if tax_lines is not None or menu_map_json is not None or exempt_ids_pg is not None:
                     commercial_flag = getattr(data, "commercial_tax_applicable", None)
                     row = await conn.fetchrow(
                         """
                         UPDATE tenant_tax_config
-                        SET tax_lines = $2::jsonb,
+                        SET tax_lines = COALESCE($2::jsonb, tax_lines),
                             category_map = COALESCE($3::jsonb, category_map),
                             commercial_tax_applicable = COALESCE($4, commercial_tax_applicable),
+                            menu_category_line_map = COALESCE($5::jsonb, menu_category_line_map),
+                            exempt_menu_category_ids = COALESCE($6::uuid[], exempt_menu_category_ids),
                             updated_at = NOW()
                         WHERE tenant_id = $1
                         RETURNING *
                         """,
                         tenant_id,
-                        json.dumps(tax_lines),
+                        json.dumps(tax_lines) if tax_lines is not None else None,
                         json.dumps(category_map) if category_map is not None else None,
                         commercial_flag,
+                        menu_map_json,
+                        exempt_ids_pg,
                     )
                 elif getattr(data, "commercial_tax_applicable", None) is not None:
                     row = await conn.fetchrow(
@@ -902,12 +987,15 @@ async def update_tax_config(request: Request, data) -> dict:
                     inc_gl_account_id, iva_gl_account_id, liquor_tax_gl_account_id,
                     tax_lines, category_map, tax_jurisdiction_code,
                     commercial_tax_applicable,
-                    iva_rate, inc_rate, liquor_tax_rate
+                    iva_rate, inc_rate, liquor_tax_rate,
+                    menu_category_line_map, exempt_menu_category_ids
                 )
                 VALUES (
                     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb, $12,
                     COALESCE($13, false),
-                    COALESCE($14, 0.19), COALESCE($15, 0.08), COALESCE($16, 0.05)
+                    COALESCE($14, 0.19), COALESCE($15, 0.08), COALESCE($16, 0.05),
+                    COALESCE($17::jsonb, '{}'::jsonb),
+                    COALESCE($18::uuid[], '{}'::uuid[])
                 )
                 ON CONFLICT (tenant_id) DO UPDATE SET
                     inc_applicable        = EXCLUDED.inc_applicable,
@@ -931,6 +1019,14 @@ async def update_tax_config(request: Request, data) -> dict:
                     iva_rate = COALESCE($14, tenant_tax_config.iva_rate),
                     inc_rate = COALESCE($15, tenant_tax_config.inc_rate),
                     liquor_tax_rate = COALESCE($16, tenant_tax_config.liquor_tax_rate),
+                    menu_category_line_map = COALESCE(
+                        $17::jsonb,
+                        tenant_tax_config.menu_category_line_map
+                    ),
+                    exempt_menu_category_ids = COALESCE(
+                        $18::uuid[],
+                        tenant_tax_config.exempt_menu_category_ids
+                    ),
                     updated_at            = NOW()
                 RETURNING *
                 """,
@@ -950,6 +1046,8 @@ async def update_tax_config(request: Request, data) -> dict:
                 iva_rate,
                 inc_rate,
                 liquor_tax_rate,
+                menu_map_json,
+                exempt_ids_pg,
             )
 
             return {"success": True, "data": decode_tax_config_jsonb(dict(row))}

--- a/sql/20260729_menu_category_tax_map.sql
+++ b/sql/20260729_menu_category_tax_map.sql
@@ -1,0 +1,25 @@
+-- warocol.com#1883 — menu category → tax line map + exempt set + product override (ADD only).
+ALTER TABLE tenant_tax_config
+    ADD COLUMN IF NOT EXISTS menu_category_line_map jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE tenant_tax_config
+    ADD COLUMN IF NOT EXISTS exempt_menu_category_ids uuid[] NOT NULL DEFAULT '{}'::uuid[];
+
+ALTER TABLE product
+    ADD COLUMN IF NOT EXISTS tax_resolution text NOT NULL DEFAULT 'inherit';
+
+ALTER TABLE product
+    ADD COLUMN IF NOT EXISTS tax_line_key text NULL;
+
+-- Soft check: inherit | exempt | line (enforced in API).
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'product_tax_resolution_check'
+    ) THEN
+        ALTER TABLE product
+            ADD CONSTRAINT product_tax_resolution_check
+            CHECK (tax_resolution IN ('inherit', 'exempt', 'line'));
+    END IF;
+END $$;

--- a/tests/test_menu_category_tax_resolve.py
+++ b/tests/test_menu_category_tax_resolve.py
@@ -1,0 +1,192 @@
+"""Menu category tax resolve — uno0uno/warocol.com#1883."""
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.tax_config import TaxConfigUpdate
+from app.services.hospitality_tax_engine import (
+    resolve_effective_tax_category,
+    resolve_product_tax_line,
+)
+from app.services.tenant_config_service import (
+    decode_tax_config_jsonb,
+    validate_tax_matrix_payload,
+)
+
+
+CAT_A = str(uuid4())
+CAT_B = str(uuid4())
+CAT_C = str(uuid4())
+
+
+def _commercial_config(**overrides):
+    base = {
+        "tax_lines": [
+            {
+                "key": "mwst",
+                "label": "MwSt 19%",
+                "rate": 0.19,
+                "included_in_price": True,
+                "gl_role": "iva",
+            },
+            {
+                "key": "mwst_reduced",
+                "label": "MwSt 7%",
+                "rate": 0.07,
+                "included_in_price": True,
+                "gl_role": "iva",
+            },
+        ],
+        "category_map": {"standard": "mwst", "liquor": "mwst_reduced", "exempt": None},
+        "commercial_tax_applicable": True,
+        "menu_category_line_map": {},
+        "exempt_menu_category_ids": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_decode_menu_maps():
+    raw = {
+        "menu_category_line_map": f'{{"{CAT_A}":"mwst","{CAT_B}":null}}',
+        "exempt_menu_category_ids": [CAT_C],
+        "tax_lines": "[]",
+        "category_map": "{}",
+    }
+    decoded = decode_tax_config_jsonb(raw)
+    assert decoded["menu_category_line_map"][CAT_A] == "mwst"
+    assert decoded["menu_category_line_map"][CAT_B] is None
+    assert decoded["exempt_menu_category_ids"] == [CAT_C]
+
+
+def test_validate_menu_map_unknown_line():
+    with pytest.raises(HTTPException) as exc:
+        validate_tax_matrix_payload(
+            [{"key": "mwst", "rate": 0.19}],
+            {"standard": "mwst", "exempt": None},
+            {CAT_A: "missing"},
+            None,
+        )
+    assert exc.value.status_code == 400
+    assert "menu_category_line_map" in str(exc.value.detail)
+
+
+def test_validate_menu_map_bad_uuid_key():
+    with pytest.raises(HTTPException) as exc:
+        validate_tax_matrix_payload(
+            [{"key": "mwst", "rate": 0.19}],
+            None,
+            {"not-a-uuid": "mwst"},
+            None,
+        )
+    assert exc.value.status_code == 400
+
+
+def test_validate_exempt_ids():
+    validate_tax_matrix_payload(
+        [{"key": "mwst", "rate": 0.19}],
+        {"standard": "mwst", "exempt": None},
+        {CAT_A: "mwst"},
+        [CAT_B],
+    )
+
+
+def test_override_exempt_beats_menu_map():
+    cfg = _commercial_config(
+        menu_category_line_map={CAT_A: "mwst_reduced"},
+    )
+    line = resolve_product_tax_line(
+        cfg,
+        category_id=CAT_A,
+        tax_resolution="exempt",
+        tax_category="standard",
+    )
+    assert line is None
+
+
+def test_override_line_beats_menu_map():
+    cfg = _commercial_config(
+        menu_category_line_map={CAT_A: "mwst"},
+    )
+    line = resolve_product_tax_line(
+        cfg,
+        category_id=CAT_A,
+        tax_resolution="line",
+        tax_line_key="mwst_reduced",
+    )
+    assert line is not None
+    assert line.key == "mwst_reduced"
+
+
+def test_exempt_set_before_menu_map():
+    cfg = _commercial_config(
+        menu_category_line_map={CAT_A: "mwst"},
+        exempt_menu_category_ids=[CAT_A],
+    )
+    line = resolve_product_tax_line(cfg, category_id=CAT_A, tax_resolution="inherit")
+    assert line is None
+
+
+def test_menu_map_then_primary_for_unmapped():
+    cfg = _commercial_config(
+        menu_category_line_map={CAT_A: "mwst_reduced"},
+    )
+    mapped = resolve_product_tax_line(cfg, category_id=CAT_A)
+    unmapped = resolve_product_tax_line(cfg, category_id=CAT_B)
+    assert mapped is not None and mapped.key == "mwst_reduced"
+    assert unmapped is not None and unmapped.key == "mwst"  # primary
+
+
+def test_empty_menu_map_dual_reads_legacy_tax_category():
+    cfg = _commercial_config()
+    liquor = resolve_product_tax_line(cfg, tax_category="liquor")
+    standard = resolve_product_tax_line(cfg, tax_category="standard")
+    assert liquor is not None and liquor.key == "mwst_reduced"
+    assert standard is not None and standard.key == "mwst"
+
+
+def test_co_ignores_menu_maps():
+    cfg = {
+        "inc_applicable": True,
+        "inc_rate": 0.08,
+        "inc_included_in_price": True,
+        "iva_applicable": False,
+        "liquor_tax_applicable": True,
+        "liquor_tax_rate": 0.05,
+        "menu_category_line_map": {CAT_A: "mwst"},
+        "exempt_menu_category_ids": [CAT_A],
+    }
+    # CO path: exempt set must not apply; use tax_category
+    line = resolve_product_tax_line(
+        cfg,
+        category_id=CAT_A,
+        tax_resolution="inherit",
+        tax_category="standard",
+    )
+    assert line is not None
+    assert line.key == "inc"
+
+
+def test_effective_category_liquor_bucket():
+    cfg = _commercial_config(
+        menu_category_line_map={CAT_A: "mwst_reduced"},
+    )
+    assert (
+        resolve_effective_tax_category(cfg, category_id=CAT_A) == "liquor"
+    )
+
+
+def test_tax_config_update_accepts_menu_fields():
+    body = TaxConfigUpdate(
+        inc_applicable=False,
+        inc_included_in_price=False,
+        iva_applicable=False,
+        iva_included_in_price=False,
+        liquor_tax_applicable=False,
+        tax_lines=[{"key": "mwst", "rate": 0.19, "gl_role": "iva"}],
+        menu_category_line_map={CAT_A: "mwst"},
+        exempt_menu_category_ids=[CAT_B],
+    )
+    assert body.menu_category_line_map[CAT_A] == "mwst"
+    assert str(body.exempt_menu_category_ids[0]) == CAT_B

--- a/tests/test_tax_config_matrix.py
+++ b/tests/test_tax_config_matrix.py
@@ -39,6 +39,8 @@ def test_decode_tax_config_jsonb_parses_asyncpg_strings():
     raw = {
         "tax_lines": '[{"key":"iva","rate":0.16}]',
         "category_map": '{"standard":"iva","exempt":null}',
+        "menu_category_line_map": '{"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee":"iva"}',
+        "exempt_menu_category_ids": '["ffffffff-0000-1111-2222-333333333333"]',
         "iva_rate": Decimal("0.19"),
     }
     decoded = decode_tax_config_jsonb(raw)
@@ -47,6 +49,8 @@ def test_decode_tax_config_jsonb_parses_asyncpg_strings():
     assert isinstance(decoded["category_map"], dict)
     assert decoded["category_map"]["standard"] == "iva"
     assert decoded["category_map"]["exempt"] is None
+    assert decoded["menu_category_line_map"]["aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"] == "iva"
+    assert decoded["exempt_menu_category_ids"] == ["ffffffff-0000-1111-2222-333333333333"]
 
 
 def test_decode_tax_config_jsonb_leaves_objects_alone():


### PR DESCRIPTION
## Summary
- ADD `menu_category_line_map` / `exempt_menu_category_ids` on `tenant_tax_config` with GET/PUT decode + validation (COALESCE-safe omit)
- ADD product `tax_resolution` (`inherit|exempt|line`) + `tax_line_key`; keep `tax_category` for CO/legacy
- `resolve_product_tax_line` implements epic order; CO ignores menu maps; empty maps dual-read legacy tags; cierre + product create/list wired

Closes uno0uno/warocol.com#1883
Parent epic: uno0uno/warocol.com#1881

## Test plan
- [x] `./venv/bin/pytest tests/test_menu_category_tax_resolve.py tests/test_tax_config_matrix.py -q` (21 passed)
- [ ] Apply `sql/20260729_menu_category_tax_map.sql` on target DB before deploy
- [ ] Manual: commercial tenant PUT menu map + exempt set round-trips on GET
- [ ] Manual: product override `exempt` / `line` beats menu map; unmapped → primary
- [ ] Manual: CO tenant still uses `tax_category` only (menu maps ignored)


Made with [Cursor](https://cursor.com)