### PR TITLE
fix(kds): soft-success stale comanda status PATCH

### DIFF
--- a/.wr/2037.yaml
+++ b/.wr/2037.yaml
@@ -1,0 +1,39 @@
+issue: 2037
+title: "KDS: 400 on comanda status when UI is stale / duplicate transition"
+repo: both
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: both
+branch: wr-2037-kds-status-idempotent
+
+paths:
+  - app/services/comandas_service.py
+  - app/core/middleware.py
+  - tests/test_comanda_status_idempotent.py
+  - ../front_nuxt/components/cocina/ComandaCard.vue
+
+ac:
+  - Same-status or already-past PATCH returns 200 no-op (no hard 400 toast)
+  - Card updates immediately via optimistic localStatus
+  - Mesa-close delivered race soft-succeeds on ready/preparing retries
+  - TenantMiddleware KDS token uses one open DB connection for both queries
+  - Focused pytest for idempotent status behavior
+
+out_of_scope:
+  - KDS UX redesign / SSE realtime
+  - Changing ALLOWED_TRANSITIONS business rules beyond soft-success
+
+hints:
+  entry: "update_comanda_status + _is_stale_status_request; TenantMiddleware kds_token block"
+  pattern: "STATUS_RANK soft-success before ALLOWED_TRANSITIONS ValidationError"
+  tests: "./venv/bin/pytest tests/test_comanda_status_idempotent.py -q"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "companion front PR; /wr-review auto"

--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -204,24 +204,24 @@ async def tenant_detection_middleware(request: Request, call_next):
         )
         kds_token = request.query_params.get('token')
         if kds_public_path and kds_token:
-            # Validate KDS token and inject tenant_id
+            # Validate KDS token and inject tenant_id (both queries inside one conn)
             try:
                 from app.database import get_db_connection as _get_conn
+                _t_row = None
                 async with _get_conn() as _conn:
                     _token_row = await _conn.fetchrow(
                         "SELECT tenant_id FROM kds_tokens WHERE token = $1 AND revoked_at IS NULL",
                         kds_token,
                     )
-                if _token_row:
-                    _tid = _token_row['tenant_id']
-                    _t_row = await _conn.fetchrow(
-                        "SELECT id AS tenant_id, name AS tenant_name, slug AS tenant_slug, slug AS tenant_email, slug AS site, name AS brand_name, true AS is_active FROM tenants WHERE id = $1",
-                        _tid,
-                    )
-                    if _t_row:
-                        request.state.tenant_context = TenantContext(dict(_t_row))
-                        response = await call_next(request)
-                        return response
+                    if _token_row:
+                        _t_row = await _conn.fetchrow(
+                            "SELECT id AS tenant_id, name AS tenant_name, slug AS tenant_slug, slug AS tenant_email, slug AS site, name AS brand_name, true AS is_active FROM tenants WHERE id = $1",
+                            _token_row['tenant_id'],
+                        )
+                if _t_row:
+                    request.state.tenant_context = TenantContext(dict(_t_row))
+                    response = await call_next(request)
+                    return response
             except Exception:
                 pass
         elif kds_public_path:

--- a/app/services/comandas_service.py
+++ b/app/services/comandas_service.py
@@ -172,7 +172,7 @@ _UNFIRED_ORDER_ITEMS_SELECT = """
     LEFT JOIN tenant_promotions tp ON tp.id = oi.applied_promotion_id
 """
 
-# Allowed status transitions — any move not in this map is rejected with 422.
+# Allowed status transitions — illegal moves raise ValidationError (HTTP 400).
 # 'recall' (delivered → ready) is handled by recall_comanda() separately.
 ALLOWED_TRANSITIONS: Dict[str, List[str]] = {
     'pending':   ['preparing', 'ready', 'cancelled'],
@@ -181,6 +181,28 @@ ALLOWED_TRANSITIONS: Dict[str, List[str]] = {
     'delivered': [],
     'cancelled': [],
 }
+
+# Happy-path rank for stale/duplicate KDS PATCHes (#2037). Same status or
+# already further along → soft success (no-op). cancelled is terminal-only.
+STATUS_RANK: Dict[str, int] = {
+    'pending': 0,
+    'preparing': 1,
+    'ready': 2,
+    'delivered': 3,
+}
+
+
+def _is_stale_status_request(current_status: str, new_status: str) -> bool:
+    """True when KDS asks for a status the comanda already has or has passed."""
+    if current_status == new_status:
+        return True
+    if current_status == 'cancelled' or new_status == 'cancelled':
+        return False
+    cur = STATUS_RANK.get(current_status)
+    nxt = STATUS_RANK.get(new_status)
+    if cur is None or nxt is None:
+        return False
+    return cur >= nxt
 
 
 async def _notify_comanda_ready(conn, tenant_id: UUID, comanda_id: UUID) -> None:
@@ -783,7 +805,8 @@ async def update_comanda_status(
 ) -> dict:
     """
     Updates comanda status and sets appropriate timestamps.
-    Enforces allowed-transition map — raises 422 for illegal transitions.
+    Enforces allowed-transition map — raises ValidationError (400) for illegal
+    transitions. Same-status or already-past requests are idempotent no-ops (#2037).
     """
     try:
         session = require_valid_session(request)
@@ -808,6 +831,21 @@ async def update_comanda_status(
                 raise NotFoundError(f"Comanda {comanda_id} no encontrada")
 
             current_status = row['status']
+
+            # Mostrador POS only: skip 'ready' — barra uses table-like lifecycle (#799)
+            # Resolve before stale check so delivered POS cards accept ready retries.
+            effective_requested = new_status
+            if new_status == 'ready' and row['source_type'] == 'pos' and not row['is_bar']:
+                effective_requested = 'delivered'
+
+            if _is_stale_status_request(current_status, effective_requested):
+                return {
+                    "success": True,
+                    "noop": True,
+                    "message": f"Comanda ya en {current_status}",
+                    "status": current_status,
+                }
+
             allowed_next = ALLOWED_TRANSITIONS.get(current_status, [])
 
             if new_status not in allowed_next:
@@ -816,9 +854,7 @@ async def update_comanda_status(
                     f"Transiciones permitidas desde '{current_status}': {allowed_next}"
                 )
 
-            # Mostrador POS only: skip 'ready' — barra uses table-like lifecycle (#799)
-            if new_status == 'ready' and row['source_type'] == 'pos' and not row['is_bar']:
-                new_status = 'delivered'
+            new_status = effective_requested
 
             sql_updates = ["status = $1", "updated_at = NOW()"]
             params: List[Any] = [new_status, comanda_id, tenant_id]
@@ -900,15 +936,19 @@ async def bulk_update_comanda_status(
 
             for row in rows:
                 current_status = row['status']
-                allowed_next = ALLOWED_TRANSITIONS.get(current_status, [])
-                if new_status not in allowed_next:
-                    skipped += 1
-                    continue
-
                 # Mostrador POS only — barra keeps ready until expedited (#799)
                 effective_status = new_status
                 if new_status == 'ready' and row['source_type'] == 'pos' and not row['is_bar']:
                     effective_status = 'delivered'
+
+                if _is_stale_status_request(current_status, effective_status):
+                    updated += 1
+                    continue
+
+                allowed_next = ALLOWED_TRANSITIONS.get(current_status, [])
+                if new_status not in allowed_next:
+                    skipped += 1
+                    continue
 
                 sql_updates = ["status = $1", "updated_at = NOW()"]
                 params: List[Any] = [effective_status, row['id'], tenant_id]

--- a/tests/test_comanda_status_idempotent.py
+++ b/tests/test_comanda_status_idempotent.py
@@ -1,0 +1,128 @@
+"""Stale/duplicate KDS status updates — warocol.com#2037."""
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.exceptions import ValidationError
+from app.services import comandas_service
+from app.services.comandas_service import _is_stale_status_request
+
+
+@pytest.mark.parametrize(
+    "current,requested,expected",
+    [
+        ("preparing", "preparing", True),
+        ("ready", "ready", True),
+        ("delivered", "delivered", True),
+        ("cancelled", "cancelled", True),
+        ("ready", "preparing", True),
+        ("delivered", "ready", True),
+        ("delivered", "preparing", True),
+        ("pending", "preparing", False),
+        ("preparing", "ready", False),
+        ("ready", "delivered", False),
+        ("delivered", "cancelled", False),
+        ("cancelled", "ready", False),
+    ],
+)
+def test_is_stale_status_request(current, requested, expected):
+    assert _is_stale_status_request(current, requested) is expected
+
+
+@pytest.mark.asyncio
+async def test_update_comanda_status_noop_when_already_ready():
+    """Duplicate ready PATCH returns success without UPDATE."""
+    comanda_id = uuid4()
+    tenant_id = uuid4()
+    request = MagicMock()
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchval = AsyncMock(return_value=True)
+    mock_conn.fetchrow = AsyncMock(
+        return_value={
+            "id": comanda_id,
+            "status": "ready",
+            "source_type": "table",
+            "is_bar": False,
+        }
+    )
+    mock_conn.execute = AsyncMock()
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    session = MagicMock(tenant_id=tenant_id)
+
+    with patch("app.services.comandas_service.require_valid_session", return_value=session), \
+         patch("app.services.comandas_service.get_db_connection", return_value=mock_cm):
+        result = await comandas_service.update_comanda_status(request, comanda_id, "ready")
+
+    assert result["success"] is True
+    assert result.get("noop") is True
+    mock_conn.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_comanda_status_noop_when_mesa_already_delivered():
+    """Mesa-close race: KDS asks ready but comanda is already delivered."""
+    comanda_id = uuid4()
+    tenant_id = uuid4()
+    request = MagicMock()
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchval = AsyncMock(return_value=True)
+    mock_conn.fetchrow = AsyncMock(
+        return_value={
+            "id": comanda_id,
+            "status": "delivered",
+            "source_type": "table",
+            "is_bar": False,
+        }
+    )
+    mock_conn.execute = AsyncMock()
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    session = MagicMock(tenant_id=tenant_id)
+
+    with patch("app.services.comandas_service.require_valid_session", return_value=session), \
+         patch("app.services.comandas_service.get_db_connection", return_value=mock_cm):
+        result = await comandas_service.update_comanda_status(request, comanda_id, "ready")
+
+    assert result["success"] is True
+    assert result.get("noop") is True
+    mock_conn.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_comanda_status_still_rejects_illegal_backward():
+    """True illegal transitions (e.g. delivered → cancelled) still 400."""
+    comanda_id = uuid4()
+    tenant_id = uuid4()
+    request = MagicMock()
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchval = AsyncMock(return_value=True)
+    mock_conn.fetchrow = AsyncMock(
+        return_value={
+            "id": comanda_id,
+            "status": "delivered",
+            "source_type": "table",
+            "is_bar": False,
+        }
+    )
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    session = MagicMock(tenant_id=tenant_id)
+
+    with patch("app.services.comandas_service.require_valid_session", return_value=session), \
+         patch("app.services.comandas_service.get_db_connection", return_value=mock_cm):
+        with pytest.raises(ValidationError):
+            await comandas_service.update_comanda_status(request, comanda_id, "cancelled")


### PR DESCRIPTION
## Summary
- Same-status / already-past `PATCH /comandas/{id}/status` returns 200 no-op (`noop: true`) so KDS retries after mesa-close or duplicate clicks do not 400
- Fix TenantMiddleware KDS token path: both DB queries run inside one open connection
- Companion front: optimistic card status

Closes https://github.com/uno0uno/warocol.com/issues/2037

## Test plan
- [ ] KDS: click Listo twice quickly — no 400 toast, card advances
- [ ] Close mesa while comanda preparing, then click Listo on KDS — soft success / card clears on refresh
- [ ] Illegal transition still rejected (e.g. delivered → cancelled)

## Validation evidence
```
./venv/bin/pytest tests/test_comanda_status_idempotent.py -q

============================= test session starts ==============================
collected 15 items
tests/test_comanda_status_idempotent.py ...............                  [100%]
============================== 15 passed in 0.04s ==============================
```

## wr-context
See `.wr/2037.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)