### PR TITLE
feat(operaciones): tenant printer assignments API (#1949)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, pos_products, pos_customers, pos_orders, categories, recipe_bases, modifiers, ingredient_purchase_units, warehouse_categories, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, ai_agents, customer_portal, leads, waros, billing, legal, onboarding, payments_webhook, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router, email_tracking
+from app.routers import auth, me, tenants, financial, suppliers, ingredients, purchases, supplier_portal, products, pos_products, pos_customers, pos_orders, categories, recipe_bases, modifiers, ingredient_purchase_units, warehouse_categories, customers, pos_cart, pos_context, orders, inventory, articles, invitations, api_tokens, public_api, v1_ordering, salaries, expenses, public_restaurant, public_table_qr, table_qr_requests, tenant_config, promotions, online_cart, online_verification, address_profile, analytics, online_orders, notifications, ai_agents, customer_portal, leads, waros, billing, legal, onboarding, payments_webhook, admin_ingredients, menu, tables, credit, cartera, cierre, payment_methods, accounting, stations, comandas, operaciones_context, operaciones_shifts, operaciones_operation_events, operaciones_printers, invoices as invoices_router, support_documents, documents as documents_router, facturacion as facturacion_router, webhooks as webhooks_router, email_tracking
 from app.config import settings
 from app.core.logging import setup_logging
 from app.core.exceptions import api_exception_handler, general_exception_handler, APIError
@@ -178,6 +178,7 @@ app.include_router(pos_orders.router)  # POS-scoped invoice emit/read for checko
 app.include_router(operaciones_context.router)  # OPERACIONES-scoped aggregator + 5 toggle PATCH endpoints
 app.include_router(operaciones_shifts.router)  # OPERACIONES shift templates CRUD (#682)
 app.include_router(operaciones_operation_events.router)  # Bitácora POS events list (#782)
+app.include_router(operaciones_printers.router)  # Printer assignments caja + stations (#1949)
 app.include_router(online_cart.router)  # Public online ordering cart
 app.include_router(online_orders.router)  # Authenticated online orders management
 app.include_router(notifications.router)  # Authenticated notifications management

--- a/app/routers/operaciones_printers.py
+++ b/app/routers/operaciones_printers.py
@@ -1,0 +1,29 @@
+"""Operaciones printer assignment API (warocol.com#1949)."""
+from fastapi import APIRouter, Depends, Request
+
+from app.core.permissions import Module, require_module
+from app.services.printer_assignments_service import (
+    PrinterAssignmentsPut,
+    get_printer_assignments,
+    put_printer_assignments,
+)
+
+router = APIRouter(prefix="/operaciones", tags=["Operaciones Printers"])
+
+
+@router.get(
+    "/printers",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def get_printers_endpoint(request: Request):
+    """Return caja + per-station printer assignments and resolved fallbacks."""
+    return await get_printer_assignments(request)
+
+
+@router.put(
+    "/printers",
+    dependencies=[Depends(require_module(Module.OPERACIONES))],
+)
+async def put_printers_endpoint(request: Request, body: PrinterAssignmentsPut):
+    """Replace tenant printer assignments (caja + station map)."""
+    return await put_printer_assignments(request, body)

--- a/app/services/printer_assignments_service.py
+++ b/app/services/printer_assignments_service.py
@@ -1,0 +1,195 @@
+"""Tenant printer assignments for POS routing (warocol.com#1949 / epic #1947).
+
+Stores QZ/OS printer names for:
+- caja (prefactura + factura)
+- optional kitchen station printers (fallback → caja)
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from fastapi import HTTPException, Request
+from pydantic import BaseModel, Field, field_validator
+
+from app.core.exceptions import AuthenticationError
+from app.core.middleware import require_valid_session
+from app.database import get_db_connection
+
+
+class StationPrinterAssignment(BaseModel):
+    station_id: UUID
+    printer_name: Optional[str] = None
+
+    @field_validator("printer_name")
+    @classmethod
+    def _strip_name(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        return cleaned or None
+
+
+class PrinterAssignmentsPut(BaseModel):
+    caja_printer_name: Optional[str] = None
+    stations: List[StationPrinterAssignment] = Field(default_factory=list)
+
+    @field_validator("caja_printer_name")
+    @classmethod
+    def _strip_caja(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        return cleaned or None
+
+
+def resolve_printer_name(
+    *,
+    caja_printer_name: Optional[str],
+    station_map: Dict[str, str],
+    station_id: Optional[str] = None,
+) -> Optional[str]:
+    """Product rule: station mapping if set, else caja. Missing caja → None."""
+    if station_id:
+        mapped = station_map.get(str(station_id))
+        if mapped:
+            return mapped
+    return caja_printer_name or None
+
+
+def _rows_to_payload(rows: list) -> Dict[str, Any]:
+    caja_printer_name: Optional[str] = None
+    stations: List[Dict[str, str]] = []
+    station_map: Dict[str, str] = {}
+    for row in rows:
+        role = row["role"]
+        name = (row["printer_name"] or "").strip()
+        if not name:
+            continue
+        if role == "caja":
+            caja_printer_name = name
+        elif role == "station" and row["station_id"] is not None:
+            sid = str(row["station_id"])
+            stations.append({"station_id": sid, "printer_name": name})
+            station_map[sid] = name
+    return {
+        "caja_printer_name": caja_printer_name,
+        "stations": stations,
+        "station_map": station_map,
+    }
+
+
+async def get_printer_assignments(request: Request) -> dict:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    async with get_db_connection(use_transaction=False) as conn:
+        rows = await conn.fetch(
+            """
+            SELECT role, station_id, printer_name
+            FROM tenant_printer_assignments
+            WHERE tenant_id = $1
+            ORDER BY role, station_id
+            """,
+            tenant_id,
+        )
+        active_stations = await conn.fetch(
+            """
+            SELECT id, name, kitchen_name, is_active
+            FROM kitchen_stations
+            WHERE tenant_id = $1 AND is_active = true
+            ORDER BY display_order, name
+            """,
+            tenant_id,
+        )
+
+    payload = _rows_to_payload(rows)
+    resolved = {
+        str(st["id"]): resolve_printer_name(
+            caja_printer_name=payload["caja_printer_name"],
+            station_map=payload["station_map"],
+            station_id=str(st["id"]),
+        )
+        for st in active_stations
+    }
+
+    return {
+        "success": True,
+        "data": {
+            "caja_printer_name": payload["caja_printer_name"],
+            "stations": payload["stations"],
+            "active_stations": [
+                {
+                    "id": str(st["id"]),
+                    "name": st["name"],
+                    "kitchen_name": st["kitchen_name"],
+                }
+                for st in active_stations
+            ],
+            "resolved": resolved,
+            "resolved_caja": payload["caja_printer_name"],
+        },
+    }
+
+
+async def put_printer_assignments(request: Request, body: PrinterAssignmentsPut) -> dict:
+    session = require_valid_session(request)
+    tenant_id = session.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    station_writes: Dict[UUID, str] = {}
+    for item in body.stations:
+        if item.printer_name:
+            station_writes[item.station_id] = item.printer_name
+
+    async with get_db_connection() as conn:
+        if station_writes:
+            found = await conn.fetchval(
+                """
+                SELECT COUNT(*)::int
+                FROM kitchen_stations
+                WHERE tenant_id = $1 AND id = ANY($2::uuid[])
+                """,
+                tenant_id,
+                list(station_writes.keys()),
+            )
+            if found != len(station_writes):
+                raise HTTPException(
+                    status_code=400,
+                    detail="One or more station_id values are invalid for this tenant",
+                )
+
+        await conn.execute(
+            "DELETE FROM tenant_printer_assignments WHERE tenant_id = $1",
+            tenant_id,
+        )
+
+        if body.caja_printer_name:
+            await conn.execute(
+                """
+                INSERT INTO tenant_printer_assignments (
+                    tenant_id, role, station_id, printer_name
+                )
+                VALUES ($1, 'caja', NULL, $2)
+                """,
+                tenant_id,
+                body.caja_printer_name,
+            )
+
+        for station_id, printer_name in station_writes.items():
+            await conn.execute(
+                """
+                INSERT INTO tenant_printer_assignments (
+                    tenant_id, role, station_id, printer_name
+                )
+                VALUES ($1, 'station', $2, $3)
+                """,
+                tenant_id,
+                station_id,
+                printer_name,
+            )
+
+    return await get_printer_assignments(request)

--- a/sql/20260731_tenant_printer_assignments.sql
+++ b/sql/20260731_tenant_printer_assignments.sql
@@ -1,0 +1,30 @@
+-- warocol.com#1949 — tenant printer routing (caja + per kitchen station)
+-- ADD/CREATE only. Printer names are OS/QZ display names (stable key).
+
+CREATE TABLE IF NOT EXISTS tenant_printer_assignments (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id uuid NOT NULL REFERENCES tenants(id),
+    role text NOT NULL CHECK (role IN ('caja', 'station')),
+    station_id uuid REFERENCES kitchen_stations(id) ON DELETE CASCADE,
+    printer_name text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT tenant_printer_assignments_role_station_chk CHECK (
+        (role = 'caja' AND station_id IS NULL)
+        OR (role = 'station' AND station_id IS NOT NULL)
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_tenant_printer_assignments_caja
+    ON tenant_printer_assignments (tenant_id)
+    WHERE role = 'caja';
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_tenant_printer_assignments_station
+    ON tenant_printer_assignments (tenant_id, station_id)
+    WHERE role = 'station';
+
+CREATE INDEX IF NOT EXISTS idx_tenant_printer_assignments_tenant
+    ON tenant_printer_assignments (tenant_id);
+
+COMMENT ON TABLE tenant_printer_assignments IS
+    'POS printer routing: one caja printer + optional per kitchen_station (#1949).';

--- a/tests/test_printer_assignments.py
+++ b/tests/test_printer_assignments.py
@@ -1,0 +1,84 @@
+"""Unit tests for printer assignment resolve + payload shaping (warocol.com#1949)."""
+from uuid import uuid4
+
+from app.services.printer_assignments_service import (
+    PrinterAssignmentsPut,
+    StationPrinterAssignment,
+    _rows_to_payload,
+    resolve_printer_name,
+)
+
+
+def test_resolve_uses_station_when_mapped():
+    caja = "CAJA_PRINTER"
+    station_id = str(uuid4())
+    assert (
+        resolve_printer_name(
+            caja_printer_name=caja,
+            station_map={station_id: "KITCHEN_A"},
+            station_id=station_id,
+        )
+        == "KITCHEN_A"
+    )
+
+
+def test_resolve_falls_back_to_caja_when_station_unmapped():
+    caja = "CAJA_PRINTER"
+    station_id = str(uuid4())
+    assert (
+        resolve_printer_name(
+            caja_printer_name=caja,
+            station_map={},
+            station_id=station_id,
+        )
+        == "CAJA_PRINTER"
+    )
+
+
+def test_resolve_returns_none_without_caja():
+    station_id = str(uuid4())
+    assert (
+        resolve_printer_name(
+            caja_printer_name=None,
+            station_map={},
+            station_id=station_id,
+        )
+        is None
+    )
+
+
+def test_resolve_caja_role_ignores_station_map_when_no_station():
+    assert (
+        resolve_printer_name(
+            caja_printer_name="CAJA",
+            station_map={str(uuid4()): "K"},
+            station_id=None,
+        )
+        == "CAJA"
+    )
+
+
+def test_rows_to_payload_shapes_caja_and_stations():
+    sid = uuid4()
+    payload = _rows_to_payload(
+        [
+            {"role": "caja", "station_id": None, "printer_name": " STAR_TP586 "},
+            {"role": "station", "station_id": sid, "printer_name": "BAR"},
+        ]
+    )
+    assert payload["caja_printer_name"] == "STAR_TP586"
+    assert payload["stations"] == [{"station_id": str(sid), "printer_name": "BAR"}]
+    assert payload["station_map"][str(sid)] == "BAR"
+
+
+def test_put_body_strips_empty_printer_names():
+    body = PrinterAssignmentsPut(
+        caja_printer_name="  ",
+        stations=[
+            StationPrinterAssignment(station_id=uuid4(), printer_name="  Kit  "),
+            StationPrinterAssignment(station_id=uuid4(), printer_name=""),
+        ],
+    )
+    assert body.caja_printer_name is None
+    assert body.stations[0].printer_name == "Kit"
+    assert body.stations[1].printer_name is None


### PR DESCRIPTION
## Summary
- CREATE `tenant_printer_assignments` (caja + per kitchen station printer names)
- GET/PUT `/operaciones/printers` gated by Module.OPERACIONES
- Resolve helper: station mapping else caja

Refs uno0uno/warocol.com#1949

## Test plan
- [ ] Apply `sql/20260731_tenant_printer_assignments.sql` on DB
- [ ] GET/PUT `/operaciones/printers` as supervisor/admin
- [ ] Unmapped station resolves to caja in GET `resolved`

## Validation evidence

```text
$ ./venv/bin/pytest tests/test_printer_assignments.py -q
collected 6 items
tests/test_printer_assignments.py ......                                 [100%]
============================== 6 passed in 0.04s ===============================
```


Made with [Cursor](https://cursor.com)