### PR TITLE
feat(customers): expose fiscal fields for CRM Clients

### DIFF
--- a/.wr/751.yaml
+++ b/.wr/751.yaml
@@ -1,0 +1,45 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 751
+title: "Show customer fiscal data in CRM Clients when present"
+repo: both
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: both
+branch: wr-751-crm-fiscal-clients
+
+paths:
+  - app/services/orders_service.py
+  - tests/test_customers_list.py
+  - tests/test_customer_detail.py
+  - pages/crm/clientes/index.vue
+  - pages/crm/clientes/[id].vue
+  - i18n/locales/es/analitica.json
+  - i18n/locales/en/analitica.json
+
+ac:
+  - GET /orders/customers includes fiscal_* fields (null when empty)
+  - GET /orders/customers/{id} includes same fiscal_* on customer
+  - CRM detail shows fiscal block only when any fiscal field present
+  - CRM list shows compact fiscal signal when present; no empty noise
+  - Focused API tests cover with/without fiscal data
+
+out_of_scope:
+  - Editing fiscal from CRM
+  - POS capture flow changes
+  - Matías / electronic invoicing
+  - Analytics clientes pages beyond shared payload
+
+hints:
+  entry: "orders_service.get_customers_list + get_customer_detail; CRM /crm/clientes"
+  pattern: "profile fiscal fields already used by POS CustomerIdentificationModal"
+  tests: "./venv/bin/pytest tests/test_customers_list.py tests/test_customer_detail.py -q"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "front companion PR on warocol.com; merge API first"

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -1860,7 +1860,11 @@ async def get_customers_list(
                     SELECT
                         p.id AS customer_id,
                         COALESCE(p.name, 'Sin identificar') AS name,
-                        p.phone_number AS phone
+                        p.phone_number AS phone,
+                        p.fiscal_id_type,
+                        p.fiscal_id,
+                        p.fiscal_business_name,
+                        p.fiscal_email
                     FROM profile p
                     INNER JOIN tenant_customers tc ON tc.profile_id = p.id
                     WHERE tc.tenant_id = $1
@@ -1881,6 +1885,10 @@ async def get_customers_list(
                     tcp.customer_id,
                     tcp.name,
                     tcp.phone,
+                    tcp.fiscal_id_type,
+                    tcp.fiscal_id,
+                    tcp.fiscal_business_name,
+                    tcp.fiscal_email,
                     COALESCE(oa.total_spent, 0)   AS total_spent,
                     COALESCE(oa.order_count, 0)   AS order_count,
                     COALESCE(oa.avg_ticket, 0)    AS avg_ticket,
@@ -1904,6 +1912,10 @@ async def get_customers_list(
                     "customer_id": str(row['customer_id']),
                     "name": row['name'],
                     "phone": row['phone'],
+                    "fiscal_id_type": row.get('fiscal_id_type'),
+                    "fiscal_id": row.get('fiscal_id'),
+                    "fiscal_business_name": row.get('fiscal_business_name'),
+                    "fiscal_email": row.get('fiscal_email'),
                     "total_spent": float(row['total_spent']),
                     "order_count": int(row['order_count']),
                     "avg_ticket": float(row['avg_ticket'] or 0),
@@ -1983,6 +1995,10 @@ async def get_customer_detail(
                     COALESCE(p.name, 'Sin identificar') AS name,
                     p.phone_number                       AS phone,
                     p.email                              AS email,
+                    p.fiscal_id_type,
+                    p.fiscal_id,
+                    p.fiscal_business_name,
+                    p.fiscal_email,
                     COUNT(o.id)                          AS total_orders,
                     SUM(o.total_amount)                  AS total_spent,
                     MIN(DATE(o.order_date AT TIME ZONE $3)) AS first_purchase,
@@ -1990,7 +2006,8 @@ async def get_customer_detail(
                 FROM orders o
                 LEFT JOIN profile p ON o.customer_id = p.id
                 WHERE {aggregate_where_clause}
-                GROUP BY o.customer_id, p.name, p.phone_number, p.email
+                GROUP BY o.customer_id, p.name, p.phone_number, p.email,
+                         p.fiscal_id_type, p.fiscal_id, p.fiscal_business_name, p.fiscal_email
                 """,
                 *aggregate_params,
             )
@@ -2002,7 +2019,11 @@ async def get_customer_detail(
                         p.id                                 AS customer_id,
                         COALESCE(p.name, 'Sin identificar') AS name,
                         p.phone_number                       AS phone,
-                        p.email                              AS email
+                        p.email                              AS email,
+                        p.fiscal_id_type,
+                        p.fiscal_id,
+                        p.fiscal_business_name,
+                        p.fiscal_email
                     FROM profile p
                     JOIN tenant_customers tc ON tc.profile_id = p.id
                     WHERE p.id = $1
@@ -2020,6 +2041,10 @@ async def get_customer_detail(
                     "name": profile_row["name"],
                     "phone": profile_row["phone"],
                     "email": profile_row["email"],
+                    "fiscal_id_type": profile_row.get("fiscal_id_type"),
+                    "fiscal_id": profile_row.get("fiscal_id"),
+                    "fiscal_business_name": profile_row.get("fiscal_business_name"),
+                    "fiscal_email": profile_row.get("fiscal_email"),
                     "total_orders": 0,
                     "total_spent": 0,
                     "first_purchase": None,
@@ -2159,6 +2184,10 @@ async def get_customer_detail(
                     "name": customer_row['name'],
                     "phone": customer_row['phone'],
                     "email": customer_row['email'],
+                    "fiscal_id_type": customer_row.get('fiscal_id_type'),
+                    "fiscal_id": customer_row.get('fiscal_id'),
+                    "fiscal_business_name": customer_row.get('fiscal_business_name'),
+                    "fiscal_email": customer_row.get('fiscal_email'),
                     "total_orders": int(customer_row['total_orders']),
                     "total_spent": float(customer_row['total_spent']),
                     "first_purchase": _date_iso(customer_row['first_purchase']),

--- a/tests/test_customer_detail.py
+++ b/tests/test_customer_detail.py
@@ -69,14 +69,77 @@ async def test_get_customer_detail_profile_without_orders_returns_zeroed_stats()
     assert result['customer']['total_spent'] == 0.0
     assert result['customer']['first_purchase'] is None
     assert result['customer']['last_purchase'] is None
+    assert result['customer']['fiscal_id_type'] is None
+    assert result['customer']['fiscal_id'] is None
+    assert result['customer']['fiscal_business_name'] is None
+    assert result['customer']['fiscal_email'] is None
     assert result['orders']['items'] == []
     assert result['orders']['total'] == 0
     fallback_query = _SeqConnCtx.latest_conn.fetchrow.await_args_list[1].args[0]
     assert "tenant_customers tc" in fallback_query
     assert "tc.profile_id" in fallback_query
     assert "tc.is_active = true" in fallback_query
+    assert "p.fiscal_id_type" in fallback_query
+    assert "p.fiscal_id" in fallback_query
     assert "tenant_members" not in fallback_query
     assert "role = 'customer'" not in fallback_query
+
+
+@pytest.mark.asyncio
+async def test_get_customer_detail_includes_fiscal_fields_when_present():
+    profile_row = {
+        'customer_id': _CUSTOMER_ID,
+        'name': 'Fiscal Customer',
+        'phone': '3001234567',
+        'email': '3001234567@customer.temp',
+        'fiscal_id_type': 'CC',
+        'fiscal_id': '1234567890',
+        'fiscal_business_name': 'Juan Perez',
+        'fiscal_email': 'juan@example.com',
+    }
+
+    with _patch_session(), _patch_conn([None, profile_row, None], [[], []]):
+        result = await orders_service.get_customer_detail(
+            Request({'type': 'http'}),
+            customer_id=_CUSTOMER_ID,
+        )
+
+    customer = result['customer']
+    assert customer['fiscal_id_type'] == 'CC'
+    assert customer['fiscal_id'] == '1234567890'
+    assert customer['fiscal_business_name'] == 'Juan Perez'
+    assert customer['fiscal_email'] == 'juan@example.com'
+
+
+@pytest.mark.asyncio
+async def test_get_customer_detail_with_orders_includes_fiscal_fields():
+    order_agg = {
+        'customer_id': _CUSTOMER_ID,
+        'name': 'Returning Customer',
+        'phone': '3009876543',
+        'email': 'buyer@example.com',
+        'fiscal_id_type': 'NIT',
+        'fiscal_id': '900111222',
+        'fiscal_business_name': 'Returning SAS',
+        'fiscal_email': None,
+        'total_orders': 2,
+        'total_spent': 50000.0,
+        'first_purchase': datetime(2026, 1, 10, tzinfo=timezone.utc),
+        'last_purchase': datetime(2026, 5, 1, tzinfo=timezone.utc),
+    }
+
+    with _patch_session(), _patch_conn([order_agg, None], [[], []]):
+        result = await orders_service.get_customer_detail(
+            Request({'type': 'http'}),
+            customer_id=_CUSTOMER_ID,
+        )
+
+    assert result['customer']['fiscal_id_type'] == 'NIT'
+    assert result['customer']['fiscal_id'] == '900111222'
+    assert result['customer']['fiscal_business_name'] == 'Returning SAS'
+    aggregate_query = _SeqConnCtx.latest_conn.fetchrow.await_args_list[0].args[0]
+    assert "p.fiscal_id_type" in aggregate_query
+    assert "p.fiscal_business_name" in aggregate_query
 
 
 @pytest.mark.asyncio

--- a/tests/test_customers_list.py
+++ b/tests/test_customers_list.py
@@ -88,3 +88,72 @@ async def test_customers_list_includes_zero_order_customer():
   assert "o.online_cart_id IS NOT NULL" in query
   assert "tenant_members" not in query
   assert "role = 'customer'" not in query
+  assert "p.fiscal_id_type" in query
+  assert "p.fiscal_id" in query
+  assert "p.fiscal_business_name" in query
+  assert "p.fiscal_email" in query
+  for row in result['data']:
+      assert 'fiscal_id_type' in row
+      assert 'fiscal_id' in row
+      assert 'fiscal_business_name' in row
+      assert 'fiscal_email' in row
+
+
+@pytest.mark.asyncio
+async def test_customers_list_includes_fiscal_fields_when_present():
+  rows = [
+      {
+          'customer_id': _CUSTOMER_WITH_ORDERS,
+          'name': 'Buyer SA',
+          'phone': '3001111111',
+          'fiscal_id_type': 'NIT',
+          'fiscal_id': '900123456',
+          'fiscal_business_name': 'Buyer SA',
+          'fiscal_email': 'factura@buyer.com',
+          'total_spent': 50000.0,
+          'order_count': 2,
+          'avg_ticket': 25000.0,
+          'last_order_date': None,
+          'total_count': 1,
+          'total_revenue': 50000.0,
+      },
+  ]
+
+  with _patch_session(), _patch_conn(rows):
+      result = await orders_service.get_customers_list(Request({'type': 'http'}))
+
+  row = result['data'][0]
+  assert row['fiscal_id_type'] == 'NIT'
+  assert row['fiscal_id'] == '900123456'
+  assert row['fiscal_business_name'] == 'Buyer SA'
+  assert row['fiscal_email'] == 'factura@buyer.com'
+
+
+@pytest.mark.asyncio
+async def test_customers_list_fiscal_fields_null_when_absent():
+  rows = [
+      {
+          'customer_id': _CUSTOMER_NO_ORDERS,
+          'name': 'Walk-in',
+          'phone': '3002222222',
+          'fiscal_id_type': None,
+          'fiscal_id': None,
+          'fiscal_business_name': None,
+          'fiscal_email': None,
+          'total_spent': 0.0,
+          'order_count': 0,
+          'avg_ticket': 0.0,
+          'last_order_date': None,
+          'total_count': 1,
+          'total_revenue': 0.0,
+      },
+  ]
+
+  with _patch_session(), _patch_conn(rows):
+      result = await orders_service.get_customers_list(Request({'type': 'http'}))
+
+  row = result['data'][0]
+  assert row['fiscal_id_type'] is None
+  assert row['fiscal_id'] is None
+  assert row['fiscal_business_name'] is None
+  assert row['fiscal_email'] is None


### PR DESCRIPTION
## Summary
- Expose `fiscal_id_type`, `fiscal_id`, `fiscal_business_name`, `fiscal_email` on `GET /orders/customers` and `GET /orders/customers/{id}`
- Cover list/detail payloads with and without fiscal data in focused tests
- Companion front PR on `warocol.com` renders these fields in CRM Clients

Closes #751

## Test plan
- [ ] Customer with fiscal data returns all four fiscal fields on list + detail
- [ ] Customer without fiscal data returns null fiscal fields; UI unchanged
- [ ] No-orders profile path still returns fiscal fields when set

## Validation evidence
```
./venv/bin/pytest tests/test_customers_list.py tests/test_customer_detail.py -q
============================= test session starts ==============================
collected 9 items
tests/test_customers_list.py ...                                         [ 33%]
tests/test_customer_detail.py ......                                     [100%]
============================== 9 passed in 0.19s ===============================
```

## wr-context
See `.wr/751.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)