### PR TITLE
feat(tax): accept tax_config on fiscal-data PUT

### DIFF
--- a/.wr/2033.yaml
+++ b/.wr/2033.yaml
@@ -1,0 +1,30 @@
+# Machine contract for wr-fast — keep ≤80 lines.
+issue: 2033
+title: "Facturación: unify Datos fiscales + Impuestos into one save"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-2033-unify-fiscal-tax
+risk: low
+
+paths:
+  - app/routers/tenant_config.py
+  - tests/test_tenant_fiscal_data.py
+
+ac:
+  - PUT fiscal-data accepts optional tax_config and persists via update_tax_config
+  - Without tax_config, profile sync (#2031) still runs
+  - GET/PUT tax-config remain (Menú readers)
+
+out_of_scope:
+  - Delete tax-config endpoints
+  - Commercial jurisdiction redesign
+
+hints:
+  entry: "update_fiscal_data tax_config → TaxConfigUpdate → update_tax_config"
+  pattern: "after fiscal upsert; force iva/inc from sales_tax_profile"
+  tests: "pytest tests/test_tenant_fiscal_data.py -q"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/routers/tenant_config.py
+++ b/app/routers/tenant_config.py
@@ -326,12 +326,14 @@ async def update_fiscal_data(request: Request, data: dict = Body(...)):
     """
     Upsert fiscal data for the active tenant.
 
-    This endpoint intentionally does not mutate tenant_tax_config. A tenant can
-    update organization type or IVA responsibility without auto-enabling INC/IVA
-    on sale lines.
+    Optional body key `tax_config` (TaxConfigUpdate shape) persists Impuestos in
+    the same request (#2033). GET/PUT /tax-config remain for Menú and other
+    callers. Without `tax_config`, sales_tax_profile still syncs IVA/INC columns
+    + tax_lines (#2031).
     """
     from app.core.middleware import require_valid_session
     from app.database import get_db_connection
+    from pydantic import ValidationError
 
     session = require_valid_session(request)
     tenant_id = session.tenant_id
@@ -342,6 +344,9 @@ async def update_fiscal_data(request: Request, data: dict = Body(...)):
     matias_company_id = _normalize_matias_company_id(data)
     electronic_invoicing_requested = bool(data.get('electronic_invoicing_requested', False))
     sales_tax_profile = _normalize_sales_tax_profile(data)
+    tax_raw = data.get('tax_config')
+    if tax_raw is not None and not isinstance(tax_raw, dict):
+        raise HTTPException(status_code=400, detail='tax_config must be an object')
 
     type_organization_id = data.get('type_organization_id', 1)
     tax_level_id = data.get('tax_level_id', 5)
@@ -412,7 +417,8 @@ async def update_fiscal_data(request: Request, data: dict = Body(...)):
             show_logo,
         )
 
-        if profile_settings:
+        # Profile-only sync when Facturación did not send a full tax_config payload.
+        if profile_settings and tax_raw is None:
             from app.services.hospitality_tax_engine import sync_co_tax_lines_for_sales_profile
 
             existing = await conn.fetchrow(
@@ -445,6 +451,20 @@ async def update_fiscal_data(request: Request, data: dict = Body(...)):
                 json.dumps(category_map),
                 json.dumps(menu_map),
             )
+
+    if tax_raw is not None:
+        payload = dict(tax_raw)
+        if profile_settings:
+            payload['iva_applicable'] = bool(profile_settings['iva_applicable'])
+            payload['inc_applicable'] = bool(profile_settings['inc_applicable'])
+        try:
+            tax_model = TaxConfigUpdate(**payload)
+        except ValidationError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f'Invalid tax_config: {exc.errors()[0].get("msg", "validation error")}',
+            ) from exc
+        await tenant_config_service.update_tax_config(request, tax_model)
 
     return {'success': True, 'message': 'Datos fiscales actualizados'}
 

--- a/tests/test_tenant_fiscal_data.py
+++ b/tests/test_tenant_fiscal_data.py
@@ -278,6 +278,78 @@ def test_put_fiscal_data_applies_explicit_profile_to_fiscal_and_tax_config():
     assert tax_call.args[4] == "[]"
 
 
+def test_put_fiscal_data_with_tax_config_delegates_to_update_tax_config():
+    """#2033 — Facturación one-save sends tax_config on fiscal-data PUT."""
+    session = _build_session()
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+    tax_update = AsyncMock(return_value={"success": True, "data": {}})
+
+    @asynccontextmanager
+    async def fiscal_db_ctx():
+        yield conn
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_enforce_db_ctx()), \
+         patch("app.database.get_db_connection", return_value=fiscal_db_ctx()), \
+         patch("app.services.tenant_config_service.update_tax_config", tax_update):
+        response = TestClient(_build_app()).put(
+            "/api/tenant/fiscal-data",
+            json={
+                "nit": "123456789",
+                "business_name": "Restaurante INC",
+                "type_organization_id": 2,
+                "tax_level_id": 5,
+                "sales_tax_profile": "inc_responsible",
+                "tax_config": {
+                    "inc_applicable": True,
+                    "inc_included_in_price": True,
+                    "iva_applicable": False,
+                    "iva_included_in_price": False,
+                    "liquor_tax_applicable": True,
+                    "liquor_tax_included_in_price": True,
+                    "iva_rate": 0.19,
+                    "inc_rate": 0.08,
+                    "liquor_tax_rate": 0.05,
+                    "tax_lines": [
+                        {
+                            "key": "inc",
+                            "label": "INC 8%",
+                            "rate": 0.08,
+                            "included_in_price": True,
+                            "gl_role": "inc",
+                            "mode": "primary",
+                            "exclusive_group": "vat",
+                        },
+                        {
+                            "key": "liquor",
+                            "label": "IVA licores 5%",
+                            "rate": 0.05,
+                            "included_in_price": True,
+                            "gl_role": "liquor",
+                            "mode": "alternate",
+                            "exclusive_group": "vat",
+                        },
+                    ],
+                    "category_map": {"standard": "inc", "liquor": "liquor", "exempt": None},
+                    "menu_category_line_map": {},
+                    "exempt_menu_category_ids": [],
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    # Full tax_config path skips profile-only sync execute #2
+    assert conn.execute.await_count == 1
+    tax_update.assert_awaited_once()
+    tax_model = tax_update.await_args.args[1]
+    assert tax_model.inc_applicable is True
+    assert tax_model.iva_applicable is False
+    assert tax_model.liquor_tax_applicable is True
+
+
 def test_put_fiscal_data_rejects_non_responsible_inc_for_legal_entity():
     session = _build_session()
 


### PR DESCRIPTION
## Summary
- `PUT /tenant/fiscal-data` accepts optional `tax_config` and applies it via `update_tax_config`
- Profile-only sync (#2031) still runs when `tax_config` is omitted
- `GET/PUT /tax-config` kept for Menú and other callers

Refs uno0uno/warocol.com#2033

## Test plan
- [x] `pytest tests/test_tenant_fiscal_data.py -q`
- [ ] Manual: CO Facturación one Guardar persists rates + profile

## Validation evidence
```
pytest tests/test_tenant_fiscal_data.py -q
10 passed in 0.13s
```

## wr-context
See `.wr/2033.yaml` on this branch.

Made with [Cursor](https://cursor.com)