### PR TITLE
fix(comandas): skip auto-print notify on checkout fire

### DIFF
--- a/.wr/1983.yaml
+++ b/.wr/1983.yaml
@@ -1,0 +1,36 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1983
+title: "Merge identical receipt lines; do not auto-print comanda on sale finalize"
+repo: both
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: both
+branch: wr-1983-receipt-merge-no-comanda-pay
+
+paths:
+  - app/services/comandas_service.py
+  - app/services/pos_cart_service.py
+  - app/services/tables_service.py
+  - tests/test_comanda_fired_notification.py
+
+ac:
+  - notify_print=False skips comanda_fired on checkout autofire
+  - Explicit fire still notifies
+
+out_of_scope:
+  - Receipt consolidate (front)
+
+hints:
+  entry: "fire_comandas(..., notify_print=False)"
+  pattern: "pos_cart complete + tables close_session"
+  tests: "./venv/bin/pytest tests/test_comanda_fired_notification.py -q"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "pair with front PR"

--- a/app/services/comandas_service.py
+++ b/app/services/comandas_service.py
@@ -262,6 +262,8 @@ async def fire_comandas(
     table_display_name: str,
     item_ids: Optional[List[UUID]] = None,
     conn=None,
+    *,
+    notify_print: bool = True,
 ) -> List[Dict[str, Any]]:
     """
     Core KDS engine — delta-send pattern.
@@ -284,16 +286,19 @@ async def fire_comandas(
         item_ids: if provided, only fire these specific order_item UUIDs
         conn: optional asyncpg connection — pass when already inside a transaction
               to avoid nested BEGIN errors; if None a new connection+transaction is created
+        notify_print: when False, skip SSE comanda_fired auto-print (checkout autofire)
     """
     if conn is not None:
         return await _fire_with_conn(
-            conn, order_id, tenant_id, source_type, table_display_name, item_ids
+            conn, order_id, tenant_id, source_type, table_display_name, item_ids,
+            notify_print=notify_print,
         )
 
     async with get_db_connection() as new_conn:
         async with new_conn.transaction():
             return await _fire_with_conn(
-                new_conn, order_id, tenant_id, source_type, table_display_name, item_ids
+                new_conn, order_id, tenant_id, source_type, table_display_name, item_ids,
+                notify_print=notify_print,
             )
 
 
@@ -304,6 +309,8 @@ async def _fire_with_conn(
     source_type: str,
     table_display_name: str,
     item_ids: Optional[List[UUID]],
+    *,
+    notify_print: bool = True,
 ) -> List[Dict[str, Any]]:
     """Internal implementation — always called with an active connection."""
 
@@ -506,7 +513,9 @@ async def _fire_with_conn(
         )
 
         # Only mesa / barra / mostrador — not delivery/pickup auto-fire (#1971)
-        if source_type in ("table", "pos"):
+        # Checkout/pay autofire sets notify_print=False so kitchen tickets are not
+        # reprinted when closing the sale (#1983).
+        if notify_print and source_type in ("table", "pos"):
             label = (table_display_name or "").strip().lower()
             # Mesa → caja; Barra (also source_type=table) + mostrador/pos → user printer
             if source_type == "table" and label not in ("barra", "bar"):

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -2577,7 +2577,8 @@ async def complete_pos_order(
                             tenant_id=tenant_id,
                             source_type=_fire_source,
                             table_display_name=_fire_label,
-                            conn=conn
+                            conn=conn,
+                            notify_print=False,
                         )
                 except Exception as _fe:
                     logger.error(f"Auto-fire failed for POS order {order_id}: {_fe}")

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -2029,7 +2029,8 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                                 tenant_id=tenant_id,
                                 source_type='table',
                                 table_display_name=table_row["name"],
-                                conn=conn
+                                conn=conn,
+                                notify_print=False,
                             )
 
                         # Mesa: auto-deliver open comandas on payment. Barra: kitchen closes

--- a/tests/test_comanda_fired_notification.py
+++ b/tests/test_comanda_fired_notification.py
@@ -258,6 +258,89 @@ async def test_fire_with_conn_notifies_when_comandas_created():
 
 
 @pytest.mark.asyncio
+async def test_fire_with_conn_skips_notify_when_notify_print_false():
+    """Checkout autofire must not emit comanda_fired SSE (#1983)."""
+    order_id = uuid4()
+    tenant_id = uuid4()
+    station_id = uuid4()
+    item_id = uuid4()
+
+    conn = MagicMock()
+    item_row = {
+        "id": item_id,
+        "product_id": uuid4(),
+        "kitchen_name": "Burger",
+        "quantity": 1,
+        "notes": None,
+        "modifiers_snapshot": None,
+    }
+
+    async def fetch_side_effect(sql, *args):
+        if "fulfillment_status = 'new'" in sql or "fulfillment_status='new'" in sql.replace(" ", ""):
+            return [item_row]
+        return []
+
+    conn.fetch = AsyncMock(side_effect=fetch_side_effect)
+    conn.fetchval = AsyncMock(side_effect=[10, 1, "Cocina"])
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {
+                "id": uuid4(),
+                "comanda_number": 10,
+                "comanda_index": 1,
+                "station_id": station_id,
+                "status": "pending",
+                "source_type": "table",
+                "table_display_name": "Mesa 1",
+                "notes": None,
+                "fired_at": datetime.now(timezone.utc),
+                "ready_at": None,
+                "created_at": datetime.now(timezone.utc),
+            },
+            {
+                "id": uuid4(),
+                "order_item_id": item_id,
+                "kitchen_name": "Burger",
+                "quantity": 1,
+                "notes": None,
+                "modifiers_snapshot": None,
+                "status": "pending",
+                "ready_at": None,
+                "created_at": datetime.now(timezone.utc),
+            },
+        ]
+    )
+    conn.execute = AsyncMock()
+
+    with patch(
+        "app.services.comandas_service.get_effective_station",
+        new=AsyncMock(return_value=station_id),
+    ), patch(
+        "app.services.comandas_service._build_comanda_print_items_for_order_item",
+        new=AsyncMock(
+            return_value=[
+                {
+                    "quantity": 1,
+                    "notes": None,
+                    "modifiers_snapshot": None,
+                    "is_promo_free": False,
+                    "kitchen_name": "Burger",
+                }
+            ]
+        ),
+    ), patch(
+        "app.services.notifications_service.notify_comanda_fired",
+        new_callable=AsyncMock,
+    ) as notify:
+        result = await _fire_with_conn(
+            conn, order_id, tenant_id, "table", "Mesa 1", None, notify_print=False
+        )
+
+    assert len(result) >= 1
+    notify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_fire_with_conn_skips_notify_for_delivery():
     order_id = uuid4()
     tenant_id = uuid4()


### PR DESCRIPTION
## Summary
- `fire_comandas(..., notify_print=False)` skips `comanda_fired` SSE
- POS complete + table close_session autofire use `notify_print=False`
- Explicit kitchen fire still notifies for auto-print

Related: uno0uno/warocol.com#1983

## Test plan
- [ ] Pay mesa/mostrador with unfired items → items mark sent, no comanda thermal print
- [ ] Explicit Agregar y enviar → comanda still auto-prints when PrintBridge up

## Validation evidence
```
./venv/bin/pytest tests/test_comanda_fired_notification.py -q
9 passed
```

## wr-context
See `.wr/1983.yaml` on this branch.

Made with [Cursor](https://cursor.com)