### PR TITLE
fix(comandas): fire must not roll back when auto-print notify fails

### DIFF
--- a/app/services/comandas_service.py
+++ b/app/services/comandas_service.py
@@ -500,7 +500,10 @@ async def _fire_with_conn(
         f"comandas={len(created_comandas)}"
     )
     if created_comandas:
-        from app.services.notifications_service import notify_comanda_fired
+        from app.services.notifications_service import (
+            build_comanda_fired_print_payload,
+            notify_comanda_fired,
+        )
 
         # Only mesa / barra / mostrador — not delivery/pickup auto-fire (#1971)
         if source_type in ("table", "pos"):
@@ -511,17 +514,24 @@ async def _fire_with_conn(
             else:
                 auto_print_target = "user"
 
-            await notify_comanda_fired(
-                conn,
-                tenant_id,
-                {
-                    "order_id": str(order_id),
-                    "source_type": source_type,
-                    "table_display_name": table_display_name,
-                    "auto_print_target": auto_print_target,
-                    "comandas": created_comandas,
-                },
-            )
+            # Never fail the fire transaction because of SSE/print notify
+            try:
+                await notify_comanda_fired(
+                    conn,
+                    tenant_id,
+                    {
+                        "order_id": str(order_id),
+                        "source_type": source_type,
+                        "table_display_name": table_display_name,
+                        "auto_print_target": auto_print_target,
+                        "comandas": build_comanda_fired_print_payload(created_comandas),
+                    },
+                )
+            except Exception as notify_err:
+                logger.error(
+                    "notify_comanda_fired failed after fire "
+                    f"(order={order_id}, tenant={tenant_id}): {notify_err}"
+                )
     return created_comandas
 
 

--- a/app/services/notifications_service.py
+++ b/app/services/notifications_service.py
@@ -2,9 +2,7 @@
 Notifications Service
 Tenant-scoped notification management for restaurant operators.
 """
-import json
-import logging
-from datetime import datetime, timezone
+from datetime import date as date_type, datetime, timezone
 from typing import Optional
 from uuid import UUID
 from uuid import NAMESPACE_URL, uuid5
@@ -13,6 +11,8 @@ from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, APIError, NotFoundError
 from app.services import billing_service, legal_service
+import json
+import logging
 
 logger = logging.getLogger(__name__)
 TERMS_ACCEPTANCE_REQUIRED_TYPE = "terms_acceptance_required"
@@ -50,16 +50,66 @@ async def create_comanda_ready_notification(
 
 
 def _json_safe(value):
-    """Serialize UUID/datetime for pg_notify payloads."""
+    """Serialize UUID/datetime/Decimal/date for pg_notify payloads."""
+    from decimal import Decimal
+
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
     if isinstance(value, UUID):
         return str(value)
     if isinstance(value, datetime):
         return value.isoformat()
+    if isinstance(value, date_type) and not isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return float(value)
     if isinstance(value, dict):
         return {str(k): _json_safe(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):
         return [_json_safe(v) for v in value]
-    return value
+    return str(value)
+
+
+def build_comanda_fired_print_payload(comandas: list) -> list:
+    """Slim printable snapshot — avoids dumping raw asyncpg / Decimal heavy rows."""
+    out = []
+    for c in comandas or []:
+        items = []
+        for i in (c.get("items") or []):
+            mods = i.get("modifiers_snapshot") or []
+            if isinstance(mods, str):
+                try:
+                    mods = json.loads(mods)
+                except (ValueError, TypeError):
+                    mods = []
+            items.append({
+                "kitchen_name": i.get("kitchen_name") or "",
+                "quantity": float(i.get("quantity") or 1),
+                "notes": i.get("notes"),
+                "modifiers_snapshot": [
+                    {
+                        "name": m.get("name") or "",
+                        "quantity": float(m.get("quantity") or 1) if m.get("quantity") is not None else 1,
+                    }
+                    for m in (mods if isinstance(mods, list) else [])
+                    if isinstance(m, dict)
+                ],
+            })
+        if not items:
+            continue
+        cid = c.get("id")
+        out.append({
+            "id": str(cid) if cid is not None else None,
+            "comanda_number": c.get("comanda_number"),
+            "comanda_index": c.get("comanda_index"),
+            "station_id": str(c["station_id"]) if c.get("station_id") is not None else None,
+            "station_name": c.get("station_name"),
+            "source_type": c.get("source_type"),
+            "table_display_name": c.get("table_display_name"),
+            "fired_at": _json_safe(c.get("fired_at")),
+            "items": items,
+        })
+    return out
 
 
 async def notify_comanda_fired(conn, tenant_id: UUID, payload: dict) -> None:
@@ -71,7 +121,8 @@ async def notify_comanda_fired(conn, tenant_id: UUID, payload: dict) -> None:
     """
     channel = "tenant_" + str(tenant_id).replace("-", "")
     notify_payload = {**_json_safe(payload), "type": "comanda_fired"}
-    await conn.execute("SELECT pg_notify($1, $2)", channel, json.dumps(notify_payload))
+    body = json.dumps(notify_payload, default=str)
+    await conn.execute("SELECT pg_notify($1, $2)", channel, body)
 
 
 async def mark_table_qr_notifications_read(

--- a/tests/test_comanda_fired_notification.py
+++ b/tests/test_comanda_fired_notification.py
@@ -55,6 +55,66 @@ async def test_notify_comanda_fired_json_safe_uuid_datetime():
 
 
 @pytest.mark.asyncio
+async def test_notify_comanda_fired_handles_decimal_in_payload():
+    from decimal import Decimal
+
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    await notifications_service.notify_comanda_fired(
+        conn,
+        uuid4(),
+        {
+            "order_id": str(uuid4()),
+            "source_type": "table",
+            "auto_print_target": "caja",
+            "comandas": [
+                {
+                    "id": uuid4(),
+                    "comanda_number": 1,
+                    "items": [
+                        {
+                            "kitchen_name": "poker",
+                            "quantity": Decimal("2"),
+                            "notes": None,
+                            "modifiers_snapshot": [{"name": "x", "price": Decimal("1000.50")}],
+                        }
+                    ],
+                }
+            ],
+        },
+    )
+    raw = conn.execute.await_args.args[2]
+    assert "poker" in raw
+    assert "1000.5" in raw or "1000.50" in raw
+
+
+def test_build_comanda_fired_print_payload_strips_decimals():
+    from decimal import Decimal
+
+    slim = notifications_service.build_comanda_fired_print_payload(
+        [
+            {
+                "id": uuid4(),
+                "comanda_number": 7,
+                "station_name": "Barra",
+                "items": [
+                    {
+                        "kitchen_name": "PASSION",
+                        "quantity": Decimal("1"),
+                        "notes": "CON PEPINILLOS",
+                        "modifiers_snapshot": [{"name": "hielo", "quantity": Decimal("1"), "price": Decimal("0")}],
+                    }
+                ],
+            }
+        ]
+    )
+    assert len(slim) == 1
+    assert slim[0]["items"][0]["quantity"] == 1.0
+    assert slim[0]["items"][0]["notes"] == "CON PEPINILLOS"
+    assert slim[0]["items"][0]["modifiers_snapshot"][0]["name"] == "hielo"
+
+
+@pytest.mark.asyncio
 async def test_fire_with_conn_notifies_when_comandas_created():
     """When fire creates comandas, notify_comanda_fired is called once."""
     order_id = uuid4()


### PR DESCRIPTION
## Summary
- Hardens `comanda_fired` JSON for Decimal/date (promo lines like HORA FELIZ)
- Sends a slim printable payload instead of raw comanda rows
- Isolates notify errors so kitchen fire still commits (items no longer stuck as Sin enviar)

Fixes local report: PASSION + poker HORA FELIZ stayed Sin enviar / did not print after #1971.

## Test plan
- [ ] Add promo item + item with note to mesa → Agregar y enviar → status becomes En cocina
- [ ] Auto-print still fires when PrintBridge + caja configured
- [ ] If PrintBridge down, items still mark as sent

## Validation evidence
```
./venv/bin/pytest tests/test_comanda_fired_notification.py -q
6 passed
```

Made with [Cursor](https://cursor.com)