### PR TITLE
fix(purchases): include paid direct credit rows for Pagos

### DIFF
--- a/app/routers/purchases.py
+++ b/app/routers/purchases.py
@@ -383,7 +383,7 @@ async def get_purchases_endpoint(
     date_filter: Optional[str] = Query(default=None, description="Filter by date range (today, yesterday, last_week, 15_days, 1_month, 3_months)"),
     include_direct_payables: bool = Query(
         default=False,
-        description="When true, also return unpaid direct purchases (crédito/received) for Pagos",
+        description="When true, also return direct credit purchases for Pagos (unpaid received + paid settlements; excludes contado)",
     ),
 ):
     """

--- a/app/services/purchases_service.py
+++ b/app/services/purchases_service.py
@@ -24,14 +24,17 @@ from app.services.email_helpers import send_quotation_email
 from app.services.gemini_service import process_invoice
 from app.services.ingredients_service import match_ingredient_by_name
 
-# Unpaid direct (crédito) payables for Pagos — see warocol.com#2110 / epic #2109.
+# Direct credit payables for Pagos — unpaid received + paid settlements (not contado).
+# See warocol.com#2110 / #2111 / epic #2109.
 _DIRECT_PAYABLES_SQL = """(
                     (tp.is_direct_entry = FALSE OR tp.is_direct_entry IS NULL)
                     OR (
                         tp.is_direct_entry = TRUE
-                        AND tp.paid_at IS NULL
-                        AND tp.status = 'received'
                         AND lower(COALESCE(tp.payment_type, '')) IS DISTINCT FROM 'contado'
+                        AND (
+                            (tp.paid_at IS NULL AND tp.status = 'received')
+                            OR tp.paid_at IS NOT NULL
+                        )
                     )
                 )"""
 
@@ -57,11 +60,11 @@ def row_matches_purchases_list_scope(
         return not is_direct
     if not is_direct:
         return True
-    return (
-        paid_at is None
-        and status == "received"
-        and (payment_type or "").strip().lower() != "contado"
-    )
+    if (payment_type or "").strip().lower() == "contado":
+        return False
+    if paid_at is None:
+        return status == "received"
+    return True
 
 
 async def get_purchases_list(

--- a/tests/test_direct_payables_list.py
+++ b/tests/test_direct_payables_list.py
@@ -1,4 +1,4 @@
-"""Unpaid direct payables list scoping for Pagos (#2110 / epic #2109)."""
+"""Direct credit payables list scoping for Pagos (#2110 / #2111 / epic #2109)."""
 
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
@@ -43,10 +43,11 @@ def test_default_list_excludes_directs():
     assert "paid_at IS NULL" not in clause
 
 
-def test_include_direct_payables_allows_unpaid_received_non_contado():
+def test_include_direct_payables_allows_unpaid_and_paid_non_contado():
     clause = direct_entry_list_clause(True)
     assert clause == _DIRECT_PAYABLES_SQL
     assert "paid_at IS NULL" in clause
+    assert "paid_at IS NOT NULL" in clause
     assert "status = 'received'" in clause
     assert "IS DISTINCT FROM 'contado'" in clause
 
@@ -62,10 +63,15 @@ def test_scope_matrix_default_excludes_all_directs():
     )
 
 
-def test_scope_matrix_flag_includes_unpaid_direct_credito_only():
-    # unpaid direct crédito received → included
+def test_scope_matrix_flag_includes_direct_credito_pending_and_paid():
+    # unpaid direct crédito received → included (Pendientes)
     assert row_matches_purchases_list_scope(
         is_direct_entry=True, paid_at=None, status="received",
+        payment_type="credito", include_direct_payables=True,
+    )
+    # paid direct crédito → included (Pagadas)
+    assert row_matches_purchases_list_scope(
+        is_direct_entry=True, paid_at="2026-08-01", status="paid",
         payment_type="credito", include_direct_payables=True,
     )
     # paid contado direct → excluded
@@ -82,11 +88,6 @@ def test_scope_matrix_flag_includes_unpaid_direct_credito_only():
     assert row_matches_purchases_list_scope(
         is_direct_entry=False, paid_at=None, status="confirmed",
         payment_type="contado", include_direct_payables=True,
-    )
-    # already-paid direct crédito → excluded from list scope
-    assert not row_matches_purchases_list_scope(
-        is_direct_entry=True, paid_at="2026-08-01", status="paid",
-        payment_type="credito", include_direct_payables=True,
     )
 
 


### PR DESCRIPTION
## Summary
- Expand `include_direct_payables` to return paid non-contado directs (Pagadas) as well as unpaid received credit directs (Pendientes).
- Contado directs stay excluded; default flag still false for abastecimiento lists.

Refs uno0uno/warocol.com#2111  
Refs uno0uno/warocol.com#2109

## Test plan
- [ ] Flag false → no directs
- [ ] Flag true unpaid credit received → list
- [ ] Flag true after pay → still listed (paid_at set)
- [ ] Contado directs never listed with flag

## Validation evidence
```
venv/bin/pytest tests/test_direct_payables_list.py -q
collected 7 items
.......                               [100%]
7 passed in 0.04s
```

Made with [Cursor](https://cursor.com)