### PR TITLE
fix(tax): load menu exempt maps in POS/orders tax config

### DIFF
--- a/.wr/1891.yaml
+++ b/.wr/1891.yaml
@@ -1,0 +1,52 @@
+# Compact plan — uno0uno/warocol.com#1891 (epic #1890 batch 1). Keep <=80 lines.
+issue: 1891
+title: "Load menu tax maps in POS/orders tax config + hide $0 tax on tickets"
+repo: both
+repo_remote: uno0uno/api-warolabs # + front PR uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: both
+branch: wr-1891-pos-tax-menu-config
+front_branch: wr-1891-hide-zero-tax-summary
+front_cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+closes: "Closes uno0uno/warocol.com#1891"
+
+paths:
+  - app/services/cierre_service.py # WIP: SELECT + decode menu maps
+  - tests/test_menu_category_tax_resolve.py # WIP: loader test
+  - ../front_nuxt/pages/pos/checkout.vue # hide summary tax rows at $0 (~4006, ~4509)
+
+ac:
+  - "_get_tenant_tax_config returns menu_category_line_map + exempt_menu_category_ids (decoded)"
+  - "Exempt menu category (inherit): POS tax-preview + completed order tax amount = 0"
+  - "Checkout Resumen de la Orden: no tax row when (standard_tax+liquor_tax)==0"
+  - "Print tickets/ventas already v-if>0 — no change unless a $0 line remains"
+  - "pytest tests/test_menu_category_tax_resolve.py passes; listed in PR"
+
+out_of_scope:
+  - DIAN/jurisdiction labels (#1892)
+  - FE auto-email (#1893)
+  - Cash keypad (#1894)
+  - Re-plumbing category_id (#1889 merged)
+  - Facturación settings UI
+
+hints:
+  entry: "cierre_service._get_tenant_tax_config → pos_cart/orders/tables tax paths"
+  pattern: "checkout.vue ~4866 / ReceiptPrintTicket.vue ~337 v-if tax > 0"
+  wip: "API diff already on main working tree — branch + commit; do not rewrite"
+  front: "v-if on summary tax divs only; keep label localization unchanged"
+  tests: "cd api_warocol.com && ./venv/bin/pytest tests/test_menu_category_tax_resolve.py -q"
+
+risk:
+  sensitive: false
+  areas: [tax-config-read]
+
+skip:
+  audits: [ux, color, typography, security-full]
+
+steps:
+  - "API: pull main, branch wr-1891-pos-tax-menu-config, commit WIP, push, PR → api-warolabs"
+  - "Front: pull main, branch wr-1891-hide-zero-tax-summary, gate checkout summary tax rows, PR → warocol.com"
+  - "Both PR bodies: Closes uno0uno/warocol.com#1891 (or Closes #1891 on warocol.com PR)"
+
+next:
+  after_pr: "/wr-next uno0uno/warocol.com#1890"

--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -124,7 +124,12 @@ async def _get_tenant_tax_config(conn, tenant_id: UUID) -> Dict[str, Any]:
     """
     Return tax config for the tenant.  Falls back to all-disabled defaults
     if no row exists (safe for tenants created before migration 027).
+
+    Includes menu_category_line_map + exempt_menu_category_ids so POS/orders
+    tax breakdown can honor Facturación category maps (#1889 follow-up).
     """
+    from app.services.tenant_config_service import decode_tax_config_jsonb
+
     row = await conn.fetchrow(
         """SELECT inc_applicable, inc_rate, inc_gl_account_code, inc_gl_account_id,
                   inc_included_in_price,
@@ -132,12 +137,13 @@ async def _get_tenant_tax_config(conn, tenant_id: UUID) -> Dict[str, Any]:
                   liquor_tax_gl_account_code, liquor_tax_gl_account_id,
                   iva_applicable, iva_rate, iva_gl_account_code, iva_gl_account_id,
                   iva_included_in_price,
-                  tax_lines, category_map, commercial_tax_applicable
+                  tax_lines, category_map, commercial_tax_applicable,
+                  menu_category_line_map, exempt_menu_category_ids
            FROM tenant_tax_config WHERE tenant_id = $1""",
         tenant_id,
     )
     if row:
-        return dict(row)
+        return decode_tax_config_jsonb(dict(row))
     return {
         "inc_applicable":             False,
         "inc_rate":                   Decimal("0.0800"),
@@ -156,6 +162,8 @@ async def _get_tenant_tax_config(conn, tenant_id: UUID) -> Dict[str, Any]:
         "tax_lines":                  None,
         "category_map":               None,
         "commercial_tax_applicable":  False,
+        "menu_category_line_map":     {},
+        "exempt_menu_category_ids":   [],
     }
 
 

--- a/tests/test_menu_category_tax_resolve.py
+++ b/tests/test_menu_category_tax_resolve.py
@@ -278,3 +278,49 @@ def test_breakdown_exempt_vs_mapped_vs_missing_category_id():
     )
     assert override_std == 0.0
     assert override_liq == 0.0
+
+
+@pytest.mark.asyncio
+async def test_get_tenant_tax_config_loads_menu_category_maps():
+    """POS tax-preview uses cierre_service loader — must include Facturación maps."""
+    from app.services.cierre_service import _get_tenant_tax_config
+
+    captured: dict = {}
+
+    class _Conn:
+        async def fetchrow(self, query, *_args):
+            captured["query"] = query
+            return {
+                "inc_applicable": False,
+                "inc_rate": None,
+                "inc_gl_account_code": None,
+                "inc_gl_account_id": None,
+                "inc_included_in_price": True,
+                "liquor_tax_applicable": False,
+                "liquor_tax_rate": None,
+                "liquor_tax_gl_account_code": None,
+                "liquor_tax_gl_account_id": None,
+                "iva_applicable": False,
+                "iva_rate": None,
+                "iva_gl_account_code": None,
+                "iva_gl_account_id": None,
+                "iva_included_in_price": False,
+                "tax_lines": '[{"key":"iva","label":"IVA 16%","rate":0.16,'
+                '"included_in_price":false,"gl_role":"iva"}]',
+                "category_map": '{"standard":"iva","liquor":"iva","exempt":null}',
+                "commercial_tax_applicable": True,
+                "menu_category_line_map": f'{{"{CAT_A}":"iva"}}',
+                "exempt_menu_category_ids": [CAT_B],
+            }
+
+    cfg = await _get_tenant_tax_config(_Conn(), uuid4())
+    assert "menu_category_line_map" in captured["query"]
+    assert "exempt_menu_category_ids" in captured["query"]
+    assert cfg["menu_category_line_map"][CAT_A] == "iva"
+    assert cfg["exempt_menu_category_ids"] == [CAT_B]
+    assert resolve_effective_tax_category(
+        cfg,
+        category_id=CAT_B,
+        tax_resolution="inherit",
+        tax_category="standard",
+    ) == "exempt"


### PR DESCRIPTION
## Summary
- `_get_tenant_tax_config` now SELECTs and decodes `menu_category_line_map` / `exempt_menu_category_ids` so POS tax-preview, orders, and mesa tax honor Facturación exempt categories.
- Regression test for loader + exempt resolve.

Closes uno0uno/warocol.com#1891

Companion front: hide $0 tax row on checkout summary (warocol.com PR).

## Test plan
- [ ] MX tenant with Cócteles exempt: Ranch Water tax-preview = 0; total = subtotal
- [ ] Mapped non-exempt category still taxes
- [ ] Pytest below

## Validation evidence

```text
cd api_warocol.com && ./venv/bin/pytest tests/test_menu_category_tax_resolve.py -q

============================= test session starts ==============================
collected 15 items
tests/test_menu_category_tax_resolve.py ...............                  [100%]
============================== 15 passed in 0.03s ==============================
```


Made with [Cursor](https://cursor.com)