### PR TITLE
feat(permissions): add CRM module and Starter plan access

### DIFF
--- a/app/core/permissions.py
+++ b/app/core/permissions.py
@@ -53,8 +53,8 @@ class Module(str, Enum):
 
     Grouped by business area as defined in Epic 2 (#164). 14 modules in
     Spanish to match the language operators use to talk about their own
-    business. Each module corresponds to a router group that Epic 2 will
-    decorate with `require_module()`.
+    business (CRM added in #1931). Each module corresponds to a router group
+    that Epic 2 will decorate with `require_module()`.
     """
     POS = "pos"                          # pos_cart, tables, comandas, online_orders
     VENTAS = "ventas"                    # orders, online_cart
@@ -63,6 +63,7 @@ class Module(str, Enum):
     OPERACIONES = "operaciones"          # tenant_config, stations
     ABASTECIMIENTO = "abastecimiento"    # purchases, suppliers, inventory, admin_ingredients, ingredient_purchase_units
     ANALITICA = "analitica"              # analytics, articles
+    CRM = "crm"                          # customers, Waros loyalty (moved from analitica)
     FINANZAS = "finanzas"                # accounting, expenses, salaries, cierre, cartera, credit, payment_methods, financial
     FACTURACION = "facturacion"          # facturacion, invoices, support_documents
     EQUIPO = "equipo"                    # tenants, invitations
@@ -87,6 +88,7 @@ DEFAULT_ROLE_MODULES: Dict[Role, FrozenSet[Module]] = {
         Module.OPERACIONES,
         Module.ABASTECIMIENTO,
         Module.ANALITICA,
+        Module.CRM,
         Module.FINANZAS,
         Module.FACTURACION,
         Module.INTEGRACIONES,
@@ -103,6 +105,7 @@ DEFAULT_ROLE_MODULES: Dict[Role, FrozenSet[Module]] = {
         Module.OPERACIONES,
         Module.ABASTECIMIENTO,
         Module.ANALITICA,
+        Module.CRM,
         # No MI_NEGOCIO — owner-only
     }),
     Role.CASHIER: frozenset({

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -329,6 +329,7 @@ STARTER_PLAN_MODULE_VALUES = frozenset({
     "operaciones",
     "abastecimiento",
     "analitica",
+    "crm",
     "finanzas",
     "integraciones",
     "equipo",

--- a/tests/test_me_access.py
+++ b/tests/test_me_access.py
@@ -121,6 +121,7 @@ def test_starter_owner_includes_all_product_modules():
         "operaciones",
         "abastecimiento",
         "analitica",
+        "crm",
         "finanzas",
         "integraciones",
         "equipo",

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -25,9 +25,9 @@ class TestRoleEnum:
 
 
 class TestModuleEnum:
-    def test_thirteen_modules_exposed(self):
-        # Eventos lives in warotickets.com, so API exposes 13 WARO modules.
-        assert len(list(Module)) == 13
+    def test_fourteen_modules_exposed(self):
+        # Eventos lives in warotickets.com; CRM added for customers/Waros (#1931).
+        assert len(list(Module)) == 14
 
     def test_no_duplicate_values(self):
         values = [m.value for m in Module]
@@ -36,7 +36,7 @@ class TestModuleEnum:
     def test_epic_2_contract_modules_present(self):
         expected = {
             "pos", "ventas", "despacho", "menu", "operaciones",
-            "abastecimiento", "analitica", "finanzas", "facturacion",
+            "abastecimiento", "analitica", "crm", "finanzas", "facturacion",
             "equipo", "integraciones", "mi_plan", "mi_negocio",
         }
         assert {m.value for m in Module} == expected


### PR DESCRIPTION
## Summary
- Add `Module.CRM = "crm"` and grant Admin/Supervisor (Owner via `_ALL_MODULES`)
- Include `crm` in `STARTER_PLAN_MODULE_VALUES` for parity with prior Analítica clientes/puntos access
- Update permissions catalog + `/me/access` Starter tests

Companion front PR: warocol.com `wr-1931-crm-module-move` (Closes uno0uno/warocol.com#1931).

## Test plan
- [ ] `/me/access` for owner/admin/supervisor includes `crm` on Starter
- [ ] Cashier still POS-only (no `crm`)
- [ ] Deploy API before or with front CRM nav

## Validation evidence
```
venv/bin/pytest tests/test_permissions.py tests/test_me_access.py -q
40 passed in 0.16s
```

## Notes
- Customer APIs remain `Module.VENTAS`; Waros admin remains `Module.POS` (front gates CRM).
- Waros UI under CRM may 403 without POS — deferred dual-allow.

## wr-context
See local `.wr/1931.yaml` (gitignored).

Made with [Cursor](https://cursor.com)