### PR TITLE
feat(analytics): category_id filter for Ventas & Rentabilidad

### DIFF
--- a/.wr/1926.yaml
+++ b/.wr/1926.yaml
@@ -1,0 +1,41 @@
+# Companion contract — API half of warocol.com#1926. Keep ≤80 lines.
+issue: 1926
+title: "Batch 1: Analítica category_id on orders + analytics endpoints"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+issue_ref: uno0uno/warocol.com#1926
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-1926-analitica-category-filters
+companion_repo: front_nuxt
+risk: low
+
+paths:
+  - app/routers/orders.py
+  - app/services/orders_service.py
+  - app/routers/analytics.py
+  - app/services/analytics_service.py
+  - tests/ (focused analytics/orders category_id)
+  - .wr/1926.yaml
+
+ac:
+  - GET /orders/dashboard|metrics|sales-flow accept optional category_id
+  - Category scopes order_items→product.category_id (item-attributed)
+  - GET /analytics/menu-analysis|food-cost accept optional category_id
+  - Omit category_id = all (unchanged behavior)
+  - Focused pytest for filter vs omit
+
+out_of_scope:
+  - /orders/tips category filter
+  - cost_resolution / costo_calculado (#1927)
+  - Front UI (companion PR)
+
+hints:
+  entry: "orders.py dashboard/metrics/sales-flow; analytics.py menu-analysis/food-cost"
+  pattern: "get_products_sold category_id filter orders_service.py:4128"
+  food_cost: "_get_food_cost_for_tenant JOIN product_costs; add product.category_id"
+  menu: "_get_menu_analysis_for_tenant already joins categories — add WHERE"
+  tests: "pytest tests/test_analytics_dual_cost.py -v; extend or new test_orders_category_filter"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/routers/analytics.py
+++ b/app/routers/analytics.py
@@ -17,7 +17,8 @@ async def get_menu_analysis(
     request: Request,
     date_from: Optional[str] = Query(None),
     date_to: Optional[str] = Query(None),
-    limit: int = Query(200, ge=1, le=500)
+    limit: int = Query(200, ge=1, le=500),
+    category_id: Optional[str] = Query(None),
 ):
     """
     Get menu analysis with profitability and popularity matrix
@@ -37,7 +38,8 @@ async def get_menu_analysis(
         request,
         date_from=date_from,
         date_to=date_to,
-        limit=limit
+        limit=limit,
+        category_id=category_id,
     )
 
 
@@ -45,7 +47,8 @@ async def get_menu_analysis(
 async def get_food_cost(
     request: Request,
     date_from: Optional[str] = Query(None),
-    date_to: Optional[str] = Query(None)
+    date_to: Optional[str] = Query(None),
+    category_id: Optional[str] = Query(None),
 ):
     """
     Get food cost percentage with month-over-month comparison
@@ -57,7 +60,8 @@ async def get_food_cost(
     return await analytics_service.get_food_cost(
         request,
         date_from=date_from,
-        date_to=date_to
+        date_to=date_to,
+        category_id=category_id,
     )
 
 

--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -18,7 +18,8 @@ router = APIRouter(prefix="/orders", tags=["Orders"])
 async def get_orders_dashboard(
     request: Request,
     payment_method: Optional[str] = Query(None),
-    status: Optional[str] = Query(None)
+    status: Optional[str] = Query(None),
+    category_id: Optional[str] = Query(None),
 ):
     """
     Returns all /ventas dashboard metrics in a single DB query:
@@ -32,7 +33,8 @@ async def get_orders_dashboard(
     return await orders_service.get_orders_dashboard(
         request,
         payment_method=payment_method,
-        status=status
+        status=status,
+        category_id=category_id,
     )
 
 
@@ -43,12 +45,14 @@ async def get_orders_metrics(
     date_to: Optional[str] = Query(None),
     payment_method: Optional[str] = Query(None),
     payment_method_id: Optional[str] = Query(None),
-    status: Optional[str] = Query(None)
+    status: Optional[str] = Query(None),
+    category_id: Optional[str] = Query(None),
 ):
     return await orders_service.get_orders_metrics(
         request, date_from=date_from, date_to=date_to,
         payment_method=payment_method, payment_method_id=payment_method_id,
-        status=status
+        status=status,
+        category_id=category_id,
     )
 
 
@@ -58,7 +62,8 @@ async def get_sales_flow(
     date_from: Optional[str] = Query(None),
     date_to: Optional[str] = Query(None),
     payment_method: Optional[str] = Query(None),
-    status: Optional[str] = Query(None)
+    status: Optional[str] = Query(None),
+    category_id: Optional[str] = Query(None),
 ):
     """
     Get sales flow data with intelligent comparison period
@@ -78,7 +83,8 @@ async def get_sales_flow(
         date_from=date_from,
         date_to=date_to,
         payment_method=payment_method,
-        status=status
+        status=status,
+        category_id=category_id,
     )
 
 

--- a/app/services/analytics_service.py
+++ b/app/services/analytics_service.py
@@ -1112,11 +1112,10 @@ async def _get_menu_analysis_for_tenant(
             parsed_date_from = today.replace(month=1, day=1)
 
         # Real/perceived costs from product table (#744/#745); BCG uses operativo when set (#747).
+        # Bind order: $1 tenant, $2 from, $3 to, $4 tz, $5 limit, optional $6 category_id
         category_filter = ""
-        limit_param = "$5"
         if category_id:
             category_filter = "AND p.category_id = $6::uuid"
-            limit_param = "$7"
 
         query = f"""
             WITH {_PRODUCT_COSTS_CTE},
@@ -1189,7 +1188,7 @@ async def _get_menu_analysis_for_tenant(
             FROM product_sales ps
             CROSS JOIN sales_stats ss
             ORDER BY ps.total_revenue DESC
-            LIMIT {limit_param}
+            LIMIT $5
         """
 
         fetch_args: List[Any] = [

--- a/app/services/analytics_service.py
+++ b/app/services/analytics_service.py
@@ -1096,7 +1096,8 @@ async def _get_menu_analysis_for_tenant(
     tenant_id: str,
     date_from: Optional[str] = None,
     date_to: Optional[str] = None,
-    limit: int = 10
+    limit: int = 10,
+    category_id: Optional[str] = None,
 ) -> dict:
     """Auth-agnostic core for menu analysis. Called by session wrapper and public API."""
     # Default to start of current year
@@ -1111,6 +1112,12 @@ async def _get_menu_analysis_for_tenant(
             parsed_date_from = today.replace(month=1, day=1)
 
         # Real/perceived costs from product table (#744/#745); BCG uses operativo when set (#747).
+        category_filter = ""
+        limit_param = "$5"
+        if category_id:
+            category_filter = "AND p.category_id = $6::uuid"
+            limit_param = "$7"
+
         query = f"""
             WITH {_PRODUCT_COSTS_CTE},
             product_sales AS (
@@ -1134,6 +1141,7 @@ async def _get_menu_analysis_for_tenant(
                 LEFT JOIN orders o ON oi.order_id = o.id
                 WHERE p.tenant_id = $1
                     AND p.is_available = true
+                    {category_filter}
                     AND (
                         o.id IS NULL OR (
                             o.status = 'completed'
@@ -1181,16 +1189,22 @@ async def _get_menu_analysis_for_tenant(
             FROM product_sales ps
             CROSS JOIN sales_stats ss
             ORDER BY ps.total_revenue DESC
-            LIMIT $5
+            LIMIT {limit_param}
         """
 
-        rows = await conn.fetch(
-            query,
+        fetch_args: List[Any] = [
             tenant_id,
             parsed_date_from,
             parsed_date_to,
             timezone_name,
-            limit
+            limit,
+        ]
+        if category_id:
+            fetch_args.append(category_id)
+
+        rows = await conn.fetch(
+            query,
+            *fetch_args,
         )
 
         menu_items = []
@@ -1257,7 +1271,8 @@ async def get_menu_analysis(
     request: Request,
     date_from: Optional[str] = None,
     date_to: Optional[str] = None,
-    limit: int = 10
+    limit: int = 10,
+    category_id: Optional[str] = None,
 ) -> dict:
     """
     Get menu analysis with product classification based on profitability and popularity
@@ -1276,7 +1291,9 @@ async def get_menu_analysis(
         tenant_id = session_context.tenant_id
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
-        return await _get_menu_analysis_for_tenant(tenant_id, date_from, date_to, limit)
+        return await _get_menu_analysis_for_tenant(
+            tenant_id, date_from, date_to, limit, category_id=category_id
+        )
     except AuthenticationError as e:
         raise e
     except Exception as e:
@@ -1291,6 +1308,7 @@ async def _get_food_cost_for_tenant(
     compare_to: Optional[str] = None,
     compare_from: Optional[str] = None,
     compare_date_to: Optional[str] = None,
+    category_id: Optional[str] = None,
 ) -> dict:
     """Auth-agnostic core for food cost. Called by session wrapper and public API."""
     # Default to start of current year
@@ -1320,6 +1338,10 @@ async def _get_food_cost_for_tenant(
             prev_date_to = parsed_date_from - timedelta(days=1)
             prev_date_from = prev_date_to - timedelta(days=days_diff - 1)
 
+        category_filter = ""
+        if category_id:
+            category_filter = "AND p.category_id = $7::uuid"
+
         query = f"""
             WITH {_PRODUCT_COSTS_CTE},
             period_costs AS (
@@ -1335,9 +1357,11 @@ async def _get_food_cost_for_tenant(
                     END as period
                 FROM order_items oi
                 JOIN orders o ON oi.order_id = o.id
+                JOIN product p ON p.id = oi.product_id
                 JOIN product_costs pc ON oi.product_id = pc.id
                 WHERE o.tenant_id = $1
                     AND o.status = 'completed'
+                    {category_filter}
                     AND (
                         (DATE(o.order_date AT TIME ZONE $6) >= $2
                             AND DATE(o.order_date AT TIME ZONE $6) <= $3)
@@ -1356,14 +1380,20 @@ async def _get_food_cost_for_tenant(
             FROM period_costs
         """
 
-        rows = await conn.fetch(
-            query,
+        fetch_args: List[Any] = [
             tenant_id,
             parsed_date_from,
             parsed_date_to,
             prev_date_from,
             prev_date_to,
             timezone_name,
+        ]
+        if category_id:
+            fetch_args.append(category_id)
+
+        rows = await conn.fetch(
+            query,
+            *fetch_args,
         )
 
         # Parse results — food_cost_pct = real (estimated_cost); operativo KPI optional (#747)
@@ -1427,7 +1457,8 @@ async def _get_food_cost_for_tenant(
 async def get_food_cost(
     request: Request,
     date_from: Optional[str] = None,
-    date_to: Optional[str] = None
+    date_to: Optional[str] = None,
+    category_id: Optional[str] = None,
 ) -> dict:
     """
     Get food cost percentage with comparison to previous period
@@ -1440,7 +1471,9 @@ async def get_food_cost(
         tenant_id = session_context.tenant_id
         if not tenant_id:
             raise AuthenticationError("Tenant ID is required")
-        return await _get_food_cost_for_tenant(tenant_id, date_from, date_to)
+        return await _get_food_cost_for_tenant(
+            tenant_id, date_from, date_to, category_id=category_id
+        )
     except AuthenticationError as e:
         raise e
     except Exception as e:

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -2186,7 +2186,8 @@ async def get_orders_metrics(
     date_to: Optional[str] = None,
     payment_method: Optional[str] = None,
     payment_method_id: Optional[str] = None,
-    status: Optional[str] = None
+    status: Optional[str] = None,
+    category_id: Optional[str] = None,
 ) -> dict:
     """
     Get sales metrics: total sales, average ticket, orders count by status
@@ -2200,53 +2201,110 @@ async def get_orders_metrics(
 
         async with get_db_connection() as conn:
             timezone_name = await resolve_tenant_timezone(conn, tenant_id)
-            # Build WHERE clause
-            where_conditions = ["tenant_id = $1", ANALYTICS_SALES_FILTER]
-            params = [tenant_id]
-            param_count = 1
-
             parsed_date_from = parse_date(date_from)
             parsed_date_to = parse_date(date_to)
-            param_count = _append_local_date_bounds(
-                where_conditions,
-                params,
-                param_count,
-                "order_date",
-                parsed_date_from,
-                parsed_date_to,
-                timezone_name,
-            )
 
-            if payment_method:
+            if category_id:
+                where_conditions = ["o.tenant_id = $1", ANALYTICS_SALES_FILTER_ALIAS_O]
+                params = [tenant_id]
+                param_count = 1
+
+                param_count = _append_local_date_bounds(
+                    where_conditions,
+                    params,
+                    param_count,
+                    "o.order_date",
+                    parsed_date_from,
+                    parsed_date_to,
+                    timezone_name,
+                )
+
+                if payment_method:
+                    param_count += 1
+                    where_conditions.append(f"o.payment_method = ${param_count}")
+                    params.append(payment_method)
+
+                if payment_method_id:
+                    param_count += 1
+                    where_conditions.append(f"o.payment_method_id = ${param_count}::uuid")
+                    params.append(payment_method_id)
+
+                if status:
+                    param_count += 1
+                    where_conditions.append(f"o.status = ${param_count}")
+                    params.append(status)
+
                 param_count += 1
-                where_conditions.append(f"payment_method = ${param_count}")
-                params.append(payment_method)
+                where_conditions.append(f"p.category_id = ${param_count}::uuid")
+                params.append(category_id)
 
-            if payment_method_id:
-                param_count += 1
-                where_conditions.append(f"payment_method_id = ${param_count}::uuid")
-                params.append(payment_method_id)
+                where_clause = " AND ".join(where_conditions)
 
-            if status:
-                param_count += 1
-                where_conditions.append(f"status = ${param_count}")
-                params.append(status)
+                metrics_query = f"""
+                    SELECT
+                        COUNT(DISTINCT o.id) as total_orders,
+                        COUNT(DISTINCT o.id) FILTER (WHERE o.status = 'completed') as completed_orders,
+                        COUNT(DISTINCT o.id) FILTER (WHERE o.status = 'cancelled') as cancelled_orders,
+                        COUNT(DISTINCT o.id) FILTER (WHERE o.status = 'pending') as pending_orders,
+                        COALESCE(SUM(COALESCE(oi.net_total, oi.subtotal)) FILTER (WHERE o.status = 'completed'), 0) as total_sales,
+                        COALESCE(
+                            SUM(COALESCE(oi.net_total, oi.subtotal)) FILTER (WHERE o.status = 'completed')
+                            / NULLIF(COUNT(DISTINCT o.id) FILTER (WHERE o.status = 'completed'), 0),
+                            0
+                        ) as avg_ticket,
+                        0 as discount_count,
+                        0 as total_discount_amount
+                    FROM orders o
+                    JOIN order_items oi ON oi.order_id = o.id
+                    JOIN product p ON p.id = oi.product_id
+                    WHERE {where_clause}
+                """
+            else:
+                # Build WHERE clause
+                where_conditions = ["tenant_id = $1", ANALYTICS_SALES_FILTER]
+                params = [tenant_id]
+                param_count = 1
 
-            where_clause = " AND ".join(where_conditions)
+                param_count = _append_local_date_bounds(
+                    where_conditions,
+                    params,
+                    param_count,
+                    "order_date",
+                    parsed_date_from,
+                    parsed_date_to,
+                    timezone_name,
+                )
 
-            metrics_query = f"""
-                SELECT
-                    COUNT(*) as total_orders,
-                    COUNT(*) FILTER (WHERE status = 'completed') as completed_orders,
-                    COUNT(*) FILTER (WHERE status = 'cancelled') as cancelled_orders,
-                    COUNT(*) FILTER (WHERE status = 'pending') as pending_orders,
-                    COALESCE(SUM(total_amount) FILTER (WHERE status = 'completed'), 0) as total_sales,
-                    COALESCE(AVG(total_amount) FILTER (WHERE status = 'completed'), 0) as avg_ticket,
-                    COUNT(*) FILTER (WHERE status = 'completed' AND discount_amount > 0) as discount_count,
-                    COALESCE(SUM(discount_amount) FILTER (WHERE status = 'completed' AND discount_amount > 0), 0) as total_discount_amount
-                FROM orders
-                WHERE {where_clause}
-            """
+                if payment_method:
+                    param_count += 1
+                    where_conditions.append(f"payment_method = ${param_count}")
+                    params.append(payment_method)
+
+                if payment_method_id:
+                    param_count += 1
+                    where_conditions.append(f"payment_method_id = ${param_count}::uuid")
+                    params.append(payment_method_id)
+
+                if status:
+                    param_count += 1
+                    where_conditions.append(f"status = ${param_count}")
+                    params.append(status)
+
+                where_clause = " AND ".join(where_conditions)
+
+                metrics_query = f"""
+                    SELECT
+                        COUNT(*) as total_orders,
+                        COUNT(*) FILTER (WHERE status = 'completed') as completed_orders,
+                        COUNT(*) FILTER (WHERE status = 'cancelled') as cancelled_orders,
+                        COUNT(*) FILTER (WHERE status = 'pending') as pending_orders,
+                        COALESCE(SUM(total_amount) FILTER (WHERE status = 'completed'), 0) as total_sales,
+                        COALESCE(AVG(total_amount) FILTER (WHERE status = 'completed'), 0) as avg_ticket,
+                        COUNT(*) FILTER (WHERE status = 'completed' AND discount_amount > 0) as discount_count,
+                        COALESCE(SUM(discount_amount) FILTER (WHERE status = 'completed' AND discount_amount > 0), 0) as total_discount_amount
+                    FROM orders
+                    WHERE {where_clause}
+                """
 
             row = await conn.fetchrow(metrics_query, *params)
 
@@ -2278,6 +2336,10 @@ async def get_orders_metrics(
                     tax_pc += 1
                     tax_where.append(f"o.payment_method_id = ${tax_pc}::uuid")
                     tax_params.append(payment_method_id)
+                if category_id:
+                    tax_pc += 1
+                    tax_where.append(f"p.category_id = ${tax_pc}::uuid")
+                    tax_params.append(category_id)
                 tax_where_sql = " AND ".join(tax_where)
                 tax_rows = await conn.fetch(
                     f"""SELECT COALESCE(p.tax_category, 'standard') AS tax_category,
@@ -2322,7 +2384,8 @@ async def get_orders_metrics(
 async def get_orders_dashboard(
     request: Request,
     payment_method: Optional[str] = None,
-    status: Optional[str] = None
+    status: Optional[str] = None,
+    category_id: Optional[str] = None,
 ) -> dict:
     """
     Returns all metrics needed for the /ventas dashboard in a single DB query.
@@ -2343,66 +2406,136 @@ async def get_orders_dashboard(
 
         async with get_db_connection() as conn:
             timezone_name = await resolve_tenant_timezone(conn, tenant_id)
-            # Build optional filters for the main (all-time) metrics
-            main_filters = []
-            params = [tenant_id]
-            param_count = 1
 
-            if payment_method:
+            if category_id:
+                main_filters = []
+                params = [tenant_id]
+                param_count = 1
+
+                if payment_method:
+                    param_count += 1
+                    main_filters.append(f"o.payment_method = ${param_count}")
+                    params.append(payment_method)
+
+                if status:
+                    param_count += 1
+                    main_filters.append(f"o.status = ${param_count}")
+                    params.append(status)
+
                 param_count += 1
-                main_filters.append(f"payment_method = ${param_count}")
-                params.append(payment_method)
+                category_param = param_count
+                params.append(category_id)
 
-            if status:
                 param_count += 1
-                main_filters.append(f"status = ${param_count}")
-                params.append(status)
+                timezone_param = param_count
+                params.append(timezone_name)
 
-            # Build FILTER clause suffix for main metrics (e.g. "AND payment_method = $2")
-            main_filter_sql = ""
-            if main_filters:
-                main_filter_sql = " AND " + " AND ".join(main_filters)
+                main_filter_sql = ""
+                if main_filters:
+                    main_filter_sql = " AND " + " AND ".join(main_filters)
 
-            param_count += 1
-            timezone_param = param_count
-            params.append(timezone_name)
+                dashboard_query = f"""
+                    SELECT
+                        COUNT(DISTINCT o.id) FILTER (WHERE o.status = 'completed'{main_filter_sql}) as main_completed,
+                        COALESCE(SUM(COALESCE(oi.net_total, oi.subtotal)) FILTER (WHERE o.status = 'completed'{main_filter_sql}), 0) as main_sales,
+                        COALESCE(
+                            SUM(COALESCE(oi.net_total, oi.subtotal)) FILTER (WHERE o.status = 'completed'{main_filter_sql})
+                            / NULLIF(COUNT(DISTINCT o.id) FILTER (WHERE o.status = 'completed'{main_filter_sql}), 0),
+                            0
+                        ) as main_avg_ticket,
+                        0 as main_discount_count,
+                        0 as main_total_discount,
 
-            dashboard_query = f"""
-                SELECT
-                    -- Main: all-time (with optional payment/status filters)
-                    COUNT(*) FILTER (WHERE status = 'completed'{main_filter_sql}) as main_completed,
-                    COALESCE(SUM(total_amount) FILTER (WHERE status = 'completed'{main_filter_sql}), 0) as main_sales,
-                    COALESCE(AVG(total_amount) FILTER (WHERE status = 'completed'{main_filter_sql}), 0) as main_avg_ticket,
-                    COUNT(*) FILTER (WHERE status = 'completed' AND discount_amount > 0{main_filter_sql}) as main_discount_count,
-                    COALESCE(SUM(discount_amount) FILTER (WHERE status = 'completed' AND discount_amount > 0{main_filter_sql}), 0) as main_total_discount,
+                        COUNT(DISTINCT o.id) FILTER (
+                            WHERE o.status = 'completed'
+                            AND DATE(o.order_date AT TIME ZONE ${timezone_param}) >= DATE_TRUNC('month', NOW() AT TIME ZONE ${timezone_param})::date
+                            {main_filter_sql}
+                        ) as month_completed,
+                        COALESCE(SUM(COALESCE(oi.net_total, oi.subtotal)) FILTER (
+                            WHERE o.status = 'completed'
+                            AND DATE(o.order_date AT TIME ZONE ${timezone_param}) >= DATE_TRUNC('month', NOW() AT TIME ZONE ${timezone_param})::date
+                            {main_filter_sql}
+                        ), 0) as month_sales,
 
-                    -- Month-to-date (with optional payment/status filters)
-                    COUNT(*) FILTER (
-                        WHERE status = 'completed'
-                        AND DATE(order_date AT TIME ZONE ${timezone_param}) >= DATE_TRUNC('month', NOW() AT TIME ZONE ${timezone_param})::date
-                        {main_filter_sql}
-                    ) as month_completed,
-                    COALESCE(SUM(total_amount) FILTER (
-                        WHERE status = 'completed'
-                        AND DATE(order_date AT TIME ZONE ${timezone_param}) >= DATE_TRUNC('month', NOW() AT TIME ZONE ${timezone_param})::date
-                        {main_filter_sql}
-                    ), 0) as month_sales,
+                        COUNT(DISTINCT o.id) FILTER (
+                            WHERE o.status = 'completed'
+                            AND DATE(o.order_date AT TIME ZONE ${timezone_param}) >= DATE_TRUNC('year', NOW() AT TIME ZONE ${timezone_param})::date
+                            {main_filter_sql}
+                        ) as year_completed,
+                        COALESCE(SUM(COALESCE(oi.net_total, oi.subtotal)) FILTER (
+                            WHERE o.status = 'completed'
+                            AND DATE(o.order_date AT TIME ZONE ${timezone_param}) >= DATE_TRUNC('year', NOW() AT TIME ZONE ${timezone_param})::date
+                            {main_filter_sql}
+                        ), 0) as year_sales
 
-                    -- Year-to-date (with optional payment/status filters)
-                    COUNT(*) FILTER (
-                        WHERE status = 'completed'
-                        AND DATE(order_date AT TIME ZONE ${timezone_param}) >= DATE_TRUNC('year', NOW() AT TIME ZONE ${timezone_param})::date
-                        {main_filter_sql}
-                    ) as year_completed,
-                    COALESCE(SUM(total_amount) FILTER (
-                        WHERE status = 'completed'
-                        AND DATE(order_date AT TIME ZONE ${timezone_param}) >= DATE_TRUNC('year', NOW() AT TIME ZONE ${timezone_param})::date
-                        {main_filter_sql}
-                    ), 0) as year_sales
+                    FROM orders o
+                    JOIN order_items oi ON oi.order_id = o.id
+                    JOIN product p ON p.id = oi.product_id
+                    WHERE o.tenant_id = $1
+                      AND p.category_id = ${category_param}::uuid
+                      AND {ANALYTICS_SALES_FILTER_ALIAS_O}
+                """
+            else:
+                # Build optional filters for the main (all-time) metrics
+                main_filters = []
+                params = [tenant_id]
+                param_count = 1
 
-                FROM orders
-                WHERE tenant_id = $1 AND {ANALYTICS_SALES_FILTER}
-            """
+                if payment_method:
+                    param_count += 1
+                    main_filters.append(f"payment_method = ${param_count}")
+                    params.append(payment_method)
+
+                if status:
+                    param_count += 1
+                    main_filters.append(f"status = ${param_count}")
+                    params.append(status)
+
+                # Build FILTER clause suffix for main metrics (e.g. "AND payment_method = $2")
+                main_filter_sql = ""
+                if main_filters:
+                    main_filter_sql = " AND " + " AND ".join(main_filters)
+
+                param_count += 1
+                timezone_param = param_count
+                params.append(timezone_name)
+
+                dashboard_query = f"""
+                    SELECT
+                        -- Main: all-time (with optional payment/status filters)
+                        COUNT(*) FILTER (WHERE status = 'completed'{main_filter_sql}) as main_completed,
+                        COALESCE(SUM(total_amount) FILTER (WHERE status = 'completed'{main_filter_sql}), 0) as main_sales,
+                        COALESCE(AVG(total_amount) FILTER (WHERE status = 'completed'{main_filter_sql}), 0) as main_avg_ticket,
+                        COUNT(*) FILTER (WHERE status = 'completed' AND discount_amount > 0{main_filter_sql}) as main_discount_count,
+                        COALESCE(SUM(discount_amount) FILTER (WHERE status = 'completed' AND discount_amount > 0{main_filter_sql}), 0) as main_total_discount,
+
+                        -- Month-to-date (with optional payment/status filters)
+                        COUNT(*) FILTER (
+                            WHERE status = 'completed'
+                            AND DATE(order_date AT TIME ZONE ${timezone_param}) >= DATE_TRUNC('month', NOW() AT TIME ZONE ${timezone_param})::date
+                            {main_filter_sql}
+                        ) as month_completed,
+                        COALESCE(SUM(total_amount) FILTER (
+                            WHERE status = 'completed'
+                            AND DATE(order_date AT TIME ZONE ${timezone_param}) >= DATE_TRUNC('month', NOW() AT TIME ZONE ${timezone_param})::date
+                            {main_filter_sql}
+                        ), 0) as month_sales,
+
+                        -- Year-to-date (with optional payment/status filters)
+                        COUNT(*) FILTER (
+                            WHERE status = 'completed'
+                            AND DATE(order_date AT TIME ZONE ${timezone_param}) >= DATE_TRUNC('year', NOW() AT TIME ZONE ${timezone_param})::date
+                            {main_filter_sql}
+                        ) as year_completed,
+                        COALESCE(SUM(total_amount) FILTER (
+                            WHERE status = 'completed'
+                            AND DATE(order_date AT TIME ZONE ${timezone_param}) >= DATE_TRUNC('year', NOW() AT TIME ZONE ${timezone_param})::date
+                            {main_filter_sql}
+                        ), 0) as year_sales
+
+                    FROM orders
+                    WHERE tenant_id = $1 AND {ANALYTICS_SALES_FILTER}
+                """
 
             row = await conn.fetchrow(dashboard_query, *params)
 
@@ -2417,60 +2550,94 @@ async def get_orders_dashboard(
             commission_savings = round(main_sales * (commission_rate / 100))
 
             # Payment breakdown — UNION ALL: order_payments (split) + legacy orders
-            breakdown_rows = await conn.fetch(
-                f"""
-                -- Split orders: amounts from order_payments
-                SELECT
-                    COALESCE(pmg.slug, op.payment_method)  AS group_slug,
-                    COALESCE(pmg.name, op.payment_method)  AS group_name,
-                    COALESCE(SUM(op.amount), 0)             AS total,
-                    COUNT(DISTINCT op.order_id)             AS order_count
-                FROM order_payments op
-                JOIN orders o ON o.id = op.order_id
-                LEFT JOIN payment_methods pm ON pm.id = op.payment_method_id
-                LEFT JOIN payment_method_groups pmg ON pmg.id = pm.group_id
-                WHERE o.tenant_id = $1
-                  AND o.status = 'completed'
-                  AND {ANALYTICS_SALES_FILTER_ALIAS_O}
-                GROUP BY COALESCE(pmg.slug, op.payment_method), COALESCE(pmg.name, op.payment_method)
-
-                UNION ALL
-
-                -- Legacy orders (no rows in order_payments): use orders.total_amount
-                SELECT
-                    COALESCE(pmg.slug, o.payment_method)  AS group_slug,
-                    COALESCE(pmg.name, o.payment_method)  AS group_name,
-                    COALESCE(SUM(o.total_amount), 0)       AS total,
-                    COUNT(*)                               AS order_count
-                FROM orders o
-                LEFT JOIN payment_methods pm ON pm.id = o.payment_method_id
-                LEFT JOIN payment_method_groups pmg ON pmg.id = pm.group_id
-                WHERE o.tenant_id = $1
-                  AND o.status = 'completed'
-                  AND {ANALYTICS_SALES_FILTER_ALIAS_O}
-                  AND NOT EXISTS (SELECT 1 FROM order_payments op WHERE op.order_id = o.id)
-                GROUP BY COALESCE(pmg.slug, o.payment_method), COALESCE(pmg.name, o.payment_method)
-                """,
-                tenant_id,
-            )
-            # Aggregate across UNION ALL branches in Python to avoid double-counting
-            bd_agg: Dict[str, Any] = {}
-            for r in breakdown_rows:
-                slug = r["group_slug"]
-                if slug is None:
-                    continue
-                if slug not in bd_agg:
-                    bd_agg[slug] = {
-                        "group_slug":  slug,
-                        "group_name":  r["group_name"],
-                        "total":       float(r["total"]),
+            if category_id:
+                breakdown_rows = await conn.fetch(
+                    f"""
+                    SELECT
+                        COALESCE(pmg.slug, o.payment_method)  AS group_slug,
+                        COALESCE(pmg.name, o.payment_method)  AS group_name,
+                        COALESCE(SUM(COALESCE(oi.net_total, oi.subtotal)), 0) AS total,
+                        COUNT(DISTINCT o.id)                    AS order_count
+                    FROM orders o
+                    JOIN order_items oi ON oi.order_id = o.id
+                    JOIN product p ON p.id = oi.product_id
+                    LEFT JOIN payment_methods pm ON pm.id = o.payment_method_id
+                    LEFT JOIN payment_method_groups pmg ON pmg.id = pm.group_id
+                    WHERE o.tenant_id = $1
+                      AND o.status = 'completed'
+                      AND {ANALYTICS_SALES_FILTER_ALIAS_O}
+                      AND p.category_id = $2::uuid
+                    GROUP BY COALESCE(pmg.slug, o.payment_method), COALESCE(pmg.name, o.payment_method)
+                    """,
+                    tenant_id,
+                    category_id,
+                )
+                payment_breakdown = [
+                    {
+                        "group_slug": r["group_slug"],
+                        "group_name": r["group_name"],
+                        "total": float(r["total"]),
                         "order_count": int(r["order_count"]),
                     }
-                else:
-                    entry = bd_agg[slug]
-                    entry["total"] = float(entry["total"]) + float(r["total"])
-                    entry["order_count"] = int(entry["order_count"]) + int(r["order_count"])
-            payment_breakdown = sorted(bd_agg.values(), key=lambda x: x["total"], reverse=True)
+                    for r in breakdown_rows
+                    if r["group_slug"] is not None
+                ]
+                payment_breakdown.sort(key=lambda x: x["total"], reverse=True)
+            else:
+                breakdown_rows = await conn.fetch(
+                    f"""
+                    -- Split orders: amounts from order_payments
+                    SELECT
+                        COALESCE(pmg.slug, op.payment_method)  AS group_slug,
+                        COALESCE(pmg.name, op.payment_method)  AS group_name,
+                        COALESCE(SUM(op.amount), 0)             AS total,
+                        COUNT(DISTINCT op.order_id)             AS order_count
+                    FROM order_payments op
+                    JOIN orders o ON o.id = op.order_id
+                    LEFT JOIN payment_methods pm ON pm.id = op.payment_method_id
+                    LEFT JOIN payment_method_groups pmg ON pmg.id = pm.group_id
+                    WHERE o.tenant_id = $1
+                      AND o.status = 'completed'
+                      AND {ANALYTICS_SALES_FILTER_ALIAS_O}
+                    GROUP BY COALESCE(pmg.slug, op.payment_method), COALESCE(pmg.name, op.payment_method)
+
+                    UNION ALL
+
+                    -- Legacy orders (no rows in order_payments): use orders.total_amount
+                    SELECT
+                        COALESCE(pmg.slug, o.payment_method)  AS group_slug,
+                        COALESCE(pmg.name, o.payment_method)  AS group_name,
+                        COALESCE(SUM(o.total_amount), 0)       AS total,
+                        COUNT(*)                               AS order_count
+                    FROM orders o
+                    LEFT JOIN payment_methods pm ON pm.id = o.payment_method_id
+                    LEFT JOIN payment_method_groups pmg ON pmg.id = pm.group_id
+                    WHERE o.tenant_id = $1
+                      AND o.status = 'completed'
+                      AND {ANALYTICS_SALES_FILTER_ALIAS_O}
+                      AND NOT EXISTS (SELECT 1 FROM order_payments op WHERE op.order_id = o.id)
+                    GROUP BY COALESCE(pmg.slug, o.payment_method), COALESCE(pmg.name, o.payment_method)
+                    """,
+                    tenant_id,
+                )
+                # Aggregate across UNION ALL branches in Python to avoid double-counting
+                bd_agg: Dict[str, Any] = {}
+                for r in breakdown_rows:
+                    slug = r["group_slug"]
+                    if slug is None:
+                        continue
+                    if slug not in bd_agg:
+                        bd_agg[slug] = {
+                            "group_slug":  slug,
+                            "group_name":  r["group_name"],
+                            "total":       float(r["total"]),
+                            "order_count": int(r["order_count"]),
+                        }
+                    else:
+                        entry = bd_agg[slug]
+                        entry["total"] = float(entry["total"]) + float(r["total"])
+                        entry["order_count"] = int(entry["order_count"]) + int(r["order_count"])
+                payment_breakdown = sorted(bd_agg.values(), key=lambda x: x["total"], reverse=True)
 
             # Tax aggregates — all-time, month-to-date, year-to-date
             _main_std = 0.0
@@ -2481,6 +2648,8 @@ async def get_orders_dashboard(
             _year_liq = 0.0
             _tax_label = "Impuesto"
             _base_filter = f"o.tenant_id = $1 AND o.status = 'completed' AND {ANALYTICS_SALES_FILTER_ALIAS_O}"
+            if category_id:
+                _base_filter += " AND p.category_id = $2::uuid"
             _tax_select = """
                 SELECT COALESCE(p.tax_category, 'standard') AS tax_category,
                        COALESCE(p.tax_resolution, 'inherit') AS tax_resolution,
@@ -2493,22 +2662,43 @@ async def get_orders_dashboard(
             """
             try:
                 tax_config = await _get_tenant_tax_config(conn, tenant_id)
-                main_tax_rows = await conn.fetch(
-                    f"{_tax_select} WHERE {_base_filter}",
-                    tenant_id
-                )
-                month_tax_rows = await conn.fetch(
-                    f"""{_tax_select} WHERE {_base_filter}
-                        AND DATE(o.order_date AT TIME ZONE $2) >= DATE_TRUNC('month', NOW() AT TIME ZONE $2)::date""",
-                    tenant_id,
-                    timezone_name,
-                )
-                year_tax_rows = await conn.fetch(
-                    f"""{_tax_select} WHERE {_base_filter}
-                        AND DATE(o.order_date AT TIME ZONE $2) >= DATE_TRUNC('year', NOW() AT TIME ZONE $2)::date""",
-                    tenant_id,
-                    timezone_name,
-                )
+                if category_id:
+                    main_tax_rows = await conn.fetch(
+                        f"{_tax_select} WHERE {_base_filter}",
+                        tenant_id,
+                        category_id,
+                    )
+                    month_tax_rows = await conn.fetch(
+                        f"""{_tax_select} WHERE {_base_filter}
+                            AND DATE(o.order_date AT TIME ZONE $3) >= DATE_TRUNC('month', NOW() AT TIME ZONE $3)::date""",
+                        tenant_id,
+                        category_id,
+                        timezone_name,
+                    )
+                    year_tax_rows = await conn.fetch(
+                        f"""{_tax_select} WHERE {_base_filter}
+                            AND DATE(o.order_date AT TIME ZONE $3) >= DATE_TRUNC('year', NOW() AT TIME ZONE $3)::date""",
+                        tenant_id,
+                        category_id,
+                        timezone_name,
+                    )
+                else:
+                    main_tax_rows = await conn.fetch(
+                        f"{_tax_select} WHERE {_base_filter}",
+                        tenant_id
+                    )
+                    month_tax_rows = await conn.fetch(
+                        f"""{_tax_select} WHERE {_base_filter}
+                            AND DATE(o.order_date AT TIME ZONE $2) >= DATE_TRUNC('month', NOW() AT TIME ZONE $2)::date""",
+                        tenant_id,
+                        timezone_name,
+                    )
+                    year_tax_rows = await conn.fetch(
+                        f"""{_tax_select} WHERE {_base_filter}
+                            AND DATE(o.order_date AT TIME ZONE $2) >= DATE_TRUNC('year', NOW() AT TIME ZONE $2)::date""",
+                        tenant_id,
+                        timezone_name,
+                    )
                 _main_std, _main_liq, _tax_label = _compute_tax_breakdown(main_tax_rows, tax_config)
                 _month_std, _month_liq, _ = _compute_tax_breakdown(month_tax_rows, tax_config)
                 _year_std, _year_liq, _ = _compute_tax_breakdown(year_tax_rows, tax_config)
@@ -3418,7 +3608,8 @@ async def get_sales_flow(
     date_from: Optional[str] = None,
     date_to: Optional[str] = None,
     payment_method: Optional[str] = None,
-    status: Optional[str] = None
+    status: Optional[str] = None,
+    category_id: Optional[str] = None,
 ) -> dict:
     """
     Get sales flow data with intelligent comparison and grouping
@@ -3467,25 +3658,56 @@ async def get_sales_flow(
             group_by = 'hour' if days_diff <= 3 else 'day'
 
             # Build WHERE conditions
-            where_conditions = ["tenant_id = $1", ANALYTICS_SALES_FILTER]
-            params = [tenant_id]
-            param_count = 1
+            if category_id:
+                where_conditions = ["o.tenant_id = $1", ANALYTICS_SALES_FILTER_ALIAS_O]
+                params = [tenant_id]
+                param_count = 1
 
-            # Add filters
-            if payment_method:
-                param_count += 1
-                where_conditions.append(f"payment_method = ${param_count}")
-                params.append(payment_method)
+                if payment_method:
+                    param_count += 1
+                    where_conditions.append(f"o.payment_method = ${param_count}")
+                    params.append(payment_method)
 
-            if status:
+                if status:
+                    param_count += 1
+                    where_conditions.append(f"o.status = ${param_count}")
+                    params.append(status)
+                else:
+                    where_conditions.append("o.status = 'completed'")
+
                 param_count += 1
-                where_conditions.append(f"status = ${param_count}")
-                params.append(status)
+                where_conditions.append(f"p.category_id = ${param_count}::uuid")
+                params.append(category_id)
+
+                where_clause = " AND ".join(where_conditions)
+                from_join = """
+                    FROM orders o
+                    JOIN order_items oi ON oi.order_id = o.id
+                    JOIN product p ON p.id = oi.product_id
+                """
+                sales_expr = "SUM(COALESCE(oi.net_total, oi.subtotal))"
+                order_date_col = "o.order_date"
             else:
-                # Default to completed if no status filter
-                where_conditions.append("status = 'completed'")
+                where_conditions = ["tenant_id = $1", ANALYTICS_SALES_FILTER]
+                params = [tenant_id]
+                param_count = 1
 
-            where_clause = " AND ".join(where_conditions)
+                if payment_method:
+                    param_count += 1
+                    where_conditions.append(f"payment_method = ${param_count}")
+                    params.append(payment_method)
+
+                if status:
+                    param_count += 1
+                    where_conditions.append(f"status = ${param_count}")
+                    params.append(status)
+                else:
+                    where_conditions.append("status = 'completed'")
+
+                where_clause = " AND ".join(where_conditions)
+                from_join = "FROM orders"
+                sales_expr = "SUM(total_amount)"
+                order_date_col = "order_date"
 
             # Build query based on grouping
             if group_by == 'hour':
@@ -3509,23 +3731,23 @@ async def get_sales_flow(
                     ),
                     current_period AS (
                         SELECT
-                            EXTRACT(HOUR FROM order_date AT TIME ZONE ${timezone_param_idx}) AS hour,
-                            SUM(total_amount) AS sales
-                        FROM orders
+                            EXTRACT(HOUR FROM {order_date_col} AT TIME ZONE ${timezone_param_idx}) AS hour,
+                            {sales_expr} AS sales
+                        {from_join}
                         WHERE {where_clause}
-                          AND DATE(order_date AT TIME ZONE ${timezone_param_idx}) >= ${date_from_param_idx}
-                          AND DATE(order_date AT TIME ZONE ${timezone_param_idx}) <= ${date_to_param_idx}
-                        GROUP BY EXTRACT(HOUR FROM order_date AT TIME ZONE ${timezone_param_idx})
+                          AND DATE({order_date_col} AT TIME ZONE ${timezone_param_idx}) >= ${date_from_param_idx}
+                          AND DATE({order_date_col} AT TIME ZONE ${timezone_param_idx}) <= ${date_to_param_idx}
+                        GROUP BY EXTRACT(HOUR FROM {order_date_col} AT TIME ZONE ${timezone_param_idx})
                     ),
                     comparison_period AS (
                         SELECT
-                            EXTRACT(HOUR FROM order_date AT TIME ZONE ${timezone_param_idx}) AS hour,
-                            SUM(total_amount) AS sales
-                        FROM orders
+                            EXTRACT(HOUR FROM {order_date_col} AT TIME ZONE ${timezone_param_idx}) AS hour,
+                            {sales_expr} AS sales
+                        {from_join}
                         WHERE {where_clause}
-                          AND DATE(order_date AT TIME ZONE ${timezone_param_idx}) >= ${comp_from_param_idx}
-                          AND DATE(order_date AT TIME ZONE ${timezone_param_idx}) <= ${comp_to_param_idx}
-                        GROUP BY EXTRACT(HOUR FROM order_date AT TIME ZONE ${timezone_param_idx})
+                          AND DATE({order_date_col} AT TIME ZONE ${timezone_param_idx}) >= ${comp_from_param_idx}
+                          AND DATE({order_date_col} AT TIME ZONE ${timezone_param_idx}) <= ${comp_to_param_idx}
+                        GROUP BY EXTRACT(HOUR FROM {order_date_col} AT TIME ZONE ${timezone_param_idx})
                     )
                     SELECT
                         h.hour,
@@ -3585,23 +3807,23 @@ async def get_sales_flow(
                     ),
                     current_period AS (
                         SELECT
-                            DATE(order_date AT TIME ZONE ${timezone_param_idx}) AS day,
-                            SUM(total_amount) AS sales
-                        FROM orders
+                            DATE({order_date_col} AT TIME ZONE ${timezone_param_idx}) AS day,
+                            {sales_expr} AS sales
+                        {from_join}
                         WHERE {where_clause}
-                          AND DATE(order_date AT TIME ZONE ${timezone_param_idx}) >= ${date_from_param_idx}
-                          AND DATE(order_date AT TIME ZONE ${timezone_param_idx}) <= ${date_to_param_idx}
-                        GROUP BY DATE(order_date AT TIME ZONE ${timezone_param_idx})
+                          AND DATE({order_date_col} AT TIME ZONE ${timezone_param_idx}) >= ${date_from_param_idx}
+                          AND DATE({order_date_col} AT TIME ZONE ${timezone_param_idx}) <= ${date_to_param_idx}
+                        GROUP BY DATE({order_date_col} AT TIME ZONE ${timezone_param_idx})
                     ),
                     comparison_period AS (
                         SELECT
-                            DATE(order_date AT TIME ZONE ${timezone_param_idx}) AS day,
-                            SUM(total_amount) AS sales
-                        FROM orders
+                            DATE({order_date_col} AT TIME ZONE ${timezone_param_idx}) AS day,
+                            {sales_expr} AS sales
+                        {from_join}
                         WHERE {where_clause}
-                          AND DATE(order_date AT TIME ZONE ${timezone_param_idx}) >= ${comp_from_param_idx}
-                          AND DATE(order_date AT TIME ZONE ${timezone_param_idx}) <= ${comp_to_param_idx}
-                        GROUP BY DATE(order_date AT TIME ZONE ${timezone_param_idx})
+                          AND DATE({order_date_col} AT TIME ZONE ${timezone_param_idx}) >= ${comp_from_param_idx}
+                          AND DATE({order_date_col} AT TIME ZONE ${timezone_param_idx}) <= ${comp_to_param_idx}
+                        GROUP BY DATE({order_date_col} AT TIME ZONE ${timezone_param_idx})
                     )
                     SELECT
                         ds.day,

--- a/tests/test_analytics_category_filter.py
+++ b/tests/test_analytics_category_filter.py
@@ -47,7 +47,11 @@ async def test_menu_analysis_with_category_id_filters_sql_and_args():
 
     sql = captured_query[0]
     assert "p.category_id = $6::uuid" in sql
-    assert CATEGORY_UUID in captured_args[0]
+    assert "LIMIT $5" in sql
+    assert "LIMIT $7" not in sql
+    assert len(captured_args[0]) == 6
+    assert captured_args[0][4] == 10
+    assert captured_args[0][5] == CATEGORY_UUID
 
 
 @pytest.mark.asyncio

--- a/tests/test_analytics_category_filter.py
+++ b/tests/test_analytics_category_filter.py
@@ -1,0 +1,107 @@
+"""Analytics category filter (#1926) — optional category_id scopes item-attributed revenue."""
+import inspect
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import analytics_service, orders_service
+
+CATEGORY_UUID = "11111111-1111-1111-1111-111111111111"
+TENANT_UUID = "00000000-0000-0000-0000-000000000099"
+
+
+def _mock_conn(fetch_impl=None):
+    mock_conn = AsyncMock()
+    mock_conn.fetchval = AsyncMock(return_value="America/Mexico_City")
+    if fetch_impl:
+        mock_conn.fetch = fetch_impl
+    else:
+        mock_conn.fetch = AsyncMock(return_value=[])
+    mock_conn.fetchrow = AsyncMock(return_value=None)
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+    return mock_cm, mock_conn
+
+
+@pytest.mark.asyncio
+async def test_menu_analysis_with_category_id_filters_sql_and_args():
+    captured_query = []
+    captured_args = []
+
+    async def capture_fetch(query, *args):
+        captured_query.append(query)
+        captured_args.append(args)
+        return []
+
+    mock_cm, _ = _mock_conn(capture_fetch)
+
+    with patch("app.services.analytics_service.get_db_connection", return_value=mock_cm):
+        await analytics_service._get_menu_analysis_for_tenant(
+            TENANT_UUID,
+            "2026-01-01",
+            "2026-01-31",
+            limit=10,
+            category_id=CATEGORY_UUID,
+        )
+
+    sql = captured_query[0]
+    assert "p.category_id = $6::uuid" in sql
+    assert CATEGORY_UUID in captured_args[0]
+
+
+@pytest.mark.asyncio
+async def test_menu_analysis_without_category_id_omits_category_filter():
+    captured_query = []
+    captured_args = []
+
+    async def capture_fetch(query, *args):
+        captured_query.append(query)
+        captured_args.append(args)
+        return []
+
+    mock_cm, _ = _mock_conn(capture_fetch)
+
+    with patch("app.services.analytics_service.get_db_connection", return_value=mock_cm):
+        await analytics_service._get_menu_analysis_for_tenant(
+            TENANT_UUID,
+            "2026-01-01",
+            "2026-01-31",
+            limit=10,
+        )
+
+    sql = captured_query[0]
+    assert "p.category_id = $" not in sql
+    assert CATEGORY_UUID not in captured_args[0]
+    assert captured_args[0][4] == 10
+
+
+@pytest.mark.asyncio
+async def test_food_cost_with_category_id_filters_sql_and_args():
+    captured_query = []
+    captured_args = []
+
+    async def capture_fetch(query, *args):
+        captured_query.append(query)
+        captured_args.append(args)
+        return []
+
+    mock_cm, _ = _mock_conn(capture_fetch)
+
+    with patch("app.services.analytics_service.get_db_connection", return_value=mock_cm):
+        await analytics_service._get_food_cost_for_tenant(
+            TENANT_UUID,
+            "2026-01-01",
+            "2026-01-31",
+            category_id=CATEGORY_UUID,
+        )
+
+    sql = captured_query[0]
+    assert "JOIN product p ON p.id = oi.product_id" in sql
+    assert "p.category_id = $7::uuid" in sql
+    assert CATEGORY_UUID in captured_args[0]
+
+
+def test_get_orders_metrics_accepts_category_id():
+    sig = inspect.signature(orders_service.get_orders_metrics)
+    assert "category_id" in sig.parameters


### PR DESCRIPTION
## Summary
- Optional `category_id` on `/orders/dashboard|metrics|sales-flow` — item-attributed revenue via order_items → product
- Optional `category_id` on `/analytics/menu-analysis` and `/food-cost`
- Omit param = previous behavior; tips unchanged

Refs uno0uno/warocol.com#1926

Companion front: https://github.com/uno0uno/warocol.com/pull/1929

## Validation evidence
```
pytest tests/test_analytics_category_filter.py tests/test_analytics_dual_cost.py -v
8 passed in 0.13s
```

## Test plan
- [ ] Starter/Pro tenant: filter Ventas by category; totals drop to category items
- [ ] Rentabilidad: Food Cost % + matrix respect category
- [ ] Empty category = all; tenant with no categories shows only “all”
- [ ] Deploy with warocol.com#1929

## wr-context
See `.wr/1926.yaml` on this branch.