### PR TITLE
feat(billing): api_tokens quota Starter=0 (#1908)

### DIFF
--- a/app/services/api_tokens_service.py
+++ b/app/services/api_tokens_service.py
@@ -350,6 +350,18 @@ async def update_api_token(request: Request, token_id: str, name: Optional[str] 
                 detail="Only admin or superuser can update API tokens"
             )
 
+        existing = await conn.fetchrow(
+            """
+            SELECT is_active
+            FROM api_tokens
+            WHERE id = $1 AND tenant_id = $2
+            """,
+            to_uuid(token_id),
+            to_uuid(tenant_id),
+        )
+        if not existing:
+            raise HTTPException(status_code=404, detail="Token not found")
+
         # Construir query dinamica
         updates = []
         params = [to_uuid(token_id), to_uuid(tenant_id)]
@@ -367,6 +379,8 @@ async def update_api_token(request: Request, token_id: str, name: Optional[str] 
             param_idx += 1
 
         if is_active is not None:
+            if is_active is True and not existing["is_active"]:
+                await check_plan_quota_growth(conn, to_uuid(tenant_id), "api_tokens")
             updates.append(f"is_active = ${param_idx}")
             params.append(is_active)
             param_idx += 1

--- a/app/services/api_tokens_service.py
+++ b/app/services/api_tokens_service.py
@@ -14,6 +14,7 @@ from app.models.api_token import (
     ApiTokenWithSecret,
     AVAILABLE_SCOPES
 )
+from app.services.billing_service import check_plan_quota_growth
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +106,8 @@ async def create_api_token(request: Request, token_data: ApiTokenCreate) -> dict
                 status_code=403,
                 detail="Only admin or superuser can create API tokens"
             )
+
+        await check_plan_quota_growth(conn, to_uuid(tenant_id), "api_tokens")
 
         # Insertar el token
         result = await conn.fetchrow("""

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -48,6 +48,7 @@ STARTER_OPERATIONAL_QUOTAS = {
     "expenses_per_period": 30,
     "supplier_payments_per_period": 30,
     "payment_methods": 5,
+    "api_tokens": 0,
     "accounting_period_closes_per_period": 3,
     "manual_journal_entries_per_period": 30,
     "modifier_groups": 4,
@@ -75,6 +76,7 @@ QUOTA_KEYS = (
     "expenses_per_period",
     "supplier_payments_per_period",
     "payment_methods",
+    "api_tokens",
     "accounting_period_closes_per_period",
     "manual_journal_entries_per_period",
     "modifier_groups",
@@ -102,6 +104,7 @@ BASE_OPERATIONAL_QUOTAS = {
     "expenses_per_period": CATALOG_UNLIMITED,
     "supplier_payments_per_period": CATALOG_UNLIMITED,
     "payment_methods": CATALOG_UNLIMITED,
+    "api_tokens": CATALOG_UNLIMITED,
     "accounting_period_closes_per_period": CATALOG_UNLIMITED,
     "manual_journal_entries_per_period": CATALOG_UNLIMITED,
     "modifier_groups": CATALOG_UNLIMITED,
@@ -142,6 +145,7 @@ ENFORCEABLE_QUOTA_RESOURCES = {
     "tenant_suppliers",
     "active_open_cash_shifts",
     "payment_methods",
+    "api_tokens",
     "modifier_groups",
     "recipe_bases",
 }
@@ -1229,6 +1233,16 @@ async def _count_quota_resource_usage(
             """,
             tenant_id,
         )
+    elif resource == "api_tokens":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM api_tokens
+            WHERE tenant_id = $1
+              AND is_active = TRUE
+            """,
+            tenant_id,
+        )
     elif resource == "modifier_groups":
         value = await conn.fetchval(
             """
@@ -2275,6 +2289,12 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
             ) AS payment_methods,
             (
                 SELECT COUNT(*)
+                FROM api_tokens atok
+                WHERE atok.tenant_id = $1
+                  AND atok.is_active = TRUE
+            ) AS api_tokens,
+            (
+                SELECT COUNT(*)
                 FROM tenant_monthly_periods tmp
                 WHERE tmp.tenant_id = $1
                   AND tmp.status = 'closed'
@@ -2403,6 +2423,10 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
             "payment_methods": metric(
                 int(quota_counts["payment_methods"] or 0),
                 effective_quotas["payment_methods"],
+            ),
+            "api_tokens": metric(
+                int(quota_counts.get("api_tokens") or 0),
+                effective_quotas["api_tokens"],
             ),
             "accounting_period_closes_per_period": metric(
                 int(quota_counts["accounting_period_closes_per_period"] or 0),

--- a/tests/test_billing_plan_quotas.py
+++ b/tests/test_billing_plan_quotas.py
@@ -8,6 +8,35 @@ from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
 from app.services import billing_service
 
 
+def _quota_counts(**overrides):
+    base = {
+        "admin_users": 0,
+        "active_sessions_per_admin_user": 0,
+        "active_kitchens": 0,
+        "active_tables_including_bar": 0,
+        "active_qr_tables": 0,
+        "completed_online_orders_per_month": 0,
+        "menu_products": 0,
+        "menu_categories": 0,
+        "tenant_ingredients": 0,
+        "tenant_suppliers": 0,
+        "direct_purchases_per_period": 0,
+        "stock_adjustments_per_period": 0,
+        "cash_closes_per_period": 0,
+        "active_open_cash_shifts": 0,
+        "expenses_per_period": 0,
+        "supplier_payments_per_period": 0,
+        "payment_methods": 0,
+        "api_tokens": 0,
+        "accounting_period_closes_per_period": 0,
+        "manual_journal_entries_per_period": 0,
+        "modifier_groups": 0,
+        "recipe_bases": 0,
+    }
+    base.update(overrides)
+    return base
+
+
 def _plan_row(slug: str, features: dict):
     now = datetime.now(timezone.utc)
     return {
@@ -36,6 +65,13 @@ def test_serialize_plan_exposes_pro_quota_defaults():
     assert plan["quotas"]["active_qr_tables"] == 20
     assert plan["quotas"]["completed_online_orders_per_month"] == 300
     assert plan["quotas"]["electronic_invoices_per_period"] == 0
+    assert plan["quotas"]["api_tokens"] == billing_service.CATALOG_UNLIMITED
+
+
+def test_serialize_plan_exposes_starter_api_tokens_zero():
+    plan = billing_service._serialize_plan(_plan_row("starter", {}))
+
+    assert plan["quotas"]["api_tokens"] == 0
 
 
 def test_serialize_plan_keeps_facturacion_legacy_invoice_limit():
@@ -95,22 +131,18 @@ async def test_remaining_usage_exposes_quota_usage_and_internal_roles_only():
                 "scans_used": 25,
                 "scans_limit": 500,
             },
-            {
-                "admin_users": 4,
-                "active_sessions_per_admin_user": 1,
-                "active_kitchens": 2,
-                "active_tables_including_bar": 7,
-                "active_qr_tables": 6,
-                "completed_online_orders_per_month": 28,
-                "menu_products": 9,
-                "menu_categories": 3,
-                "tenant_ingredients": 0,
-                "tenant_suppliers": 0,
-                "direct_purchases_per_period": 0,
-                "stock_adjustments_per_period": 0,
-                "modifier_groups": 1,
-                "recipe_bases": 2,
-            },
+            _quota_counts(
+                admin_users=4,
+                active_sessions_per_admin_user=1,
+                active_kitchens=2,
+                active_tables_including_bar=7,
+                active_qr_tables=6,
+                completed_online_orders_per_month=28,
+                menu_products=9,
+                menu_categories=3,
+                modifier_groups=1,
+                recipe_bases=2,
+            ),
         ]
     )
     conn.fetchval = AsyncMock(return_value=12)
@@ -165,22 +197,14 @@ async def test_remaining_usage_exposes_effective_quota_override_state():
                 "scans_used": 0,
                 "scans_limit": 500,
             },
-            {
-                "admin_users": 4,
-                "active_sessions_per_admin_user": 1,
-                "active_kitchens": 3,
-                "active_tables_including_bar": 7,
-                "active_qr_tables": 6,
-                "completed_online_orders_per_month": 28,
-                "menu_products": 0,
-                "menu_categories": 0,
-                "tenant_ingredients": 0,
-                "tenant_suppliers": 0,
-                "direct_purchases_per_period": 0,
-                "stock_adjustments_per_period": 0,
-                "modifier_groups": 0,
-                "recipe_bases": 0,
-            },
+            _quota_counts(
+                admin_users=4,
+                active_sessions_per_admin_user=1,
+                active_kitchens=3,
+                active_tables_including_bar=7,
+                active_qr_tables=6,
+                completed_online_orders_per_month=28,
+            ),
         ]
     )
     conn.fetchval = AsyncMock(return_value=0)
@@ -227,22 +251,14 @@ async def test_remaining_usage_exposes_disabled_override_as_unlimited():
                 "scans_used": 0,
                 "scans_limit": 500,
             },
-            {
-                "admin_users": 4,
-                "active_sessions_per_admin_user": 1,
-                "active_kitchens": 2,
-                "active_tables_including_bar": 7,
-                "active_qr_tables": 6,
-                "completed_online_orders_per_month": 301,
-                "menu_products": 0,
-                "menu_categories": 0,
-                "tenant_ingredients": 0,
-                "tenant_suppliers": 0,
-                "direct_purchases_per_period": 0,
-                "stock_adjustments_per_period": 0,
-                "modifier_groups": 0,
-                "recipe_bases": 0,
-            },
+            _quota_counts(
+                admin_users=4,
+                active_sessions_per_admin_user=1,
+                active_kitchens=2,
+                active_tables_including_bar=7,
+                active_qr_tables=6,
+                completed_online_orders_per_month=301,
+            ),
         ]
     )
     conn.fetchval = AsyncMock(return_value=0)

--- a/tests/test_billing_remaining_usage.py
+++ b/tests/test_billing_remaining_usage.py
@@ -45,6 +45,7 @@ def _quota_counts_row(**overrides):
         "expenses_per_period": 0,
         "supplier_payments_per_period": 0,
         "payment_methods": 0,
+        "api_tokens": 0,
         "accounting_period_closes_per_period": 0,
         "manual_journal_entries_per_period": 0,
         "modifier_groups": 0,
@@ -257,6 +258,7 @@ async def test_remaining_usage_starter_without_subscription_exposes_catalog_quot
                 "expenses_per_period": 30,
                 "supplier_payments_per_period": 30,
                 "payment_methods": 5,
+                "api_tokens": 0,
                 "accounting_period_closes_per_period": 3,
                 "manual_journal_entries_per_period": 30,
                 "modifier_groups": 4,
@@ -303,6 +305,9 @@ async def test_remaining_usage_starter_without_subscription_exposes_catalog_quot
     assert usage["quota_usage"]["expenses_per_period"]["limit"] == 30
     assert usage["quota_usage"]["supplier_payments_per_period"]["limit"] == 30
     assert usage["quota_usage"]["payment_methods"]["limit"] == 5
+    assert usage["quota_usage"]["api_tokens"]["limit"] == 0
+    assert usage["quota_usage"]["api_tokens"]["used"] == 0
+    assert usage["quota_usage"]["api_tokens"]["remaining"] == 0
     assert usage["quota_usage"]["accounting_period_closes_per_period"]["limit"] == 3
     assert usage["quota_usage"]["manual_journal_entries_per_period"]["limit"] == 30
     assert usage["quota_usage"]["modifier_groups"]["used"] == 4

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -1238,6 +1238,43 @@ async def test_payment_methods_growth_quota_allows_below_limit():
 
 
 @pytest.mark.asyncio
+async def test_api_tokens_growth_quota_blocks_at_starter_zero():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_starter_plan_row("api_tokens", 0))
+    conn.fetchval = AsyncMock(return_value=0)
+
+    with pytest.raises(APIError) as exc:
+        await billing_service.check_plan_quota_growth(conn, tenant_id, "api_tokens")
+
+    assert exc.value.status_code == 429
+    assert exc.value.details["code"] == "quota_exceeded"
+    assert exc.value.details["resource"] == "api_tokens"
+    assert exc.value.details["limit"] == 0
+    assert "FROM api_tokens" in conn.fetchval.await_args.args[0]
+    assert "is_active = TRUE" in conn.fetchval.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_api_tokens_growth_quota_allows_below_paid_limit():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value={
+            "plan_slug": "pro",
+            "plan_features": {"quotas": {"api_tokens": billing_service.CATALOG_UNLIMITED}},
+            "override_id": None,
+            "limit_override": None,
+            "override_disabled": False,
+            "override_reason": None,
+        }
+    )
+    conn.fetchval = AsyncMock(return_value=2)
+
+    await billing_service.check_plan_quota_growth(conn, tenant_id, "api_tokens")
+
+
+@pytest.mark.asyncio
 async def test_supplier_payments_period_quota_uses_paid_at():
     tenant_id = uuid4()
     period_start = datetime(2026, 7, 1, tzinfo=timezone.utc)

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -9,7 +9,15 @@ import pytest
 from fastapi import HTTPException
 
 from app.core.exceptions import APIError
-from app.services import billing_service, invitation_service, online_cart_service, public_restaurant_service, stations_service, tables_service
+from app.services import (
+    api_tokens_service,
+    billing_service,
+    invitation_service,
+    online_cart_service,
+    public_restaurant_service,
+    stations_service,
+    tables_service,
+)
 
 
 def _db_context(conn):
@@ -1272,6 +1280,48 @@ async def test_api_tokens_growth_quota_allows_below_paid_limit():
     conn.fetchval = AsyncMock(return_value=2)
 
     await billing_service.check_plan_quota_growth(conn, tenant_id, "api_tokens")
+
+
+@pytest.mark.asyncio
+async def test_api_token_reactivate_checks_growth_quota():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    token_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {"role": "admin"},
+            {"is_active": False},
+        ]
+    )
+    quota_error = APIError("Límite del plan alcanzado", status_code=429)
+    session = {"user_id": str(user_id), "tenant_id": str(tenant_id)}
+
+    with (
+        patch(
+            "app.services.api_tokens_service.get_session_from_request",
+            new=AsyncMock(return_value=session),
+        ),
+        patch(
+            "app.services.api_tokens_service.get_db_connection",
+            side_effect=_db_context(conn),
+        ),
+        patch(
+            "app.services.api_tokens_service.check_plan_quota_growth",
+            new=AsyncMock(side_effect=quota_error),
+        ) as quota_check,
+    ):
+        with pytest.raises(APIError) as exc:
+            await api_tokens_service.update_api_token(
+                _request(),
+                str(token_id),
+                is_active=True,
+            )
+
+    assert exc.value.status_code == 429
+    quota_check.assert_awaited_once()
+    assert quota_check.await_args.args[2] == "api_tokens"
+    assert conn.fetchrow.await_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add operational quota `api_tokens` (Starter **0**, paid unlimited) with usage count of active tokens.
- Enforce `check_plan_quota_growth` in `create_api_token` → 429 `quota_exceeded` at cap.

Refs uno0uno/warocol.com#1908

## Test plan
- [ ] Starter: POST `/api-tokens` returns 429
- [ ] Paid/unlimited: create key still works
- [ ] remaining-usage exposes `api_tokens` limit 0 on Starter

## Validation evidence
```text
$ pytest tests/test_billing_plan_quotas.py tests/test_billing_remaining_usage.py \
    tests/test_quota_enforcement.py::test_api_tokens_growth_quota_blocks_at_starter_zero \
    tests/test_quota_enforcement.py::test_api_tokens_growth_quota_allows_below_paid_limit -q --tb=line
16 passed in 0.13s
```

Made with [Cursor](https://cursor.com)