### PR TITLE
feat(auth): platform superuser emails via env without member seats

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -161,6 +161,9 @@ class Settings(BaseSettings):
     facturador_legal_city: str = Field(default='', alias='FACTURADOR_LEGAL_CITY')
     facturador_legal_support_email: str = Field(default='', alias='FACTURADOR_LEGAL_SUPPORT_EMAIL')
 
+    # Platform operators — effective superuser on all tenants without tenant_members
+    platform_superuser_emails: str = Field(default='', alias='PLATFORM_SUPERUSER_EMAILS')
+
     class Config:
         env_file = ".env"
         extra = "ignore"  # Ignore extra environment variables

--- a/app/core/platform_superusers.py
+++ b/app/core/platform_superusers.py
@@ -1,0 +1,46 @@
+"""Platform superuser allowlist from env (no tenant_members required)."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import FrozenSet, Optional
+
+from app.core.email_utils import normalize_email
+
+
+def parse_platform_superuser_emails(raw: Optional[str]) -> FrozenSet[str]:
+    """Parse comma-separated PLATFORM_SUPERUSER_EMAILS into normalized emails."""
+    if not raw or not str(raw).strip():
+        return frozenset()
+    return frozenset(
+        normalize_email(part)
+        for part in str(raw).split(",")
+        if part.strip()
+    )
+
+
+@lru_cache(maxsize=1)
+def _allowlist_from_settings() -> FrozenSet[str]:
+    from app.config import settings
+
+    return parse_platform_superuser_emails(settings.platform_superuser_emails)
+
+
+def clear_platform_superuser_cache() -> None:
+    """Test helper — drop cached allowlist after monkeypatching settings."""
+    _allowlist_from_settings.cache_clear()
+
+
+def platform_superuser_emails() -> FrozenSet[str]:
+    return _allowlist_from_settings()
+
+
+def is_platform_superuser_email(email: Optional[str]) -> bool:
+    if not email:
+        return False
+    return normalize_email(email) in platform_superuser_emails()
+
+
+def platform_superuser_email_list() -> list[str]:
+    """Sorted list for SQL ``<> ALL($n::text[])`` bindings."""
+    return sorted(platform_superuser_emails())

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -8,6 +8,7 @@ from fastapi import Request, HTTPException, Response
 from app.config import settings
 from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES, is_legacy_internal_team_role
 from app.core.onboarding_access import next_step_for_state
+from app.core.platform_superusers import is_platform_superuser_email
 from typing import List, Optional
 
 logger = logging.getLogger(__name__)
@@ -409,7 +410,10 @@ async def get_session_from_request(request: Request) -> Optional[dict]:
                 return None
 
             resolved_role = session_result['role']
-            if resolved_role is not None and not is_legacy_internal_team_role(resolved_role):
+            if is_platform_superuser_email(session_result.get('email')):
+                # Env allowlist elevates without a tenant_members row.
+                resolved_role = 'superuser'
+            elif resolved_role is not None and not is_legacy_internal_team_role(resolved_role):
                 await conn.execute("""
                     UPDATE sessions
                     SET is_active = false,

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -120,27 +120,27 @@ async def get_session_data(request: Request, response: Response) -> SessionRespo
                 )
                 if role_result:
                     user_role = role_result['role']
-                    if not is_legacy_internal_team_role(user_role):
-                        await conn.execute(
-                            """
-                            UPDATE sessions
-                            SET is_active = false,
-                                ended_at = NOW(),
-                                end_reason = 'customer_role_denied'
-                            WHERE id = $1 AND is_active = true
-                            """,
-                            session_token,
-                        )
-                        await clear_session_cookie(response, session_token)
-                        logger.warning(
-                            "Denied /auth/session for non-team role %s on session %s",
-                            user_role,
-                            session_token[:8],
-                        )
-                        raise AuthenticationError("Access denied")
 
             if is_platform_superuser_email(session_result.get('email')):
                 user_role = 'superuser'
+            elif user_role is not None and not is_legacy_internal_team_role(user_role):
+                await conn.execute(
+                    """
+                    UPDATE sessions
+                    SET is_active = false,
+                        ended_at = NOW(),
+                        end_reason = 'customer_role_denied'
+                    WHERE id = $1 AND is_active = true
+                    """,
+                    session_token,
+                )
+                await clear_session_cookie(response, session_token)
+                logger.warning(
+                    "Denied /auth/session for non-team role %s on session %s",
+                    user_role,
+                    session_token[:8],
+                )
+                raise AuthenticationError("Access denied")
 
             # Build response models
             user = ProfileUser(

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -10,6 +10,7 @@ from app.core.exceptions import AuthenticationError
 from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES, is_legacy_internal_team_role
 from app.core.onboarding_access import next_step_for_state
 from app.core.middleware import require_valid_session
+from app.core.platform_superusers import is_platform_superuser_email
 from app.models.auth import (
     ProfileAvatarResponse,
     ProfileUser,
@@ -138,6 +139,9 @@ async def get_session_data(request: Request, response: Response) -> SessionRespo
                         )
                         raise AuthenticationError("Access denied")
 
+            if is_platform_superuser_email(session_result.get('email')):
+                user_role = 'superuser'
+
             # Build response models
             user = ProfileUser(
                 id=session_result['user_id'],
@@ -192,7 +196,8 @@ async def switch_tenant(request: Request, response: Response, tenant_slug: str) 
         session_context = require_valid_session(request)
         current_session_token = await get_session_token(request)
         if not is_legacy_internal_team_role(session_context.role):
-            raise AuthenticationError("Access denied to this tenant")
+            if not is_platform_superuser_email(session_context.email):
+                raise AuthenticationError("Access denied to this tenant")
         
         # Get the target site from encrypted origin header
         target_site = None
@@ -255,28 +260,40 @@ async def switch_tenant(request: Request, response: Response, tenant_slug: str) 
             # The `tm.is_active = true` filter is load-bearing: without it,
             # soft-deleted (terminated) members can switch back to a tenant
             # they were removed from. See docs/permissions-router-mapping.md §9.
-            tenant_access_query = """
-                SELECT t.id, t.name, t.slug, ts.site
-                FROM tenants t
-                INNER JOIN tenant_members tm ON t.id = tm.tenant_id
-                LEFT JOIN tenant_sites ts ON t.id = ts.tenant_id AND ts.is_active = true
-                WHERE t.slug = $1
-                  AND tm.user_id = $2
-                  AND tm.is_active = true
-                  AND tm.role = ANY($3::text[])
-                LIMIT 1
-            """
-            tenant_access_result = await conn.fetchrow(
-                tenant_access_query,
-                tenant_slug,
-                user_id,
-                list(LEGACY_INTERNAL_TEAM_ROLES),
-            )
-            
+            # Platform allowlist may switch without a membership row.
+            if is_platform_superuser_email(session_context.email):
+                tenant_access_result = await conn.fetchrow(
+                    """
+                    SELECT t.id, t.name, t.slug, ts.site
+                    FROM tenants t
+                    LEFT JOIN tenant_sites ts ON t.id = ts.tenant_id AND ts.is_active = true
+                    WHERE t.slug = $1
+                    LIMIT 1
+                    """,
+                    tenant_slug,
+                )
+            else:
+                tenant_access_result = await conn.fetchrow(
+                    """
+                    SELECT t.id, t.name, t.slug, ts.site
+                    FROM tenants t
+                    INNER JOIN tenant_members tm ON t.id = tm.tenant_id
+                    LEFT JOIN tenant_sites ts ON t.id = ts.tenant_id AND ts.is_active = true
+                    WHERE t.slug = $1
+                      AND tm.user_id = $2
+                      AND tm.is_active = true
+                      AND tm.role = ANY($3::text[])
+                    LIMIT 1
+                    """,
+                    tenant_slug,
+                    user_id,
+                    list(LEGACY_INTERNAL_TEAM_ROLES),
+                )
+
             if not tenant_access_result:
                 logger.warning(f"Access denied to tenant {tenant_slug} for user {user_id}")
                 raise AuthenticationError("Access denied to this tenant")
-            
+
             tenant_id = tenant_access_result['id']
             tenant_name = tenant_access_result['name']
             tenant_site = tenant_access_result['site']

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -1139,15 +1139,23 @@ async def _count_quota_resource_usage(
     exclude_pending_invitation_id: Optional[UUID] = None,
 ) -> int:
     if resource == "admin_users":
+        from app.core.platform_superusers import platform_superuser_email_list
+
+        allowlist = platform_superuser_email_list()
         value = await conn.fetchval(
             """
             SELECT
                 (
                     SELECT COUNT(DISTINCT tm.id)
                     FROM tenant_members tm
+                    INNER JOIN profile p ON p.id = tm.user_id
                     WHERE tm.tenant_id = $1
                       AND tm.is_active
                       AND tm.role = ANY($2::text[])
+                      AND (
+                        cardinality($4::text[]) = 0
+                        OR lower(trim(p.email)) <> ALL($4::text[])
+                      )
                 )
                 +
                 (
@@ -1157,11 +1165,16 @@ async def _count_quota_resource_usage(
                       AND ti.status = 'pending'
                       AND ti.role = ANY($2::text[])
                       AND NOT ($3::uuid IS NOT NULL AND ti.id = $3)
+                      AND (
+                        cardinality($4::text[]) = 0
+                        OR lower(trim(ti.email)) <> ALL($4::text[])
+                      )
                 )
             """,
             tenant_id,
             list(LEGACY_INTERNAL_TEAM_ROLES),
             exclude_pending_invitation_id,
+            allowlist,
         )
     elif resource == "active_kitchens":
         value = await conn.fetchval(

--- a/app/services/magic_link_service.py
+++ b/app/services/magic_link_service.py
@@ -14,6 +14,7 @@ from app.core.exceptions import AuthenticationError, ValidationError
 from app.core.email_utils import normalize_email
 from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
 from app.core.onboarding_access import next_step_for_state
+from app.core.platform_superusers import is_platform_superuser_email
 from app.models.auth import (
     MagicLinkResponse,
     RegistrationAttribution,
@@ -63,6 +64,62 @@ async def _lookup_internal_team_member(conn, email: str) -> Optional[Any]:
         email,
         list(LEGACY_INTERNAL_TEAM_ROLES),
     )
+
+
+async def _lookup_platform_superuser(conn, email: str, tenant_id: UUID) -> Optional[Any]:
+    """Resolve env allowlisted operator without a tenant_members row."""
+    if not is_platform_superuser_email(email) or not tenant_id:
+        return None
+    return await conn.fetchrow(
+        """
+        SELECT p.id as user_id, p.email, p.name,
+               'superuser'::text AS role,
+               $2::uuid AS tenant_id,
+               COALESCE(t.lifecycle_status, 'active') AS lifecycle_status,
+               o.state AS onboarding_state
+        FROM profile p
+        LEFT JOIN tenants t ON t.id = $2
+        LEFT JOIN tenant_onboarding o
+          ON o.tenant_id = t.id AND o.owner_user_id = p.id
+        WHERE lower(trim(p.email)) = $1
+        LIMIT 1
+        """,
+        email,
+        tenant_id,
+    )
+
+
+_PLATFORM_VERIFY_BY_CODE = """
+    SELECT mt.*, p.email, p.name, p.id as user_id, p.created_at as user_created_at,
+           'superuser'::text AS user_role,
+           COALESCE(t.lifecycle_status, 'active') AS lifecycle_status,
+           o.state AS onboarding_state, o.email_verified_at
+    FROM magic_tokens mt
+    JOIN profile p ON mt.user_id = p.id
+    INNER JOIN tenants t ON t.id = mt.tenant_id
+    LEFT JOIN tenant_onboarding o
+      ON o.tenant_id = t.id AND o.owner_user_id = p.id
+    WHERE lower(trim(p.email)) = $1 AND mt.verification_code = $2
+      AND mt.expires_at > NOW() AND mt.used = false
+      AND mt.purpose = 'login'
+    LIMIT 1
+"""
+
+_PLATFORM_VERIFY_BY_TOKEN = """
+    SELECT mt.*, p.email, p.name, p.id as user_id, p.created_at as user_created_at,
+           'superuser'::text AS user_role,
+           COALESCE(t.lifecycle_status, 'active') AS lifecycle_status,
+           o.state AS onboarding_state, o.email_verified_at
+    FROM magic_tokens mt
+    JOIN profile p ON mt.user_id = p.id
+    INNER JOIN tenants t ON t.id = mt.tenant_id
+    LEFT JOIN tenant_onboarding o
+      ON o.tenant_id = t.id AND o.owner_user_id = p.id
+    WHERE lower(trim(p.email)) = $1 AND mt.token = $2
+      AND mt.expires_at > NOW() AND mt.used = false
+      AND mt.purpose = 'login'
+    LIMIT 1
+"""
 
 
 async def _tenant_email_branding(conn, tenant_id: UUID) -> dict[str, str]:
@@ -255,6 +312,10 @@ async def send_magic_link(request: Request, email: str, redirect: Optional[str] 
         async with get_db_connection() as conn:
             user_result = await _lookup_internal_team_member(conn, email)
             if not user_result:
+                user_result = await _lookup_platform_superuser(
+                    conn, email, tenant_context.tenant_id
+                )
+            if not user_result:
                 registration_draft = await get_resumable_registration_draft(conn, email)
             else:
                 registration_draft = None
@@ -407,6 +468,12 @@ async def verify_code(request: Request, response: Response, email: str, code: st
                 code,
                 list(LEGACY_INTERNAL_TEAM_ROLES),
             )
+            if not token_data and is_platform_superuser_email(email):
+                token_data = await conn.fetchrow(
+                    _PLATFORM_VERIFY_BY_CODE,
+                    email,
+                    code,
+                )
             
             if not token_data:
                 registration = await _complete_registration_login(
@@ -563,6 +630,12 @@ async def verify_token(request: Request, response: Response, email: str, token: 
                 token,
                 list(LEGACY_INTERNAL_TEAM_ROLES),
             )
+            if not token_data and is_platform_superuser_email(email):
+                token_data = await conn.fetchrow(
+                    _PLATFORM_VERIFY_BY_TOKEN,
+                    email,
+                    token,
+                )
             
             if not token_data:
                 registration = await _complete_registration_login(

--- a/app/services/salary_service.py
+++ b/app/services/salary_service.py
@@ -12,6 +12,7 @@ from datetime import datetime, date
 from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import ValidationError, NotFoundError
+from app.core.platform_superusers import platform_superuser_email_list
 from app.services.aws_s3_service import AWSS3Service
 from app.services.account_role_service import (
     AccountRole,
@@ -525,6 +526,7 @@ async def get_employees_with_salary(request: Request) -> EmployeesWithSalaryResp
         current_period = datetime.now().strftime('%Y-%m')
 
         # Get employees with salary config and last payment
+        allowlist = platform_superuser_email_list()
         query = """
             SELECT
                 tm.id,
@@ -556,10 +558,14 @@ async def get_employees_with_salary(request: Request) -> EmployeesWithSalaryResp
                 AND es.period_month = $2
             WHERE tm.tenant_id = $1
                 AND tm.role != 'customer'
+                AND (
+                  cardinality($3::text[]) = 0
+                  OR lower(trim(p.email)) <> ALL($3::text[])
+                )
             ORDER BY p.name
         """
 
-        rows = await conn.fetch(query, tenant_id, current_period)
+        rows = await conn.fetch(query, tenant_id, current_period, allowlist)
 
         employees = []
         for row in rows:

--- a/app/services/tenants_service.py
+++ b/app/services/tenants_service.py
@@ -6,6 +6,10 @@ from app.database import get_db_connection
 from app.core.middleware import require_valid_session
 from app.core.exceptions import AuthenticationError, AuthorizationError, ValidationError
 from app.core.internal_roles import LEGACY_INTERNAL_TEAM_ROLES
+from app.core.platform_superusers import (
+    is_platform_superuser_email,
+    platform_superuser_email_list,
+)
 from app.models.auth import Tenant, UserTenantsResponse
 from app.models.tenant import (
     TenantMembersResponse, TenantMemberDetail, TenantMemberProfile,
@@ -38,6 +42,27 @@ _USER_TENANTS_QUERY_WITHOUT_UI_LOCALE = _USER_TENANTS_QUERY.replace(
     "",
 )
 
+_PLATFORM_ALL_TENANTS_QUERY = """
+    SELECT DISTINCT
+      t.id,
+      t.name,
+      t.slug,
+      tpp.ui_locale
+    FROM tenants t
+    LEFT JOIN tenant_public_profiles tpp ON tpp.tenant_id = t.id
+    ORDER BY t.name
+"""
+
+_PLATFORM_ALL_TENANTS_QUERY_WITHOUT_UI_LOCALE = """
+    SELECT DISTINCT
+      t.id,
+      t.name,
+      t.slug,
+      NULL AS ui_locale
+    FROM tenants t
+    ORDER BY t.name
+"""
+
 async def get_user_tenants(request: Request) -> UserTenantsResponse:
     """
     Get tenants associated with the current user from session
@@ -49,25 +74,31 @@ async def get_user_tenants(request: Request) -> UserTenantsResponse:
         
         
         async with get_db_connection(use_transaction=False) as conn:
-            # Get tenants where the user has an ACTIVE membership (#201).
+            # Platform allowlist sees every tenant; others only ACTIVE memberships (#201).
             # Terminated members keep their row with the old role; without the
             # is_active filter, the sidebar tenant switcher shows tenants the
             # user can't actually access. See docs/permissions-router-mapping.md §9.
             try:
-                tenant_rows = await conn.fetch(
-                    _USER_TENANTS_QUERY,
-                    user_id,
-                    list(LEGACY_INTERNAL_TEAM_ROLES),
-                )
+                if is_platform_superuser_email(session_context.email):
+                    tenant_rows = await conn.fetch(_PLATFORM_ALL_TENANTS_QUERY)
+                else:
+                    tenant_rows = await conn.fetch(
+                        _USER_TENANTS_QUERY,
+                        user_id,
+                        list(LEGACY_INTERNAL_TEAM_ROLES),
+                    )
             except asyncpg.UndefinedColumnError:
                 logger.warning(
                     "tenant_public_profiles.ui_locale missing; returning es until migration 100"
                 )
-                tenant_rows = await conn.fetch(
-                    _USER_TENANTS_QUERY_WITHOUT_UI_LOCALE,
-                    user_id,
-                    list(LEGACY_INTERNAL_TEAM_ROLES),
-                )
+                if is_platform_superuser_email(session_context.email):
+                    tenant_rows = await conn.fetch(_PLATFORM_ALL_TENANTS_QUERY_WITHOUT_UI_LOCALE)
+                else:
+                    tenant_rows = await conn.fetch(
+                        _USER_TENANTS_QUERY_WITHOUT_UI_LOCALE,
+                        user_id,
+                        list(LEGACY_INTERNAL_TEAM_ROLES),
+                    )
             
             
             # Convert to Tenant models
@@ -109,6 +140,8 @@ async def get_tenant_members(request: Request) -> TenantMembersResponse:
         async with get_db_connection() as conn:
             # Get tenant members with their profile information
             # Exclude 'customer' role - those are POS clients, not team members
+            # Exclude PLATFORM_SUPERUSER_EMAILS so operators never appear in Equipo
+            allowlist = platform_superuser_email_list()
             query = """
                 SELECT
                     tm.id,
@@ -124,6 +157,10 @@ async def get_tenant_members(request: Request) -> TenantMembersResponse:
                 INNER JOIN profile p ON tm.user_id = p.id
                 WHERE tm.tenant_id = $1
                   AND tm.role IN ('superuser', 'admin', 'employee', 'member', 'promotor')
+                  AND (
+                    cardinality($2::text[]) = 0
+                    OR lower(trim(p.email)) <> ALL($2::text[])
+                  )
                 ORDER BY
                     CASE tm.role
                         WHEN 'superuser' THEN 1
@@ -136,7 +173,7 @@ async def get_tenant_members(request: Request) -> TenantMembersResponse:
                     p.name, p.user_name
             """
 
-            member_rows = await conn.fetch(query, current_tenant_id)
+            member_rows = await conn.fetch(query, current_tenant_id, allowlist)
 
             # Convert to TenantMemberDetail models
             members = []
@@ -168,9 +205,13 @@ async def get_tenant_members(request: Request) -> TenantMembersResponse:
                 LEFT JOIN profile p ON ti.user_id = p.id
                 LEFT JOIN profile inviter ON ti.invited_by = inviter.id
                 WHERE ti.tenant_id = $1 AND ti.status = 'pending'
+                  AND (
+                    cardinality($2::text[]) = 0
+                    OR lower(trim(ti.email)) <> ALL($2::text[])
+                  )
                 ORDER BY ti.expires_at DESC
             """
-            invitation_rows = await conn.fetch(invitations_query, current_tenant_id)
+            invitation_rows = await conn.fetch(invitations_query, current_tenant_id, allowlist)
 
             pending_invitations = [
                 PendingInvitation(

--- a/tests/test_platform_superusers.py
+++ b/tests/test_platform_superusers.py
@@ -65,11 +65,8 @@ def test_security_injects_superuser_role(monkeypatch):
     config_mod.settings = config_mod.Settings()
     clear_platform_superuser_cache()
 
-    from app.core.platform_superusers import is_platform_superuser_email
-
-    row_email = "ops@warocol.com"
     resolved_role = None
-    if is_platform_superuser_email(row_email):
+    if is_platform_superuser_email("ops@warocol.com"):
         resolved_role = "superuser"
     assert resolved_role == "superuser"
 
@@ -77,6 +74,31 @@ def test_security_injects_superuser_role(monkeypatch):
     if is_platform_superuser_email("normal@warocol.com"):
         resolved_role = "superuser"
     assert resolved_role == "admin"
+
+
+def test_platform_overrides_customer_before_denial(monkeypatch):
+    """Match get_session_data / security ordering: allowlist before customer deny."""
+    monkeypatch.setenv("PLATFORM_SUPERUSER_EMAILS", "ops@warocol.com")
+    import app.config as config_mod
+
+    config_mod.settings = config_mod.Settings()
+    clear_platform_superuser_cache()
+
+    from app.core.internal_roles import is_legacy_internal_team_role
+
+    def resolve(email: str, membership_role: str | None) -> str:
+        role = membership_role
+        if is_platform_superuser_email(email):
+            return "superuser"
+        if role is not None and not is_legacy_internal_team_role(role):
+            return "DENIED"
+        return role  # type: ignore[return-value]
+
+    assert resolve("ops@warocol.com", "customer") == "superuser"
+    assert resolve("ops@warocol.com", None) == "superuser"
+    assert resolve("normal@warocol.com", "customer") == "DENIED"
+    assert resolve("normal@warocol.com", "admin") == "admin"
+
 
 
 def test_members_exclusion_predicate():

--- a/tests/test_platform_superusers.py
+++ b/tests/test_platform_superusers.py
@@ -1,0 +1,105 @@
+"""Unit tests for PLATFORM_SUPERUSER_EMAILS allowlist (#776)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.platform_superusers import (
+    clear_platform_superuser_cache,
+    is_platform_superuser_email,
+    parse_platform_superuser_emails,
+    platform_superuser_email_list,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_platform_superuser_cache()
+    yield
+    clear_platform_superuser_cache()
+
+
+def test_parse_empty_env():
+    assert parse_platform_superuser_emails("") == frozenset()
+    assert parse_platform_superuser_emails(None) == frozenset()
+    assert parse_platform_superuser_emails("  ,  , ") == frozenset()
+
+
+def test_parse_comma_separated_case_insensitive():
+    emails = parse_platform_superuser_emails(
+        "Anderson.Electronico@gmail.com, other@WARO.CO "
+    )
+    assert emails == frozenset(
+        {"anderson.electronico@gmail.com", "other@waro.co"}
+    )
+
+
+def test_is_platform_superuser_email_reads_settings(monkeypatch):
+    import app.config as config_mod
+
+    monkeypatch.setenv(
+        "PLATFORM_SUPERUSER_EMAILS",
+        "anderson.electronico@gmail.com",
+    )
+    config_mod.settings = config_mod.Settings()
+    clear_platform_superuser_cache()
+
+    assert is_platform_superuser_email("Anderson.Electronico@gmail.com") is True
+    assert is_platform_superuser_email("someone.else@example.com") is False
+    assert platform_superuser_email_list() == ["anderson.electronico@gmail.com"]
+
+    monkeypatch.setenv("PLATFORM_SUPERUSER_EMAILS", "")
+    config_mod.settings = config_mod.Settings()
+    clear_platform_superuser_cache()
+    assert is_platform_superuser_email("anderson.electronico@gmail.com") is False
+
+
+def test_security_injects_superuser_role(monkeypatch):
+    """Allowlisted email gets effective superuser even when JOIN role is None."""
+    monkeypatch.setenv(
+        "PLATFORM_SUPERUSER_EMAILS",
+        "ops@warocol.com",
+    )
+    import app.config as config_mod
+
+    config_mod.settings = config_mod.Settings()
+    clear_platform_superuser_cache()
+
+    from app.core.platform_superusers import is_platform_superuser_email
+
+    row_email = "ops@warocol.com"
+    resolved_role = None
+    if is_platform_superuser_email(row_email):
+        resolved_role = "superuser"
+    assert resolved_role == "superuser"
+
+    resolved_role = "admin"
+    if is_platform_superuser_email("normal@warocol.com"):
+        resolved_role = "superuser"
+    assert resolved_role == "admin"
+
+
+def test_members_exclusion_predicate():
+    """Mirrors SQL: empty allowlist keeps everyone; match drops platform emails."""
+    allowlist = platform_superuser_email_list()
+    # empty by default in this process unless env set
+    assert allowlist == [] or isinstance(allowlist, list)
+
+    allowlist = ["anderson.electronico@gmail.com"]
+    members = [
+        {"email": "anderson.electronico@gmail.com"},
+        {"email": "chef@restaurant.com"},
+    ]
+    kept = [
+        m
+        for m in members
+        if not allowlist or m["email"].lower().strip() not in allowlist
+    ]
+    assert [m["email"] for m in kept] == ["chef@restaurant.com"]
+
+
+def test_quota_exclusion_predicate():
+    allowlist = {"ops@warocol.com"}
+    member_emails = ["ops@warocol.com", "admin@tenant.com"]
+    counted = [e for e in member_emails if e not in allowlist]
+    assert counted == ["admin@tenant.com"]


### PR DESCRIPTION
## Summary
- Adds `PLATFORM_SUPERUSER_EMAILS` allowlist so operators get effective `superuser` on any tenant without `tenant_members` rows
- Excludes allowlisted emails from Equipo members/salary listings and `admin_users` quota counts
- Enables login, tenant list, and switch-tenant without membership for allowlisted profiles

## Test plan
- [ ] Set `PLATFORM_SUPERUSER_EMAILS=anderson.electronico@gmail.com` and restart API
- [ ] Log in without a membership row → session role is `superuser`
- [ ] Confirm user absent from Equipo members and salary employee lists
- [ ] Confirm `admin_users` quota does not count that email
- [ ] Remove email from env → privilege revoked; other users unchanged
- [ ] `venv/bin/pytest tests/test_platform_superusers.py -q`

Closes #776

Made with [Cursor](https://cursor.com)