### PR TITLE
feat(onboarding): set profile and tenant locale from country

### DIFF
--- a/app/core/country_locale.py
+++ b/app/core/country_locale.py
@@ -1,0 +1,36 @@
+"""Map business country codes to default UI locales (onboarding v1).
+
+Persisted preferred_locale / tenant ui_locale follow the final country, not cookie.
+Align with front_nuxt/utils/countryLocale.ts.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from app.core.tenant_prefs import DEFAULT_TENANT_UI_LOCALE, validate_ui_locale
+
+# Spanish-speaking markets in the financial catalog (epic #2100 v1).
+ES_LATAM_COUNTRY_CODES = frozenset({
+    "CO",
+    "MX",
+    "CR",
+    "UY",
+    "CL",
+    "PE",
+    "AR",
+    "DO",
+    "PA",
+    "ES",
+})
+
+
+def locale_from_country(country_code: Optional[str]) -> str:
+    """Return UI locale for a business country. Unknown / empty → es."""
+    code = str(country_code or "").strip().upper()
+    if code == "US":
+        return validate_ui_locale("en")
+    if code == "BR":
+        return validate_ui_locale("pt")
+    if code in ES_LATAM_COUNTRY_CODES:
+        return validate_ui_locale("es")
+    return validate_ui_locale(DEFAULT_TENANT_UI_LOCALE)

--- a/app/services/onboarding_service.py
+++ b/app/services/onboarding_service.py
@@ -738,12 +738,8 @@ async def update_onboarding_financial_profile(
                     "state": context["state"],
                 },
             )
-        await apply_onboarding_locales_from_country(
-            conn,
-            tenant_id=tenant_id,
-            country_code=country_code,
-            user_id=context.get("owner_user_id"),
-        )
+        # Locales are set on first financial apply only — do not overwrite on
+        # idempotent starter_active retries (avoids clobbering mid-onboarding edits).
         result = dict(profile)
         result["business_name"] = context["business_name"]
         result["lifecycle_status"] = "active"

--- a/app/services/onboarding_service.py
+++ b/app/services/onboarding_service.py
@@ -25,6 +25,7 @@ from app.services.hospitality_tax_jurisdictions import (
     normalize_jurisdiction_code,
 )
 from app.services.hospitality_tax_packs import ensure_wave1_tax_pack
+from app.core.country_locale import locale_from_country
 from app.core.timezones import seed_tenant_timezone_from_country
 
 MAX_EMAIL_REQUESTS = 5
@@ -653,6 +654,41 @@ async def _promote_onboarding_identity(conn, tenant_id: UUID) -> str:
     return state_row["state"]
 
 
+async def apply_onboarding_locales_from_country(
+    conn,
+    *,
+    tenant_id: UUID,
+    country_code: str,
+    user_id: Optional[UUID] = None,
+) -> str:
+    """Persist profile preferred_locale and tenant ui_locale from business country."""
+    locale = locale_from_country(country_code)
+    if user_id is not None:
+        await conn.execute(
+            """
+            UPDATE profile
+            SET preferred_locale = $2, updated_at = NOW()
+            WHERE id = $1
+            """,
+            user_id,
+            locale,
+        )
+    await conn.execute(
+        """
+        INSERT INTO tenant_public_profiles (tenant_id, slug, display_name, ui_locale)
+        SELECT t.id, t.slug, t.name, $2
+        FROM tenants t
+        WHERE t.id = $1
+        ON CONFLICT (tenant_id) DO UPDATE
+            SET ui_locale = EXCLUDED.ui_locale,
+                updated_at = now()
+        """,
+        tenant_id,
+        locale,
+    )
+    return locale
+
+
 async def update_onboarding_financial_profile(
     conn,
     tenant_id: Optional[UUID],
@@ -661,7 +697,7 @@ async def update_onboarding_financial_profile(
     tenant_id = _require_tenant_id(tenant_id)
     context = await conn.fetchrow(
         """
-        SELECT t.lifecycle_status, t.name AS business_name, o.state
+        SELECT t.lifecycle_status, t.name AS business_name, o.state, o.owner_user_id
         FROM tenants t
         JOIN tenant_onboarding o ON o.tenant_id = t.id
         WHERE t.id = $1
@@ -702,6 +738,12 @@ async def update_onboarding_financial_profile(
                     "state": context["state"],
                 },
             )
+        await apply_onboarding_locales_from_country(
+            conn,
+            tenant_id=tenant_id,
+            country_code=country_code,
+            user_id=context.get("owner_user_id"),
+        )
         result = dict(profile)
         result["business_name"] = context["business_name"]
         result["lifecycle_status"] = "active"
@@ -783,6 +825,12 @@ async def update_onboarding_financial_profile(
                 detail=f"Unsupported jurisdiction {jurisdiction} for {country_code}",
             )
     await seed_tenant_timezone_from_country(conn, tenant_id, country_code)
+    await apply_onboarding_locales_from_country(
+        conn,
+        tenant_id=tenant_id,
+        country_code=country_code,
+        user_id=context.get("owner_user_id"),
+    )
     state = await _promote_onboarding_identity(conn, tenant_id)
     result = dict(profile)
     result["business_name"] = data.business_name

--- a/tests/test_country_locale.py
+++ b/tests/test_country_locale.py
@@ -1,0 +1,18 @@
+from app.core.country_locale import locale_from_country
+
+
+def test_locale_from_country_core_markets():
+    assert locale_from_country("CO") == "es"
+    assert locale_from_country("US") == "en"
+    assert locale_from_country("BR") == "pt"
+
+
+def test_locale_from_country_latam_and_unknown():
+    assert locale_from_country("MX") == "es"
+    assert locale_from_country("AR") == "es"
+    assert locale_from_country("PA") == "es"
+    assert locale_from_country("DE") == "es"  # v1: other/unknown → es
+    assert locale_from_country("ZZ") == "es"
+    assert locale_from_country("") == "es"
+    assert locale_from_country(None) == "es"
+    assert locale_from_country(" us ") == "en"

--- a/tests/test_onboarding_registration.py
+++ b/tests/test_onboarding_registration.py
@@ -301,3 +301,43 @@ def test_migration_has_database_idempotency_and_lifecycle_guards():
     assert "tenant_members_pending_owner_unique" in sql
     assert "onboarding_email_challenges" in sql
     assert "DEFAULT 'active'" in sql
+
+
+@pytest.mark.asyncio
+async def test_apply_onboarding_locales_from_country_sets_profile_and_tenant():
+    from app.services.onboarding_service import apply_onboarding_locales_from_country
+
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value="OK")
+    user_id = uuid4()
+    tenant_id = uuid4()
+
+    locale = await apply_onboarding_locales_from_country(
+        conn,
+        tenant_id=tenant_id,
+        country_code="US",
+        user_id=user_id,
+    )
+    assert locale == "en"
+    assert conn.execute.await_count == 2
+    profile_sql, profile_user, profile_locale = conn.execute.await_args_list[0].args[:3]
+    assert "UPDATE profile" in profile_sql
+    assert "preferred_locale" in profile_sql
+    assert profile_user == user_id
+    assert profile_locale == "en"
+    tenant_sql, tenant_arg, tenant_locale = conn.execute.await_args_list[1].args[:3]
+    assert "tenant_public_profiles" in tenant_sql
+    assert "ui_locale" in tenant_sql
+    assert tenant_arg == tenant_id
+    assert tenant_locale == "en"
+
+    conn.execute.reset_mock()
+    locale_co = await apply_onboarding_locales_from_country(
+        conn,
+        tenant_id=tenant_id,
+        country_code="CO",
+        user_id=user_id,
+    )
+    assert locale_co == "es"
+    assert conn.execute.await_args_list[0].args[2] == "es"
+    assert conn.execute.await_args_list[1].args[2] == "es"

--- a/tests/test_onboarding_registration.py
+++ b/tests/test_onboarding_registration.py
@@ -341,3 +341,120 @@ async def test_apply_onboarding_locales_from_country_sets_profile_and_tenant():
     assert locale_co == "es"
     assert conn.execute.await_args_list[0].args[2] == "es"
     assert conn.execute.await_args_list[1].args[2] == "es"
+
+
+@pytest.mark.asyncio
+async def test_financial_profile_create_applies_locales_from_country():
+    """Wiring: first financial apply awaits locale helper with owner + country."""
+    from app.models.onboarding import OnboardingBusinessProfileUpdate
+    from app.services.onboarding_service import update_onboarding_financial_profile
+
+    tenant_id = uuid4()
+    owner_id = uuid4()
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        {
+            "lifecycle_status": "pending",
+            "state": "business_profile_pending",
+            "business_name": "Negocio pendiente",
+            "owner_user_id": owner_id,
+        },
+        {
+            "profile_tenant_id": tenant_id,
+            "country_code": "CO",
+            "base_currency_code": "COP",
+            "accounting_localization": "WARO_CO_PUC_V1",
+            "document_mode": "fiscal_integrated",
+            "fiscal_provider": "matias",
+            "selection_revision": 1,
+            "profile_created_at": None,
+            "profile_updated_at": None,
+        },
+        {"state": "starter_active"},
+    ])
+    conn.execute = AsyncMock(return_value="OK")
+
+    apply_locales = AsyncMock(return_value="es")
+    with patch(
+        "app.services.onboarding_service.financial_service.seed_tenant_accounts",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.onboarding_service.ensure_wave1_tax_pack",
+        new=AsyncMock(),
+    ), patch(
+        "app.services.onboarding_service.seed_tenant_timezone_from_country",
+        new=AsyncMock(return_value="America/Bogota"),
+    ), patch(
+        "app.services.onboarding_service.apply_onboarding_locales_from_country",
+        new=apply_locales,
+    ), patch(
+        "app.services.onboarding_service._promote_onboarding_identity",
+        new=AsyncMock(return_value="starter_active"),
+    ):
+        await update_onboarding_financial_profile(
+            conn,
+            tenant_id,
+            OnboardingBusinessProfileUpdate(
+                business_name="Cafe Central",
+                country_code="CO",
+                base_currency_code="COP",
+            ),
+        )
+
+    apply_locales.assert_awaited_once_with(
+        conn,
+        tenant_id=tenant_id,
+        country_code="CO",
+        user_id=owner_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_starter_active_idempotent_skips_locale_rewrite():
+    """Idempotent financial retry must not re-apply locales."""
+    from app.models.onboarding import OnboardingBusinessProfileUpdate
+    from app.services.onboarding_service import update_onboarding_financial_profile
+
+    tenant_id = uuid4()
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(side_effect=[
+        {
+            "lifecycle_status": "active",
+            "state": "starter_active",
+            "business_name": "Cafe Central",
+            "owner_user_id": uuid4(),
+        },
+        {
+            "profile_tenant_id": tenant_id,
+            "country_code": "US",
+            "base_currency_code": "USD",
+            "accounting_localization": "WARO_HOSPITALITY_GLOBAL_V1",
+            "document_mode": "waro_commercial",
+            "fiscal_provider": None,
+            "selection_revision": 4,
+            "profile_created_at": None,
+            "profile_updated_at": None,
+        },
+        {"state": "starter_active"},
+    ])
+    conn.execute = AsyncMock(side_effect=["UPDATE 1", "UPDATE 1"])
+
+    apply_locales = AsyncMock(return_value="en")
+    with patch(
+        "app.services.onboarding_service.apply_onboarding_locales_from_country",
+        new=apply_locales,
+    ):
+        result = await update_onboarding_financial_profile(
+            conn,
+            tenant_id,
+            OnboardingBusinessProfileUpdate(
+                business_name="Cafe Central",
+                country_code="US",
+                base_currency_code="USD",
+                tax_jurisdiction_code="US-FL",
+            ),
+        )
+
+    assert result.data.profile.selection_revision == 4
+    apply_locales.assert_not_awaited()
+    assert conn.execute.await_count == 2


### PR DESCRIPTION
## Summary
- Add shared country→UI locale map (`CO/MX/…→es`, `US→en`, `BR→pt`, else `es`).
- On onboarding financial apply, persist `profile.preferred_locale` and `tenant_public_profiles.ui_locale` together.
- API is authoritative; clients do not send preferred_locale.

Refs uno0uno/warocol.com#2103

## Test plan
- [ ] Register US → profile+tenant `en`
- [ ] Register CO → both `es`
- [ ] Confirm financial country/currency validation unchanged

## Validation evidence
```text
venv/bin/pytest tests/test_country_locale.py tests/test_onboarding_registration.py -q
collected 11 items
tests/test_country_locale.py ..                                          [ 18%]
tests/test_onboarding_registration.py .........                          [100%]
11 passed in 0.16s
```

Made with [Cursor](https://cursor.com)