### PR TITLE
feat(tax): POS/GL override vs stack + inclusive liquor (#765)

### DIFF
--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -133,7 +133,7 @@ async def _get_tenant_tax_config(conn, tenant_id: UUID) -> Dict[str, Any]:
     row = await conn.fetchrow(
         """SELECT inc_applicable, inc_rate, inc_gl_account_code, inc_gl_account_id,
                   inc_included_in_price,
-                  liquor_tax_applicable, liquor_tax_rate,
+                  liquor_tax_applicable, liquor_tax_rate, liquor_tax_included_in_price,
                   liquor_tax_gl_account_code, liquor_tax_gl_account_id,
                   iva_applicable, iva_rate, iva_gl_account_code, iva_gl_account_id,
                   iva_included_in_price,
@@ -152,6 +152,7 @@ async def _get_tenant_tax_config(conn, tenant_id: UUID) -> Dict[str, Any]:
         "inc_included_in_price":      True,
         "liquor_tax_applicable":      False,
         "liquor_tax_rate":            Decimal("0.0000"),
+        "liquor_tax_included_in_price": False,
         "liquor_tax_gl_account_code": None,
         "liquor_tax_gl_account_id":   None,
         "iva_applicable":             False,
@@ -414,40 +415,26 @@ async def _post_order_gl_entry(
         order_id,
     )
 
-    # ── Accumulate subtotals per tax category ─────────────────────────────
+    # ── Calculate taxes per item (alternate/stack + included_in_price) ────
     from app.services.hospitality_tax_engine import (
         compute_gl_category_taxes,
-        resolve_effective_tax_category,
+        compute_items_tax_totals,
     )
 
-    standard_subtotal = Decimal("0")
-    liquor_subtotal   = Decimal("0")
-    for item in order_items:
-        cat = resolve_effective_tax_category(
-            tax_config,
-            category_id=item["category_id"],
-            tax_resolution=item["tax_resolution"] or "inherit",
-            tax_line_key=item["tax_line_key"],
-            tax_category=item["tax_category"] or "standard",
-        )
-        sub = Decimal(str(item["subtotal"]))
-        if cat == "liquor":
-            liquor_subtotal += sub
-        elif cat == "exempt":
-            pass  # $0 tax contribution
-        else:  # standard (or unknown — fall back to standard)
-            standard_subtotal += sub
-    # No items at all → treat total as standard (backwards-compatible fallback)
-    if not order_items:
-        standard_subtotal = total_amount
+    if order_items:
+        tax_result = compute_items_tax_totals(order_items, tax_config)
+    else:
+        # No items at all → treat total as standard (backwards-compatible fallback)
+        tax_result = compute_gl_category_taxes(total_amount, Decimal("0"), tax_config)
 
-    # ── Calculate taxes per category (profile-driven tax_lines) ───────────
-    tax_result = compute_gl_category_taxes(
-        standard_subtotal, liquor_subtotal, tax_config,
-    )
-    standard_tax = tax_result["standard_tax"]
-    liquor_tax = tax_result["liquor_tax"]
-    standard_is_additive = tax_result["standard_is_additive"]
+    standard_tax = Decimal(str(tax_result["standard_tax"] or 0))
+    liquor_tax = Decimal(str(tax_result["liquor_tax"] or 0))
+    standard_additive = Decimal(str(tax_result.get("standard_additive") or 0))
+    liquor_additive = Decimal(str(tax_result.get("liquor_additive") or 0))
+    if "standard_additive" not in tax_result and tax_result.get("standard_is_additive"):
+        standard_additive = standard_tax
+    if "liquor_additive" not in tax_result and tax_result.get("liquor_is_additive"):
+        liquor_additive = liquor_tax
     standard_acct_id = None
     liquor_acct_id = None
 
@@ -464,9 +451,9 @@ async def _post_order_gl_entry(
         liquor_acct_id = tax_account.id if tax_account else None
 
     # ── Compute debit_total and net_revenue ───────────────────────────────
-    # Additive taxes (non-included INC/IVA, liquor) increase what the customer pays.
-    # Extractive taxes are already embedded in total_amount.
-    additive_extra = (standard_tax if standard_is_additive else Decimal("0")) + liquor_tax
+    # Additive taxes (non-included INC/IVA/liquor) increase what the customer pays.
+    # Extractive taxes are already embedded in total_amount (#765 liquor Incluido).
+    additive_extra = standard_additive + liquor_additive
     debit_total    = total_amount + additive_extra
     net_revenue    = debit_total - standard_tax - liquor_tax
     # Invariant: DR debit_total = CR net_revenue + CR standard_tax + CR liquor_tax ✓

--- a/app/services/hospitality_tax_engine.py
+++ b/app/services/hospitality_tax_engine.py
@@ -104,24 +104,16 @@ def _row_field(row: Any, key: str, default: Any = None) -> Any:
         return default
 
 
-def resolve_product_tax_line(
+def _resolve_selected_tax_line_key(
     tax_config: Mapping[str, Any],
+    profile: TaxProfile,
     *,
     category_id: Any = None,
     tax_resolution: Optional[str] = "inherit",
     tax_line_key: Optional[str] = None,
     tax_category: Optional[str] = "standard",
-) -> Optional[TaxLine]:
-    """Epic #1881 order: override → exempt set → menu map → primary.
-
-    Works for commercial ``tax_lines`` and CO column profiles (iva|inc|liquor).
-    Empty menu map + empty exempt set dual-reads legacy tax_category so
-    existing standard/liquor POS keeps working until maps are configured.
-    """
-    profile = resolve_tax_profile(tax_config)
-    legacy_category = tax_category or "standard"
-
-    # commercial_tax_applicable=false yields empty profile.lines
+) -> Optional[str]:
+    """Epic #1881 order → selected line key (None = exempt / no tax)."""
     if not profile.lines:
         return None
 
@@ -130,9 +122,9 @@ def resolve_product_tax_line(
         return None
     if resolution == "line":
         key = (tax_line_key or "").strip()
-        return profile.lines.get(key) if key else None
+        return key if key and key in profile.lines else None
 
-    # inherit
+    legacy_category = tax_category or "standard"
     cat_id = str(category_id).strip() if category_id is not None else ""
     exempt_ids = _as_uuid_str_set(tax_config.get("exempt_menu_category_ids"))
     if cat_id and cat_id in exempt_ids:
@@ -143,14 +135,68 @@ def resolve_product_tax_line(
         key = menu_map[cat_id]
         if not key:
             return None
-        return profile.lines.get(key)
+        return key if key in profile.lines else None
 
     # Dual-read: no menu maps configured yet → legacy fiscal tags.
     if not menu_map and not exempt_ids:
-        return profile.line_for_category(legacy_category)
+        line = profile.line_for_category(legacy_category)
+        return line.key if line else None
 
-    # Unmapped menu category → primary line.
-    return profile.primary_line()
+    primary = profile.primary_line()
+    return primary.key if primary else None
+
+
+def resolve_product_tax_lines(
+    tax_config: Mapping[str, Any],
+    *,
+    category_id: Any = None,
+    tax_resolution: Optional[str] = "inherit",
+    tax_line_key: Optional[str] = None,
+    tax_category: Optional[str] = "standard",
+) -> List[TaxLine]:
+    """Applicable lines for a product (#765): honors alternate vs stack modes."""
+    profile = resolve_tax_profile(tax_config)
+    selected = _resolve_selected_tax_line_key(
+        tax_config,
+        profile,
+        category_id=category_id,
+        tax_resolution=tax_resolution,
+        tax_line_key=tax_line_key,
+        tax_category=tax_category,
+    )
+    if selected is None:
+        return []
+    resolution = (tax_resolution or "inherit").strip().lower()
+    if resolution == "line":
+        line = profile.lines.get(selected)
+        return [line] if line else []
+    return resolve_applicable_tax_lines(profile, selected_key=selected)
+
+
+def resolve_product_tax_line(
+    tax_config: Mapping[str, Any],
+    *,
+    category_id: Any = None,
+    tax_resolution: Optional[str] = "inherit",
+    tax_line_key: Optional[str] = None,
+    tax_category: Optional[str] = "standard",
+) -> Optional[TaxLine]:
+    """Epic #1881 order: override → exempt set → menu map → primary.
+
+    Returns the selected/mapped line (not the full stack). Use
+    ``resolve_product_tax_lines`` when amounts must include stacked tributes.
+    """
+    lines = resolve_product_tax_lines(
+        tax_config,
+        category_id=category_id,
+        tax_resolution=tax_resolution,
+        tax_line_key=tax_line_key,
+        tax_category=tax_category,
+    )
+    if not lines:
+        return None
+    # Prefer the mapped/selected line (last in stack = selected) for bucket labels.
+    return lines[-1]
 
 
 def resolve_effective_tax_category(
@@ -385,6 +431,73 @@ def tax_amount_decimal(base: Decimal, line: TaxLine) -> Tuple[Decimal, bool]:
     return amount * rate, True
 
 
+def compute_items_tax_totals(
+    items_rows: Sequence[Any],
+    tax_config: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """Per-item tax totals honoring alternate/stack + included_in_price (#765)."""
+    profile = resolve_tax_profile(tax_config)
+    standard_tax = Decimal("0")
+    liquor_tax = Decimal("0")
+    standard_additive = Decimal("0")
+    liquor_additive = Decimal("0")
+    standard_gl_role: Optional[str] = None
+    liquor_gl_role: Optional[str] = None
+
+    for row in items_rows:
+        base = Decimal(str(_row_field(row, "subtotal") or 0))
+        if base <= 0:
+            continue
+        applied = resolve_product_tax_lines(
+            tax_config,
+            category_id=_row_field(row, "category_id"),
+            tax_resolution=_row_field(row, "tax_resolution") or "inherit",
+            tax_line_key=_row_field(row, "tax_line_key"),
+            tax_category=_row_field(row, "tax_category") or "standard",
+        )
+        if not applied:
+            continue
+        bucket = resolve_effective_tax_category(
+            tax_config,
+            category_id=_row_field(row, "category_id"),
+            tax_resolution=_row_field(row, "tax_resolution") or "inherit",
+            tax_line_key=_row_field(row, "tax_line_key"),
+            tax_category=_row_field(row, "tax_category") or "standard",
+        )
+        if bucket == "exempt":
+            continue
+        for line in applied:
+            tax, is_additive = tax_amount_decimal(base, line)
+            if tax <= 0:
+                continue
+            if bucket == "liquor":
+                liquor_tax += tax
+                if is_additive:
+                    liquor_additive += tax
+                if liquor_gl_role is None:
+                    liquor_gl_role = line.gl_role
+            else:
+                standard_tax += tax
+                if is_additive:
+                    standard_additive += tax
+                if standard_gl_role is None:
+                    standard_gl_role = line.gl_role
+
+    primary = profile.primary_line()
+    return {
+        "standard_tax": standard_tax,
+        "liquor_tax": liquor_tax,
+        "standard_additive": standard_additive,
+        "liquor_additive": liquor_additive,
+        "standard_is_additive": standard_additive > 0,
+        "liquor_is_additive": liquor_additive > 0,
+        "standard_gl_role": standard_gl_role or (primary.gl_role if primary else None),
+        "liquor_gl_role": liquor_gl_role,
+        "primary_line": primary,
+        "profile": profile,
+    }
+
+
 def compute_category_breakdown(
     items_rows: Sequence[Any],
     tax_config: Mapping[str, Any],
@@ -392,35 +505,43 @@ def compute_category_breakdown(
     """Compat wrapper: (standard_tax, liquor_tax, standard_tax_label).
 
     Dual-reads menu-category maps + product override when present on rows;
-    otherwise uses legacy tax_category.
+    otherwise uses legacy tax_category. Uses per-item alternate/stack resolve (#765)
+    with POS-style whole-unit rounding via ``tax_amount_float``.
     """
     profile = resolve_tax_profile(tax_config)
+    standard_tax = 0.0
+    liquor_tax = 0.0
 
-    def _effective_cat(row: Any) -> str:
-        return resolve_effective_tax_category(
+    for row in items_rows:
+        base = float(_row_field(row, "subtotal") or 0)
+        if base <= 0:
+            continue
+        applied = resolve_product_tax_lines(
             tax_config,
             category_id=_row_field(row, "category_id"),
             tax_resolution=_row_field(row, "tax_resolution") or "inherit",
             tax_line_key=_row_field(row, "tax_line_key"),
             tax_category=_row_field(row, "tax_category") or "standard",
         )
+        if not applied:
+            continue
+        bucket = resolve_effective_tax_category(
+            tax_config,
+            category_id=_row_field(row, "category_id"),
+            tax_resolution=_row_field(row, "tax_resolution") or "inherit",
+            tax_line_key=_row_field(row, "tax_line_key"),
+            tax_category=_row_field(row, "tax_category") or "standard",
+        )
+        if bucket == "exempt":
+            continue
+        amount = sum(tax_amount_float(base, line) for line in applied)
+        if bucket == "liquor":
+            liquor_tax += amount
+        else:
+            standard_tax += amount
 
-    def _subtotal(category: str) -> float:
-        total = 0.0
-        for row in items_rows:
-            if _effective_cat(row) == category:
-                total += float(_row_field(row, "subtotal") or 0)
-        return total
-
-    std_base = _subtotal("standard")
-    liq_base = _subtotal("liquor")
-
-    std_line = profile.line_for_category("standard")
-    liq_line = profile.line_for_category("liquor")
-
-    standard_tax = tax_amount_float(std_base, std_line) if std_line and std_base > 0 else 0.0
-    liquor_tax = tax_amount_float(liq_base, liq_line) if liq_line and liq_base > 0 else 0.0
-    label = std_line.label if std_line else "Impuesto"
+    primary = profile.primary_line()
+    label = primary.label if primary else "Impuesto"
     return float(standard_tax), float(liquor_tax), label
 
 
@@ -429,7 +550,11 @@ def compute_gl_category_taxes(
     liquor_subtotal: Decimal,
     tax_config: Mapping[str, Any],
 ) -> Dict[str, Any]:
-    """GL amounts for standard + liquor categories (cierre order post)."""
+    """GL amounts for standard + liquor category subtotals (cierre fallback).
+
+    Prefer ``compute_items_tax_totals`` when order lines are available so stack
+    modes and per-line included flags are exact.
+    """
     profile = resolve_tax_profile(tax_config)
     std_line = profile.line_for_category("standard")
     liq_line = profile.line_for_category("liquor")
@@ -437,6 +562,7 @@ def compute_gl_category_taxes(
     standard_tax = Decimal("0")
     liquor_tax = Decimal("0")
     standard_is_additive = False
+    liquor_is_additive = False
     standard_gl_role: Optional[str] = None
     liquor_gl_role: Optional[str] = None
 
@@ -445,13 +571,16 @@ def compute_gl_category_taxes(
         standard_gl_role = std_line.gl_role
 
     if liq_line and liquor_subtotal > 0:
-        liquor_tax, _ = tax_amount_decimal(liquor_subtotal, liq_line)
+        liquor_tax, liquor_is_additive = tax_amount_decimal(liquor_subtotal, liq_line)
         liquor_gl_role = liq_line.gl_role
 
     return {
         "standard_tax": standard_tax,
         "liquor_tax": liquor_tax,
+        "standard_additive": standard_tax if standard_is_additive else Decimal("0"),
+        "liquor_additive": liquor_tax if liquor_is_additive else Decimal("0"),
         "standard_is_additive": standard_is_additive,
+        "liquor_is_additive": liquor_is_additive,
         "standard_gl_role": standard_gl_role,
         "liquor_gl_role": liquor_gl_role,
         "primary_line": profile.primary_line(),
@@ -513,7 +642,7 @@ def annotate_line_tax_amounts(
     Mutates dict lines in place when they are mutable mappings; always returns
     the annotated list. When ``reconcile_to`` is (standard_tax, liquor_tax),
     adjusts the last taxable line in each bucket so Σ line taxes match the
-    cart-level category rounding.
+    cart-level category rounding. Stack modes sum all applicable tributes (#765).
     """
     out: List[Dict[str, Any]] = []
     bucket_indices: Dict[str, List[int]] = {"standard": [], "liquor": []}
@@ -521,7 +650,7 @@ def annotate_line_tax_amounts(
     for idx, raw in enumerate(lines):
         line = dict(raw) if not isinstance(raw, dict) else raw
         base = _line_tax_base(line)
-        tax_line = resolve_product_tax_line(
+        applied = resolve_product_tax_lines(
             tax_config,
             category_id=line.get("category_id"),
             tax_resolution=line.get("tax_resolution") or "inherit",
@@ -535,17 +664,17 @@ def annotate_line_tax_amounts(
             tax_line_key=line.get("tax_line_key"),
             tax_category=line.get("tax_category") or "standard",
         )
-        if tax_line is None or base <= 0:
+        if not applied or base <= 0:
             line["tax_amount"] = 0.0
             line["tax_label"] = None
             line["tax_rate"] = None
             line["included_in_price"] = None
         else:
-            amount = tax_amount_float(base, tax_line)
+            amount = sum(tax_amount_float(base, tax_line) for tax_line in applied)
             line["tax_amount"] = float(amount)
-            line["tax_label"] = tax_line.label
-            line["tax_rate"] = float(tax_line.rate)
-            line["included_in_price"] = bool(tax_line.included_in_price)
+            line["tax_label"] = " + ".join(tax_line.label for tax_line in applied)
+            line["tax_rate"] = float(applied[-1].rate)
+            line["included_in_price"] = all(tax_line.included_in_price for tax_line in applied)
             if bucket in bucket_indices and amount > 0:
                 bucket_indices[bucket].append(idx)
 

--- a/app/services/pos_context_service.py
+++ b/app/services/pos_context_service.py
@@ -81,6 +81,8 @@ SELECT
     ttc.iva_rate,
     ttc.iva_included_in_price,
     ttc.liquor_tax_applicable,
+    ttc.liquor_tax_rate,
+    ttc.liquor_tax_included_in_price,
     ttc.tax_lines,
     ttc.category_map,
     ttc.commercial_tax_applicable,
@@ -172,6 +174,16 @@ async def get_restaurant_context(tenant_id: UUID) -> Optional[Dict[str, Any]]:
         'iva_rate': float(row['iva_rate']) if row['iva_rate'] is not None else 0.19,
         'iva_included_in_price': bool(row['iva_included_in_price']) if row['iva_included_in_price'] is not None else False,
         'liquor_tax_applicable': bool(row['liquor_tax_applicable']) if row['liquor_tax_applicable'] is not None else False,
+        'liquor_tax_rate': (
+            float(row['liquor_tax_rate'])
+            if ('liquor_tax_rate' in row.keys() and row['liquor_tax_rate'] is not None)
+            else 0.05
+        ),
+        'liquor_tax_included_in_price': (
+            bool(row['liquor_tax_included_in_price'])
+            if ('liquor_tax_included_in_price' in row.keys() and row['liquor_tax_included_in_price'] is not None)
+            else False
+        ),
         'tax_lines': row['tax_lines'] if 'tax_lines' in row.keys() else None,
         'category_map': row['category_map'] if 'category_map' in row.keys() else None,
         'commercial_tax_applicable': (

--- a/tests/test_hospitality_tax_engine.py
+++ b/tests/test_hospitality_tax_engine.py
@@ -6,10 +6,13 @@ from app.services.hospitality_tax_engine import (
     annotate_line_tax_amounts,
     compute_category_breakdown,
     compute_gl_category_taxes,
+    compute_items_tax_totals,
     liquor_tax_label_for_config,
     resolve_applicable_tax_lines,
     resolve_effective_tax_category,
+    resolve_product_tax_lines,
     resolve_tax_profile,
+    tax_amount_decimal,
     tax_amount_float,
 )
 from app.services.hospitality_tax_packs import (
@@ -190,7 +193,8 @@ def test_annotate_line_tax_mx_exclusive_sums_to_cart():
     assert annotated[0]["included_in_price"] is False
     assert annotated[0]["tax_amount"] == round(207 * 0.16)
     assert sum(float(l["tax_amount"]) for l in annotated) == cart_tax
-    assert cart_tax == round((207 + 1740) * 0.16)
+    # Per-item rounding (#765) — not one round on the summed base.
+    assert cart_tax == round(207 * 0.16) + round(1740 * 0.16)
 
 
 def test_annotate_line_tax_exempt_is_zero():
@@ -363,3 +367,132 @@ def test_resolve_applicable_primary_selection():
     profile = resolve_tax_profile(cfg)
     applied = resolve_applicable_tax_lines(profile, selected_key="btw_reduced")
     assert [line.key for line in applied] == ["btw_reduced"]
+
+
+def test_co_liquor_included_gl_extract_not_additive():
+    """#765 — Bebidas→liquor Incluido: extract 30000@5% ≈ 1428.57, not 1500."""
+    cfg = {
+        "inc_applicable": False,
+        "iva_applicable": True,
+        "iva_rate": 0.19,
+        "iva_included_in_price": True,
+        "liquor_tax_applicable": True,
+        "liquor_tax_rate": 0.05,
+        "liquor_tax_included_in_price": True,
+        "commercial_tax_applicable": False,
+        "tax_lines": [
+            {
+                "key": "iva",
+                "label": "IVA 19%",
+                "rate": 0.19,
+                "included_in_price": True,
+                "gl_role": "iva",
+                "mode": "primary",
+                "exclusive_group": "vat",
+            },
+            {
+                "key": "liquor",
+                "label": "IVA licores 5%",
+                "rate": 0.05,
+                "included_in_price": True,
+                "gl_role": "liquor",
+                "mode": "alternate",
+                "exclusive_group": "vat",
+            },
+        ],
+        "category_map": {"standard": "iva", "liquor": "liquor", "exempt": None},
+        "menu_category_line_map": {
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb": "liquor",
+        },
+    }
+    cat = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    applied = resolve_product_tax_lines(cfg, category_id=cat)
+    assert [line.key for line in applied] == ["liquor"]
+    tax, is_additive = tax_amount_decimal(Decimal("30000"), applied[0])
+    assert is_additive is False
+    assert tax == Decimal("30000") - (Decimal("30000") / Decimal("1.05"))
+    assert abs(float(tax) - 1428.57142857) < 1e-6
+
+    totals = compute_items_tax_totals(
+        [{"category_id": cat, "subtotal": Decimal("30000")}],
+        cfg,
+    )
+    assert totals["liquor_is_additive"] is False
+    assert totals["liquor_additive"] == Decimal("0")
+    assert totals["liquor_tax"] == tax
+    assert additive_order_tax_total(0, float(tax), cfg) == 0.0
+
+    # Fallback subtotal path also honors included flag.
+    gl = compute_gl_category_taxes(Decimal("0"), Decimal("30000"), cfg)
+    assert gl["liquor_is_additive"] is False
+    assert gl["liquor_tax"] == tax
+
+
+def test_override_mapped_category_only_alternate_rate():
+    """#765 — override: mapped Bebidas use liquor only, not IVA+liquor."""
+    cfg = tax_config_from_wave1_pack(WAVE2_MULTI_TAX_PACKS["DE"])
+    cat = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+    cfg["menu_category_line_map"] = {cat: "mwst_standard"}
+    applied = resolve_product_tax_lines(cfg, category_id=cat)
+    assert [line.key for line in applied] == ["mwst_standard"]
+    rows = [{"category_id": cat, "subtotal": 10000}]
+    std, liq, _ = compute_category_breakdown(rows, cfg)
+    assert std == 0.0
+    assert liq == 1900.0
+    assert resolve_effective_tax_category(cfg, category_id=cat) == "liquor"
+
+
+def test_stack_mode_sums_primary_and_selected():
+    """#765 — stack adds both primary and selected tributes."""
+    cfg = {
+        "commercial_tax_applicable": True,
+        "tax_lines": [
+            {
+                "key": "iva",
+                "label": "IVA 16%",
+                "rate": 0.16,
+                "included_in_price": False,
+                "gl_role": "iva",
+                "mode": "primary",
+                "exclusive_group": "vat",
+            },
+            {
+                "key": "tourist",
+                "label": "Tourist 2%",
+                "rate": 0.02,
+                "included_in_price": False,
+                "gl_role": "iva",
+                "mode": "stack",
+            },
+        ],
+        "category_map": {"standard": "iva", "liquor": "iva", "exempt": None},
+        "menu_category_line_map": {
+            "dddddddd-dddd-dddd-dddd-dddddddddddd": "tourist",
+        },
+    }
+    cat = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+    applied = resolve_product_tax_lines(cfg, category_id=cat)
+    assert [line.key for line in applied] == ["iva", "tourist"]
+    rows = [{"category_id": cat, "subtotal": 10000}]
+    std, liq, _ = compute_category_breakdown(rows, cfg)
+    assert std == 1600.0 + 200.0
+    assert liq == 0.0
+
+    annotated = annotate_line_tax_amounts(
+        [{
+            "id": "1",
+            "category_id": cat,
+            "net_total": 10000,
+            "tax_resolution": "inherit",
+        }],
+        cfg,
+        reconcile_to=(std, liq),
+    )
+    assert annotated[0]["tax_amount"] == 1800.0
+    assert "IVA 16%" in annotated[0]["tax_label"]
+    assert "Tourist 2%" in annotated[0]["tax_label"]
+
+    totals = compute_items_tax_totals(rows, cfg)
+    assert totals["standard_tax"] == Decimal("1800")
+    assert totals["standard_is_additive"] is True
+    assert totals["standard_additive"] == Decimal("1800")


### PR DESCRIPTION
## Summary
- Wire `resolve_applicable_tax_lines` into product resolve, POS annotate, and per-item GL totals (alternate XOR primary; stack sums both).
- Liquor Incluido: extract `price − price/(1+r)` (e.g. 30000@5% ≈ 1428.57); cierre no longer adds included liquor to debit.
- POS context + cierre load `liquor_tax_included_in_price` / `liquor_tax_rate` for dual-read.

Closes #765  
Parent epic: uno0uno/warocol.com#2027

## Validation evidence
```text
$ ./venv/bin/pytest tests/test_hospitality_tax_engine.py tests/test_menu_category_tax_resolve.py -q
============================= test session starts ==============================
collected 35 items
tests/test_hospitality_tax_engine.py ....................
tests/test_menu_category_tax_resolve.py ...............
============================== 35 passed in 0.14s ==============================
```

## Test plan
- [ ] CO tenant with Restaurante CO (liquor Incluido): GL liquor tax on 30000 ≈ 1428.57, not 1500
- [ ] Mapped Bebidas → only 5% alternate (no 19%+5%)
- [ ] Custom stack line: POS/GL show both taxes
- [ ] Additive liquor (included=false) still adds to debit_total


Made with [Cursor](https://cursor.com)