### PR TITLE
fix(pos): split wallet apply + credit on customer CRM

### DIFF
--- a/.wr/2020.yaml
+++ b/.wr/2020.yaml
@@ -1,0 +1,36 @@
+issue: 2020
+title: "fix(pos): split wallet apply + credit on customer CRM"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-2020-split-wallet-credit-crm
+issue_url: https://github.com/uno0uno/warocol.com/issues/2020
+
+paths:
+  - app/services/credit_service.py
+  - app/services/pos_cart_service.py
+  - app/services/tables_service.py
+  - app/services/orders_service.py
+  - tests/test_split_credit_wallet_crm.py
+
+ac:
+  - Split with customer_wallet posts apply movement per tender (counter + mesa)
+  - Split with credit leaves payment_status credit/partial + credit_paid_amount for Cartera
+  - CRM can show wallet debit and Cartera row after reproduction sale
+
+out_of_scope:
+  - Wallet COP table UI (#2021)
+  - Sale-completed email/FEV UX
+
+hints:
+  entry: "sync_order_split_credit_status; add_order_payment; add_session_payment; close_session split"
+  pattern: "credit_service.sync_order_split_credit_status"
+  tests: "./venv/bin/pytest tests/test_split_credit_wallet_crm.py -q"
+
+risk:
+  sensitive: true
+  areas: [payments, wallet, credit, cartera]
+
+next:
+  after_pr: "merge API PR, then /wr-fast #2021"

--- a/app/services/credit_service.py
+++ b/app/services/credit_service.py
@@ -21,6 +21,79 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
+async def sync_order_split_credit_status(
+    conn,
+    order_id: UUID,
+    *,
+    settlement_complete: bool = False,
+) -> str:
+    """Derive payment_status + credit_paid_amount from active order_payments.
+
+    Split tenders that include ``credit`` must leave receivable outstanding so
+    Cartera (payment_status IN credit/partial) can show the debt. Non-credit
+    tenders (cash, wallet, card, …) seed ``credit_paid_amount``.
+
+    When there is no credit tender, ``payment_status='paid'`` is only written if
+    ``settlement_complete`` is true (avoids marking mid-split orders as paid).
+
+    Returns the payment_status written on the order.
+    """
+    order_row = await conn.fetchrow(
+        "SELECT total_amount, payment_status FROM orders WHERE id = $1",
+        order_id,
+    )
+    if not order_row:
+        return "paid"
+
+    total = round(float(order_row["total_amount"] or 0), 2)
+    payments = await conn.fetch(
+        """
+        SELECT payment_method, amount
+        FROM order_payments
+        WHERE order_id = $1 AND voided_at IS NULL
+        """,
+        order_id,
+    )
+    credit_sum = round(
+        sum(float(p["amount"]) for p in payments if p["payment_method"] == "credit"),
+        2,
+    )
+    non_credit_sum = round(
+        sum(float(p["amount"]) for p in payments if p["payment_method"] != "credit"),
+        2,
+    )
+
+    if credit_sum <= 0.01:
+        if not settlement_complete:
+            status = "partial"
+            credit_paid = 0.0
+        else:
+            status = "paid"
+            credit_paid = 0.0
+    elif non_credit_sum <= 0.01:
+        status = "credit"
+        credit_paid = 0.0
+    else:
+        status = "partial"
+        # Remaining ≈ credit tender(s), capped by order merchandise total
+        # (tips may sit in order_payments above total_amount).
+        credit_paid = max(0.0, round(total - min(credit_sum, total), 2))
+
+    await conn.execute(
+        """
+        UPDATE orders
+        SET payment_status = $2,
+            credit_paid_amount = $3
+        WHERE id = $1
+        """,
+        order_id,
+        status,
+        credit_paid,
+    )
+    return status
+
+
 async def _resolve_credit_payment_debit_account(
     conn,
     tenant_id: UUID,

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -4258,6 +4258,10 @@ async def create_manual_order(
                                 user_id,
                                 payment_row["id"],
                             )
+                    from app.services.credit_service import sync_order_split_credit_status
+                    payment_status = await sync_order_split_credit_status(
+                        conn, order_id, settlement_complete=True,
+                    )
                 elif payment_method == "customer_wallet" and customer_uuid:
                     from app.services.customer_wallet_service import apply_wallet_for_order
 

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -1585,6 +1585,7 @@ async def add_order_payment(
                 is_complete = remaining <= 0.01  # tolerance for rounding
 
                 # 5. Update order status
+                final_payment_status = "partial"
                 if is_complete:
                     award_customer_id = await conn.fetchval(
                         "SELECT customer_id FROM orders WHERE id = $1",
@@ -1596,12 +1597,16 @@ async def add_order_payment(
                         SET status = 'completed',
                             payment_method = $2,
                             payment_method_id = $3::uuid,
-                            payment_status = 'paid',
                             order_date = COALESCE(order_date, now())
                         WHERE id = $1
                         """,
                         order_id, payment_method,
                         payment_method_id,
+                    )
+                    # Keep credit receivable when a split tender is credit (#2020).
+                    from app.services.credit_service import sync_order_split_credit_status
+                    final_payment_status = await sync_order_split_credit_status(
+                        conn, order_id, settlement_complete=True,
                     )
                     # Mostrador: auto-deliver; barra: keep comandas open (#799).
                     _bar_order = await conn.fetchval(
@@ -1700,7 +1705,7 @@ async def add_order_payment(
                 "total_amount": total_amount,
                 "charged_amount": amount_due,
                 "payment_method": payment_method,
-                "payment_status": "paid" if is_complete else "partial",
+                "payment_status": final_payment_status if is_complete else "partial",
                 "status": "completed" if is_complete else order_row["status"],
             }
         }
@@ -2640,9 +2645,9 @@ async def complete_pos_order(
                         cart_id
                     )
                     if _split_is_complete:
-                        await conn.execute(
-                            "UPDATE orders SET payment_status = 'paid' WHERE id = $1",
-                            order_id
+                        from app.services.credit_service import sync_order_split_credit_status
+                        await sync_order_split_credit_status(
+                            conn, order_id, settlement_complete=True,
                         )
                     # Mostrador/delivery: auto-deliver after checkout. Barra: kitchen
                     # closes comandas manually (warocol.com#799).

--- a/app/services/pos_cart_service.py
+++ b/app/services/pos_cart_service.py
@@ -1795,7 +1795,24 @@ async def void_order_payment(
                 # 3. Lock the parent order to coordinate concurrent voids.
                 await conn.execute("SELECT 1 FROM orders WHERE id = $1 FOR UPDATE", order_id)
 
-                was_paid = payment_row["payment_status"] == "paid"
+                total_amount = float(payment_row["total_amount"])
+                amount_due = split_settlement_amount_due(
+                    total_amount,
+                    float(payment_row["tip_amount"] or 0),
+                    float(payment_row["tip_tax_amount"] or 0),
+                    await _additive_tax_for_order(
+                        conn,
+                        order_id,
+                        await _get_tenant_tax_config(conn, tenant_id),
+                    ),
+                )
+                paid_before_row = await conn.fetchrow(
+                    "SELECT COALESCE(SUM(amount), 0) AS paid FROM order_payments WHERE order_id = $1 AND voided_at IS NULL",
+                    order_id,
+                )
+                paid_before = float(paid_before_row["paid"])
+                # Settled includes credit splits that stay payment_status=partial (#2020).
+                was_settled = (amount_due - paid_before) <= 0.01
 
                 # 4. Mark payment as voided (soft delete).
                 await conn.execute(
@@ -1827,26 +1844,15 @@ async def void_order_payment(
                     order_id,
                 )
                 paid_total = float(paid_row["paid"])
-                total_amount = float(payment_row["total_amount"])
-                amount_due = split_settlement_amount_due(
-                    total_amount,
-                    float(payment_row["tip_amount"] or 0),
-                    float(payment_row["tip_tax_amount"] or 0),
-                    await _additive_tax_for_order(
-                        conn,
-                        order_id,
-                        await _get_tenant_tax_config(conn, tenant_id),
-                    ),
-                )
                 remaining = max(0.0, amount_due - paid_total)
                 is_complete = remaining <= 0.01
 
-                # 6. If voiding flipped the order out of fully-paid, reopen.
-                reopened = was_paid and not is_complete
+                # 6. If voiding flipped the order out of fully settled, reopen.
+                from app.services.credit_service import sync_order_split_credit_status
+                reopened = was_settled and not is_complete
                 if reopened:
-                    await conn.execute(
-                        "UPDATE orders SET payment_status = 'partial' WHERE id = $1",
-                        order_id,
+                    await sync_order_split_credit_status(
+                        conn, order_id, settlement_complete=False,
                     )
                     await conn.execute(
                         "UPDATE pos_carts SET status = 'active', updated_at = NOW() WHERE id = $1",
@@ -1855,6 +1861,10 @@ async def void_order_payment(
                     # Reverse the posted GL entry — same transaction, atomic.
                     await void_order_journal_entry_in_txn(
                         conn, tenant_id, order_id, user_id, normalized_reason,
+                    )
+                else:
+                    await sync_order_split_credit_status(
+                        conn, order_id, settlement_complete=is_complete,
                     )
 
                 await record_operation_event(

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -1685,7 +1685,9 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                             float(_mesa_tip_tax_amount),
                         )
 
-                    if payment_method == 'customer_wallet' and customer_id:
+                    # Full-session wallet debit only for non-split closes.
+                    # In split_mode each order_payments row applies its portion (#2020).
+                    if payment_method == 'customer_wallet' and customer_id and not split_mode:
                         from app.services.customer_wallet_service import (
                             apply_wallet_for_session_orders,
                         )
@@ -1701,7 +1703,7 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                             session_row["id"],
                         )
                         _tip_settlement = _Dec("0")
-                        if not split_mode and float(tip_amount or 0) > 0:
+                        if float(tip_amount or 0) > 0:
                             _tip_settlement = _Dec(str(tip_settlement_total(
                                 float(tip_amount), float(_mesa_tip_tax_amount),
                             )))
@@ -1863,6 +1865,25 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                                 )
                                 if i == 0:
                                     _split_first_payment_id_mesa = str(inserted_row["id"])
+                                if (
+                                    payment_method == "customer_wallet"
+                                    and customer_id
+                                    and float(portion) > 0
+                                ):
+                                    from app.services.customer_wallet_service import (
+                                        apply_wallet_for_order,
+                                    )
+                                    from decimal import Decimal as _Dec
+
+                                    await apply_wallet_for_order(
+                                        conn,
+                                        UUID(str(customer_id)),
+                                        UUID(str(tenant_id)),
+                                        _Dec(str(portion)),
+                                        ord_row["id"],
+                                        UUID(str(user_id)) if user_id else None,
+                                        inserted_row["id"],
+                                    )
 
                         # Split GL when first payment completes the session.
                         first_tip_order = await conn.fetchrow(
@@ -1889,6 +1910,14 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
                             split_tip_amount,
                             split_tip_tax_amount,
                         )
+                        from app.services.credit_service import sync_order_split_credit_status
+                        _first_split_complete = (split_amount_due - split_paid_total) <= 0.01
+                        for _sync_ord in order_rows:
+                            await sync_order_split_credit_status(
+                                conn,
+                                _sync_ord["id"],
+                                settlement_complete=_first_split_complete,
+                            )
                         if split_amount_due - split_paid_total <= 0.01:
                             try:
                                 split_tax_config = await _get_tenant_tax_config(conn, tenant_id)
@@ -2256,7 +2285,7 @@ async def add_session_payment(
                 order_rows = await conn.fetch(
                     """
                     SELECT id, order_number, total_amount, payment_method,
-                           payment_method_id, order_date
+                           payment_method_id, order_date, customer_id
                     FROM orders
                     WHERE table_session_id = $1 AND status = 'completed'
                     ORDER BY created_at
@@ -2265,6 +2294,15 @@ async def add_session_payment(
                 )
                 if not order_rows:
                     raise APIError("No split payment orders found for this session — call close with split_mode=True first", status_code=400)
+                session_customer_id = next(
+                    (r["customer_id"] for r in order_rows if r["customer_id"]),
+                    None,
+                )
+                if payment_method == "customer_wallet" and not session_customer_id:
+                    raise APIError(
+                        "La billetera requiere un cliente en la mesa",
+                        status_code=400,
+                    )
 
                 session_total = sum(float(r["total_amount"]) for r in order_rows)
                 order_ids = [r["id"] for r in order_rows]
@@ -2355,6 +2393,23 @@ async def add_session_payment(
                     )
                     if i == 0:
                         first_payment_id = str(inserted_row["id"])
+                    if (
+                        payment_method == "customer_wallet"
+                        and session_customer_id
+                        and float(portion) > 0
+                    ):
+                        from app.services.customer_wallet_service import apply_wallet_for_order
+                        from decimal import Decimal as _Dec
+
+                        await apply_wallet_for_order(
+                            conn,
+                            UUID(str(session_customer_id)),
+                            UUID(str(tenant_id)),
+                            _Dec(str(portion)),
+                            ord_row["id"],
+                            UUID(str(user_id)) if user_id else None,
+                            inserted_row["id"],
+                        )
 
                 # Recompute paid total
                 paid_row = await conn.fetchrow(
@@ -2371,11 +2426,26 @@ async def add_session_payment(
                 remaining = max(0.0, amount_due - paid_total)
                 is_complete = remaining <= 0.01
 
+                from app.services.credit_service import sync_order_split_credit_status
+                for _sync_ord in order_rows:
+                    await sync_order_split_credit_status(
+                        conn,
+                        _sync_ord["id"],
+                        settlement_complete=is_complete,
+                    )
+
                 if is_complete:
-                    # Mark all orders as fully paid
+                    # Session settlement complete — credit tenders stay partial/credit via sync above (#2020).
                     await conn.execute(
-                        "UPDATE orders SET payment_status = 'paid' WHERE table_session_id = $1 AND status = 'completed' AND payment_status = 'partial'",
+                        """
+                        UPDATE orders
+                        SET payment_method = $2,
+                            payment_method_id = $3::uuid
+                        WHERE table_session_id = $1 AND status = 'completed'
+                        """,
                         session_row["id"],
+                        payment_method,
+                        payment_method_id,
                     )
                     try:
                         split_tax_config = await _get_tenant_tax_config(conn, tenant_id)

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -5322,7 +5322,7 @@ async def void_table_payment(
                 # same method, same paid_at, not voided. Lock them all.
                 sibling_rows = await conn.fetch(
                     """
-                    SELECT op.id, op.order_id, op.amount
+                    SELECT op.id, op.order_id, op.amount, o.customer_id
                     FROM order_payments op
                     JOIN orders o ON o.id = op.order_id
                     WHERE o.table_session_id = $1
@@ -5346,6 +5346,27 @@ async def void_table_payment(
                     [r["id"] for r in sibling_rows],
                     normalized_reason,
                 )
+
+                # 5b. Restore wallet for each voided wallet tender portion (#2020).
+                if target["payment_method"] == "customer_wallet":
+                    from app.services.customer_wallet_service import (
+                        restore_wallet_for_order_payment_void,
+                    )
+                    from decimal import Decimal as _Dec
+
+                    for sib in sibling_rows:
+                        if not sib["customer_id"] or float(sib["amount"] or 0) <= 0:
+                            continue
+                        await restore_wallet_for_order_payment_void(
+                            conn,
+                            UUID(str(sib["customer_id"])),
+                            UUID(str(tenant_id)),
+                            _Dec(str(sib["amount"])),
+                            sib["order_id"],
+                            UUID(str(sib["id"])),
+                            UUID(str(user_id)) if user_id else None,
+                            notes=f"Anulación pago mesa: {normalized_reason}",
+                        )
 
                 # 6. Recompute session-wide paid_total / remaining.
                 session_orders = await conn.fetch(
@@ -5378,14 +5399,16 @@ async def void_table_payment(
                 remaining = max(0.0, amount_due - paid_total)
                 is_complete = remaining <= 0.01
 
-                # 7. Reopen if voiding flipped the session out of fully-paid.
+                # 7. Reopen if voiding flipped the session out of fully settled.
+                # Credit splits close with payment_status partial/credit (#2020).
+                from app.services.credit_service import sync_order_split_credit_status
                 was_closed = session_row["closed_at"] is not None
                 reopened = was_closed and not is_complete
-                if reopened:
-                    await conn.execute(
-                        "UPDATE orders SET payment_status = 'partial' WHERE table_session_id = $1 AND status = 'completed' AND payment_status = 'paid'",
-                        session_row["id"],
+                for oid in order_ids:
+                    await sync_order_split_credit_status(
+                        conn, oid, settlement_complete=is_complete and not reopened,
                     )
+                if reopened:
                     await conn.execute(
                         "UPDATE table_sessions SET closed_at = NULL WHERE id = $1",
                         session_row["id"],

--- a/tests/test_split_credit_wallet_crm.py
+++ b/tests/test_split_credit_wallet_crm.py
@@ -1,0 +1,160 @@
+"""#2020 — split wallet apply + credit receivable for CRM Cartera."""
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services.credit_service import sync_order_split_credit_status
+from app.services import pos_cart_service
+
+
+@pytest.mark.asyncio
+async def test_sync_wallet_plus_credit_keeps_partial_and_seeds_credit_paid():
+    order_id = uuid4()
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"total_amount": 133_000.0, "payment_status": "partial"})
+    conn.fetch = AsyncMock(return_value=[
+        {"payment_method": "customer_wallet", "amount": 100_000.0},
+        {"payment_method": "credit", "amount": 33_000.0},
+    ])
+    conn.execute = AsyncMock()
+
+    status = await sync_order_split_credit_status(
+        conn, order_id, settlement_complete=True,
+    )
+
+    assert status == "partial"
+    conn.execute.assert_awaited_once()
+    args = conn.execute.await_args.args
+    assert args[1] == order_id
+    assert args[2] == "partial"
+    assert args[3] == 100_000.0
+
+
+@pytest.mark.asyncio
+async def test_sync_credit_only_sets_credit_status():
+    order_id = uuid4()
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"total_amount": 50_000.0, "payment_status": "partial"})
+    conn.fetch = AsyncMock(return_value=[
+        {"payment_method": "credit", "amount": 50_000.0},
+    ])
+    conn.execute = AsyncMock()
+
+    status = await sync_order_split_credit_status(
+        conn, order_id, settlement_complete=True,
+    )
+
+    assert status == "credit"
+    assert conn.execute.await_args.args[2] == "credit"
+    assert conn.execute.await_args.args[3] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_sync_no_credit_mid_split_stays_partial():
+    order_id = uuid4()
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"total_amount": 100_000.0, "payment_status": "partial"})
+    conn.fetch = AsyncMock(return_value=[
+        {"payment_method": "customer_wallet", "amount": 40_000.0},
+    ])
+    conn.execute = AsyncMock()
+
+    status = await sync_order_split_credit_status(
+        conn, order_id, settlement_complete=False,
+    )
+
+    assert status == "partial"
+    assert conn.execute.await_args.args[2] == "partial"
+
+
+@pytest.mark.asyncio
+async def test_sync_no_credit_settlement_complete_marks_paid():
+    order_id = uuid4()
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"total_amount": 100_000.0, "payment_status": "partial"})
+    conn.fetch = AsyncMock(return_value=[
+        {"payment_method": "customer_wallet", "amount": 40_000.0},
+        {"payment_method": "cash", "amount": 60_000.0},
+    ])
+    conn.execute = AsyncMock()
+
+    status = await sync_order_split_credit_status(
+        conn, order_id, settlement_complete=True,
+    )
+
+    assert status == "paid"
+
+
+@pytest.mark.asyncio
+async def test_add_order_payment_final_credit_tender_not_paid():
+    """Completing a split with credit must not force payment_status=paid."""
+    tenant_id = uuid4()
+    user_id = uuid4()
+    cart_id = uuid4()
+    order_id = uuid4()
+    payment_id = uuid4()
+    customer_id = uuid4()
+
+    mock_conn = AsyncMock()
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    class _Txn:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *args):
+            return None
+
+    mock_conn.transaction = MagicMock(return_value=_Txn())
+    mock_conn.fetchrow = AsyncMock(side_effect=[
+        {"id": cart_id, "tenant_id": tenant_id},
+        {
+            "id": order_id,
+            "total_amount": 100.0,
+            "tip_amount": 0,
+            "tip_source": "none",
+            "tip_taxable": False,
+            "tip_tax_amount": 0,
+            "status": "active",
+            "payment_status": "partial",
+            "customer_id": customer_id,
+            "order_number": 17449,
+        },
+        {"paid_total": 70.0},
+        {"id": payment_id},
+        {"paid_total": 100.0},
+    ])
+    mock_conn.fetchval = AsyncMock(return_value=customer_id)
+    mock_conn.execute = AsyncMock()
+    mock_conn.fetch = AsyncMock(return_value=[])
+
+    with patch("app.services.pos_cart_service.require_valid_session") as mock_sess, \
+         patch("app.services.pos_cart_service.get_db_connection", return_value=mock_cm), \
+         patch("app.services.pos_cart_service._get_tenant_tax_config", new=AsyncMock(return_value={})), \
+         patch("app.services.pos_cart_service._additive_tax_for_order", new=AsyncMock(return_value=0.0)), \
+         patch(
+             "app.services.credit_service.sync_order_split_credit_status",
+             new=AsyncMock(return_value="partial"),
+         ) as sync_credit, \
+         patch("app.services.pos_cart_service.finalize_open_comandas", new=AsyncMock()):
+        mock_sess.return_value = MagicMock(tenant_id=tenant_id, user_id=user_id)
+        result = await pos_cart_service.add_order_payment(
+            MagicMock(),
+            str(cart_id),
+            amount=30.0,
+            payment_method="credit",
+        )
+
+    assert result["data"]["is_complete"] is True
+    assert result["data"]["payment_status"] == "partial"
+    sync_credit.assert_awaited_once()
+    assert sync_credit.await_args.kwargs.get("settlement_complete") is True
+    status_updates = [
+        c.args[0] for c in mock_conn.execute.await_args_list
+        if isinstance(c.args[0], str) and "UPDATE orders" in c.args[0]
+    ]
+    assert any("payment_method" in sql for sql in status_updates)
+    assert not any("payment_status = 'paid'" in sql for sql in status_updates)


### PR DESCRIPTION
## Summary
- Add `sync_order_split_credit_status` so split tenders with `credit` stay `partial`/`credit` and seed `credit_paid_amount` for Cartera.
- Mesa split: apply wallet per `order_payments` portion (stop full-session debit on split close); counter already applied per tender.
- Manual order splits sync credit status after inserting payments.

Tracks: https://github.com/uno0uno/warocol.com/issues/2020

## Test plan
- [ ] Counter split: wallet + credit → CRM wallet shows `apply`, Cartera shows remaining credit
- [ ] Mesa split: wallet tender on later payment → wallet movement linked to payment row
- [ ] Split without credit still ends `paid` when settlement completes

## Validation evidence
```
./venv/bin/pytest tests/test_split_credit_wallet_crm.py -q
============================== 5 passed in 0.07s ===============================
```

## wr-context
See `.wr/2020.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)