### PR TITLE
feat(operaciones): GET printers for POS/Ventas/Despacho (#1951)

### DIFF
--- a/app/core/permissions.py
+++ b/app/core/permissions.py
@@ -412,6 +412,79 @@ def require_module(module: Module) -> Callable[[Request], Awaitable[None]]:
     return dependency
 
 
+def require_any_module(*modules: Module) -> Callable[[Request], Awaitable[None]]:
+    """Like ``require_module`` but allows access when the role has *any* module.
+
+    Used for read endpoints shared across POS / Ventas / Despacho / Operaciones
+    (e.g. printer assignment GET for ticket routing).
+    """
+    if not modules:
+        raise ValueError("require_any_module needs at least one Module")
+
+    async def dependency(request: Request) -> None:
+        from app.core.middleware import get_session_context  # local import to avoid cycle
+
+        session = get_session_context(request)
+        if not session.is_valid:
+            return
+
+        tenant_id = session.tenant_id
+        if not tenant_id:
+            return
+
+        from app.services.billing_service import (
+            STARTER_PLAN_MODULE_VALUES,
+            STARTER_PLAN_SLUG,
+            get_effective_plan_slug,
+        )
+
+        async with get_db_connection() as conn:
+            plan_slug = await get_effective_plan_slug(conn, tenant_id)
+        if plan_slug == STARTER_PLAN_SLUG:
+            if not any(m.value in STARTER_PLAN_MODULE_VALUES for m in modules):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=(
+                        "Módulo no disponible en el plan Starter: "
+                        + ", ".join(m.value for m in modules)
+                    ),
+                )
+
+        mode = await get_enforcement_mode(tenant_id)
+        if mode == "disabled":
+            return
+
+        path = request.url.path
+        raw_role = session.role
+        primary = modules[0]
+        if not raw_role:
+            _shadow_or_deny(
+                mode, tenant_id, session.user_id, None, primary,
+                reason="no-membership", path=path,
+            )
+            return
+
+        try:
+            normalized = normalize_role(raw_role)
+        except ValueError:
+            _shadow_or_deny(
+                mode, tenant_id, session.user_id, raw_role, primary,
+                reason="unknown-role", path=path,
+            )
+            return
+
+        allowed = await get_role_modules(tenant_id, normalized)
+        if any(module in allowed for module in modules):
+            return
+
+        _shadow_or_deny(
+            mode, tenant_id, session.user_id, normalized.value, primary,
+            reason="not-in-matrix", path=path,
+        )
+
+    return dependency
+
+
 # ─────────────────────────────────────────────────────────────────────
 # Auto-handoff predicate for the waiter attribution family
 # (warocol.com#574 — POS session override; warocol.com#575 — order

--- a/app/routers/operaciones_printers.py
+++ b/app/routers/operaciones_printers.py
@@ -1,7 +1,7 @@
-"""Operaciones printer assignment API (warocol.com#1949)."""
+"""Operaciones printer assignment API (warocol.com#1949 / #1951)."""
 from fastapi import APIRouter, Depends, Request
 
-from app.core.permissions import Module, require_module
+from app.core.permissions import Module, require_any_module, require_module
 from app.services.printer_assignments_service import (
     PrinterAssignmentsPut,
     get_printer_assignments,
@@ -13,10 +13,23 @@ router = APIRouter(prefix="/operaciones", tags=["Operaciones Printers"])
 
 @router.get(
     "/printers",
-    dependencies=[Depends(require_module(Module.OPERACIONES))],
+    dependencies=[
+        Depends(
+            require_any_module(
+                Module.POS,
+                Module.VENTAS,
+                Module.DESPACHO,
+                Module.OPERACIONES,
+            )
+        )
+    ],
 )
 async def get_printers_endpoint(request: Request):
-    """Return caja + per-station printer assignments and resolved fallbacks."""
+    """Return caja + per-station printer assignments and resolved fallbacks.
+
+    Readable from POS/Ventas/Despacho so cashiers can route tickets without
+    Operaciones module (warocol.com#1951). Writes stay Operaciones-only.
+    """
     return await get_printer_assignments(request)
 
 


### PR DESCRIPTION
## Summary
- Add `require_any_module` and gate GET `/operaciones/printers` for POS | Ventas | Despacho | Operaciones.
- PUT remains Operaciones-only so cashiers can resolve ticket printers without Operaciones write access.

Refs uno0uno/warocol.com#1951

Stacked on `wr-1949-operaciones-impresoras` (#748).

## Test plan
- [ ] Cashier (POS-only) can GET `/operaciones/printers` when enforcement is on
- [ ] Kitchen/Despacho role can GET
- [ ] PUT still 403 for cashier

## Validation evidence
```text
./venv/bin/pytest tests/test_printer_assignments.py -q
6 passed in 0.50s
```

Made with [Cursor](https://cursor.com)