### PR TITLE
fix(pos): keep liquor tax on mesa close breakdown

### DIFF
--- a/.wr/2035.yaml
+++ b/.wr/2035.yaml
@@ -1,0 +1,28 @@
+issue: 2035
+title: "POS mesa close: liquor tax missing from receipt detail under INC"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-2035-mesa-close-liquor-tax-breakdown
+risk: low
+
+paths:
+  - app/services/tables_service.py
+  - tests/test_hospitality_tax_engine.py
+
+ac:
+  - close_session tax rows include category_id / tax_resolution / tax_line_key per item
+  - menu-mapped liquor not collapsed into primary INC/IVA when tax_category=standard
+  - regression test documents buggy GROUP BY shape vs item-level fix
+
+out_of_scope:
+  - Front receipt changes
+  - Counter/cart complete (already item-level)
+
+hints:
+  entry: "tables_service.close_session tax_rows fetch ~2159"
+  tests: "pytest tests/test_hospitality_tax_engine.py::test_menu_mapped_liquor_not_lost_when_legacy_tax_category_standard -q"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/services/tables_service.py
+++ b/app/services/tables_service.py
@@ -2156,16 +2156,22 @@ async def close_session(request: Request, table_id: UUID, payment_method: Option
 
                 tax_config = await _get_tenant_tax_config(conn_ids, tenant_id)
                 _liq_label = liquor_tax_label_for_config(tax_config)
+                # Item-level rows (keep category_id / overrides). GROUP BY
+                # tax_category alone collapses menu-mapped liquor into INC/IVA
+                # when products still have legacy tax_category=standard
+                # (warocol.com#2035).
                 tax_rows = await conn_ids.fetch(
                     """
                     SELECT
                         COALESCE(p.tax_category, 'standard') AS tax_category,
-                        COALESCE(SUM(COALESCE(oi.net_total, oi.subtotal)), 0) AS subtotal
+                        COALESCE(p.tax_resolution, 'inherit') AS tax_resolution,
+                        p.tax_line_key AS tax_line_key,
+                        p.category_id::text AS category_id,
+                        COALESCE(oi.net_total, oi.subtotal, 0) AS subtotal
                     FROM order_items oi
                     JOIN orders o ON o.id = oi.order_id
                     JOIN product p ON p.id = oi.product_id
                     WHERE o.id = ANY($1::uuid[])
-                    GROUP BY COALESCE(p.tax_category, 'standard')
                     """,
                     [r["id"] for r in order_rows],
                 )

--- a/tests/test_hospitality_tax_engine.py
+++ b/tests/test_hospitality_tax_engine.py
@@ -499,6 +499,57 @@ def test_stack_mode_sums_primary_and_selected():
     assert totals["standard_additive"] == Decimal("1800")
 
 
+def test_menu_mapped_liquor_not_lost_when_legacy_tax_category_standard():
+    """#2035 — mesa close must not GROUP BY tax_category only (INC eats liquor)."""
+    liquor_cat = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    cfg = {
+        "inc_applicable": True,
+        "inc_rate": 0.08,
+        "inc_included_in_price": True,
+        "iva_applicable": False,
+        "liquor_tax_applicable": True,
+        "liquor_tax_rate": 0.05,
+        "liquor_tax_included_in_price": True,
+        "tax_lines": [
+            {
+                "key": "inc",
+                "label": "INC 8%",
+                "rate": 0.08,
+                "included_in_price": True,
+                "gl_role": "inc",
+                "mode": "primary",
+                "exclusive_group": "vat",
+            },
+            {
+                "key": "liquor",
+                "label": "IVA licores 5%",
+                "rate": 0.05,
+                "included_in_price": True,
+                "gl_role": "liquor",
+                "mode": "alternate",
+                "exclusive_group": "vat",
+            },
+        ],
+        "category_map": {"standard": "inc", "liquor": "liquor", "exempt": None},
+        "menu_category_line_map": {liquor_cat: "liquor"},
+    }
+    # Legacy product tag is still standard — liquor comes from menu map.
+    item_rows = [
+        {"tax_category": "standard", "category_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "subtotal": 238000},
+        {"tax_category": "standard", "category_id": liquor_cat, "subtotal": 30000},
+    ]
+    std, liq, label = compute_category_breakdown(item_rows, cfg)
+    assert label == "INC 8%"
+    assert std == 17630.0  # 238000 * 0.08/1.08
+    assert liq == 1429.0   # 30000 * 0.05/1.05
+
+    # Buggy mesa-close shape: collapsed by tax_category only → liquor vanishes.
+    collapsed = [{"tax_category": "standard", "subtotal": 268000}]
+    buggy_std, buggy_liq, _ = compute_category_breakdown(collapsed, cfg)
+    assert buggy_liq == 0.0
+    assert buggy_std == 19852.0
+
+
 def test_sync_co_tax_lines_flips_iva_to_inc_and_keeps_custom():
     """#2031 — Perfil de ventas must rewrite tax_lines so POS is not hybrid."""
     cat = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"


### PR DESCRIPTION
## Summary
- Mesa `close_session` tax breakdown now uses item-level rows (`category_id`, resolution, line key)
- Fixes receipt Detalle de impuestos dropping IVA licores 5% when primary is INC (products still `tax_category=standard`)

Closes uno0uno/warocol.com#2035

## Test plan
- [x] `pytest tests/test_hospitality_tax_engine.py::test_menu_mapped_liquor_not_lost_when_legacy_tax_category_standard -q`
- [ ] Manual: mesa with INC + Bebidas liquor map → close → Detalle shows INC and IVA licores 5%

## Validation evidence
```
pytest …test_menu_mapped_liquor_not_lost… -q
1 passed
```
Reproduced order #17368: buggy (19852, 0) → fixed (17630, 1429).

## wr-context
See `.wr/2035.yaml` on this branch.

Made with [Cursor](https://cursor.com)