### PR TITLE
fix(tax): POS tax path honors menu-category exempt map (#1889)

### DIFF
--- a/.wr/1889.yaml
+++ b/.wr/1889.yaml
@@ -1,0 +1,36 @@
+# Compact plan for wr-fast #1889. Keep <=80 lines.
+issue: 1889
+title: "fix(tax): POS tax path ignores menu-category exempt map"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-1889-pos-tax-menu-category
+risk: low
+closes: "uno0uno/warocol.com#1889"
+
+paths:
+  - app/services/pos_cart_service.py
+  - app/services/orders_service.py
+  - tests/test_menu_category_tax_resolve.py
+
+ac:
+  - "tax-preview + order tax SELECTs pass category_id, tax_resolution, tax_line_key"
+  - "Exempt menu category + inherit → 0 tax"
+  - "Mapped menu category still applies mapped line"
+  - "Product override exempt/line still wins"
+  - "pytest covers exempt vs mapped vs missing-category regression"
+  - "PR Closes uno0uno/warocol.com#1889"
+
+out_of_scope:
+  - "Facturación UI; Menú inherit UX; CO matrix; POS summary redesign"
+
+hints:
+  entry: "pos_cart_service._tax_rows_from_evaluated_lines:251 drops category_id; get_cart_items SELECT lacks tax_resolution"
+  bug: "Without category_id, resolve falls through to primary line when maps/exempt exist"
+  fix: "Pass category_id/tax_resolution/tax_line_key on cart items + tax rows; fix orders_service tax SELECTs (~886, ~4242, complete path ~2580)"
+  tests: "./venv/bin/pytest tests/test_menu_category_tax_resolve.py -q"
+  pattern: "cierre_service already SELECTs tax_resolution + tax_line_key — mirror that"
+
+skip:
+  audits: [ux, color, typography, security]

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -322,8 +322,21 @@ def _tax_detail_rows(
     standard_tax_label: str,
     tax_config: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
-    std_base = sum(float(r["subtotal"]) for r in items_rows if r["tax_category"] == "standard")
-    liq_base = sum(float(r["subtotal"]) for r in items_rows if r["tax_category"] == "liquor")
+    from app.services.hospitality_tax_engine import resolve_effective_tax_category
+
+    def _effective(row: Any) -> str:
+        if tax_config is None:
+            return str(_row_get(row, "tax_category") or "standard")
+        return resolve_effective_tax_category(
+            tax_config,
+            category_id=_row_get(row, "category_id"),
+            tax_resolution=_row_get(row, "tax_resolution") or "inherit",
+            tax_line_key=_row_get(row, "tax_line_key"),
+            tax_category=_row_get(row, "tax_category") or "standard",
+        )
+
+    std_base = sum(float(r["subtotal"]) for r in items_rows if _effective(r) == "standard")
+    liq_base = sum(float(r["subtotal"]) for r in items_rows if _effective(r) == "liquor")
     rows: List[Dict[str, Any]] = []
     if standard_tax > 0:
         rows.append({"label": standard_tax_label, "base": std_base, "amount": standard_tax})
@@ -884,6 +897,9 @@ async def get_order_by_id(
                 tax_config = await _get_tenant_tax_config(conn, tenant_id)
                 items_rows = await conn.fetch(
                     """SELECT COALESCE(p.tax_category, 'standard') AS tax_category,
+                              COALESCE(p.tax_resolution, 'inherit') AS tax_resolution,
+                              p.tax_line_key AS tax_line_key,
+                              p.category_id::text AS category_id,
                               COALESCE(oi.net_total, oi.subtotal, 0) AS subtotal
                        FROM order_items oi
                        JOIN product p ON p.id = oi.product_id
@@ -2262,12 +2278,14 @@ async def get_orders_metrics(
                 tax_where_sql = " AND ".join(tax_where)
                 tax_rows = await conn.fetch(
                     f"""SELECT COALESCE(p.tax_category, 'standard') AS tax_category,
-                               COALESCE(SUM(oi.subtotal), 0) AS subtotal
+                               COALESCE(p.tax_resolution, 'inherit') AS tax_resolution,
+                               p.tax_line_key AS tax_line_key,
+                               p.category_id::text AS category_id,
+                               COALESCE(oi.subtotal, 0) AS subtotal
                         FROM order_items oi
                         JOIN product p ON p.id = oi.product_id
                         JOIN orders o ON o.id = oi.order_id
-                        WHERE {tax_where_sql}
-                        GROUP BY COALESCE(p.tax_category, 'standard')""",
+                        WHERE {tax_where_sql}""",
                     *tax_params
                 )
                 _total_std_tax, _total_liq_tax, _tax_label = _compute_tax_breakdown(tax_rows, tax_config)
@@ -2462,7 +2480,10 @@ async def get_orders_dashboard(
             _base_filter = f"o.tenant_id = $1 AND o.status = 'completed' AND {ANALYTICS_SALES_FILTER_ALIAS_O}"
             _tax_select = """
                 SELECT COALESCE(p.tax_category, 'standard') AS tax_category,
-                       COALESCE(SUM(oi.subtotal), 0) AS subtotal
+                       COALESCE(p.tax_resolution, 'inherit') AS tax_resolution,
+                       p.tax_line_key AS tax_line_key,
+                       p.category_id::text AS category_id,
+                       COALESCE(oi.subtotal, 0) AS subtotal
                 FROM order_items oi
                 JOIN product p ON p.id = oi.product_id
                 JOIN orders o ON o.id = oi.order_id
@@ -2470,20 +2491,18 @@ async def get_orders_dashboard(
             try:
                 tax_config = await _get_tenant_tax_config(conn, tenant_id)
                 main_tax_rows = await conn.fetch(
-                    f"{_tax_select} WHERE {_base_filter} GROUP BY COALESCE(p.tax_category, 'standard')",
+                    f"{_tax_select} WHERE {_base_filter}",
                     tenant_id
                 )
                 month_tax_rows = await conn.fetch(
                     f"""{_tax_select} WHERE {_base_filter}
-                        AND DATE(o.order_date AT TIME ZONE $2) >= DATE_TRUNC('month', NOW() AT TIME ZONE $2)::date
-                        GROUP BY COALESCE(p.tax_category, 'standard')""",
+                        AND DATE(o.order_date AT TIME ZONE $2) >= DATE_TRUNC('month', NOW() AT TIME ZONE $2)::date""",
                     tenant_id,
                     timezone_name,
                 )
                 year_tax_rows = await conn.fetch(
                     f"""{_tax_select} WHERE {_base_filter}
-                        AND DATE(o.order_date AT TIME ZONE $2) >= DATE_TRUNC('year', NOW() AT TIME ZONE $2)::date
-                        GROUP BY COALESCE(p.tax_category, 'standard')""",
+                        AND DATE(o.order_date AT TIME ZONE $2) >= DATE_TRUNC('year', NOW() AT TIME ZONE $2)::date""",
                     tenant_id,
                     timezone_name,
                 )
@@ -4240,6 +4259,9 @@ async def send_invoice_email(
         tax_config = await _get_tenant_tax_config(conn, tenant_id)
         items_for_tax = await conn.fetch(
             """SELECT COALESCE(p.tax_category, 'standard') AS tax_category,
+                      COALESCE(p.tax_resolution, 'inherit') AS tax_resolution,
+                      p.tax_line_key AS tax_line_key,
+                      p.category_id::text AS category_id,
                       COALESCE(oi.net_total, oi.subtotal, 0) AS subtotal
                FROM order_items oi
                JOIN product p ON p.id = oi.product_id

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -138,6 +138,8 @@ def _cart_items_to_promo_lines(items: List[dict]) -> List[dict]:
             "quantity": quantity,
             "subtotal": float(item["subtotal"]),
             "tax_category": item.get("tax_category") or "standard",
+            "tax_resolution": item.get("tax_resolution") or "inherit",
+            "tax_line_key": item.get("tax_line_key"),
             "promo_opt_out": bool(item.get("promo_opt_out")),
         }
         if raw_unit_price is not None:
@@ -249,13 +251,23 @@ def _manual_discount_amount(
 
 
 def _tax_rows_from_evaluated_lines(lines: Sequence[dict]) -> List[dict]:
-    grouped: Dict[str, float] = {}
+    """Item-level rows for hospitality resolve (menu category + override).
+
+    Do not collapse by legacy tax_category — that drops category_id and makes
+    exempt/mapped menu categories fall through to the primary line (#1889).
+    """
+    rows: List[dict] = []
     for line in lines:
-        category = line.get("tax_category") or "standard"
-        grouped[category] = grouped.get(category, 0.0) + float(
-            line.get("net_total", line.get("subtotal_after_promo", line["subtotal"]))
-        )
-    return [{"tax_category": k, "subtotal": v} for k, v in grouped.items()]
+        rows.append({
+            "tax_category": line.get("tax_category") or "standard",
+            "tax_resolution": line.get("tax_resolution") or "inherit",
+            "tax_line_key": line.get("tax_line_key"),
+            "category_id": line.get("category_id"),
+            "subtotal": float(
+                line.get("net_total", line.get("subtotal_after_promo", line["subtotal"]))
+            ),
+        })
+    return rows
 
 
 async def get_or_create_active_cart(
@@ -523,6 +535,8 @@ async def get_cart_items(conn, cart_id: UUID) -> List[dict]:
             p.name as product_name,
             p.category_id as category_id,
             COALESCE(p.tax_category, 'standard') AS tax_category,
+            COALESCE(p.tax_resolution, 'inherit') AS tax_resolution,
+            p.tax_line_key AS tax_line_key,
             p.is_resale as product_is_resale,
             COALESCE(
                 json_agg(
@@ -548,7 +562,8 @@ async def get_cart_items(conn, cart_id: UUID) -> List[dict]:
                  ci.notes, ci.promo_opt_out, ci.locked_promotion_id, ci.promotion_locked_at,
                  ci.locked_promo_eligible_subtotal, ci.locked_promo_eligible_unit_price,
                  ci.locked_promotion_name, ci.locked_promo_type, ci.locked_promo_savings,
-                 ci.created_at, p.name, p.category_id, p.tax_category, p.is_resale
+                 ci.created_at, p.name, p.category_id, p.tax_category, p.tax_resolution,
+                 p.tax_line_key, p.is_resale
         ORDER BY ci.created_at
     """
     items_rows = await conn.fetch(items_query, cart_id)
@@ -565,6 +580,8 @@ async def get_cart_items(conn, cart_id: UUID) -> List[dict]:
             "product_id": str(item_row['product_id']),
             "category_id": str(item_row['category_id']) if item_row['category_id'] else None,
             "tax_category": item_row['tax_category'] or 'standard',
+            "tax_resolution": item_row['tax_resolution'] or 'inherit',
+            "tax_line_key": item_row['tax_line_key'],
             "product": {
                 "id": str(item_row['product_id']),
                 "name": item_row['product_name'],
@@ -1246,9 +1263,21 @@ async def get_cart_tax_preview(
             promo_lines,
             manual_discount_amount=float(discount_amount or 0),
         )
-        tax_category_by_id = {line["id"]: line["tax_category"] for line in promo_lines}
+        tax_fields_by_id = {
+            line["id"]: {
+                "tax_category": line.get("tax_category") or "standard",
+                "category_id": line.get("category_id"),
+                "tax_resolution": line.get("tax_resolution") or "inherit",
+                "tax_line_key": line.get("tax_line_key"),
+            }
+            for line in promo_lines
+        }
         for line in checkout_eval["lines"]:
-            line["tax_category"] = tax_category_by_id.get(line["id"], "standard")
+            fields = tax_fields_by_id.get(line["id"], {})
+            line["tax_category"] = fields.get("tax_category", "standard")
+            line["category_id"] = fields.get("category_id")
+            line["tax_resolution"] = fields.get("tax_resolution", "inherit")
+            line["tax_line_key"] = fields.get("tax_line_key")
 
         tax_config = await _get_tenant_tax_config(conn, tenant_id)
         tax_rows = _tax_rows_from_evaluated_lines(checkout_eval["lines"])
@@ -2578,6 +2607,9 @@ async def complete_pos_order(
 
                     items_tax_rows = await conn.fetch(
                         """SELECT COALESCE(p.tax_category, 'standard') AS tax_category,
+                                  COALESCE(p.tax_resolution, 'inherit') AS tax_resolution,
+                                  p.tax_line_key AS tax_line_key,
+                                  p.category_id::text AS category_id,
                                   COALESCE(oi.subtotal, 0) AS subtotal
                            FROM order_items oi
                            JOIN product p ON p.id = oi.product_id

--- a/tests/test_menu_category_tax_resolve.py
+++ b/tests/test_menu_category_tax_resolve.py
@@ -6,9 +6,11 @@ from fastapi import HTTPException
 
 from app.models.tax_config import TaxConfigUpdate
 from app.services.hospitality_tax_engine import (
+    compute_category_breakdown,
     resolve_effective_tax_category,
     resolve_product_tax_line,
 )
+from app.services.pos_cart_service import _tax_rows_from_evaluated_lines
 from app.services.tenant_config_service import (
     decode_tax_config_jsonb,
     validate_tax_matrix_payload,
@@ -190,3 +192,89 @@ def test_tax_config_update_accepts_menu_fields():
     )
     assert body.menu_category_line_map[CAT_A] == "mwst"
     assert str(body.exempt_menu_category_ids[0]) == CAT_B
+
+
+def test_pos_tax_rows_preserve_menu_category_fields():
+    """#1889 — do not collapse lines by legacy tax_category."""
+    rows = _tax_rows_from_evaluated_lines(
+        [
+            {
+                "tax_category": "standard",
+                "tax_resolution": "inherit",
+                "tax_line_key": None,
+                "category_id": CAT_B,
+                "subtotal": 145.0,
+            },
+            {
+                "tax_category": "standard",
+                "tax_resolution": "inherit",
+                "tax_line_key": None,
+                "category_id": CAT_A,
+                "net_total": 100.0,
+                "subtotal": 100.0,
+            },
+        ]
+    )
+    assert len(rows) == 2
+    assert rows[0]["category_id"] == CAT_B
+    assert rows[0]["tax_resolution"] == "inherit"
+    assert rows[1]["subtotal"] == 100.0
+
+
+def test_breakdown_exempt_vs_mapped_vs_missing_category_id():
+    """#1889 regression: missing category_id must not tax exempt categories as primary."""
+    cfg = _commercial_config(
+        menu_category_line_map={CAT_A: "mwst"},
+        exempt_menu_category_ids=[CAT_B],
+        category_map={"standard": "mwst", "liquor": "mwst", "exempt": None},
+    )
+    # Bug shape (old POS): only tax_category
+    bug_std, bug_liq, _ = compute_category_breakdown(
+        [{"tax_category": "standard", "subtotal": 145.0}],
+        cfg,
+    )
+    assert bug_std + bug_liq > 0
+
+    # Exempt category with inherit
+    ok_std, ok_liq, _ = compute_category_breakdown(
+        [
+            {
+                "tax_category": "standard",
+                "tax_resolution": "inherit",
+                "category_id": CAT_B,
+                "subtotal": 145.0,
+            }
+        ],
+        cfg,
+    )
+    assert ok_std == 0.0
+    assert ok_liq == 0.0
+
+    # Mapped category still taxes (bucket uses legacy standard/liquor lines)
+    mapped_std, mapped_liq, _ = compute_category_breakdown(
+        [
+            {
+                "tax_category": "standard",
+                "tax_resolution": "inherit",
+                "category_id": CAT_A,
+                "subtotal": 100.0,
+            }
+        ],
+        cfg,
+    )
+    assert mapped_std + mapped_liq > 0
+
+    # Product override exempt wins over mapped category
+    override_std, override_liq, _ = compute_category_breakdown(
+        [
+            {
+                "tax_category": "standard",
+                "tax_resolution": "exempt",
+                "category_id": CAT_A,
+                "subtotal": 100.0,
+            }
+        ],
+        cfg,
+    )
+    assert override_std == 0.0
+    assert override_liq == 0.0


### PR DESCRIPTION
## Summary
- Cart tax-preview keeps `category_id` / `tax_resolution` / `tax_line_key` instead of collapsing by legacy `tax_category`
- Order complete/detail and analytics tax SELECTs pass the same fields into `compute_category_breakdown`
- Exempt menu categories no longer fall through to primary IVA

Closes uno0uno/warocol.com#1889

## Test plan
- [ ] MX tenant: Cócteles exempt product (Ranch Water) → tax-preview IVA = 0
- [ ] Bebidas mapped to IVA → tax still applies
- [ ] Product override exempt/line still wins

## Validation evidence
```
$ ./venv/bin/pytest tests/test_menu_category_tax_resolve.py -q
============================= test session starts ==============================
platform darwin -- Python 3.12.1, pytest-8.3.4, pluggy-1.6.0
rootdir: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
configfile: pytest.ini
plugins: anyio-4.12.1, asyncio-0.24.0, cov-6.0.0
asyncio: mode=Mode.AUTO, default_loop_scope=function
collected 14 items

tests/test_menu_category_tax_resolve.py ..............                   [100%]

============================== 14 passed in 0.04s ==============================
```

## wr-context
See `.wr/1889.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)