### PR TITLE
feat(tax): tax-line mode + included_in_price contract (#764)

### DIFF
--- a/app/models/tax_config.py
+++ b/app/models/tax_config.py
@@ -25,6 +25,10 @@ class TaxConfigResponse(BaseModel):
     liquor_tax_rate: Decimal
     liquor_tax_gl_account_code: str
     liquor_tax_gl_account_id: Optional[UUID] = None
+    liquor_tax_included_in_price: bool = Field(
+        default=False,
+        description="CO liquor column Incluido/Suma; tax_lines[].included_in_price preferred when set",
+    )
     tax_lines: Optional[List[Dict[str, Any]]] = Field(
         default=None,
         description="Optional profile tax_lines[]; when null, INC/IVA/liquor columns adapt",
@@ -59,6 +63,10 @@ class TaxConfigUpdate(BaseModel):
     iva_applicable: bool
     iva_included_in_price: bool
     liquor_tax_applicable: bool
+    liquor_tax_included_in_price: Optional[bool] = Field(
+        default=None,
+        description="Omit to leave unchanged; Incluido/Suma for CO liquor column",
+    )
     inc_gl_account_id: Optional[UUID] = None
     iva_gl_account_id: Optional[UUID] = None
     liquor_tax_gl_account_id: Optional[UUID] = None

--- a/app/services/hospitality_tax_engine.py
+++ b/app/services/hospitality_tax_engine.py
@@ -11,6 +11,9 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 import json
 
 
+TAX_LINE_MODES = frozenset({"primary", "alternate", "stack"})
+
+
 @dataclass(frozen=True)
 class TaxLine:
     key: str
@@ -20,6 +23,8 @@ class TaxLine:
     gl_role: str  # resolve_tax_account kind: inc | iva | liquor
     gl_account_id: Any = None
     gl_account_code: Optional[str] = None
+    mode: str = "primary"  # primary | alternate | stack
+    exclusive_group: Optional[str] = None  # e.g. vat — refuse stack within same group
 
 
 @dataclass(frozen=True)
@@ -34,6 +39,9 @@ class TaxProfile:
         return self.lines.get(key)
 
     def primary_line(self) -> Optional[TaxLine]:
+        for line in self.lines.values():
+            if line.mode == "primary":
+                return line
         return self.line_for_category("standard")
 
 
@@ -189,6 +197,18 @@ def liquor_tax_label_for_config(tax_config: Mapping[str, Any]) -> str:
     return "IVA licores 5%"
 
 
+def _normalize_tax_line_mode(raw: Any) -> str:
+    mode = str(raw or "primary").strip().lower()
+    return mode if mode in TAX_LINE_MODES else "primary"
+
+
+def _normalize_exclusive_group(raw: Any) -> Optional[str]:
+    if raw is None:
+        return None
+    group = str(raw).strip()
+    return group or None
+
+
 def _line_from_mapping(item: Mapping[str, Any]) -> Optional[TaxLine]:
     key = str(item.get("key") or "").strip()
     if not key:
@@ -205,6 +225,16 @@ def _line_from_mapping(item: Mapping[str, Any]) -> Optional[TaxLine]:
         gl_role=gl_role,
         gl_account_id=item.get("gl_account_id"),
         gl_account_code=item.get("gl_account_code"),
+        mode=_normalize_tax_line_mode(item.get("mode")),
+        exclusive_group=_normalize_exclusive_group(item.get("exclusive_group")),
+    )
+
+
+def _co_columns_active(tax_config: Mapping[str, Any]) -> bool:
+    return bool(
+        tax_config.get("inc_applicable")
+        or tax_config.get("iva_applicable")
+        or tax_config.get("liquor_tax_applicable")
     )
 
 
@@ -226,6 +256,8 @@ def _profile_from_co_columns(tax_config: Mapping[str, Any]) -> TaxProfile:
             gl_role="inc",
             gl_account_id=tax_config.get("inc_gl_account_id"),
             gl_account_code=tax_config.get("inc_gl_account_code"),
+            mode="primary",
+            exclusive_group="vat",
         )
         category_map["standard"] = "inc"
     elif tax_config.get("iva_applicable"):
@@ -238,6 +270,8 @@ def _profile_from_co_columns(tax_config: Mapping[str, Any]) -> TaxProfile:
             gl_role="iva",
             gl_account_id=tax_config.get("iva_gl_account_id"),
             gl_account_code=tax_config.get("iva_gl_account_code"),
+            mode="primary",
+            exclusive_group="vat",
         )
         category_map["standard"] = "iva"
 
@@ -247,22 +281,59 @@ def _profile_from_co_columns(tax_config: Mapping[str, Any]) -> TaxProfile:
             key="liquor",
             label="IVA licores 5%" if abs(rate - 0.05) < 1e-9 else f"IVA licores {round(rate * 100)}%",
             rate=rate,
-            included_in_price=False,  # CO liquor tax is always additive
+            included_in_price=bool(tax_config.get("liquor_tax_included_in_price", False)),
             gl_role="liquor",
             gl_account_id=tax_config.get("liquor_tax_gl_account_id"),
             gl_account_code=tax_config.get("liquor_tax_gl_account_code"),
+            mode="alternate",
+            exclusive_group="vat",
         )
         category_map["liquor"] = "liquor"
 
     return TaxProfile(lines=lines, category_map=category_map)
 
 
+def resolve_applicable_tax_lines(
+    profile: TaxProfile,
+    *,
+    selected_key: Optional[str] = None,
+) -> List[TaxLine]:
+    """Seed for #765: lines that apply for a mapped/selected key.
+
+    - alternate: selected replaces primary (override)
+    - stack: primary + selected when both exist
+    - primary / missing mode: selected only (or primary when no selection)
+    """
+    primary = profile.primary_line()
+    key = (selected_key or "").strip()
+    if not key:
+        return [primary] if primary else []
+    selected = profile.lines.get(key)
+    if selected is None:
+        return [primary] if primary else []
+
+    mode = selected.mode if selected.mode in TAX_LINE_MODES else "primary"
+    if mode == "alternate":
+        return [selected]
+    if mode == "stack":
+        out: List[TaxLine] = []
+        if primary is not None and primary.key != selected.key:
+            out.append(primary)
+        out.append(selected)
+        return out
+    return [selected]
+
+
 def resolve_tax_profile(tax_config: Mapping[str, Any]) -> TaxProfile:
     """Build a TaxProfile from explicit tax_lines or CO column adapter."""
     raw_lines = _as_mapping_list(tax_config.get("tax_lines"))
     if raw_lines:
-        # Commercial disable: keep stored lines in DB but apply no tax (#1868).
-        if tax_config.get("commercial_tax_applicable") is False:
+        # Commercial disable (#1868): empty profile for commercial-only tenants.
+        # CO may persist tax_lines while commercial_tax_applicable stays false.
+        if (
+            tax_config.get("commercial_tax_applicable") is False
+            and not _co_columns_active(tax_config)
+        ):
             return TaxProfile(
                 lines={},
                 category_map={"standard": None, "liquor": None, "exempt": None},

--- a/app/services/hospitality_tax_packs.py
+++ b/app/services/hospitality_tax_packs.py
@@ -225,6 +225,8 @@ WAVE2_MULTI_TAX_PACKS: Dict[str, Dict[str, Any]] = {
                 "rate": 0.07,
                 "included_in_price": False,
                 "gl_role": "iva",
+                "mode": "primary",
+                "exclusive_group": "vat",
             },
             {
                 "key": "mwst_standard",
@@ -232,6 +234,8 @@ WAVE2_MULTI_TAX_PACKS: Dict[str, Dict[str, Any]] = {
                 "rate": 0.19,
                 "included_in_price": False,
                 "gl_role": "iva",
+                "mode": "alternate",
+                "exclusive_group": "vat",
             },
         ],
         "category_map": {
@@ -248,6 +252,8 @@ WAVE2_MULTI_TAX_PACKS: Dict[str, Dict[str, Any]] = {
                 "rate": 0.09,
                 "included_in_price": False,
                 "gl_role": "iva",
+                "mode": "primary",
+                "exclusive_group": "vat",
             },
             {
                 "key": "btw_standard",
@@ -255,6 +261,8 @@ WAVE2_MULTI_TAX_PACKS: Dict[str, Dict[str, Any]] = {
                 "rate": 0.21,
                 "included_in_price": False,
                 "gl_role": "iva",
+                "mode": "alternate",
+                "exclusive_group": "vat",
             },
         ],
         "category_map": {

--- a/app/services/tenant_config_service.py
+++ b/app/services/tenant_config_service.py
@@ -648,6 +648,9 @@ def decode_tax_config_jsonb(data: Mapping[str, Any]) -> Dict[str, Any]:
     return out
 
 
+_TAX_LINE_MODES = frozenset({"primary", "alternate", "stack"})
+
+
 def validate_tax_matrix_payload(
     tax_lines: Optional[List[Any]],
     category_map: Optional[Mapping[str, Any]],
@@ -674,6 +677,29 @@ def validate_tax_matrix_payload(
             if rate < 0:
                 raise HTTPException(
                     status_code=400, detail=f"tax line '{key}' rate must be >= 0"
+                )
+            mode_raw = item.get("mode", "primary")
+            mode = str(mode_raw or "primary").strip().lower()
+            if mode not in _TAX_LINE_MODES:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"tax line '{key}' mode must be one of "
+                        f"primary|alternate|stack"
+                    ),
+                )
+            group_raw = item.get("exclusive_group")
+            if (
+                mode == "stack"
+                and group_raw is not None
+                and str(group_raw).strip()
+            ):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"tax line '{key}' cannot use mode=stack inside "
+                        f"exclusive_group '{str(group_raw).strip()}'"
+                    ),
                 )
             line_keys.add(key)
 
@@ -878,6 +904,7 @@ async def update_tax_config(request: Request, data) -> dict:
         iva_rate = _optional_co_rate(data, "iva_rate")
         inc_rate = _optional_co_rate(data, "inc_rate")
         liquor_tax_rate = _optional_co_rate(data, "liquor_tax_rate")
+        liquor_included = getattr(data, "liquor_tax_included_in_price", None)
         menu_map_json = _encode_menu_category_line_map(menu_category_line_map)
         exempt_ids_pg = _encode_exempt_menu_category_ids(exempt_menu_category_ids)
 
@@ -983,7 +1010,7 @@ async def update_tax_config(request: Request, data) -> dict:
                     tenant_id,
                     inc_applicable, inc_included_in_price,
                     iva_applicable, iva_included_in_price,
-                    liquor_tax_applicable,
+                    liquor_tax_applicable, liquor_tax_included_in_price,
                     inc_gl_account_id, iva_gl_account_id, liquor_tax_gl_account_id,
                     tax_lines, category_map, tax_jurisdiction_code,
                     commercial_tax_applicable,
@@ -991,11 +1018,12 @@ async def update_tax_config(request: Request, data) -> dict:
                     menu_category_line_map, exempt_menu_category_ids
                 )
                 VALUES (
-                    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb, $12,
-                    COALESCE($13, false),
-                    COALESCE($14, 0.19), COALESCE($15, 0.08), COALESCE($16, 0.05),
-                    COALESCE($17::jsonb, '{}'::jsonb),
-                    COALESCE($18::uuid[], '{}'::uuid[])
+                    $1, $2, $3, $4, $5, $6, COALESCE($7, false),
+                    $8, $9, $10, $11::jsonb, $12::jsonb, $13,
+                    COALESCE($14, false),
+                    COALESCE($15, 0.19), COALESCE($16, 0.08), COALESCE($17, 0.05),
+                    COALESCE($18::jsonb, '{}'::jsonb),
+                    COALESCE($19::uuid[], '{}'::uuid[])
                 )
                 ON CONFLICT (tenant_id) DO UPDATE SET
                     inc_applicable        = EXCLUDED.inc_applicable,
@@ -1003,6 +1031,9 @@ async def update_tax_config(request: Request, data) -> dict:
                     iva_applicable        = EXCLUDED.iva_applicable,
                     iva_included_in_price = EXCLUDED.iva_included_in_price,
                     liquor_tax_applicable = EXCLUDED.liquor_tax_applicable,
+                    liquor_tax_included_in_price = COALESCE(
+                        $7, tenant_tax_config.liquor_tax_included_in_price
+                    ),
                     inc_gl_account_id = COALESCE(EXCLUDED.inc_gl_account_id, tenant_tax_config.inc_gl_account_id),
                     iva_gl_account_id = COALESCE(EXCLUDED.iva_gl_account_id, tenant_tax_config.iva_gl_account_id),
                     liquor_tax_gl_account_id = COALESCE(EXCLUDED.liquor_tax_gl_account_id, tenant_tax_config.liquor_tax_gl_account_id),
@@ -1016,15 +1047,15 @@ async def update_tax_config(request: Request, data) -> dict:
                         EXCLUDED.commercial_tax_applicable,
                         tenant_tax_config.commercial_tax_applicable
                     ),
-                    iva_rate = COALESCE($14, tenant_tax_config.iva_rate),
-                    inc_rate = COALESCE($15, tenant_tax_config.inc_rate),
-                    liquor_tax_rate = COALESCE($16, tenant_tax_config.liquor_tax_rate),
+                    iva_rate = COALESCE($15, tenant_tax_config.iva_rate),
+                    inc_rate = COALESCE($16, tenant_tax_config.inc_rate),
+                    liquor_tax_rate = COALESCE($17, tenant_tax_config.liquor_tax_rate),
                     menu_category_line_map = COALESCE(
-                        $17::jsonb,
+                        $18::jsonb,
                         tenant_tax_config.menu_category_line_map
                     ),
                     exempt_menu_category_ids = COALESCE(
-                        $18::uuid[],
+                        $19::uuid[],
                         tenant_tax_config.exempt_menu_category_ids
                     ),
                     updated_at            = NOW()
@@ -1036,6 +1067,7 @@ async def update_tax_config(request: Request, data) -> dict:
                 data.iva_applicable,
                 data.iva_included_in_price,
                 data.liquor_tax_applicable,
+                liquor_included,
                 data.inc_gl_account_id,
                 data.iva_gl_account_id,
                 data.liquor_tax_gl_account_id,

--- a/sql/20260801_liquor_tax_included_in_price.sql
+++ b/sql/20260801_liquor_tax_included_in_price.sql
@@ -1,0 +1,3 @@
+-- api-warolabs#764 — CO liquor Incluido/Suma column (ADD only).
+ALTER TABLE tenant_tax_config
+    ADD COLUMN IF NOT EXISTS liquor_tax_included_in_price boolean NOT NULL DEFAULT false;

--- a/tests/test_hospitality_tax_engine.py
+++ b/tests/test_hospitality_tax_engine.py
@@ -7,11 +7,16 @@ from app.services.hospitality_tax_engine import (
     compute_category_breakdown,
     compute_gl_category_taxes,
     liquor_tax_label_for_config,
+    resolve_applicable_tax_lines,
     resolve_effective_tax_category,
     resolve_tax_profile,
     tax_amount_float,
 )
-from app.services.hospitality_tax_packs import WAVE2_SIMPLE_TAX_PACKS, tax_config_from_wave1_pack
+from app.services.hospitality_tax_packs import (
+    WAVE2_MULTI_TAX_PACKS,
+    WAVE2_SIMPLE_TAX_PACKS,
+    tax_config_from_wave1_pack,
+)
 
 
 def _inc_config(*, included: bool = True, rate: float = 0.08):
@@ -262,3 +267,99 @@ def test_co_distinct_liquor_still_buckets_liquor():
     assert label == "INC 8%"
     assert liquor_tax_label_for_config(cfg) == "IVA licores 5%"
     assert resolve_effective_tax_category(cfg, tax_category="liquor") == "liquor"
+
+
+def test_co_liquor_honors_included_in_price_column():
+    cfg = _co_full()
+    cfg["liquor_tax_included_in_price"] = True
+    profile = resolve_tax_profile(cfg)
+    liquor = profile.line_for_category("liquor")
+    assert liquor is not None
+    assert liquor.included_in_price is True
+    assert liquor.mode == "alternate"
+    assert liquor.exclusive_group == "vat"
+    # Extractive: 20000 * 0.05 / 1.05 ≈ 952
+    assert tax_amount_float(20000, liquor) == 952.0
+
+
+def test_co_tax_lines_apply_when_commercial_flag_false():
+    """#764 — CO may persist tax_lines without enabling commercial flag."""
+    cfg = {
+        "inc_applicable": False,
+        "iva_applicable": True,
+        "iva_rate": 0.19,
+        "iva_included_in_price": True,
+        "liquor_tax_applicable": True,
+        "liquor_tax_rate": 0.05,
+        "liquor_tax_included_in_price": True,
+        "commercial_tax_applicable": False,
+        "tax_lines": [
+            {
+                "key": "iva",
+                "label": "IVA 19%",
+                "rate": 0.19,
+                "included_in_price": True,
+                "gl_role": "iva",
+                "mode": "primary",
+                "exclusive_group": "vat",
+            },
+            {
+                "key": "liquor",
+                "label": "IVA licores 5%",
+                "rate": 0.05,
+                "included_in_price": True,
+                "gl_role": "liquor",
+                "mode": "alternate",
+                "exclusive_group": "vat",
+            },
+        ],
+        "category_map": {"standard": "iva", "liquor": "liquor", "exempt": None},
+    }
+    profile = resolve_tax_profile(cfg)
+    assert set(profile.lines) == {"iva", "liquor"}
+    assert profile.lines["liquor"].included_in_price is True
+    assert profile.lines["liquor"].mode == "alternate"
+
+
+def test_resolve_applicable_alternate_wins_over_primary():
+    cfg = tax_config_from_wave1_pack(WAVE2_MULTI_TAX_PACKS["DE"])
+    profile = resolve_tax_profile(cfg)
+    applied = resolve_applicable_tax_lines(profile, selected_key="mwst_standard")
+    assert [line.key for line in applied] == ["mwst_standard"]
+    assert applied[0].mode == "alternate"
+
+
+def test_resolve_applicable_stack_adds_primary_and_selected():
+    cfg = {
+        "commercial_tax_applicable": True,
+        "tax_lines": [
+            {
+                "key": "iva",
+                "label": "IVA 16%",
+                "rate": 0.16,
+                "included_in_price": False,
+                "gl_role": "iva",
+                "mode": "primary",
+                "exclusive_group": "vat",
+            },
+            {
+                "key": "tourist",
+                "label": "Tourist 2%",
+                "rate": 0.02,
+                "included_in_price": False,
+                "gl_role": "iva",
+                "mode": "stack",
+            },
+        ],
+        "category_map": {"standard": "iva", "liquor": "iva", "exempt": None},
+    }
+    profile = resolve_tax_profile(cfg)
+    applied = resolve_applicable_tax_lines(profile, selected_key="tourist")
+    assert [line.key for line in applied] == ["iva", "tourist"]
+
+
+def test_resolve_applicable_primary_selection():
+    cfg = tax_config_from_wave1_pack(WAVE2_MULTI_TAX_PACKS["NL"])
+    profile = resolve_tax_profile(cfg)
+    applied = resolve_applicable_tax_lines(profile, selected_key="btw_reduced")
+    assert [line.key for line in applied] == ["btw_reduced"]

--- a/tests/test_tax_config_matrix.py
+++ b/tests/test_tax_config_matrix.py
@@ -114,6 +114,111 @@ def test_validate_allows_null_exempt_and_zero_rate():
     )
 
 
+def test_validate_accepts_mode_and_exclusive_group():
+    validate_tax_matrix_payload(
+        [
+            {
+                "key": "iva",
+                "rate": 0.19,
+                "mode": "primary",
+                "exclusive_group": "vat",
+                "included_in_price": True,
+            },
+            {
+                "key": "liquor",
+                "rate": 0.05,
+                "mode": "alternate",
+                "exclusive_group": "vat",
+                "included_in_price": True,
+            },
+            {
+                "key": "tourist",
+                "rate": 0.02,
+                "mode": "stack",
+                "included_in_price": False,
+            },
+        ],
+        {"standard": "iva", "liquor": "liquor", "exempt": None},
+    )
+
+
+def test_validate_rejects_invalid_mode():
+    with pytest.raises(HTTPException) as exc:
+        validate_tax_matrix_payload(
+            [{"key": "iva", "rate": 0.19, "mode": "xor"}],
+            {"standard": "iva", "exempt": None},
+        )
+    assert exc.value.status_code == 400
+    assert "mode must be one of" in str(exc.value.detail)
+
+
+def test_validate_rejects_stack_inside_exclusive_group():
+    with pytest.raises(HTTPException) as exc:
+        validate_tax_matrix_payload(
+            [
+                {
+                    "key": "iva",
+                    "rate": 0.19,
+                    "mode": "primary",
+                    "exclusive_group": "vat",
+                },
+                {
+                    "key": "frontera",
+                    "rate": 0.08,
+                    "mode": "stack",
+                    "exclusive_group": "vat",
+                },
+            ],
+            {"standard": "iva", "exempt": None},
+        )
+    assert exc.value.status_code == 400
+    assert "cannot use mode=stack inside exclusive_group" in str(exc.value.detail)
+
+
+def test_mode_included_round_trip_shape():
+    """GET→PUT→GET preserves mode + included_in_price on tax_lines."""
+    lines = [
+        {
+            "key": "iva",
+            "label": "IVA 19%",
+            "rate": 0.19,
+            "included_in_price": True,
+            "gl_role": "iva",
+            "mode": "primary",
+            "exclusive_group": "vat",
+        },
+        {
+            "key": "liquor",
+            "label": "IVA licores 5%",
+            "rate": 0.05,
+            "included_in_price": True,
+            "gl_role": "liquor",
+            "mode": "alternate",
+            "exclusive_group": "vat",
+        },
+    ]
+    as_strings = {
+        "tax_lines": __import__("json").dumps(lines),
+        "category_map": __import__("json").dumps(
+            {"standard": "iva", "liquor": "liquor", "exempt": None}
+        ),
+        "liquor_tax_included_in_price": True,
+    }
+    got = decode_tax_config_jsonb(as_strings)
+    validate_tax_matrix_payload(got["tax_lines"], got["category_map"])
+    again = decode_tax_config_jsonb(
+        {
+            "tax_lines": __import__("json").dumps(got["tax_lines"]),
+            "category_map": __import__("json").dumps(got["category_map"]),
+            "liquor_tax_included_in_price": got["liquor_tax_included_in_price"],
+        }
+    )
+    assert again["tax_lines"][0]["mode"] == "primary"
+    assert again["tax_lines"][1]["mode"] == "alternate"
+    assert again["tax_lines"][1]["included_in_price"] is True
+    assert again["liquor_tax_included_in_price"] is True
+
+
 def test_co_rate_fields_on_update_model():
     body = TaxConfigUpdate(
         inc_applicable=True,


### PR DESCRIPTION
## Summary
- Add `mode` (`primary`|`alternate`|`stack`) and optional `exclusive_group` on tax lines; PUT validates and refuses stack inside an exclusive group.
- Honor liquor `included_in_price` from config (new `liquor_tax_included_in_price` column + tax_lines); CO may persist tax_lines while `commercial_tax_applicable` stays false.
- Seed `resolve_applicable_tax_lines` for override vs stack (consumed by #765). DE/NL packs mark multi-rate lines as alternate.

Closes #764  
Parent epic: uno0uno/warocol.com#2027

## Validation evidence
```text
$ ./venv/bin/pytest tests/test_hospitality_tax_engine.py tests/test_tax_config_matrix.py tests/test_menu_category_tax_resolve.py tests/test_hospitality_tax_packs.py -q
============================= test session starts ==============================
collected 92 items
tests/test_hospitality_tax_engine.py .................
tests/test_tax_config_matrix.py .............
tests/test_menu_category_tax_resolve.py ...............
tests/test_hospitality_tax_packs.py ...........................................
============================== 92 passed in 0.30s ==============================
```

## Test plan
- [ ] Apply `sql/20260801_liquor_tax_included_in_price.sql` on target DB
- [ ] PUT tax-config with CO tax_lines (mode + included) and confirm GET round-trip
- [ ] Confirm invalid mode / stack+exclusive_group returns 400
- [ ] Smoke: existing CO column-only tenants still additive liquor (default false)


Made with [Cursor](https://cursor.com)