### PR TITLE
fix(billing): block Starter shift template create/reactivate

### DIFF
--- a/.wr/1916.yaml
+++ b/.wr/1916.yaml
@@ -1,0 +1,41 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1916
+title: "Starter: block creating Operaciones Turnos (shift templates) with Mi Plan modal"
+repo: both
+repo_remote: uno0uno/api-warolabs + uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: both
+branch: wr-1916-starter-shift-templates
+
+paths:
+  - app/services/billing_service.py
+  - app/services/shift_templates_service.py
+  - tests/test_quota_enforcement.py
+  - pages/operaciones/turnos.vue  # front_nuxt
+
+ac:
+  - "Starter Nuevo turno → Mi Plan modal, no create"
+  - "API create/reactivate → 403 starter_plan_restriction"
+  - "Front maps error to Mi Plan modal"
+  - "List/edit/deactivate allowed"
+  - "Pro unchanged"
+  - "API pytest for assert"
+
+out_of_scope:
+  - Promociones quotas
+  - Personalizar/Propinas locks
+  - active_open_cash_shifts arqueo quota
+  - Country banner (#1917)
+
+hints:
+  entry: "assert_starter_shift_template_growth_allowed"
+  pattern: "billing_service.assert_starter_toggle_allowed + mesas starter modal"
+  tests: "pytest tests/test_quota_enforcement.py -k shift_template_growth -q"
+
+risk: low
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "merge API then front; manual Starter Turnos smoke"

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -358,6 +358,21 @@ async def assert_starter_toggle_allowed(conn, tenant_id: UUID, column_name: str,
         )
 
 
+async def assert_starter_shift_template_growth_allowed(conn, tenant_id: UUID) -> None:
+    """Block Starter create/reactivate of Operaciones shift templates (warocol.com#1916)."""
+    if await is_starter_plan(conn, tenant_id):
+        raise APIError(
+            "Función no disponible en el plan Starter",
+            status_code=403,
+            details={
+                "code": "starter_plan_restriction",
+                "feature": "shift_templates",
+                "upgrade_url": QUOTA_UPGRADE_URL,
+                "message": QUOTA_CONTACT_MESSAGE,
+            },
+        )
+
+
 async def _default_scan_limit_for_tenant(conn, tenant_id: UUID) -> int:
     plan_slug = await get_effective_plan_slug(conn, tenant_id)
     if plan_slug == STARTER_PLAN_SLUG:

--- a/app/services/shift_templates_service.py
+++ b/app/services/shift_templates_service.py
@@ -10,6 +10,7 @@ from app.core.exceptions import AuthenticationError
 from app.core.middleware import require_valid_session
 from app.database import get_db_connection
 from app.models.shift_template import ShiftTemplateCreate, ShiftTemplatePatch, _validate_shift_window
+from app.services.billing_service import assert_starter_shift_template_growth_allowed
 
 import logging
 
@@ -62,6 +63,7 @@ async def create_shift_template(request: Request, body: ShiftTemplateCreate) -> 
 
     try:
         async with get_db_connection() as conn:
+            await assert_starter_shift_template_growth_allowed(conn, tenant_id)
             row = await conn.fetchrow(
                 """
                 INSERT INTO tenant_shift_templates (
@@ -108,7 +110,7 @@ async def patch_shift_template(
     async with get_db_connection() as conn:
         existing = await conn.fetchrow(
             """
-            SELECT start_time, end_time, crosses_midnight
+            SELECT start_time, end_time, crosses_midnight, is_active
             FROM tenant_shift_templates
             WHERE id = $1 AND tenant_id = $2
             """,
@@ -117,6 +119,9 @@ async def patch_shift_template(
         )
         if not existing:
             raise HTTPException(status_code=404, detail="Shift template not found")
+
+        if data_dict.get("is_active") is True and not existing["is_active"]:
+            await assert_starter_shift_template_growth_allowed(conn, tenant_id)
 
         merged_start: time = data_dict.get("start_time", existing["start_time"])
         merged_end: time = data_dict.get("end_time", existing["end_time"])

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -970,6 +970,41 @@ async def test_assert_starter_toggle_rejects_locked_operaciones_toggles(toggle):
 
 
 @pytest.mark.asyncio
+async def test_assert_starter_shift_template_growth_rejects_starter():
+    tenant_id = uuid4()
+    conn = MagicMock()
+
+    with patch.object(
+        billing_service,
+        "get_effective_plan_slug",
+        new=AsyncMock(return_value="starter"),
+    ):
+        with pytest.raises(APIError) as exc:
+            await billing_service.assert_starter_shift_template_growth_allowed(
+                conn, tenant_id
+            )
+
+    assert exc.value.status_code == 403
+    assert exc.value.details["code"] == "starter_plan_restriction"
+    assert exc.value.details["feature"] == "shift_templates"
+
+
+@pytest.mark.asyncio
+async def test_assert_starter_shift_template_growth_allows_non_starter():
+    tenant_id = uuid4()
+    conn = MagicMock()
+
+    with patch.object(
+        billing_service,
+        "get_effective_plan_slug",
+        new=AsyncMock(return_value="pro"),
+    ):
+        await billing_service.assert_starter_shift_template_growth_allowed(
+            conn, tenant_id
+        )
+
+
+@pytest.mark.asyncio
 async def test_default_scan_limit_for_starter_is_ten():
     conn = MagicMock()
     conn.fetchrow = AsyncMock(return_value={"scan_limit": 10})


### PR DESCRIPTION
## Summary
- Add `assert_starter_shift_template_growth_allowed` (403 `starter_plan_restriction`, feature `shift_templates`).
- Enforce on Operaciones shift template **create** and **reactivate** (`is_active` false→true). List/edit/deactivate unchanged.

Closes uno0uno/warocol.com#1916

## Test plan
- [ ] Starter create shift template → 403
- [ ] Starter reactivate → 403
- [ ] Pro create/reactivate OK
- [ ] Starter edit/deactivate OK

## Validation evidence
```text
$ ./venv/bin/pytest tests/test_quota_enforcement.py -k shift_template_growth -q --tb=short
collected 60 items / 58 deselected / 2 selected
tests/test_quota_enforcement.py ..                                       [100%]
======================= 2 passed, 58 deselected in 0.15s =======================
```

## wr-context
See `.wr/1916.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)