### PR TITLE
fix(tax): global chart TAX_PAYABLE fallback for commercial IVA (#1903)

### DIFF
--- a/app/services/account_role_service.py
+++ b/app/services/account_role_service.py
@@ -277,6 +277,17 @@ async def resolve_payment_account(
     return account
 
 
+# CO-specific tax roles. Non-CO global chart only seeds TAX_PAYABLE (2100);
+# commercial packs still use gl_role iva/inc/liquor — fall back when missing.
+_TAX_ROLES_WITH_GLOBAL_FALLBACK = frozenset(
+    {
+        AccountRole.INC_PAYABLE,
+        AccountRole.IVA_PAYABLE,
+        AccountRole.LIQUOR_TAX_PAYABLE,
+    }
+)
+
+
 async def resolve_tax_account(
     conn,
     tenant_id: UUID,
@@ -290,6 +301,7 @@ async def resolve_tax_account(
     account_id = tax_config.get(id_field)
     if account_id and not isinstance(account_id, UUID):
         account_id = UUID(str(account_id))
+    source = "{}_tax".format(tax_kind)
     try:
         return await resolve_configured_account(
             conn,
@@ -297,9 +309,22 @@ async def resolve_tax_account(
             account_id,
             tax_config.get(code_field),
             role,
-            source="{}_tax".format(tax_kind),
+            source=source,
         )
     except MissingAccountRoleError:
+        if role in _TAX_ROLES_WITH_GLOBAL_FALLBACK:
+            try:
+                return await resolve_account(
+                    conn,
+                    tenant_id,
+                    AccountRole.TAX_PAYABLE,
+                    required=True,
+                    source="{}_fallback".format(source),
+                )
+            except MissingAccountRoleError:
+                if required:
+                    raise
+                return None
         if required:
             raise
         return None

--- a/tests/test_account_role_resolution.py
+++ b/tests/test_account_role_resolution.py
@@ -17,6 +17,7 @@ from app.services.account_role_service import (
     ensure_matias_dian,
     resolve_account,
     resolve_payment_account,
+    resolve_tax_account,
 )
 
 
@@ -215,3 +216,64 @@ def test_migration_defines_scoped_uuid_bindings_and_compatibility_backfill():
     assert "ADD COLUMN IF NOT EXISTS gl_account_id UUID" in migration
     assert "methods.gl_account_id IS NULL" in migration
     assert "config.inc_gl_account_id IS NULL" in migration
+
+
+@pytest.mark.asyncio
+async def test_global_iva_falls_back_to_tax_payable_when_iva_role_missing():
+    """MX/global packs use gl_role=iva but chart only seeds TAX_PAYABLE (#1903)."""
+    tenant_id = uuid4()
+    tax_payable = AccountRef(
+        uuid4(), "2100", "Tax payable", AccountRole.TAX_PAYABLE, "localization_default"
+    )
+    conn = MagicMock()
+    tax_config = {
+        "iva_gl_account_id": None,
+        "iva_gl_account_code": "2408",  # stale CO code — must not block fallback
+    }
+
+    with patch(
+        "app.services.account_role_service.resolve_account_by_id",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "app.services.account_role_service.resolve_legacy_account",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "app.services.account_role_service.resolve_account",
+        new=AsyncMock(
+            side_effect=[
+                MissingAccountRoleError(tenant_id, AccountRole.IVA_PAYABLE, "iva_tax"),
+                tax_payable,
+            ]
+        ),
+    ) as resolve_role:
+        account = await resolve_tax_account(conn, tenant_id, tax_config, "iva")
+
+    assert account == tax_payable
+    assert resolve_role.await_args_list[0].args[2] == AccountRole.IVA_PAYABLE
+    assert resolve_role.await_args_list[1].args[2] == AccountRole.TAX_PAYABLE
+
+
+@pytest.mark.asyncio
+async def test_co_iva_uses_iva_payable_without_tax_payable_fallback():
+    tenant_id = uuid4()
+    iva_payable = AccountRef(
+        uuid4(), "2408", "IVA por pagar", AccountRole.IVA_PAYABLE, "localization_default"
+    )
+    conn = MagicMock()
+    tax_config = {"iva_gl_account_id": None, "iva_gl_account_code": None}
+
+    with patch(
+        "app.services.account_role_service.resolve_account_by_id",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "app.services.account_role_service.resolve_legacy_account",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "app.services.account_role_service.resolve_account",
+        new=AsyncMock(return_value=iva_payable),
+    ) as resolve_role:
+        account = await resolve_tax_account(conn, tenant_id, tax_config, "iva")
+
+    assert account == iva_payable
+    resolve_role.assert_awaited_once()
+    assert resolve_role.await_args.args[2] == AccountRole.IVA_PAYABLE


### PR DESCRIPTION
## Summary
- When `IVA_PAYABLE` / `INC_PAYABLE` / `LIQUOR_TAX_PAYABLE` are missing, `resolve_tax_account` falls back to `TAX_PAYABLE` (global hospitality chart)
- Stale CO legacy codes that do not exist on the tenant no longer block posting
- CO PUC keeps primary tax roles when configured

Closes uno0uno/warocol.com#1903

## Test plan
- [ ] MX tenant taxed cash sale posts `orden`: DR Cash, CR Sales, CR Tax payable (2100)
- [ ] CO tenant with IVA still uses IVA payable account
- [ ] Exempt-only sale still posts 2-line Cash/Sales

## Validation evidence
```
$ venv/bin/pytest tests/test_account_role_resolution.py -q
12 passed in 0.06s
```

## wr-context
See `.wr/1903.yaml` on this branch (LLM contract; gitignored locally).

Made with [Cursor](https://cursor.com)