### PR TITLE
fix(tax): sync CO tax_lines on sales tax profile flip

### DIFF
--- a/.wr/2031.yaml
+++ b/.wr/2031.yaml
@@ -1,0 +1,32 @@
+# Machine contract for wr-fast — keep ≤80 lines.
+issue: 2031
+title: "Facturación: sync sales tax profile and Impuestos tax_lines in one save"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-2031-tax-profile-tax-lines-sync
+risk: low
+
+paths:
+  - app/services/hospitality_tax_engine.py
+  - app/routers/tenant_config.py
+  - tests/test_hospitality_tax_engine.py
+  - tests/test_tenant_fiscal_data.py
+
+ac:
+  - PUT fiscal-data with sales_tax_profile rewrites tax_lines + maps (no hybrid IVA flags + IVA lines)
+  - Liquor and custom tax_lines preserved on IVA↔INC flip
+  - Menu map keys iva↔inc remapped to active primary (cleared when non-responsible)
+
+out_of_scope:
+  - Commercial matrix / jurisdiction packs
+  - Matias emit / FEV changes
+
+hints:
+  entry: "put_fiscal_data profile_settings → sync_co_tax_lines_for_sales_profile"
+  pattern: "hospitality_tax_engine sync helper + UPSERT tax_lines jsonb"
+  tests: "pytest tests/test_hospitality_tax_engine.py tests/test_tenant_fiscal_data.py -q"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/routers/tenant_config.py
+++ b/app/routers/tenant_config.py
@@ -2,6 +2,7 @@
 Tenant configuration router - admin endpoints for managing public profiles
 Authentication required
 """
+import json
 from datetime import date as _date
 from uuid import UUID
 from asyncpg.exceptions import UniqueViolationError
@@ -412,18 +413,37 @@ async def update_fiscal_data(request: Request, data: dict = Body(...)):
         )
 
         if profile_settings:
+            from app.services.hospitality_tax_engine import sync_co_tax_lines_for_sales_profile
+
+            existing = await conn.fetchrow(
+                "SELECT * FROM tenant_tax_config WHERE tenant_id = $1",
+                tenant_id,
+            )
+            cfg = dict(existing) if existing else {}
+            tax_lines, category_map, menu_map = sync_co_tax_lines_for_sales_profile(
+                cfg,
+                iva_applicable=bool(profile_settings['iva_applicable']),
+                inc_applicable=bool(profile_settings['inc_applicable']),
+            )
             await conn.execute(
                 """INSERT INTO tenant_tax_config (
-                       tenant_id, inc_applicable, iva_applicable, updated_at
+                       tenant_id, inc_applicable, iva_applicable,
+                       tax_lines, category_map, menu_category_line_map, updated_at
                    )
-                   VALUES ($1, $2, $3, now())
+                   VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6::jsonb, now())
                    ON CONFLICT (tenant_id) DO UPDATE SET
                        inc_applicable = EXCLUDED.inc_applicable,
                        iva_applicable = EXCLUDED.iva_applicable,
+                       tax_lines = EXCLUDED.tax_lines,
+                       category_map = EXCLUDED.category_map,
+                       menu_category_line_map = EXCLUDED.menu_category_line_map,
                        updated_at = now()""",
                 tenant_id,
                 profile_settings['inc_applicable'],
                 profile_settings['iva_applicable'],
+                json.dumps(tax_lines),
+                json.dumps(category_map),
+                json.dumps(menu_map),
             )
 
     return {'success': True, 'message': 'Datos fiscales actualizados'}

--- a/app/services/hospitality_tax_engine.py
+++ b/app/services/hospitality_tax_engine.py
@@ -339,6 +339,91 @@ def _profile_from_co_columns(tax_config: Mapping[str, Any]) -> TaxProfile:
     return TaxProfile(lines=lines, category_map=category_map)
 
 
+def sync_co_tax_lines_for_sales_profile(
+    tax_config: Mapping[str, Any],
+    *,
+    iva_applicable: bool,
+    inc_applicable: bool,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Optional[str]], Dict[str, Optional[str]]]:
+    """Rewrite CO tax_lines/maps when Perfil de ventas flips IVA↔INC (#2031).
+
+    Preserves liquor + custom lines. Remaps menu/category map keys that pointed
+    at the old primary (iva↔inc) so POS does not keep stale IVA labels under INC.
+    """
+    cfg = dict(tax_config)
+    cfg["iva_applicable"] = bool(iva_applicable)
+    cfg["inc_applicable"] = bool(inc_applicable)
+    # Defaults when columns never set (fresh INSERT path).
+    if cfg.get("iva_rate") is None:
+        cfg["iva_rate"] = 0.19
+    if cfg.get("inc_rate") is None:
+        cfg["inc_rate"] = 0.08
+
+    profile = _profile_from_co_columns(cfg)
+    primary = profile.primary_line()
+    primary_key = primary.key if primary else None
+
+    existing = _as_mapping_list(cfg.get("tax_lines"))
+    kept: List[Dict[str, Any]] = []
+    for item in existing:
+        key = str(item.get("key") or "").strip()
+        if not key or key in ("iva", "inc"):
+            continue
+        kept.append(dict(item))
+
+    out_lines: List[Dict[str, Any]] = []
+    if primary is not None:
+        out_lines.append({
+            "key": primary.key,
+            "label": primary.label,
+            "rate": primary.rate,
+            "included_in_price": primary.included_in_price,
+            "gl_role": primary.gl_role,
+            "mode": "primary",
+            "exclusive_group": primary.exclusive_group or "vat",
+        })
+    out_lines.extend(kept)
+
+    # If columns say liquor on but tax_lines lacked it, seed from columns.
+    if cfg.get("liquor_tax_applicable") and not any(
+        str(x.get("key") or "") == "liquor" for x in out_lines
+    ):
+        liquor = profile.lines.get("liquor")
+        if liquor is not None:
+            out_lines.append({
+                "key": liquor.key,
+                "label": liquor.label,
+                "rate": liquor.rate,
+                "included_in_price": liquor.included_in_price,
+                "gl_role": liquor.gl_role,
+                "mode": "alternate",
+                "exclusive_group": liquor.exclusive_group or "vat",
+            })
+
+    category_map = {
+        "standard": primary_key,
+        "liquor": "liquor" if any(str(x.get("key") or "") == "liquor" for x in out_lines) else primary_key,
+        "exempt": None,
+    }
+    raw_map = _as_category_map(cfg.get("category_map"))
+    if raw_map.get("exempt") is not None:
+        category_map["exempt"] = raw_map.get("exempt")
+
+    menu_map = _as_menu_category_line_map(cfg.get("menu_category_line_map"))
+    remapped: Dict[str, Optional[str]] = {}
+    for cat_id, line_key in menu_map.items():
+        if line_key is None:
+            remapped[cat_id] = None
+            continue
+        if line_key in ("iva", "inc"):
+            # Flip to active primary, or clear when non-responsible (#2031).
+            remapped[cat_id] = primary_key
+        else:
+            remapped[cat_id] = line_key
+
+    return out_lines, category_map, remapped
+
+
 def resolve_applicable_tax_lines(
     profile: TaxProfile,
     *,

--- a/tests/test_hospitality_tax_engine.py
+++ b/tests/test_hospitality_tax_engine.py
@@ -12,6 +12,7 @@ from app.services.hospitality_tax_engine import (
     resolve_effective_tax_category,
     resolve_product_tax_lines,
     resolve_tax_profile,
+    sync_co_tax_lines_for_sales_profile,
     tax_amount_decimal,
     tax_amount_float,
 )
@@ -496,3 +497,83 @@ def test_stack_mode_sums_primary_and_selected():
     assert totals["standard_tax"] == Decimal("1800")
     assert totals["standard_is_additive"] is True
     assert totals["standard_additive"] == Decimal("1800")
+
+
+def test_sync_co_tax_lines_flips_iva_to_inc_and_keeps_custom():
+    """#2031 — Perfil de ventas must rewrite tax_lines so POS is not hybrid."""
+    cat = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    cfg = {
+        "iva_applicable": True,
+        "iva_rate": 0.19,
+        "iva_included_in_price": True,
+        "inc_applicable": False,
+        "inc_rate": 0.08,
+        "inc_included_in_price": True,
+        "liquor_tax_applicable": True,
+        "liquor_tax_rate": 0.05,
+        "liquor_tax_included_in_price": True,
+        "tax_lines": [
+            {
+                "key": "iva",
+                "label": "IVA 19%",
+                "rate": 0.19,
+                "included_in_price": True,
+                "gl_role": "iva",
+                "mode": "primary",
+                "exclusive_group": "vat",
+            },
+            {
+                "key": "liquor",
+                "label": "IVA licores 5%",
+                "rate": 0.05,
+                "included_in_price": True,
+                "gl_role": "liquor",
+                "mode": "alternate",
+                "exclusive_group": "vat",
+            },
+            {
+                "key": "bebidas",
+                "label": "Bebidas 5%",
+                "rate": 0.05,
+                "included_in_price": True,
+                "gl_role": "iva",
+                "mode": "alternate",
+                "exclusive_group": "vat",
+            },
+        ],
+        "category_map": {"standard": "iva", "liquor": "liquor", "exempt": None},
+        "menu_category_line_map": {cat: "iva"},
+    }
+    lines, category_map, menu_map = sync_co_tax_lines_for_sales_profile(
+        cfg,
+        iva_applicable=False,
+        inc_applicable=True,
+    )
+    assert [x["key"] for x in lines] == ["inc", "liquor", "bebidas"]
+    assert lines[0]["label"] == "INC 8%"
+    assert lines[0]["mode"] == "primary"
+    assert category_map["standard"] == "inc"
+    assert category_map["liquor"] == "liquor"
+    assert menu_map[cat] == "inc"
+
+
+def test_sync_co_tax_lines_clears_primary_when_non_responsible():
+    lines, category_map, menu_map = sync_co_tax_lines_for_sales_profile(
+        {
+            "tax_lines": [
+                {
+                    "key": "iva",
+                    "label": "IVA 19%",
+                    "rate": 0.19,
+                    "mode": "primary",
+                    "gl_role": "iva",
+                },
+            ],
+            "menu_category_line_map": {"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa": "iva"},
+        },
+        iva_applicable=False,
+        inc_applicable=False,
+    )
+    assert lines == []
+    assert category_map["standard"] is None
+    assert menu_map["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"] is None

--- a/tests/test_tenant_fiscal_data.py
+++ b/tests/test_tenant_fiscal_data.py
@@ -37,6 +37,7 @@ def _enforce_db_ctx():
     async def _ctx():
         conn = MagicMock()
         conn.fetchval = AsyncMock(return_value="enforce")
+        conn.fetchrow = AsyncMock(return_value=None)
         conn.fetch = AsyncMock(return_value=[])
         yield conn
     return _ctx
@@ -244,6 +245,7 @@ def test_put_fiscal_data_applies_explicit_profile_to_fiscal_and_tax_config():
     session = _build_session()
     conn = MagicMock()
     conn.execute = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value=None)
 
     @asynccontextmanager
     async def fiscal_db_ctx():
@@ -271,7 +273,9 @@ def test_put_fiscal_data_applies_explicit_profile_to_fiscal_and_tax_config():
     assert fiscal_call.args[5] == 2
     assert fiscal_call.args[7] == "non_responsible_iva_inc"
     assert "tenant_tax_config" in tax_call.args[0]
-    assert tax_call.args[2:] == (False, False)
+    assert tax_call.args[2:4] == (False, False)
+    assert "tax_lines" in tax_call.args[0]
+    assert tax_call.args[4] == "[]"
 
 
 def test_put_fiscal_data_rejects_non_responsible_inc_for_legal_entity():


### PR DESCRIPTION
## Summary
- On PUT fiscal-data with `sales_tax_profile`, rewrite `tax_lines`, `category_map`, and menu map via `sync_co_tax_lines_for_sales_profile`
- Preserve liquor + custom lines; remap stale `iva`↔`inc` menu keys (clear when non-responsible)
- Tests for flip + fiscal UPSERT path

Refs uno0uno/warocol.com#2031

## Test plan
- [x] `pytest tests/test_hospitality_tax_engine.py tests/test_tenant_fiscal_data.py -q` (31 passed)
- [ ] Manual: flip Perfil de ventas IVA→INC once; POS/Impuestos show INC without second Impuestos save

## wr-context
See `.wr/2031.yaml` on this branch.

Made with [Cursor](https://cursor.com)