### PR TITLE
fix(tax): tenant tax labels + same-key pack bucketing (#1899)

### DIFF
--- a/app/services/hospitality_tax_engine.py
+++ b/app/services/hospitality_tax_engine.py
@@ -157,7 +157,14 @@ def resolve_effective_tax_category(
     tax_line_key: Optional[str] = None,
     tax_category: Optional[str] = "standard",
 ) -> str:
-    """Map resolved line → standard|liquor|exempt for legacy POS/GL buckets."""
+    """Map resolved line → standard|liquor|exempt for legacy POS/GL buckets.
+
+    When ``category_map.standard`` and ``category_map.liquor`` share the same
+    tax line key (common in MX / single-rate packs), do **not** dump every
+    taxable item into ``liquor`` — that made receipts show CO "IVA licores 5%"
+    for ordinary IVA 16% (#1899). Use the distinct liquor key only when it
+    differs from standard; otherwise fall back to the product's fiscal tag.
+    """
     line = resolve_product_tax_line(
         tax_config,
         category_id=category_id,
@@ -168,10 +175,22 @@ def resolve_effective_tax_category(
     if line is None:
         return "exempt"
     profile = resolve_tax_profile(tax_config)
+    standard_key = profile.category_map.get("standard")
     liquor_key = profile.category_map.get("liquor")
-    if liquor_key and line.key == liquor_key:
+    if liquor_key and liquor_key != standard_key and line.key == liquor_key:
+        return "liquor"
+    legacy = str(tax_category or "standard").strip().lower()
+    if legacy == "liquor" and liquor_key and line.key == liquor_key:
         return "liquor"
     return "standard"
+
+
+def liquor_tax_label_for_config(tax_config: Mapping[str, Any]) -> str:
+    """Label for the liquor bucket — tenant tax_lines[].label, never a hard-coded CO string."""
+    line = resolve_tax_profile(tax_config).line_for_category("liquor")
+    if line and line.label:
+        return line.label
+    return "IVA licores 5%"
 
 
 def _line_from_mapping(item: Mapping[str, Any]) -> Optional[TaxLine]:
@@ -383,3 +402,99 @@ def tip_tax_is_additive(tax_config: Mapping[str, Any]) -> bool:
 def primary_gl_role(tax_config: Mapping[str, Any]) -> Optional[str]:
     line = resolve_tax_profile(tax_config).primary_line()
     return line.gl_role if line else None
+
+
+def additive_order_tax_total(
+    standard_tax: float,
+    liquor_tax: float,
+    tax_config: Mapping[str, Any],
+) -> float:
+    """Tax dollars added on top of product total_amount (cierre debit_total rule).
+
+    Included-in-price standard tax is extractive (already in prices) — omit it.
+    Liquor / any non-included bucket line is additive.
+    """
+    profile = resolve_tax_profile(tax_config)
+    std_line = profile.line_for_category("standard")
+    liq_line = profile.line_for_category("liquor")
+    std_extra = float(standard_tax or 0) if (std_line and not std_line.included_in_price) else 0.0
+    # Liquor with no line → 0; included liquor line (rare commercial) → omit
+    if liq_line is None:
+        liq_extra = 0.0
+    elif liq_line.included_in_price:
+        liq_extra = 0.0
+    else:
+        liq_extra = float(liquor_tax or 0)
+    return float(std_extra + liq_extra)
+
+
+def _line_tax_base(line: Mapping[str, Any]) -> float:
+    """Same base as POS `_tax_rows_from_evaluated_lines` (post-promo/manual net)."""
+    return float(
+        line.get("net_total", line.get("subtotal_after_promo", line.get("subtotal", 0))) or 0
+    )
+
+
+def annotate_line_tax_amounts(
+    lines: Sequence[Mapping[str, Any]],
+    tax_config: Mapping[str, Any],
+    *,
+    reconcile_to: Optional[Tuple[float, float]] = None,
+) -> List[Dict[str, Any]]:
+    """Attach per-line tax_amount / tax_label for POS Orden display.
+
+    Mutates dict lines in place when they are mutable mappings; always returns
+    the annotated list. When ``reconcile_to`` is (standard_tax, liquor_tax),
+    adjusts the last taxable line in each bucket so Σ line taxes match the
+    cart-level category rounding.
+    """
+    out: List[Dict[str, Any]] = []
+    bucket_indices: Dict[str, List[int]] = {"standard": [], "liquor": []}
+
+    for idx, raw in enumerate(lines):
+        line = dict(raw) if not isinstance(raw, dict) else raw
+        base = _line_tax_base(line)
+        tax_line = resolve_product_tax_line(
+            tax_config,
+            category_id=line.get("category_id"),
+            tax_resolution=line.get("tax_resolution") or "inherit",
+            tax_line_key=line.get("tax_line_key"),
+            tax_category=line.get("tax_category") or "standard",
+        )
+        bucket = resolve_effective_tax_category(
+            tax_config,
+            category_id=line.get("category_id"),
+            tax_resolution=line.get("tax_resolution") or "inherit",
+            tax_line_key=line.get("tax_line_key"),
+            tax_category=line.get("tax_category") or "standard",
+        )
+        if tax_line is None or base <= 0:
+            line["tax_amount"] = 0.0
+            line["tax_label"] = None
+            line["tax_rate"] = None
+            line["included_in_price"] = None
+        else:
+            amount = tax_amount_float(base, tax_line)
+            line["tax_amount"] = float(amount)
+            line["tax_label"] = tax_line.label
+            line["tax_rate"] = float(tax_line.rate)
+            line["included_in_price"] = bool(tax_line.included_in_price)
+            if bucket in bucket_indices and amount > 0:
+                bucket_indices[bucket].append(idx)
+
+        out.append(line)
+
+    if reconcile_to is not None:
+        targets = {"standard": float(reconcile_to[0] or 0), "liquor": float(reconcile_to[1] or 0)}
+        for bucket, target in targets.items():
+            indices = bucket_indices.get(bucket) or []
+            if not indices:
+                continue
+            current = sum(float(out[i].get("tax_amount") or 0) for i in indices)
+            delta = round(target - current)
+            if delta == 0:
+                continue
+            last = out[indices[-1]]
+            last["tax_amount"] = float(round(float(last.get("tax_amount") or 0) + delta))
+
+    return out

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -343,11 +343,9 @@ def _tax_detail_rows(
     if liquor_tax > 0:
         liquor_label = "IVA licores 5%"
         if tax_config is not None:
-            from app.services.hospitality_tax_engine import resolve_tax_profile
+            from app.services.hospitality_tax_engine import liquor_tax_label_for_config
 
-            liq_line = resolve_tax_profile(tax_config).line_for_category("liquor")
-            if liq_line:
-                liquor_label = liq_line.label
+            liquor_label = liquor_tax_label_for_config(tax_config)
         rows.append({"label": liquor_label, "base": liq_base, "amount": liquor_tax})
     return rows
 
@@ -893,8 +891,12 @@ async def get_order_by_id(
             _std_tax = 0.0
             _liq_tax = 0.0
             _tax_label = "Impuesto"
+            _liq_label = "IVA licores 5%"
             try:
+                from app.services.hospitality_tax_engine import liquor_tax_label_for_config
+
                 tax_config = await _get_tenant_tax_config(conn, tenant_id)
+                _liq_label = liquor_tax_label_for_config(tax_config)
                 items_rows = await conn.fetch(
                     """SELECT COALESCE(p.tax_category, 'standard') AS tax_category,
                               COALESCE(p.tax_resolution, 'inherit') AS tax_resolution,
@@ -1029,6 +1031,7 @@ async def get_order_by_id(
                     "standard_tax": _std_tax,
                     "liquor_tax": _liq_tax,
                     "standard_tax_label": _tax_label,
+                    "liquor_tax_label": _liq_label,
                     "promo_savings": _promo_summary["promo_savings"],
                     "promo_breakdown": _promo_summary["promo_breakdown"],
                     "waro_redemption_summary": _waro_summary,

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -270,6 +270,75 @@ def _tax_rows_from_evaluated_lines(lines: Sequence[dict]) -> List[dict]:
     return rows
 
 
+def _reinject_tax_fields_on_eval_lines(
+    promo_lines: Sequence[dict],
+    eval_lines: Sequence[dict],
+) -> None:
+    """Copy product tax classification onto promotion-evaluated lines."""
+    tax_fields_by_id = {
+        line["id"]: {
+            "tax_category": line.get("tax_category") or "standard",
+            "category_id": line.get("category_id"),
+            "tax_resolution": line.get("tax_resolution") or "inherit",
+            "tax_line_key": line.get("tax_line_key"),
+        }
+        for line in promo_lines
+    }
+    for line in eval_lines:
+        fields = tax_fields_by_id.get(line["id"], {})
+        line["tax_category"] = fields.get("tax_category", "standard")
+        line["category_id"] = fields.get("category_id")
+        line["tax_resolution"] = fields.get("tax_resolution", "inherit")
+        line["tax_line_key"] = fields.get("tax_line_key")
+
+
+def _settlement_taxes_from_eval_lines(
+    eval_lines: Sequence[dict],
+    tax_config: dict,
+) -> tuple[float, float, str, str, float]:
+    """Return standard_tax, liquor_tax, std_label, liq_label, additive_tax for POS settlement."""
+    from app.services.hospitality_tax_engine import (
+        additive_order_tax_total,
+        liquor_tax_label_for_config,
+    )
+    from app.services.orders_service import _compute_tax_breakdown
+
+    std, liq, label = _compute_tax_breakdown(
+        _tax_rows_from_evaluated_lines(eval_lines),
+        tax_config,
+    )
+    additive = additive_order_tax_total(float(std), float(liq), tax_config)
+    return (
+        float(std),
+        float(liq),
+        label,
+        liquor_tax_label_for_config(tax_config),
+        float(additive),
+    )
+
+
+async def _additive_tax_for_order(conn, order_id, tax_config: dict) -> float:
+    """Additive tax on an existing order (net_total base — matches cierre)."""
+    from app.services.hospitality_tax_engine import additive_order_tax_total
+    from app.services.orders_service import _compute_tax_breakdown
+
+    rows = await conn.fetch(
+        """
+        SELECT COALESCE(p.tax_category, 'standard') AS tax_category,
+               COALESCE(p.tax_resolution, 'inherit') AS tax_resolution,
+               p.tax_line_key AS tax_line_key,
+               p.category_id::text AS category_id,
+               COALESCE(oi.net_total, oi.subtotal, 0) AS subtotal
+        FROM order_items oi
+        JOIN product p ON p.id = oi.product_id
+        WHERE oi.order_id = $1
+        """,
+        order_id,
+    )
+    std, liq, _ = _compute_tax_breakdown(rows, tax_config)
+    return float(additive_order_tax_total(float(std), float(liq), tax_config))
+
+
 async def get_or_create_active_cart(
     request: Request,
     customer_id: UUID,
@@ -1226,6 +1295,7 @@ async def get_cart_tax_preview(
     Issue #982 — evaluates tenant promotions first, then applies optional
     manual discount_amount on the promo-adjusted subtotal.
     """
+    from app.services.hospitality_tax_engine import annotate_line_tax_amounts
     from app.services.orders_service import _compute_tax_breakdown
     from app.services.promotions_service import evaluate_checkout_promotions
 
@@ -1249,6 +1319,7 @@ async def get_cart_tax_preview(
                 "standard_tax": 0.0,
                 "liquor_tax": 0.0,
                 "standard_tax_label": "Impuesto",
+                "liquor_tax_label": "IVA licores 5%",
                 "subtotal": 0,
                 "promo_savings": 0,
                 "subtotal_after_promos": 0,
@@ -1282,11 +1353,20 @@ async def get_cart_tax_preview(
         tax_config = await _get_tenant_tax_config(conn, tenant_id)
         tax_rows = _tax_rows_from_evaluated_lines(checkout_eval["lines"])
         std_tax, liq_tax, tax_label = _compute_tax_breakdown(tax_rows, tax_config)
+        from app.services.hospitality_tax_engine import liquor_tax_label_for_config
+
+        liq_label = liquor_tax_label_for_config(tax_config)
+        annotate_line_tax_amounts(
+            checkout_eval["lines"],
+            tax_config,
+            reconcile_to=(float(std_tax), float(liq_tax)),
+        )
 
     return {
         "standard_tax": float(std_tax),
         "liquor_tax": float(liq_tax),
         "standard_tax_label": tax_label,
+        "liquor_tax_label": liq_label,
         "subtotal": checkout_eval["subtotal"],
         "promo_savings": checkout_eval["promo_savings"],
         "subtotal_after_promos": checkout_eval["subtotal_after_promos"],
@@ -1438,6 +1518,11 @@ async def add_order_payment(
                     total_amount,
                     resolved_tip_amount,
                     resolved_tip_tax_amount,
+                    await _additive_tax_for_order(
+                        conn,
+                        order_id,
+                        await _get_tenant_tax_config(conn, tenant_id),
+                    ),
                 )
                 paid_before_row = await conn.fetchrow(
                     """
@@ -1742,6 +1827,11 @@ async def void_order_payment(
                     total_amount,
                     float(payment_row["tip_amount"] or 0),
                     float(payment_row["tip_tax_amount"] or 0),
+                    await _additive_tax_for_order(
+                        conn,
+                        order_id,
+                        await _get_tenant_tax_config(conn, tenant_id),
+                    ),
                 )
                 remaining = max(0.0, amount_due - paid_total)
                 is_complete = remaining <= 0.01
@@ -2122,22 +2212,35 @@ async def complete_pos_order(
                 _promo_breakdown = checkout_eval.get("promo_breakdown") or []
                 _eval_by_id = {line["id"]: line for line in checkout_eval["lines"]}
 
+                _reinject_tax_fields_on_eval_lines(promo_lines, checkout_eval["lines"])
+                (
+                    _standard_tax,
+                    _liquor_tax,
+                    _standard_tax_label,
+                    _liquor_tax_label,
+                    _additive_tax,
+                ) = _settlement_taxes_from_eval_lines(checkout_eval["lines"], tax_config)
+                _settlement_due = split_settlement_amount_due(
+                    float(_discounted_total),
+                    float(tip_amount),
+                    _tip_tax_amount,
+                    _additive_tax,
+                )
+
                 # Issue #524 — single-payment cash flow stores cash_received on the orders row.
                 # Split mode keeps it NULL here and stores per-line on order_payments below (step 7a).
                 # warocol.com#637 — when tipping is in effect, cash_received must cover
-                # total + tip (the customer must hand over enough physical cash for both).
+                # total + additive tax + tip (the customer must hand over enough physical cash).
                 _orders_cash_received: Optional[float] = None
                 if not split_mode and cash_received is not None:
                     if payment_method != 'cash':
                         raise APIError("cash_received solo aplica a pagos en efectivo", status_code=400)
-                    _required_cash = float(_discounted_total) + tip_settlement_total(
-                        float(tip_amount), _tip_tax_amount,
-                    )
+                    _required_cash = _settlement_due
                     if cash_received < _required_cash:
-                        if tip_amount > 0:
+                        if tip_amount > 0 or _additive_tax > 0:
                             raise APIError(
-                                f"Efectivo recibido ({cash_received}) debe ser mayor o igual al total + propina"
-                                f" (+ IVA propina si aplica) ({_required_cash})",
+                                f"Efectivo recibido ({cash_received}) debe ser mayor o igual al total a pagar"
+                                f" ({_required_cash})",
                                 status_code=400,
                             )
                         raise APIError(
@@ -2205,11 +2308,7 @@ async def complete_pos_order(
                 logger.info(f"Created order #{order_number} from cart {cart_id}")
 
                 if not split_mode and payment_method == WALLET_PAYMENT_SLUG:
-                    wallet_due = Decimal(str(split_settlement_amount_due(
-                        float(_discounted_total),
-                        float(tip_amount),
-                        float(_tip_tax_amount),
-                    )))
+                    wallet_due = Decimal(str(_settlement_due))
                     await apply_wallet_for_order(
                         conn,
                         customer_id,
@@ -2486,7 +2585,7 @@ async def complete_pos_order(
                 # 7a. In split mode: record first payment; cart stays active.
                 # Issue #524: split_first_cash_received is captured when the first split is cash.
                 _split_paid_total = 0.0
-                _split_remaining = float(_discounted_total)
+                _split_remaining = float(_settlement_due)
                 _split_is_complete = False
                 _split_first_payment_id: Optional[str] = None
                 if split_mode and split_first_amount > 0:
@@ -2498,9 +2597,7 @@ async def complete_pos_order(
                                 f"Efectivo recibido ({split_first_cash_received}) debe ser mayor o igual al monto ({split_first_amount})",
                                 status_code=400,
                             )
-                    _amount_due = split_settlement_amount_due(
-                        float(_discounted_total), float(tip_amount), _tip_tax_amount,
-                    )
+                    _amount_due = _settlement_due
                     if split_first_amount - _amount_due > 0.01:
                         raise APIError(
                             f"El pago excede el saldo pendiente ({_amount_due})",
@@ -2598,30 +2695,7 @@ async def complete_pos_order(
                     except Exception as e:
                         logger.error(f"COGS GL entry failed for POS order {order_id}: {e}")
 
-                # Compute tax breakdown for receipt display (same engine as cart/orders)
-                _standard_tax = 0.0
-                _liquor_tax = 0.0
-                _standard_tax_label = "Impuesto"
-                try:
-                    from app.services.orders_service import _compute_tax_breakdown
-
-                    items_tax_rows = await conn.fetch(
-                        """SELECT COALESCE(p.tax_category, 'standard') AS tax_category,
-                                  COALESCE(p.tax_resolution, 'inherit') AS tax_resolution,
-                                  p.tax_line_key AS tax_line_key,
-                                  p.category_id::text AS category_id,
-                                  COALESCE(oi.subtotal, 0) AS subtotal
-                           FROM order_items oi
-                           JOIN product p ON p.id = oi.product_id
-                           WHERE oi.order_id = $1""",
-                        order_id
-                    )
-                    _standard_tax, _liquor_tax, _standard_tax_label = _compute_tax_breakdown(
-                        items_tax_rows, tax_config,
-                    )
-                except Exception as e:
-                    logger.warning(f"Tax breakdown computation failed for order {order_id}: {e}")
-
+                # Tax already computed pre-insert for settlement (additive IVA etc.).
                 _waro_redemption_summary = await _get_order_waro_redemption_summary(conn, order_id)
 
                 # Capture values needed after the transaction closes
@@ -2644,9 +2718,7 @@ async def complete_pos_order(
                         "tip_source": tip_source,
                         "tip_taxable": _tip_taxable,
                         "tip_tax_amount": float(_tip_tax_amount),
-                        "charged_amount": float(_discounted_total) + tip_settlement_total(
-                            float(tip_amount), _tip_tax_amount,
-                        ),
+                        "charged_amount": float(_settlement_due),
                         "payment_method": payment_method,
                         "payment_status": payment_status,
                         "status": order_status,
@@ -2656,6 +2728,7 @@ async def complete_pos_order(
                         "standard_tax": _standard_tax,
                         "liquor_tax": _liquor_tax,
                         "standard_tax_label": _standard_tax_label,
+                        "liquor_tax_label": _liquor_tax_label,
                         "next_table_session_id": str(new_table_session_id) if new_table_session_id else None,
                         "subtotal": cart_subtotal,
                         "promo_savings": _promo_savings,

--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -80,7 +80,12 @@ SELECT
     ttc.iva_applicable,
     ttc.iva_rate,
     ttc.iva_included_in_price,
-    ttc.liquor_tax_applicable
+    ttc.liquor_tax_applicable,
+    ttc.tax_lines,
+    ttc.category_map,
+    ttc.commercial_tax_applicable,
+    ttc.menu_category_line_map,
+    ttc.exempt_menu_category_ids
 FROM tenants t
 LEFT JOIN tenant_public_profiles tpp ON tpp.tenant_id = t.id
 LEFT JOIN tenant_fiscal_data      fd  ON fd.tenant_id  = t.id
@@ -157,6 +162,32 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
     readiness = await get_readiness(tenant_id)
     invoicing_ready = bool(readiness and readiness.get('ready'))
 
+    from app.services.tenant_config_service import decode_tax_config_jsonb
+
+    tax_config_raw = {
+        'inc_applicable': bool(row['inc_applicable']) if row['inc_applicable'] is not None else False,
+        'inc_rate': float(row['inc_rate']) if row['inc_rate'] is not None else 0.08,
+        'inc_included_in_price': bool(row['inc_included_in_price']) if row['inc_included_in_price'] is not None else False,
+        'iva_applicable': bool(row['iva_applicable']) if row['iva_applicable'] is not None else False,
+        'iva_rate': float(row['iva_rate']) if row['iva_rate'] is not None else 0.19,
+        'iva_included_in_price': bool(row['iva_included_in_price']) if row['iva_included_in_price'] is not None else False,
+        'liquor_tax_applicable': bool(row['liquor_tax_applicable']) if row['liquor_tax_applicable'] is not None else False,
+        'tax_lines': row['tax_lines'] if 'tax_lines' in row.keys() else None,
+        'category_map': row['category_map'] if 'category_map' in row.keys() else None,
+        'commercial_tax_applicable': (
+            bool(row['commercial_tax_applicable'])
+            if ('commercial_tax_applicable' in row.keys() and row['commercial_tax_applicable'] is not None)
+            else None
+        ),
+        'menu_category_line_map': (
+            row['menu_category_line_map'] if 'menu_category_line_map' in row.keys() else None
+        ),
+        'exempt_menu_category_ids': (
+            row['exempt_menu_category_ids'] if 'exempt_menu_category_ids' in row.keys() else None
+        ),
+    }
+    tax_config = decode_tax_config_jsonb(tax_config_raw)
+
     return {
         'display_name': row['display_name'],
         'timezone': normalize_timezone(row['timezone'] if 'timezone' in row else None),
@@ -228,15 +259,7 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
             'phone': row['fiscal_phone'],
             'email': row['fiscal_email'],
         },
-        'tax_config': {
-            'inc_applicable': bool(row['inc_applicable']) if row['inc_applicable'] is not None else False,
-            'inc_rate': float(row['inc_rate']) if row['inc_rate'] is not None else 0.08,
-            'inc_included_in_price': bool(row['inc_included_in_price']) if row['inc_included_in_price'] is not None else False,
-            'iva_applicable': bool(row['iva_applicable']) if row['iva_applicable'] is not None else False,
-            'iva_rate': float(row['iva_rate']) if row['iva_rate'] is not None else 0.19,
-            'iva_included_in_price': bool(row['iva_included_in_price']) if row['iva_included_in_price'] is not None else False,
-            'liquor_tax_applicable': bool(row['liquor_tax_applicable']) if row['liquor_tax_applicable'] is not None else False,
-        },
+        'tax_config': tax_config,
         'invoicing_ready': invoicing_ready,
         # WARO software + Matias facturador labels for tickets (env-driven; not tenant issuer)
         'platform_legal': get_platform_legal_for_print(),

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -2118,8 +2118,12 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
             _std_tax = 0.0
             _liq_tax = 0.0
             _tax_label = "Impuesto"
+            _liq_label = "IVA licores 5%"
             try:
+                from app.services.hospitality_tax_engine import liquor_tax_label_for_config
+
                 tax_config = await _get_tenant_tax_config(conn_ids, tenant_id)
+                _liq_label = liquor_tax_label_for_config(tax_config)
                 tax_rows = await conn_ids.fetch(
                     """
                     SELECT
@@ -2169,6 +2173,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                 "standard_tax": float(_std_tax),
                 "liquor_tax": float(_liq_tax),
                 "standard_tax_label": _tax_label,
+                "liquor_tax_label": _liq_label,
                 "promo_savings": float(_promo_savings),
                 "promo_breakdown": _promo_breakdown,
                 "payment_method": payment_method,
@@ -2680,11 +2685,13 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
             _std_tax = 0.0
             _liq_tax = 0.0
             _tax_label = "Impuesto"
+            _liq_label = "IVA licores 5%"
             _promo_savings = 0.0
             _subtotal_after_promos = float(session_row["running_total"])
             _promo_breakdown: List[dict] = []
             _promo_lines_by_id: Dict[str, dict] = {}
             try:
+                from app.services.hospitality_tax_engine import liquor_tax_label_for_config
                 from app.services.orders_service import _compute_tax_breakdown
                 from app.services.promotions_service import (
                     enrich_order_item_rows_with_promo_basis,
@@ -2693,6 +2700,7 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                 )
 
                 tax_config = await _get_tenant_tax_config(conn, tenant_id)
+                _liq_label = liquor_tax_label_for_config(tax_config)
                 order_ids = [o["id"] for o in orders]
                 if order_ids:
                     eval_rows = await conn.fetch(
@@ -2848,6 +2856,7 @@ async def get_current_session(request: Request, table_id: UUID) -> dict:
                     "standard_tax": float(_std_tax),
                     "liquor_tax": float(_liq_tax),
                     "standard_tax_label": _tax_label,
+                    "liquor_tax_label": _liq_label,
                     "minimum_consumption": _minimum_consumption_state(
                         session_row,
                         partial_paid_total,

--- a/app/services/tip_tax_service.py
+++ b/app/services/tip_tax_service.py
@@ -55,6 +55,14 @@ def split_settlement_amount_due(
     order_total: float,
     tip_amount: float,
     tip_tax_amount: float = 0,
+    additive_tax: float = 0,
 ) -> float:
-    """warocol.com#737 + #740 — order total + tip + tip tax."""
-    return float(order_total) + tip_settlement_total(tip_amount, tip_tax_amount)
+    """warocol.com#737 + #740 — order total + additive tax + tip + tip tax.
+
+    ``additive_tax`` is IVA/etc. charged on top of product prices (not included_in_price).
+    """
+    return (
+        float(order_total)
+        + float(additive_tax or 0)
+        + tip_settlement_total(tip_amount, tip_tax_amount)
+    )

--- a/tests/test_hospitality_tax_engine.py
+++ b/tests/test_hospitality_tax_engine.py
@@ -2,11 +2,16 @@
 from decimal import Decimal
 
 from app.services.hospitality_tax_engine import (
+    additive_order_tax_total,
+    annotate_line_tax_amounts,
     compute_category_breakdown,
     compute_gl_category_taxes,
+    liquor_tax_label_for_config,
+    resolve_effective_tax_category,
     resolve_tax_profile,
     tax_amount_float,
 )
+from app.services.hospitality_tax_packs import WAVE2_SIMPLE_TAX_PACKS, tax_config_from_wave1_pack
 
 
 def _inc_config(*, included: bool = True, rate: float = 0.08):
@@ -149,3 +154,111 @@ def test_gl_decimal_inc_extractive():
     assert result["standard_gl_role"] == "inc"
     # 10800 - 10800/1.08 = 800
     assert result["standard_tax"] == Decimal("800")
+
+
+def _mx_config():
+    return tax_config_from_wave1_pack(WAVE2_SIMPLE_TAX_PACKS["MX"])
+
+
+def test_annotate_line_tax_mx_exclusive_sums_to_cart():
+    """Per-line IVA 16% amounts reconcile to category-level cart taxes."""
+    cfg = _mx_config()
+    lines = [
+        {
+            "id": "a",
+            "tax_category": "standard",
+            "net_total": 207,
+            "tax_resolution": "inherit",
+        },
+        {
+            "id": "b",
+            "tax_category": "standard",
+            "net_total": 1740,
+            "tax_resolution": "inherit",
+        },
+    ]
+    tax_rows = [{"tax_category": "standard", "subtotal": line["net_total"]} for line in lines]
+    std, liq, _ = compute_category_breakdown(tax_rows, cfg)
+    cart_tax = std + liq
+    annotated = annotate_line_tax_amounts(lines, cfg, reconcile_to=(std, liq))
+    assert annotated[0]["tax_label"] == "IVA 16%"
+    assert annotated[0]["included_in_price"] is False
+    assert annotated[0]["tax_amount"] == round(207 * 0.16)
+    assert sum(float(l["tax_amount"]) for l in annotated) == cart_tax
+    assert cart_tax == round((207 + 1740) * 0.16)
+
+
+def test_annotate_line_tax_exempt_is_zero():
+    cfg = _mx_config()
+    lines = [
+        {
+            "id": "taxable",
+            "tax_category": "standard",
+            "net_total": 10000,
+            "tax_resolution": "inherit",
+        },
+        {
+            "id": "exempt",
+            "tax_category": "exempt",
+            "net_total": 5000,
+            "tax_resolution": "inherit",
+        },
+        {
+            "id": "product_exempt",
+            "tax_category": "standard",
+            "net_total": 3000,
+            "tax_resolution": "exempt",
+        },
+    ]
+    tax_rows = [
+        {
+            "tax_category": line["tax_category"],
+            "tax_resolution": line["tax_resolution"],
+            "subtotal": line["net_total"],
+        }
+        for line in lines
+    ]
+    std, liq, _ = compute_category_breakdown(tax_rows, cfg)
+    annotated = annotate_line_tax_amounts(lines, cfg, reconcile_to=(std, liq))
+    assert annotated[0]["tax_amount"] == 1600.0
+    assert annotated[1]["tax_amount"] == 0.0
+    assert annotated[1]["tax_label"] is None
+    assert annotated[2]["tax_amount"] == 0.0
+    assert sum(float(l["tax_amount"]) for l in annotated) == std + liq
+
+
+def test_additive_order_tax_total_mx_vs_co_inc():
+    mx = _mx_config()
+    assert additive_order_tax_total(371, 0, mx) == 371.0
+    assert additive_order_tax_total(0, 371, mx) == 371.0
+
+    co = _inc_config(included=True)
+    assert additive_order_tax_total(800, 0, co) == 0.0
+    co_liq = _co_full()
+    assert additive_order_tax_total(800, 1000, co_liq) == 1000.0
+
+
+def test_mx_same_key_buckets_to_standard_not_liquor():
+    """#1899 — MX maps standard+liquor → iva; tax must land in standard_tax."""
+    cfg = _mx_config()
+    rows = [{"tax_category": "standard", "subtotal": 580}]
+    std, liq, label = compute_category_breakdown(rows, cfg)
+    assert label == "IVA 16%"
+    assert std == 93.0
+    assert liq == 0.0
+    assert resolve_effective_tax_category(cfg, tax_category="standard") == "standard"
+    assert liquor_tax_label_for_config(cfg) == "IVA 16%"
+
+
+def test_co_distinct_liquor_still_buckets_liquor():
+    cfg = _co_full()
+    rows = [
+        {"tax_category": "standard", "subtotal": 10800},
+        {"tax_category": "liquor", "subtotal": 20000},
+    ]
+    std, liq, label = compute_category_breakdown(rows, cfg)
+    assert std == 800.0
+    assert liq == 1000.0
+    assert label == "INC 8%"
+    assert liquor_tax_label_for_config(cfg) == "IVA licores 5%"
+    assert resolve_effective_tax_category(cfg, tax_category="liquor") == "liquor"


### PR DESCRIPTION
## Summary
- Same-key commercial packs (e.g. MX IVA) no longer dump tax into `liquor_tax`; prefer standard when category map keys collide
- Expose `liquor_tax_label` from `tax_lines` on tax-preview, complete, mesa, and order detail
- Include additive tax in settlement totals and restaurant-context `tax_lines` for POS Total a Pagar

Closes uno0uno/warocol.com#1899

## Test plan
- [ ] `venv/bin/pytest tests/test_hospitality_tax_engine.py tests/test_menu_category_tax_resolve.py -q`
- [ ] MX tenant: Tequila taxed → prefactura/print show **IVA 16%** (not IVA licores 5%)
- [ ] CO tenant with distinct liquor line: liquor label still shown when liquor_tax > 0
- [ ] Exempt-only ticket: no $0 tax line
- [ ] MX cash/total settlement includes additive IVA


Made with [Cursor](https://cursor.com)