### PR TITLE
fix(billing): enable Despacho module on Starter

### DIFF
--- a/.wr/1925.yaml
+++ b/.wr/1925.yaml
@@ -1,0 +1,33 @@
+# Machine contract for wr-fast — keep ≤80 lines.
+issue: 1925
+title: "Starter: enable Despacho module (domicilios / en-mesa / comandas nav)"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-1925-starter-despacho
+risk: low
+
+paths:
+  - app/services/billing_service.py
+  - tests/test_me_access.py
+  - .wr/1925.yaml
+
+ac:
+  - despacho in STARTER_PLAN_MODULE_VALUES /me/access for Starter owner/admin
+  - Sub-tabs still gated by tenant Operaciones flags (unchanged locks)
+  - Cashier without despacho role modules stays without despacho
+  - Focused access test asserts starter includes despacho
+
+out_of_scope:
+  - Unlocking comandas_enabled / tables_enabled / kds on Starter
+  - Analítica filters / food-cost (#1928)
+  - Front nav hard-codes (uses /me/access)
+
+hints:
+  entry: "STARTER_PLAN_MODULE_VALUES — billing_service.py"
+  pattern: "me.py _intersect_plan_modules + require_module starter gate"
+  tests: "pytest tests/test_me_access.py -v -k starter_owner"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -324,6 +324,7 @@ async def get_effective_plan_quotas(conn, tenant_id: UUID) -> Dict[str, int]:
 STARTER_PLAN_MODULE_VALUES = frozenset({
     "pos",
     "ventas",
+    "despacho",
     "menu",
     "operaciones",
     "abastecimiento",

--- a/tests/test_me_access.py
+++ b/tests/test_me_access.py
@@ -116,6 +116,7 @@ def test_starter_owner_includes_all_product_modules():
     for module in (
         "pos",
         "ventas",
+        "despacho",
         "menu",
         "operaciones",
         "abastecimiento",


### PR DESCRIPTION
## Summary
- Add `despacho` to `STARTER_PLAN_MODULE_VALUES` so Starter owners/admins get Despacho via `/me/access`
- Extend starter access test to assert `despacho` is present
- Sub-tab gates (`comandas_enabled`, tables+QR) unchanged

Closes #1925

## Test plan
- [ ] `pytest tests/test_me_access.py -v -k starter_owner`
- [ ] Starter tenant: Despacho appears in sidebar; `/despacho/domicilios` does not 403 for missing module
- [ ] Cashier still has no despacho module
- [ ] En mesa / Comandas tabs still respect Operaciones locks

## wr-context
See `.wr/1925.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)