### PR TITLE
fix(comandas): fallback comanda last in SSE print payload

### DIFF
--- a/.wr/1973.yaml
+++ b/.wr/1973.yaml
@@ -1,0 +1,41 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1973
+title: "Always print fallback comanda last when no kitchen stations"
+repo: both
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-1973-fallback-comanda-print
+
+paths:
+  - app/services/notifications_service.py
+  - tests/test_comanda_fired_notification.py
+  - tests/test_comanda_item_notes.py
+  - composables/useAutoComandaPrint.ts
+  - composables/useAutoComandaPrint.test.ts
+
+ac:
+  - No-station fire creates fallback, marks sent
+  - Fallback last in SSE printable payload
+  - Auto-print prints fallback (mesa→caja)
+  - Mixed batch: station first, fallback last
+  - Focused API + front tests
+
+out_of_scope:
+  - Multi-station printer redesign
+  - Requiring stations configured
+
+hints:
+  entry: "build_comanda_fired_print_payload + orderComandasForPrint"
+  pattern: "print_fallback last; station_id null still prints"
+  tests: "API: ./venv/bin/pytest tests/test_comanda_fired_notification.py tests/test_comanda_item_notes.py -q | Front: bunx vitest run composables/useAutoComandaPrint.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "pair API+front; restart uvicorn for local test"

--- a/app/services/notifications_service.py
+++ b/app/services/notifications_service.py
@@ -71,7 +71,7 @@ def _json_safe(value):
 
 
 def build_comanda_fired_print_payload(comandas: list) -> list:
-    """Slim printable snapshot — avoids dumping raw asyncpg / Decimal heavy rows."""
+    """Slim printable snapshot — station groups first, print_fallback last (#1973)."""
     out = []
     for c in comandas or []:
         items = []
@@ -82,8 +82,12 @@ def build_comanda_fired_print_payload(comandas: list) -> list:
                     mods = json.loads(mods)
                 except (ValueError, TypeError):
                     mods = []
+            kitchen_name = (i.get("kitchen_name") or "").strip()
+            if not kitchen_name:
+                # Fallback rows must still print a line (#1973)
+                kitchen_name = (i.get("product_name") or i.get("name") or "Item").strip() or "Item"
             items.append({
-                "kitchen_name": i.get("kitchen_name") or "",
+                "kitchen_name": kitchen_name,
                 "quantity": float(i.get("quantity") or 1),
                 "notes": i.get("notes"),
                 "modifiers_snapshot": [
@@ -107,8 +111,11 @@ def build_comanda_fired_print_payload(comandas: list) -> list:
             "source_type": c.get("source_type"),
             "table_display_name": c.get("table_display_name"),
             "fired_at": _json_safe(c.get("fired_at")),
+            "print_fallback": bool(c.get("print_fallback")),
             "items": items,
         })
+    # Guarantee fallback tickets print after station tickets
+    out.sort(key=lambda row: 1 if row.get("print_fallback") else 0)
     return out
 
 

--- a/tests/test_comanda_fired_notification.py
+++ b/tests/test_comanda_fired_notification.py
@@ -112,6 +112,59 @@ def test_build_comanda_fired_print_payload_strips_decimals():
     assert slim[0]["items"][0]["quantity"] == 1.0
     assert slim[0]["items"][0]["notes"] == "CON PEPINILLOS"
     assert slim[0]["items"][0]["modifiers_snapshot"][0]["name"] == "hielo"
+    assert slim[0]["print_fallback"] is False
+
+
+def test_build_comanda_fired_print_payload_puts_fallback_last():
+    station_id = uuid4()
+    slim = notifications_service.build_comanda_fired_print_payload(
+        [
+            {
+                "id": None,
+                "comanda_number": 10,
+                "station_id": None,
+                "station_name": "Sin cocina asignada",
+                "print_fallback": True,
+                "items": [{"kitchen_name": "PASSION", "quantity": 1, "notes": "CON PEPINILLOS"}],
+            },
+            {
+                "id": station_id,
+                "comanda_number": 10,
+                "station_id": station_id,
+                "station_name": "Parrilla",
+                "print_fallback": False,
+                "items": [{"kitchen_name": "Burger", "quantity": 1}],
+            },
+        ]
+    )
+    assert len(slim) == 2
+    assert slim[0]["station_name"] == "Parrilla"
+    assert slim[0]["print_fallback"] is False
+    assert slim[1]["print_fallback"] is True
+    assert slim[1]["station_id"] is None
+    assert slim[1]["station_name"] == "Sin cocina asignada"
+
+
+def test_build_comanda_fired_print_payload_all_unrouted_still_prints():
+    slim = notifications_service.build_comanda_fired_print_payload(
+        [
+            {
+                "id": None,
+                "comanda_number": 3,
+                "station_id": None,
+                "station_name": "Sin cocina asignada",
+                "print_fallback": True,
+                "items": [
+                    {"kitchen_name": "poker 330", "quantity": 2, "notes": None},
+                    {"kitchen_name": "", "product_name": "coctel PASSION", "quantity": 1, "notes": "x"},
+                ],
+            }
+        ]
+    )
+    assert len(slim) == 1
+    assert slim[0]["print_fallback"] is True
+    assert slim[0]["items"][0]["kitchen_name"] == "poker 330"
+    assert slim[0]["items"][1]["kitchen_name"] == "coctel PASSION"
 
 
 @pytest.mark.asyncio

--- a/tests/test_comanda_item_notes.py
+++ b/tests/test_comanda_item_notes.py
@@ -168,9 +168,13 @@ async def test_fire_comandas_returns_printable_fallback_for_item_without_station
     ]
 
     mock_conn.fetchrow.assert_not_awaited()
-    update_sql = " ".join(mock_conn.execute.await_args.args[0].split())
+    update_call = next(
+        call for call in mock_conn.execute.await_args_list
+        if "UPDATE order_items" in call.args[0]
+    )
+    update_sql = " ".join(update_call.args[0].split())
     assert "UPDATE order_items SET fulfillment_status = 'sent'" in update_sql
-    assert mock_conn.execute.await_args.args[1] == [order_item_id]
+    assert update_call.args[1] == [order_item_id]
 
 
 @pytest.mark.asyncio
@@ -279,5 +283,13 @@ async def test_fire_comandas_keeps_station_group_and_adds_unrouted_fallback():
 
     assert fallback["station_id"] is None
     assert fallback["station_name"] == "Sin cocina asignada"
+    assert fallback["print_fallback"] is True
     assert fallback["items"][0]["order_item_id"] == unrouted_item_id
     assert fallback["items"][0]["notes"] == "sin papa"
+
+    # SSE printable order: station first, fallback last (#1973)
+    from app.services.notifications_service import build_comanda_fired_print_payload
+
+    slim = build_comanda_fired_print_payload(result)
+    assert slim[0]["print_fallback"] is False
+    assert slim[-1]["print_fallback"] is True


### PR DESCRIPTION
## Summary
- Preserve `print_fallback` and sort fallback tickets **last** in `comanda_fired` printable payload
- Empty kitchen_name falls back to product name so unrouted items still print
- Tests: all-unrouted + mixed station/fallback order

Related: uno0uno/warocol.com#1973

## Test plan
- [ ] Fire items with no stations → items marked sent; fallback prints on caja
- [ ] Mixed station + unrouted → station ticket then fallback
- [ ] Promo/note lines still fire after #754

## Validation evidence
```
./venv/bin/pytest tests/test_comanda_fired_notification.py tests/test_comanda_item_notes.py -q
11 passed
```

## wr-context
See `.wr/1973.yaml` on this branch.

Made with [Cursor](https://cursor.com)