### PR TITLE
fix(tax): CO honor Facturación menu category → liquor/exempt maps

### DIFF
--- a/app/services/hospitality_tax_engine.py
+++ b/app/services/hospitality_tax_engine.py
@@ -106,16 +106,12 @@ def resolve_product_tax_line(
 ) -> Optional[TaxLine]:
     """Epic #1881 order: override → exempt set → menu map → primary.
 
-    CO / column-only configs ignore menu maps and use legacy tax_category.
+    Works for commercial ``tax_lines`` and CO column profiles (iva|inc|liquor).
     Empty menu map + empty exempt set dual-reads legacy tax_category so
     existing standard/liquor POS keeps working until maps are configured.
     """
     profile = resolve_tax_profile(tax_config)
     legacy_category = tax_category or "standard"
-
-    # No commercial tax_lines → CO adapter; ignore menu maps.
-    if not _as_mapping_list(tax_config.get("tax_lines")):
-        return profile.line_for_category(legacy_category)
 
     # commercial_tax_applicable=false yields empty profile.lines
     if not profile.lines:

--- a/tests/test_menu_category_tax_resolve.py
+++ b/tests/test_menu_category_tax_resolve.py
@@ -148,7 +148,7 @@ def test_empty_menu_map_dual_reads_legacy_tax_category():
     assert standard is not None and standard.key == "mwst"
 
 
-def test_co_ignores_menu_maps():
+def test_co_applies_menu_maps():
     cfg = {
         "inc_applicable": True,
         "inc_rate": 0.08,
@@ -156,18 +156,33 @@ def test_co_ignores_menu_maps():
         "iva_applicable": False,
         "liquor_tax_applicable": True,
         "liquor_tax_rate": 0.05,
-        "menu_category_line_map": {CAT_A: "mwst"},
-        "exempt_menu_category_ids": [CAT_A],
+        "menu_category_line_map": {CAT_A: "liquor"},
+        "exempt_menu_category_ids": [CAT_B],
     }
-    # CO path: exempt set must not apply; use tax_category
-    line = resolve_product_tax_line(
+    liquor = resolve_product_tax_line(
         cfg,
         category_id=CAT_A,
         tax_resolution="inherit",
         tax_category="standard",
     )
-    assert line is not None
-    assert line.key == "inc"
+    assert liquor is not None and liquor.key == "liquor"
+
+    exempt = resolve_product_tax_line(
+        cfg,
+        category_id=CAT_B,
+        tax_resolution="inherit",
+        tax_category="standard",
+    )
+    assert exempt is None
+
+    # Unmapped category → primary INC
+    primary = resolve_product_tax_line(
+        cfg,
+        category_id=CAT_C,
+        tax_resolution="inherit",
+        tax_category="standard",
+    )
+    assert primary is not None and primary.key == "inc"
 
 
 def test_effective_category_liquor_bucket():


### PR DESCRIPTION
## Summary
- CO column tax config now applies `menu_category_line_map` / exempt sets (same resolve order as commercial)
- Fixes Facturación Bebidas → IVA licores 5% not affecting POS/GL (#762)

## Test plan
- [x] `pytest tests/test_menu_category_tax_resolve.py` (15 passed)
- [ ] POS sale with product in liquor-mapped category → GL shows IVA licores
- [ ] Unmapped category still uses primary IVA 19%

Closes #762

Made with [Cursor](https://cursor.com)