### PR TITLE
feat(comandas): SSE comanda_fired for auto-print

### DIFF
--- a/.wr/1971.yaml
+++ b/.wr/1971.yaml
@@ -1,0 +1,47 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1971
+title: "Auto-print comandas to caja / user printer on add-to-table and counter-bar send"
+repo: both
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-1971-auto-print-comandas
+
+paths:
+  - app/services/notifications_service.py
+  - app/services/comandas_service.py
+  - tests/test_comanda_fired_notification.py
+  - composables/useAutoComandaPrint.ts
+  - composables/useAutoComandaPrint.test.ts
+  - composables/useUserPrinterPreference.ts
+  - composables/useNotifications.ts
+  - pages/operaciones/impresoras.vue
+
+ac:
+  - Agregar a mesa auto-prints to caja when PrintBridge + caja configured
+  - Mostrador/barra send auto-prints when user has one printer + PrintBridge
+  - At most one printer per user (localStorage)
+  - No PrintBridge → no print attempt (silent)
+  - Dedupe by comanda id across SSE duplicates
+  - Focused API + front tests
+
+out_of_scope:
+  - Multi-station kitchen routing for auto-print
+  - Multiple printers per user
+  - Remote/cloud print queue
+  - Factura/prefactura auto-print
+
+hints:
+  entry: "fire_comandas → notify_comanda_fired SSE; useNotifications onmessage gate"
+  pattern: "SSE-only (no notifications row); mesa→caja; barra/pos→user printer"
+  tests: "API: ./venv/bin/pytest tests/test_comanda_fired_notification.py -q | Front: bunx vitest run composables/useAutoComandaPrint.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "merge API before front if deploy order matters; both needed for E2E"

--- a/app/services/comandas_service.py
+++ b/app/services/comandas_service.py
@@ -502,24 +502,26 @@ async def _fire_with_conn(
     if created_comandas:
         from app.services.notifications_service import notify_comanda_fired
 
-        label = (table_display_name or "").strip().lower()
-        # Mesa → caja; Barra (also source_type=table) + mostrador/pos → user printer
-        if source_type == "table" and label not in ("barra", "bar"):
-            auto_print_target = "caja"
-        else:
-            auto_print_target = "user"
+        # Only mesa / barra / mostrador — not delivery/pickup auto-fire (#1971)
+        if source_type in ("table", "pos"):
+            label = (table_display_name or "").strip().lower()
+            # Mesa → caja; Barra (also source_type=table) + mostrador/pos → user printer
+            if source_type == "table" and label not in ("barra", "bar"):
+                auto_print_target = "caja"
+            else:
+                auto_print_target = "user"
 
-        await notify_comanda_fired(
-            conn,
-            tenant_id,
-            {
-                "order_id": str(order_id),
-                "source_type": source_type,
-                "table_display_name": table_display_name,
-                "auto_print_target": auto_print_target,
-                "comandas": created_comandas,
-            },
-        )
+            await notify_comanda_fired(
+                conn,
+                tenant_id,
+                {
+                    "order_id": str(order_id),
+                    "source_type": source_type,
+                    "table_display_name": table_display_name,
+                    "auto_print_target": auto_print_target,
+                    "comandas": created_comandas,
+                },
+            )
     return created_comandas
 
 

--- a/app/services/comandas_service.py
+++ b/app/services/comandas_service.py
@@ -499,6 +499,27 @@ async def _fire_with_conn(
         f"fired={fired_count} skipped={skipped} "
         f"comandas={len(created_comandas)}"
     )
+    if created_comandas:
+        from app.services.notifications_service import notify_comanda_fired
+
+        label = (table_display_name or "").strip().lower()
+        # Mesa → caja; Barra (also source_type=table) + mostrador/pos → user printer
+        if source_type == "table" and label not in ("barra", "bar"):
+            auto_print_target = "caja"
+        else:
+            auto_print_target = "user"
+
+        await notify_comanda_fired(
+            conn,
+            tenant_id,
+            {
+                "order_id": str(order_id),
+                "source_type": source_type,
+                "table_display_name": table_display_name,
+                "auto_print_target": auto_print_target,
+                "comandas": created_comandas,
+            },
+        )
     return created_comandas
 
 

--- a/app/services/notifications_service.py
+++ b/app/services/notifications_service.py
@@ -49,6 +49,31 @@ async def create_comanda_ready_notification(
     await conn.execute("SELECT pg_notify($1, $2)", channel, json.dumps(notify_payload))
 
 
+def _json_safe(value):
+    """Serialize UUID/datetime for pg_notify payloads."""
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    return value
+
+
+async def notify_comanda_fired(conn, tenant_id: UUID, payload: dict) -> None:
+    """
+    SSE-only signal when comandas are fired (warocol.com#1971).
+
+    Does NOT insert a notifications row — avoids toast/bell noise. Clients with
+    PrintBridge connected may auto-print; others ignore.
+    """
+    channel = "tenant_" + str(tenant_id).replace("-", "")
+    notify_payload = {**_json_safe(payload), "type": "comanda_fired"}
+    await conn.execute("SELECT pg_notify($1, $2)", channel, json.dumps(notify_payload))
+
+
 async def mark_table_qr_notifications_read(
     conn,
     tenant_id: UUID,

--- a/tests/test_comanda_fired_notification.py
+++ b/tests/test_comanda_fired_notification.py
@@ -142,3 +142,77 @@ async def test_fire_with_conn_notifies_when_comandas_created():
     assert args[2]["order_id"] == str(order_id)
     assert args[2]["auto_print_target"] == "caja"
     assert len(args[2]["comandas"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_fire_with_conn_skips_notify_for_delivery():
+    order_id = uuid4()
+    tenant_id = uuid4()
+    station_id = uuid4()
+    item_id = uuid4()
+    item_row = {
+        "id": item_id,
+        "product_id": uuid4(),
+        "kitchen_name": "Burger",
+        "quantity": 1,
+        "notes": None,
+        "modifiers_snapshot": None,
+    }
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[item_row])
+    conn.fetchval = AsyncMock(side_effect=[10, 1, "Cocina"])
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {
+                "id": uuid4(),
+                "comanda_number": 10,
+                "comanda_index": 1,
+                "station_id": station_id,
+                "status": "pending",
+                "source_type": "delivery",
+                "table_display_name": "Domicilio #10",
+                "notes": None,
+                "fired_at": datetime.now(timezone.utc),
+                "ready_at": None,
+                "created_at": datetime.now(timezone.utc),
+            },
+            {
+                "id": uuid4(),
+                "order_item_id": item_id,
+                "kitchen_name": "Burger",
+                "quantity": 1,
+                "notes": None,
+                "modifiers_snapshot": None,
+                "status": "pending",
+                "ready_at": None,
+                "created_at": datetime.now(timezone.utc),
+            },
+        ]
+    )
+    conn.execute = AsyncMock()
+
+    with patch(
+        "app.services.comandas_service.get_effective_station",
+        new=AsyncMock(return_value=station_id),
+    ), patch(
+        "app.services.comandas_service._build_comanda_print_items_for_order_item",
+        new=AsyncMock(
+            return_value=[
+                {
+                    "quantity": 1,
+                    "notes": None,
+                    "modifiers_snapshot": None,
+                    "is_promo_free": False,
+                    "kitchen_name": "Burger",
+                }
+            ]
+        ),
+    ), patch(
+        "app.services.notifications_service.notify_comanda_fired",
+        new_callable=AsyncMock,
+    ) as notify:
+        await _fire_with_conn(
+            conn, order_id, tenant_id, "delivery", "Domicilio #10", None
+        )
+
+    notify.assert_not_awaited()

--- a/tests/test_comanda_fired_notification.py
+++ b/tests/test_comanda_fired_notification.py
@@ -1,0 +1,144 @@
+"""Tests for comanda_fired SSE notify on fire_comandas (warocol.com#1971)."""
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services import notifications_service
+from app.services.comandas_service import _fire_with_conn
+
+
+@pytest.mark.asyncio
+async def test_notify_comanda_fired_is_sse_only_no_insert():
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    tenant_id = uuid4()
+    payload = {
+        "order_id": str(uuid4()),
+        "source_type": "table",
+        "comandas": [{"id": str(uuid4()), "comanda_number": 1, "items": []}],
+    }
+
+    await notifications_service.notify_comanda_fired(conn, tenant_id, payload)
+
+    assert conn.execute.await_count == 1
+    sql = conn.execute.await_args.args[0]
+    assert "pg_notify" in sql
+    assert "INSERT INTO notifications" not in sql
+    notify_json = conn.execute.await_args.args[2]
+    assert '"type": "comanda_fired"' in notify_json or '"type":"comanda_fired"' in notify_json.replace(
+        " ", ""
+    )
+
+
+@pytest.mark.asyncio
+async def test_notify_comanda_fired_json_safe_uuid_datetime():
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    cid = uuid4()
+    fired = datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc)
+
+    await notifications_service.notify_comanda_fired(
+        conn,
+        uuid4(),
+        {
+            "order_id": uuid4(),
+            "source_type": "pos",
+            "comandas": [{"id": cid, "fired_at": fired, "items": []}],
+        },
+    )
+
+    raw = conn.execute.await_args.args[2]
+    assert str(cid) in raw
+    assert "2026-07-31T12:00:00" in raw
+
+
+@pytest.mark.asyncio
+async def test_fire_with_conn_notifies_when_comandas_created():
+    """When fire creates comandas, notify_comanda_fired is called once."""
+    order_id = uuid4()
+    tenant_id = uuid4()
+    station_id = uuid4()
+    item_id = uuid4()
+
+    conn = MagicMock()
+    # rows for new items
+    item_row = {
+        "id": item_id,
+        "product_id": uuid4(),
+        "kitchen_name": "Burger",
+        "quantity": 1,
+        "notes": None,
+        "modifiers_snapshot": None,
+    }
+
+    async def fetch_side_effect(sql, *args):
+        if "fulfillment_status = 'new'" in sql or "fulfillment_status='new'" in sql.replace(" ", ""):
+            return [item_row]
+        return []
+
+    conn.fetch = AsyncMock(side_effect=fetch_side_effect)
+    conn.fetchval = AsyncMock(side_effect=[10, 1, "Cocina"])  # order_number, index, station name
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {
+                "id": uuid4(),
+                "comanda_number": 10,
+                "comanda_index": 1,
+                "station_id": station_id,
+                "status": "pending",
+                "source_type": "table",
+                "table_display_name": "Mesa 1",
+                "notes": None,
+                "fired_at": datetime.now(timezone.utc),
+                "ready_at": None,
+                "created_at": datetime.now(timezone.utc),
+            },
+            {
+                "id": uuid4(),
+                "order_item_id": item_id,
+                "kitchen_name": "Burger",
+                "quantity": 1,
+                "notes": None,
+                "modifiers_snapshot": None,
+                "status": "pending",
+                "ready_at": None,
+                "created_at": datetime.now(timezone.utc),
+            },
+        ]
+    )
+    conn.execute = AsyncMock()
+
+    with patch(
+        "app.services.comandas_service.get_effective_station",
+        new=AsyncMock(return_value=station_id),
+    ), patch(
+        "app.services.comandas_service._build_comanda_print_items_for_order_item",
+        new=AsyncMock(
+            return_value=[
+                {
+                    "quantity": 1,
+                    "notes": None,
+                    "modifiers_snapshot": None,
+                    "is_promo_free": False,
+                    "kitchen_name": "Burger",
+                }
+            ]
+        ),
+    ), patch(
+        "app.services.notifications_service.notify_comanda_fired",
+        new_callable=AsyncMock,
+    ) as notify:
+        result = await _fire_with_conn(
+            conn, order_id, tenant_id, "table", "Mesa 1", None
+        )
+
+    assert len(result) >= 1
+    notify.assert_awaited_once()
+    args = notify.await_args.args
+    assert args[1] == tenant_id
+    assert args[2]["source_type"] == "table"
+    assert args[2]["order_id"] == str(order_id)
+    assert args[2]["auto_print_target"] == "caja"
+    assert len(args[2]["comandas"]) >= 1


### PR DESCRIPTION
## Summary
- Emit SSE-only `comanda_fired` (no notifications row / no toast) after `fire_comandas`
- Payload includes printable comandas + `auto_print_target` (`caja` for mesa, `user` for barra/mostrador)
- Companion front PR consumes SSE and prints via PrintBridge when connected

Related: uno0uno/warocol.com#1971

## Test plan
- [ ] Fire mesa comanda → SSE payload has `auto_print_target: caja`
- [ ] Fire barra/mostrador → `auto_print_target: user`
- [ ] No new row in notifications bell for `comanda_fired`

## Validation evidence
```
./venv/bin/pytest tests/test_comanda_fired_notification.py -q
collected 3 items
tests/test_comanda_fired_notification.py ...
============================== 3 passed in 0.06s ===============================
```

## wr-context
See `.wr/1971.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)