### PR TITLE
test(billing): lock CRM Waros, wallet, and cartera as unlimited

### DIFF
--- a/tests/test_billing_plan_quotas.py
+++ b/tests/test_billing_plan_quotas.py
@@ -280,3 +280,41 @@ async def test_remaining_usage_exposes_disabled_override_as_unlimited():
         "disabled": True,
         "reason": "Pilot",
     }
+
+
+# ── CRM unlimited-by-design (#1932 / epic #1930 Batch 2) ───────────────────
+# Waros rules, wallet recharges, and customer cartera (credit) payments must
+# never appear in enforceable/period/scoped quota catalogs.
+
+_CRM_UNLIMITED_RESOURCE_ALIASES = frozenset({
+    "waros",
+    "waros_rules",
+    "waro_rules",
+    "wallet",
+    "wallet_recharges",
+    "customer_wallet",
+    "cartera",
+    "cartera_payments",
+    "credit_payments",
+    "crm",
+})
+
+
+def test_crm_loyalty_wallet_cartera_not_in_quota_catalogs():
+    catalogs = (
+        billing_service.ENFORCEABLE_QUOTA_RESOURCES
+        | billing_service.PERIOD_QUOTA_RESOURCES
+        | billing_service.SCOPED_QUOTA_RESOURCES
+    )
+    overlap = _CRM_UNLIMITED_RESOURCE_ALIASES & catalogs
+    assert overlap == frozenset(), (
+        "CRM loyalty/wallet/cartera must stay unlimited; unexpected quota keys: "
+        f"{sorted(overlap)}"
+    )
+
+
+def test_supplier_payments_period_quota_is_not_customer_cartera():
+    """Regression guard: do not confuse supplier AP with customer credit pay."""
+    assert "supplier_payments_per_period" in billing_service.PERIOD_QUOTA_RESOURCES
+    assert "cartera_payments" not in billing_service.PERIOD_QUOTA_RESOURCES
+    assert "credit_payments" not in billing_service.PERIOD_QUOTA_RESOURCES

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -1465,3 +1465,42 @@ def test_manual_journal_allowed_source_modules_match_count_filter():
     )
     assert "system" not in MANUAL_JOURNAL_SOURCE_MODULES
     assert "orden" not in MANUAL_JOURNAL_SOURCE_MODULES
+
+
+# ── CRM unlimited-by-design (#1932) ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_crm_waros_rules_quota_resource_is_rejected():
+    """Waros rule growth must not be enforceable via plan quota helpers."""
+    conn = MagicMock()
+    with pytest.raises(ValueError, match="Unsupported quota resource"):
+        await billing_service.check_plan_quota_growth(conn, uuid4(), "waros_rules")
+
+
+@pytest.mark.asyncio
+async def test_crm_wallet_recharge_period_quota_resource_is_rejected():
+    conn = MagicMock()
+    with pytest.raises(ValueError, match="Unsupported period quota resource"):
+        await billing_service.check_plan_quota_period(conn, uuid4(), "wallet_recharges")
+
+
+@pytest.mark.asyncio
+async def test_crm_cartera_credit_payment_period_quota_resource_is_rejected():
+    conn = MagicMock()
+    with pytest.raises(ValueError, match="Unsupported period quota resource"):
+        await billing_service.check_plan_quota_period(conn, uuid4(), "cartera_payments")
+
+
+def test_crm_service_modules_do_not_call_plan_quota_helpers():
+    """Wallet / credit / waros services must stay off billing quota enforcement."""
+    import inspect
+
+    from app.services import credit_service, customer_wallet_service, waros_service
+
+    for mod in (customer_wallet_service, credit_service, waros_service):
+        src = inspect.getsource(mod)
+        assert "check_plan_quota_growth" not in src, mod.__name__
+        assert "check_plan_quota_period" not in src, mod.__name__
+        assert "check_plan_quota_scoped" not in src, mod.__name__
+        assert "ENFORCEABLE_QUOTA_RESOURCES" not in src, mod.__name__


### PR DESCRIPTION
## Summary
- Regression-lock CRM growth surfaces as **unlimited by design**: Waros rules, wallet recharges, and customer cartera (credit) payments
- Assert those resource aliases stay out of enforceable/period/scoped quota catalogs
- Reject fake CRM quota resources on `check_plan_quota_growth` / `check_plan_quota_period`
- Assert wallet / credit / waros services do not call plan quota helpers

No production billing behavior change — policy lock-in only.

Closes uno0uno/warocol.com#1932

## Test plan
- [ ] New CRM unlimited tests pass in CI
- [ ] Starter can still upsert/toggle Waros rules without quota 403
- [ ] Wallet recharge and credit payment paths unchanged (no new 429 from billing quotas)
- [ ] Do not confuse with `supplier_payments_per_period` (supplier AP, not customer cartera)

## Validation evidence
```
venv/bin/pytest tests/test_billing_plan_quotas.py tests/test_quota_enforcement.py -q
76 passed in 0.19s
```

## Policy
CRM loyalty + wallet + cartera = unlimited by design.

Made with [Cursor](https://cursor.com)