### PR TITLE
feat(billing): add Starter quota for tenant_promotions

### DIFF
--- a/.wr/1921.yaml
+++ b/.wr/1921.yaml
@@ -1,0 +1,42 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1921
+title: "Starter: growth quota for Operaciones Promociones (tenant_promotions)"
+repo: both
+repo_remote: uno0uno/api-warolabs + uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: both
+branch: wr-1921-promotions-quota
+
+paths:
+  - app/services/billing_service.py
+  - app/services/promotions_service.py
+  - tests/test_quota_enforcement.py
+  - composables/useBilling.ts
+  - pages/operaciones/promociones/index.vue
+  - components/promociones/PromocionPanel.vue
+  - pages/gestion/billing/uso.vue
+
+ac:
+  - "tenant_promotions Starter=1 Pro unlimited"
+  - "Count all tenant_promotions rows (delete frees slot)"
+  - "create enforces check_plan_quota_growth 429"
+  - "Front CTA + panel catch → Mi Plan modal"
+  - "Mi Plan uso shows metric"
+  - "pytest at/below/unlimited"
+
+out_of_scope:
+  - Bitácora/Personalizar/Propinas
+  - Promo checkout evaluation
+
+hints:
+  entry: "check_plan_quota_growth tenant_promotions + useOperationalQuotaGate"
+  pattern: "api_tokens quota (#1908)"
+  tests: "./venv/bin/pytest tests/test_quota_enforcement.py -k tenant_promotions -q"
+
+risk: low
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "merge API then front; smoke Starter create 2nd promo"

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -49,6 +49,7 @@ STARTER_OPERATIONAL_QUOTAS = {
     "supplier_payments_per_period": 30,
     "payment_methods": 5,
     "api_tokens": 0,
+    "tenant_promotions": 1,
     "accounting_period_closes_per_period": 3,
     "manual_journal_entries_per_period": 30,
     "modifier_groups": 4,
@@ -77,6 +78,7 @@ QUOTA_KEYS = (
     "supplier_payments_per_period",
     "payment_methods",
     "api_tokens",
+    "tenant_promotions",
     "accounting_period_closes_per_period",
     "manual_journal_entries_per_period",
     "modifier_groups",
@@ -105,6 +107,7 @@ BASE_OPERATIONAL_QUOTAS = {
     "supplier_payments_per_period": CATALOG_UNLIMITED,
     "payment_methods": CATALOG_UNLIMITED,
     "api_tokens": CATALOG_UNLIMITED,
+    "tenant_promotions": CATALOG_UNLIMITED,
     "accounting_period_closes_per_period": CATALOG_UNLIMITED,
     "manual_journal_entries_per_period": CATALOG_UNLIMITED,
     "modifier_groups": CATALOG_UNLIMITED,
@@ -146,6 +149,7 @@ ENFORCEABLE_QUOTA_RESOURCES = {
     "active_open_cash_shifts",
     "payment_methods",
     "api_tokens",
+    "tenant_promotions",
     "modifier_groups",
     "recipe_bases",
 }
@@ -1258,6 +1262,16 @@ async def _count_quota_resource_usage(
             """,
             tenant_id,
         )
+    elif resource == "tenant_promotions":
+        # Count all promotion rows (hard delete frees a slot; is_active toggle does not).
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM tenant_promotions
+            WHERE tenant_id = $1
+            """,
+            tenant_id,
+        )
     elif resource == "modifier_groups":
         value = await conn.fetchval(
             """
@@ -2310,6 +2324,11 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
             ) AS api_tokens,
             (
                 SELECT COUNT(*)
+                FROM tenant_promotions tpromo
+                WHERE tpromo.tenant_id = $1
+            ) AS tenant_promotions,
+            (
+                SELECT COUNT(*)
                 FROM tenant_monthly_periods tmp
                 WHERE tmp.tenant_id = $1
                   AND tmp.status = 'closed'
@@ -2442,6 +2461,10 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
             "api_tokens": metric(
                 int(quota_counts.get("api_tokens") or 0),
                 effective_quotas["api_tokens"],
+            ),
+            "tenant_promotions": metric(
+                int(quota_counts.get("tenant_promotions") or 0),
+                effective_quotas["tenant_promotions"],
             ),
             "accounting_period_closes_per_period": metric(
                 int(quota_counts["accounting_period_closes_per_period"] or 0),

--- a/app/services/promotions_service.py
+++ b/app/services/promotions_service.py
@@ -21,6 +21,7 @@ from app.models.tenant_promotion import (
     PromotionUpdate,
     ScopeType,
 )
+from app.services.billing_service import check_plan_quota_growth
 from app.services.operation_events_service import DOMAIN_POS, record_operation_event
 
 logger = logging.getLogger(__name__)
@@ -915,6 +916,7 @@ async def create_promotion(request: Request, body: PromotionCreate) -> dict:
 
     try:
         async with get_db_connection() as conn:
+            await check_plan_quota_growth(conn, tenant_id, "tenant_promotions")
             overlap_warnings = await detect_promotion_overlaps(
                 conn,
                 tenant_id,

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -1299,6 +1299,54 @@ async def test_api_tokens_growth_quota_blocks_at_starter_zero():
 
 
 @pytest.mark.asyncio
+async def test_tenant_promotions_growth_quota_blocks_at_starter_one():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_starter_plan_row("tenant_promotions", 1))
+    conn.fetchval = AsyncMock(return_value=1)
+
+    with pytest.raises(APIError) as exc:
+        await billing_service.check_plan_quota_growth(
+            conn, tenant_id, "tenant_promotions"
+        )
+
+    assert exc.value.status_code == 429
+    assert exc.value.details["code"] == "quota_exceeded"
+    assert exc.value.details["resource"] == "tenant_promotions"
+    assert exc.value.details["limit"] == 1
+    assert "FROM tenant_promotions" in conn.fetchval.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_tenant_promotions_growth_quota_allows_below_starter_limit():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=_starter_plan_row("tenant_promotions", 1))
+    conn.fetchval = AsyncMock(return_value=0)
+
+    await billing_service.check_plan_quota_growth(conn, tenant_id, "tenant_promotions")
+
+
+@pytest.mark.asyncio
+async def test_tenant_promotions_growth_quota_allows_unlimited_pro():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value={
+            "plan_slug": "pro",
+            "plan_features": {
+                "quotas": {"tenant_promotions": billing_service.CATALOG_UNLIMITED}
+            },
+            "override_limit": None,
+            "override_expires_at": None,
+        }
+    )
+    conn.fetchval = AsyncMock(return_value=50)
+
+    await billing_service.check_plan_quota_growth(conn, tenant_id, "tenant_promotions")
+
+
+@pytest.mark.asyncio
 async def test_api_tokens_growth_quota_allows_below_paid_limit():
     tenant_id = uuid4()
     conn = MagicMock()


### PR DESCRIPTION
## Summary
- Add growth quota `tenant_promotions` (Starter **1**, Pro unlimited).
- Count **all** `tenant_promotions` rows (hard delete frees a slot; `is_active` toggle does not).
- Enforce on promotion **create** via `check_plan_quota_growth` (429 `quota_exceeded`).

Closes uno0uno/warocol.com#1921

## Test plan
- [ ] Starter with 0 promos: create OK
- [ ] Starter with 1 promo: create → 429
- [ ] Pro: create unrestricted
- [ ] Delete promo then create again on Starter → OK

## Validation evidence
```text
$ ./venv/bin/pytest tests/test_quota_enforcement.py -k tenant_promotions -q --tb=short
collected 63 items / 60 deselected / 3 selected
tests/test_quota_enforcement.py ...                                      [100%]
======================= 3 passed, 60 deselected in 0.13s =======================
```

## wr-context
See `.wr/1921.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)