### PR TITLE
feat(expenses): credit payables create, settle, and Pagos feed

### DIFF
--- a/app/models/expense.py
+++ b/app/models/expense.py
@@ -67,6 +67,7 @@ class ExpenseBase(BaseModel):
     recurring_end_date: Optional[date] = Field(None, alias='recurringEndDate')
     payment_method: Optional[str] = Field('cash', alias='paymentMethod')
     payment_method_id: Optional[str] = Field(None, alias='paymentMethodId')
+    payment_type: Optional[str] = Field('contado', alias='paymentType')  # contado | credito
     expense_type: Optional[ExpenseType] = Field(None, alias='expenseType')
 
     class Config:
@@ -86,6 +87,7 @@ class ExpenseUpdate(BaseModel):
     recurring_end_date: Optional[date] = Field(None, alias='recurringEndDate')
     payment_method: Optional[str] = Field(None, alias='paymentMethod')
     payment_method_id: Optional[str] = Field(None, alias='paymentMethodId')
+    payment_type: Optional[str] = Field(None, alias='paymentType')
     expense_type: Optional[ExpenseType] = Field(None, alias='expenseType')
 
     class Config:
@@ -99,6 +101,7 @@ class Expense(ExpenseBase):
     source_system: Optional[str] = Field(None, alias='sourceSystem')
     expense_number: Optional[str] = Field(None, alias='expenseNumber')
     created_at: datetime = Field(alias='createdAt')
+    paid_at: Optional[datetime] = Field(None, alias='paidAt')
     category: Optional[ExpenseCategory] = None
     attachments: Optional[List[Dict[str, Any]]] = Field(default_factory=list)
 

--- a/app/routers/expenses.py
+++ b/app/routers/expenses.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, APIRouter, Request, Response, Query, File, UploadFile
+from fastapi import Depends, APIRouter, Request, Response, Query, File, UploadFile, Form
 from app.core.permissions import Module, require_module
 from uuid import UUID
 from typing import Optional, List
@@ -6,6 +6,8 @@ from app.services.expenses_service import (
     get_expense_categories,
     get_expenses_list,
     get_expense_by_id,
+    get_expense_credit_payables,
+    pay_expense,
     delete_expense,
     get_expense_history,
     get_recurring_instances,
@@ -35,6 +37,15 @@ async def get_categories_endpoint(
     """
     return await get_expense_categories(request, response)
 
+@router.get("/payables", response_model=ExpensesListResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
+async def get_expense_payables_endpoint(
+    request: Request,
+    response: Response,
+    limit: int = Query(default=250, ge=1, le=250),
+):
+    """Unpaid credit expenses for Pagos hub (#2113)."""
+    return await get_expense_credit_payables(request, response, limit=limit)
+
 @router.get("", response_model=ExpensesListResponse, dependencies=[Depends(require_module(Module.FINANZAS))])
 async def get_expenses_endpoint(
     request: Request,
@@ -63,6 +74,31 @@ async def get_expense_by_id_endpoint(
     Get a single expense by ID with attachments
     """
     return await get_expense_by_id(request, response, expense_id)
+
+@router.post("/{expense_id}/pay", dependencies=[Depends(require_module(Module.FINANZAS))])
+async def pay_expense_endpoint(
+    expense_id: UUID,
+    request: Request,
+    response: Response,
+    payment_method: str = Form(...),
+    payment_method_id: Optional[UUID] = Form(None),
+    payment_reference: Optional[str] = Form(None),
+    payment_amount: Optional[float] = Form(None),
+    payment_date: Optional[str] = Form(None),
+    notes: Optional[str] = Form(None),
+):
+    """Settle unpaid credit expense (Pagos)."""
+    return await pay_expense(
+        request,
+        response,
+        expense_id,
+        payment_method=payment_method,
+        payment_method_id=payment_method_id,
+        payment_reference=payment_reference,
+        payment_amount=payment_amount,
+        payment_date=payment_date,
+        notes=notes,
+    )
 
 @router.post("/{expense_id}/attachments", dependencies=[Depends(require_module(Module.FINANZAS))])
 async def upload_expense_attachments_endpoint(

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -47,6 +47,7 @@ STARTER_OPERATIONAL_QUOTAS = {
     "active_open_cash_shifts": 1,
     "expenses_per_period": 30,
     "supplier_payments_per_period": 30,
+    "expense_payments_per_period": 30,
     "payment_methods": 5,
     "api_tokens": 0,
     "tenant_promotions": 1,
@@ -76,6 +77,7 @@ QUOTA_KEYS = (
     "active_open_cash_shifts",
     "expenses_per_period",
     "supplier_payments_per_period",
+    "expense_payments_per_period",
     "payment_methods",
     "api_tokens",
     "tenant_promotions",
@@ -105,6 +107,7 @@ BASE_OPERATIONAL_QUOTAS = {
     "active_open_cash_shifts": CATALOG_UNLIMITED,
     "expenses_per_period": CATALOG_UNLIMITED,
     "supplier_payments_per_period": CATALOG_UNLIMITED,
+    "expense_payments_per_period": CATALOG_UNLIMITED,
     "payment_methods": CATALOG_UNLIMITED,
     "api_tokens": CATALOG_UNLIMITED,
     "tenant_promotions": CATALOG_UNLIMITED,
@@ -159,6 +162,7 @@ PERIOD_QUOTA_RESOURCES = {
     "cash_closes_per_period",
     "expenses_per_period",
     "supplier_payments_per_period",
+    "expense_payments_per_period",
     "accounting_period_closes_per_period",
     "manual_journal_entries_per_period",
 }
@@ -705,6 +709,21 @@ async def _count_period_quota_usage(
             FROM tenant_purchases
             WHERE tenant_id = $1
               AND paid_at IS NOT NULL
+              AND paid_at >= $2
+              AND paid_at < $3
+            """,
+            tenant_id,
+            period_start,
+            period_end,
+        )
+    elif resource == "expense_payments_per_period":
+        value = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM tenant_expenses
+            WHERE tenant_id = $1
+              AND paid_at IS NOT NULL
+              AND lower(COALESCE(payment_type, '')) = 'credito'
               AND paid_at >= $2
               AND paid_at < $3
             """,
@@ -2327,6 +2346,15 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
             ) AS supplier_payments_per_period,
             (
                 SELECT COUNT(*)
+                FROM tenant_expenses te_paid
+                WHERE te_paid.tenant_id = $1
+                  AND te_paid.paid_at IS NOT NULL
+                  AND lower(COALESCE(te_paid.payment_type, '')) = 'credito'
+                  AND te_paid.paid_at >= $2
+                  AND te_paid.paid_at < $3
+            ) AS expense_payments_per_period,
+            (
+                SELECT COUNT(*)
                 FROM payment_methods pm
                 WHERE pm.tenant_id = $1
                   AND pm.is_active = TRUE
@@ -2468,6 +2496,10 @@ async def get_remaining_billing_usage(conn, tenant_id: UUID) -> Dict[str, Any]:
             "supplier_payments_per_period": metric(
                 int(quota_counts["supplier_payments_per_period"] or 0),
                 effective_quotas["supplier_payments_per_period"],
+            ),
+            "expense_payments_per_period": metric(
+                int(quota_counts.get("expense_payments_per_period") or 0),
+                effective_quotas["expense_payments_per_period"],
             ),
             "payment_methods": metric(
                 int(quota_counts["payment_methods"] or 0),

--- a/app/services/expenses_service.py
+++ b/app/services/expenses_service.py
@@ -1569,14 +1569,24 @@ async def update_expense(
                     transaction_date,
                     is_recurring,
                     frequency,
-                    recurring_end_date
+                    recurring_end_date,
+                    payment_type,
+                    paid_at
                 FROM tenant_expenses
                 WHERE id = $1 AND tenant_id = $2
             """, expense_id, tenant_id)
 
             if not old_expense:
                 raise HTTPException(status_code=404, detail="Expense not found")
-            
+
+            _old_ptype = (old_expense["payment_type"] if "payment_type" in old_expense.keys() else None) or "contado"
+            _old_paid = old_expense["paid_at"] if "paid_at" in old_expense.keys() else None
+            if _old_ptype == "credito" and _old_paid is not None:
+                raise HTTPException(
+                    status_code=409,
+                    detail="No se puede editar un gasto a crédito ya pagado",
+                )
+
             # Update expense with recurring fields
             await conn.execute("""
                 UPDATE tenant_expenses
@@ -1733,6 +1743,9 @@ async def update_expense(
                     e.frequency,
                     e.recurring_end_date,
                     e.payment_method,
+                    e.payment_method_id,
+                    e.payment_type,
+                    e.paid_at,
                     c.id as cat_id,
                     c.category_code,
                     c.category_name,
@@ -1765,15 +1778,18 @@ async def update_expense(
                 frequency=full_expense['frequency'],
                 recurringEndDate=full_expense['recurring_end_date'],
                 paymentMethod=full_expense['payment_method'],
+                paymentMethodId=full_expense['payment_method_id'] if 'payment_method_id' in full_expense.keys() else None,
+                paymentType=(full_expense['payment_type'] if 'payment_type' in full_expense.keys() else None) or 'contado',
+                paidAt=full_expense['paid_at'] if 'paid_at' in full_expense.keys() else None,
                 category=category
             )
 
-            # Update GL: void old entry + post new (graceful degrade)
+            # Update GL: void old entry + post new (contado soft-degrades; credit fails closed)
+            _ptype = (full_expense['payment_type'] if 'payment_type' in full_expense.keys() else None) or 'contado'
+            _pmid = full_expense['payment_method_id'] if 'payment_method_id' in full_expense.keys() else None
             try:
                 async with conn.transaction():
                     await _void_expense_gl_entry(conn, tenant_id, expense_id, "Gasto actualizado")
-                    _ptype = (full_expense['payment_type'] if 'payment_type' in full_expense.keys() else None) or 'contado'
-                    _pmid = full_expense['payment_method_id'] if 'payment_method_id' in full_expense.keys() else None
                     await _post_expense_gl_entry(
                         conn, tenant_id, expense_id,
                         float(full_expense['amount']),
@@ -1784,11 +1800,19 @@ async def update_expense(
                         payment_type=_ptype,
                         payment_method_id=UUID(_pmid) if _pmid else None,
                     )
+            except MissingAccountRoleError:
+                raise
+            except HTTPException:
+                raise
             except Exception as _gl_err:
+                if _ptype == "credito":
+                    raise
                 logger.warning(f"[GL] GL update failed for expense {expense_id}: {_gl_err}")
 
             return ExpenseResponse(data=expense)
 
+    except MissingAccountRoleError:
+        raise
     except AuthenticationError:
         raise
     except HTTPException:
@@ -1823,6 +1847,14 @@ async def update_expense_json(
 
             if not old_expense:
                 raise HTTPException(status_code=404, detail="Expense not found")
+
+            _old_ptype = (old_expense["payment_type"] if "payment_type" in old_expense.keys() else None) or "contado"
+            _old_paid = old_expense["paid_at"] if "paid_at" in old_expense.keys() else None
+            if _old_ptype == "credito" and _old_paid is not None:
+                raise HTTPException(
+                    status_code=409,
+                    detail="No se puede editar un gasto a crédito ya pagado",
+                )
 
             # Build update fields
             update_fields = []
@@ -1937,12 +1969,12 @@ async def update_expense_json(
                 category=category
             )
 
-            # Update GL: void old entry + post new (graceful degrade)
+            # Update GL: void old entry + post new (contado soft-degrades; credit fails closed)
+            _ptype = (full_expense['payment_type'] if 'payment_type' in full_expense.keys() else None) or 'contado'
+            _pmid = full_expense['payment_method_id'] if 'payment_method_id' in full_expense.keys() else None
             try:
                 async with conn.transaction():
                     await _void_expense_gl_entry(conn, tenant_id, expense_id, "Gasto actualizado")
-                    _ptype = (full_expense['payment_type'] if 'payment_type' in full_expense.keys() else None) or 'contado'
-                    _pmid = full_expense['payment_method_id'] if 'payment_method_id' in full_expense.keys() else None
                     await _post_expense_gl_entry(
                         conn, tenant_id, expense_id,
                         float(full_expense['amount']),
@@ -1953,11 +1985,19 @@ async def update_expense_json(
                         payment_type=_ptype,
                         payment_method_id=UUID(_pmid) if _pmid else None,
                     )
+            except MissingAccountRoleError:
+                raise
+            except HTTPException:
+                raise
             except Exception as _gl_err:
+                if _ptype == "credito":
+                    raise
                 logger.warning(f"[GL] GL update failed for expense {expense_id}: {_gl_err}")
 
             return ExpenseResponse(data=expense)
 
+    except MissingAccountRoleError:
+        raise
     except AuthenticationError:
         raise
     except HTTPException:

--- a/app/services/expenses_service.py
+++ b/app/services/expenses_service.py
@@ -252,6 +252,12 @@ async def _post_expense_gl_entry(
         tenant_id, period_year, period_month,
     )
     if closed:
+        msg = (
+            f"[GL] Period {period_year}-{period_month:02d} is closed — "
+            f"cannot post credit expense {expense_id}"
+        )
+        if is_credit:
+            raise HTTPException(status_code=409, detail=msg)
         logger.warning(
             f"[GL] Period {period_year}-{period_month:02d} is closed — "
             f"skip GL post for expense {expense_id}"
@@ -310,10 +316,9 @@ async def _post_expense_payment_gl_entry(
         """SELECT id
              FROM tenant_journal_entries
             WHERE tenant_id = $1
-              AND source_module = 'gastos'
+              AND source_module = 'gastos_payment'
               AND source_id = $2
               AND status = 'posted'
-              AND description LIKE 'Pago gasto%'
             LIMIT 1""",
         tenant_id,
         expense_id,
@@ -335,10 +340,13 @@ async def _post_expense_payment_gl_entry(
         period_month,
     )
     if closed:
-        logger.warning(
-            f"[GL] Period {period_year}-{period_month:02d} closed — skip expense payment GL for {expense_id}"
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"[GL] Period {period_year}-{period_month:02d} is closed — "
+                f"cannot settle expense {expense_id}"
+            ),
         )
-        return
 
     debit_acct = await resolve_account(
         conn, tenant_id, AccountRole.ACCOUNTS_PAYABLE, source="expense_payment"
@@ -357,7 +365,7 @@ async def _post_expense_payment_gl_entry(
                (tenant_id, entry_date, period_year, period_month,
                 description, source_module, source_id, status,
                 total_debit, total_credit, posted_at)
-           VALUES ($1, $2, $3, $4, $5, 'gastos', $6, 'posted', $7, $8, NOW())
+           VALUES ($1, $2, $3, $4, $5, 'gastos_payment', $6, 'posted', $7, $8, NOW())
            RETURNING id""",
             tenant_id,
             entry_date,
@@ -401,76 +409,79 @@ async def _void_expense_gl_entry(
     reason: str = "Gasto modificado o eliminado",
 ) -> None:
     """
-    Find and void the most recent posted GL entry for a gastos expense.
+    Void all posted GL entries for a gastos expense (create + settlement).
     Silently skips if no entry found (pre-#377 expense) or period is closed.
     Caller must wrap in try/except for graceful degrade.
     """
-    entry = await conn.fetchrow(
+    entries = await conn.fetch(
         """SELECT id, entry_date, period_year, period_month, description,
-                  total_debit, total_credit
+                  total_debit, total_credit, source_module
            FROM tenant_journal_entries
-           WHERE tenant_id = $1 AND source_module = 'gastos' AND source_id = $2
-                 AND status = 'posted'
-           ORDER BY created_at DESC
-           LIMIT 1""",
+           WHERE tenant_id = $1
+             AND source_id = $2
+             AND source_module IN ('gastos', 'gastos_payment')
+             AND status = 'posted'
+           ORDER BY created_at ASC""",
         tenant_id, expense_id,
     )
-    if not entry:
+    if not entries:
         logger.info(f"[GL] No posted GL entry for expense {expense_id} — skip void")
         return
 
-    closed = await conn.fetchval(
-        """SELECT 1 FROM tenant_monthly_periods
-           WHERE tenant_id = $1 AND year = $2 AND month = $3 AND status = 'closed'""",
-        tenant_id, entry['period_year'], entry['period_month'],
-    )
-    if closed:
-        logger.warning(
-            f"[GL] Period {entry['period_year']}-{entry['period_month']:02d} is closed — "
-            f"skip GL void for expense {expense_id}"
+    for entry in entries:
+        closed = await conn.fetchval(
+            """SELECT 1 FROM tenant_monthly_periods
+               WHERE tenant_id = $1 AND year = $2 AND month = $3 AND status = 'closed'""",
+            tenant_id, entry['period_year'], entry['period_month'],
         )
-        return
+        if closed:
+            logger.warning(
+                f"[GL] Period {entry['period_year']}-{entry['period_month']:02d} is closed — "
+                f"skip GL void for expense {expense_id} entry {entry['id']}"
+            )
+            continue
 
-    original_lines = await conn.fetch(
-        """SELECT account_id, debit, credit, description, line_order
-           FROM tenant_journal_lines
-           WHERE journal_entry_id = $1 ORDER BY line_order""",
-        entry['id'],
-    )
-
-    async with conn.transaction():
-        await conn.execute(
-            "UPDATE tenant_journal_entries SET status = 'voided', voided_at = NOW() WHERE id = $1",
+        original_lines = await conn.fetch(
+            """SELECT account_id, debit, credit, description, line_order
+               FROM tenant_journal_lines
+               WHERE journal_entry_id = $1 ORDER BY line_order""",
             entry['id'],
         )
 
-        rev_row = await conn.fetchrow(
-            """INSERT INTO tenant_journal_entries
-                   (tenant_id, entry_date, period_year, period_month,
-                    description, source_module, source_id, status,
-                    total_debit, total_credit, posted_at)
-               VALUES ($1, $2, $3, $4, $5, 'system', $6, 'posted', $7, $8, NOW())
-               RETURNING id""",
-            tenant_id, entry['entry_date'], entry['period_year'], entry['period_month'],
-            f"Reversión: {entry['description']} — {reason}",
-            entry['id'],
-            float(entry['total_debit']), float(entry['total_credit']),
-        )
-        rev_id = rev_row['id']
-
-        for line in original_lines:
+        async with conn.transaction():
             await conn.execute(
-                """INSERT INTO tenant_journal_lines
-                       (journal_entry_id, account_id, debit, credit, description, line_order)
-                   VALUES ($1, $2, $3, $4, $5, $6)""",
-                rev_id, line['account_id'],
-                float(line['credit']), float(line['debit']),
-                line['description'], line['line_order'],
+                "UPDATE tenant_journal_entries SET status = 'voided', voided_at = NOW() WHERE id = $1",
+                entry['id'],
             )
 
-    logger.info(
-        f"[GL] ✅ Voided GL entry {entry['id']} → reversing {rev_id} for expense {expense_id}"
-    )
+            rev_row = await conn.fetchrow(
+                """INSERT INTO tenant_journal_entries
+                       (tenant_id, entry_date, period_year, period_month,
+                        description, source_module, source_id, status,
+                        total_debit, total_credit, posted_at)
+                   VALUES ($1, $2, $3, $4, $5, 'system', $6, 'posted', $7, $8, NOW())
+                   RETURNING id""",
+                tenant_id, entry['entry_date'], entry['period_year'], entry['period_month'],
+                f"Reversión: {entry['description']} — {reason}",
+                entry['id'],
+                float(entry['total_debit']), float(entry['total_credit']),
+            )
+            rev_id = rev_row['id']
+
+            for line in original_lines:
+                await conn.execute(
+                    """INSERT INTO tenant_journal_lines
+                           (journal_entry_id, account_id, debit, credit, description, line_order)
+                       VALUES ($1, $2, $3, $4, $5, $6)""",
+                    rev_id, line['account_id'],
+                    float(line['credit'] or 0), float(line['debit'] or 0),
+                    line['description'], line['line_order'],
+                )
+
+        logger.info(
+            f"[GL] ✅ Voided GL entry {entry['id']} → reversing {rev_id} for expense {expense_id}"
+        )
+
 
 
 async def get_expense_categories(
@@ -1405,7 +1416,9 @@ async def pay_expense(
             payment_method,
             str(payment_method_id) if payment_method_id else None,
         )
-        amount = float(payment_amount) if payment_amount is not None else float(row["amount"])
+        amount = float(row["amount"])
+        if payment_amount is not None and abs(float(payment_amount) - amount) > 0.01:
+            raise HTTPException(status_code=400, detail="Partial expense payments are not supported")
         if payment_date:
             try:
                 payment_dt = datetime.fromisoformat(payment_date.replace("Z", "+00:00"))
@@ -1413,6 +1426,22 @@ async def pay_expense(
                 payment_dt = datetime.utcnow()
         else:
             payment_dt = datetime.utcnow()
+
+        try:
+            await _post_expense_payment_gl_entry(
+                conn=conn,
+                tenant_id=tenant_id,
+                expense_id=expense_id,
+                amount=amount,
+                payment_date=payment_dt,
+                description=f"Pago gasto {row['expense_number'] or expense_id}",
+                payment_method=method_slug,
+                payment_method_id=UUID(method_id) if method_id else None,
+            )
+        except MissingAccountRoleError:
+            raise
+        except HTTPException:
+            raise
 
         await conn.execute(
             """
@@ -1428,20 +1457,6 @@ async def pay_expense(
             method_slug,
             method_id,
         )
-
-        try:
-            await _post_expense_payment_gl_entry(
-                conn=conn,
-                tenant_id=tenant_id,
-                expense_id=expense_id,
-                amount=amount,
-                payment_date=payment_dt,
-                description=f"Pago gasto {row['expense_number'] or expense_id}",
-                payment_method=method_slug,
-                payment_method_id=UUID(method_id) if method_id else None,
-            )
-        except MissingAccountRoleError:
-            raise
 
         return {"success": True, "message": "Expense payment registered successfully"}
 
@@ -1757,6 +1772,8 @@ async def update_expense(
             try:
                 async with conn.transaction():
                     await _void_expense_gl_entry(conn, tenant_id, expense_id, "Gasto actualizado")
+                    _ptype = (full_expense['payment_type'] if 'payment_type' in full_expense.keys() else None) or 'contado'
+                    _pmid = full_expense['payment_method_id'] if 'payment_method_id' in full_expense.keys() else None
                     await _post_expense_gl_entry(
                         conn, tenant_id, expense_id,
                         float(full_expense['amount']),
@@ -1764,6 +1781,8 @@ async def update_expense(
                         full_expense['description'],
                         full_expense['category_code'],
                         full_expense['payment_method'],
+                        payment_type=_ptype,
+                        payment_method_id=UUID(_pmid) if _pmid else None,
                     )
             except Exception as _gl_err:
                 logger.warning(f"[GL] GL update failed for expense {expense_id}: {_gl_err}")
@@ -1919,6 +1938,8 @@ async def update_expense_json(
             try:
                 async with conn.transaction():
                     await _void_expense_gl_entry(conn, tenant_id, expense_id, "Gasto actualizado")
+                    _ptype = (full_expense['payment_type'] if 'payment_type' in full_expense.keys() else None) or 'contado'
+                    _pmid = full_expense['payment_method_id'] if 'payment_method_id' in full_expense.keys() else None
                     await _post_expense_gl_entry(
                         conn, tenant_id, expense_id,
                         float(full_expense['amount']),
@@ -1926,6 +1947,8 @@ async def update_expense_json(
                         full_expense['description'],
                         full_expense['category_code'],
                         full_expense['payment_method'],
+                        payment_type=_ptype,
+                        payment_method_id=UUID(_pmid) if _pmid else None,
                     )
             except Exception as _gl_err:
                 logger.warning(f"[GL] GL update failed for expense {expense_id}: {_gl_err}")

--- a/app/services/expenses_service.py
+++ b/app/services/expenses_service.py
@@ -1901,6 +1901,7 @@ async def update_expense_json(
                     e.amount, e.description, e.source_system, e.created_at,
                     e.transaction_date, e.is_recurring, e.frequency, e.recurring_end_date,
                     e.payment_method, e.payment_method_id::text as payment_method_id, e.expense_type,
+                    e.payment_type, e.paid_at,
                     c.id as cat_id, c.category_code, c.category_name,
                     c.description as cat_description, c.is_active as cat_active
                 FROM tenant_expenses e
@@ -1931,6 +1932,8 @@ async def update_expense_json(
                 recurringEndDate=full_expense['recurring_end_date'],
                 paymentMethod=full_expense['payment_method'],
                 paymentMethodId=full_expense['payment_method_id'],
+                paymentType=(full_expense['payment_type'] if 'payment_type' in full_expense.keys() else None) or 'contado',
+                paidAt=full_expense['paid_at'] if 'paid_at' in full_expense.keys() else None,
                 category=category
             )
 

--- a/app/services/expenses_service.py
+++ b/app/services/expenses_service.py
@@ -25,8 +25,54 @@ from app.models.expense import (
 from app.services.billing_service import check_plan_quota_period
 from app.services.purchase_tracking_service import upload_purchase_attachments
 from app.services.aws_s3_service import AWSS3Service
+from app.core.timezones import local_date_for_tenant, resolve_tenant_timezone
+from app.services.account_role_service import (
+    AccountRole,
+    MissingAccountRoleError,
+    resolve_account,
+    resolve_payment_account,
+)
 
 logger = logging.getLogger(__name__)
+
+CONTADO_REQUIRES_PAYMENT_METHOD = (
+    "Contado requires a payment method. Use credito when payment is not registered yet."
+)
+
+
+def _normalize_payment_type(value: Optional[str]) -> str:
+    normalized = (value or "contado").strip().lower()
+    if normalized not in ("contado", "credito"):
+        raise HTTPException(status_code=400, detail="paymentType must be contado or credito")
+    return normalized
+
+
+def assert_contado_requires_payment_method(
+    payment_type: Optional[str],
+    payment_method: Optional[str],
+    payment_method_id: Optional[str] = None,
+) -> None:
+    if _normalize_payment_type(payment_type) != "contado":
+        return
+    if (payment_method and str(payment_method).strip()) or payment_method_id:
+        return
+    raise HTTPException(status_code=400, detail=CONTADO_REQUIRES_PAYMENT_METHOD)
+
+
+def _row_has(row, key: str) -> bool:
+    try:
+        return key in row.keys()
+    except Exception:
+        return False
+
+
+def _expense_payable_fields(row) -> Dict[str, Any]:
+    return {
+        "paymentMethod": row["payment_method"],
+        "paymentMethodId": row["payment_method_id"] if _row_has(row, "payment_method_id") else None,
+        "paymentType": (row["payment_type"] if _row_has(row, "payment_type") else None) or "contado",
+        "paidAt": row["paid_at"] if _row_has(row, "paid_at") else None,
+    }
 
 
 def _looks_like_uuid(value: Optional[str]) -> bool:
@@ -138,13 +184,17 @@ async def _post_expense_gl_entry(
     description: str,
     category_code: str,
     payment_method: Optional[str],
+    payment_type: str = "contado",
+    payment_method_id: Optional[UUID] = None,
 ) -> None:
     """
     Post an auto GL entry for a gastos expense.
-    Silently skips if: no mapping found, account missing, or period closed.
-    Caller must wrap in try/except for graceful degrade.
+
+    Contado: category mapping debit / cash-default credit (soft-skip if missing).
+    Credito: category mapping debit / ACCOUNTS_PAYABLE credit (MissingAccountRoleError re-raised).
     """
-    # 1. Look up GL mapping for this tenant × category
+    is_credit = _normalize_payment_type(payment_type) == "credito"
+
     mapping = await conn.fetchrow(
         """SELECT debit_account_code, credit_cash_account_code, credit_default_account_code
            FROM expense_category_gl_mappings
@@ -152,35 +202,48 @@ async def _post_expense_gl_entry(
         tenant_id, category_code,
     )
     if not mapping:
-        logger.warning(
-            f"[GL] No mapping for category '{category_code}' on tenant {tenant_id} — skip GL post"
-        )
+        msg = f"[GL] No mapping for category '{category_code}' on tenant {tenant_id}"
+        if is_credit:
+            raise HTTPException(status_code=409, detail=f"{msg} — required for credit expense")
+        logger.warning(f"{msg} — skip GL post")
         return
 
     debit_code = mapping['debit_account_code']
-    credit_code = (
-        mapping['credit_cash_account_code']
-        if payment_method == 'cash'
-        else mapping['credit_default_account_code']
-    )
-
-    # 2. Resolve account UUIDs from codes
     debit_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
+        "SELECT id, code FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
         tenant_id, debit_code,
     )
-    credit_acct = await conn.fetchrow(
-        "SELECT id FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
-        tenant_id, credit_code,
-    )
-    if not debit_acct or not credit_acct:
-        logger.warning(
-            f"[GL] Account not found (debit={debit_code}, credit={credit_code}) "
-            f"for tenant {tenant_id} — skip GL post"
-        )
+    if not debit_acct:
+        msg = f"[GL] Debit account {debit_code} not found for tenant {tenant_id}"
+        if is_credit:
+            raise HTTPException(status_code=409, detail=f"{msg} — required for credit expense")
+        logger.warning(f"{msg} — skip GL post")
         return
 
-    # 3. Check period is open
+    if is_credit:
+        credit_ref = await resolve_account(
+            conn, tenant_id, AccountRole.ACCOUNTS_PAYABLE, source="expense_credit"
+        )
+        credit_acct_id = credit_ref.id
+        credit_code = credit_ref.code
+    else:
+        credit_code = (
+            mapping['credit_cash_account_code']
+            if payment_method == 'cash'
+            else mapping['credit_default_account_code']
+        )
+        credit_acct = await conn.fetchrow(
+            "SELECT id, code FROM tenant_accounts WHERE tenant_id = $1 AND code = $2 AND is_active = true",
+            tenant_id, credit_code,
+        )
+        if not credit_acct:
+            logger.warning(
+                f"[GL] Account not found (debit={debit_code}, credit={credit_code}) "
+                f"for tenant {tenant_id} — skip GL post"
+            )
+            return
+        credit_acct_id = credit_acct["id"]
+
     period_year = transaction_date.year
     period_month = transaction_date.month
     closed = await conn.fetchval(
@@ -195,7 +258,6 @@ async def _post_expense_gl_entry(
         )
         return
 
-    # 4. Insert header + lines atomically
     amount_val = float(Decimal(str(amount)))
     async with conn.transaction():
         entry_row = await conn.fetchrow(
@@ -220,12 +282,115 @@ async def _post_expense_gl_entry(
             """INSERT INTO tenant_journal_lines
                    (journal_entry_id, account_id, debit, credit, description, line_order)
                VALUES ($1, $2, 0, $3, $4, 1)""",
-            entry_id, credit_acct['id'], amount_val, description,
+            entry_id, credit_acct_id, amount_val, description,
         )
 
     logger.info(
         f"[GL] ✅ Posted entry {entry_id} for expense {expense_id} "
-        f"(debit={debit_code}, credit={credit_code})"
+        f"(debit={debit_code}, credit={credit_code}, payment_type={payment_type})"
+    )
+
+
+async def _post_expense_payment_gl_entry(
+    conn,
+    tenant_id: UUID,
+    expense_id: UUID,
+    amount: float,
+    payment_date: datetime,
+    description: str,
+    payment_method: Optional[str],
+    payment_method_id: Optional[UUID],
+) -> None:
+    """Settle credit expense: debit ACCOUNTS_PAYABLE, credit cash/bank."""
+    amount_decimal = Decimal(str(amount))
+    if amount_decimal <= 0:
+        return
+
+    existing = await conn.fetchval(
+        """SELECT id
+             FROM tenant_journal_entries
+            WHERE tenant_id = $1
+              AND source_module = 'gastos'
+              AND source_id = $2
+              AND status = 'posted'
+              AND description LIKE 'Pago gasto%'
+            LIMIT 1""",
+        tenant_id,
+        expense_id,
+    )
+    if existing:
+        logger.info(f"[GL] Expense payment GL already exists for expense {expense_id}")
+        return
+
+    timezone_name = await resolve_tenant_timezone(conn, tenant_id)
+    entry_date = local_date_for_tenant(payment_date, timezone_name)
+    period_year = entry_date.year
+    period_month = entry_date.month
+
+    closed = await conn.fetchval(
+        """SELECT 1 FROM tenant_monthly_periods
+           WHERE tenant_id = $1 AND year = $2 AND month = $3 AND status = 'closed'""",
+        tenant_id,
+        period_year,
+        period_month,
+    )
+    if closed:
+        logger.warning(
+            f"[GL] Period {period_year}-{period_month:02d} closed — skip expense payment GL for {expense_id}"
+        )
+        return
+
+    debit_acct = await resolve_account(
+        conn, tenant_id, AccountRole.ACCOUNTS_PAYABLE, source="expense_payment"
+    )
+    credit_acct = await resolve_payment_account(
+        conn,
+        tenant_id,
+        payment_method,
+        payment_method_id=payment_method_id,
+        source="expense_payment",
+    )
+    amount_value = float(amount_decimal)
+    async with conn.transaction():
+        entry_row = await conn.fetchrow(
+            """INSERT INTO tenant_journal_entries
+               (tenant_id, entry_date, period_year, period_month,
+                description, source_module, source_id, status,
+                total_debit, total_credit, posted_at)
+           VALUES ($1, $2, $3, $4, $5, 'gastos', $6, 'posted', $7, $8, NOW())
+           RETURNING id""",
+            tenant_id,
+            entry_date,
+            period_year,
+            period_month,
+            description,
+            expense_id,
+            amount_value,
+            amount_value,
+        )
+        entry_id = entry_row["id"]
+        await conn.execute(
+            """INSERT INTO tenant_journal_lines
+               (journal_entry_id, account_id, debit, credit, description, line_order)
+           VALUES ($1, $2, $3, 0, $4, 0)""",
+            entry_id,
+            debit_acct.id,
+            amount_value,
+            description,
+        )
+        await conn.execute(
+            """INSERT INTO tenant_journal_lines
+               (journal_entry_id, account_id, debit, credit, description, line_order)
+           VALUES ($1, $2, 0, $3, $4, 1)""",
+            entry_id,
+            credit_acct.id,
+            amount_value,
+            description,
+        )
+
+    logger.info(
+        f"[GL] ✅ Posted expense payment entry {entry_id} for expense {expense_id} "
+        f"(AP={debit_acct.code}, settlement={credit_acct.code})"
     )
 
 
@@ -512,6 +677,8 @@ async def get_expenses_list(
                     recurringEndDate=row['recurring_end_date'],
                     paymentMethod=row['payment_method'],
                     paymentMethodId=row['payment_method_id'],
+                    paymentType=(row['payment_type'] if 'payment_type' in row.keys() else None) or 'contado',
+                    paidAt=row['paid_at'] if 'paid_at' in row.keys() else None,
                     expenseType=row['expense_type'],
                     category=category
                 ))
@@ -569,6 +736,8 @@ async def get_expense_by_id(
                     e.payment_method,
                     e.payment_method_id::text as payment_method_id,
                     e.expense_type,
+                    e.payment_type,
+                    e.paid_at,
                     c.id as cat_id,
                     c.category_code,
                     c.category_name,
@@ -644,6 +813,8 @@ async def get_expense_by_id(
                 recurringEndDate=full_expense['recurring_end_date'],
                 paymentMethod=full_expense['payment_method'],
                 paymentMethodId=full_expense['payment_method_id'],
+                paymentType=(full_expense['payment_type'] if 'payment_type' in full_expense.keys() else None) or 'contado',
+                paidAt=full_expense['paid_at'] if 'paid_at' in full_expense.keys() else None,
                 expenseType=full_expense['expense_type'],
                 category=category,
                 attachments=attachments
@@ -932,12 +1103,26 @@ async def create_expense_json(
             if not category_exists:
                 raise HTTPException(status_code=400, detail="Invalid expense category")
 
-            payment_method_raw, payment_method_id = await _resolve_payment_method(
-                conn,
-                tenant_id,
+            payment_type = _normalize_payment_type(expense_data.payment_type)
+            assert_contado_requires_payment_method(
+                payment_type,
                 expense_data.payment_method,
                 expense_data.payment_method_id,
             )
+
+            if payment_type == "credito" and not (
+                expense_data.payment_method or expense_data.payment_method_id
+            ):
+                payment_method_raw, payment_method_id = None, None
+            else:
+                payment_method_raw, payment_method_id = await _resolve_payment_method(
+                    conn,
+                    tenant_id,
+                    expense_data.payment_method,
+                    expense_data.payment_method_id,
+                )
+
+            paid_at_value = None if payment_type == "credito" else datetime.utcnow()
 
             await check_plan_quota_period(conn, tenant_id, "expenses_per_period")
 
@@ -960,8 +1145,10 @@ async def create_expense_json(
                     recurring_end_date,
                     payment_method,
                     payment_method_id,
-                    expense_type
-                ) VALUES ($1, $2, $3, $4, $5, $6, 'manual', $7, $8, $9, $10, $11, $12::uuid, $13)
+                    expense_type,
+                    payment_type,
+                    paid_at
+                ) VALUES ($1, $2, $3, $4, $5, $6, 'manual', $7, $8, $9, $10, $11, $12::uuid, $13, $14, $15)
                 RETURNING id, created_at
             """,
                 tenant_id,
@@ -976,7 +1163,9 @@ async def create_expense_json(
                 expense_data.recurring_end_date,
                 payment_method_raw,
                 payment_method_id,
-                expense_data.expense_type
+                expense_data.expense_type,
+                payment_type,
+                paid_at_value,
             )
 
             expense_id = row['id']
@@ -1000,6 +1189,8 @@ async def create_expense_json(
                     e.payment_method,
                     e.payment_method_id::text as payment_method_id,
                     e.expense_type,
+                    e.payment_type,
+                    e.paid_at,
                     c.id as cat_id,
                     c.category_code,
                     c.category_name,
@@ -1034,11 +1225,12 @@ async def create_expense_json(
                 recurringEndDate=full_expense['recurring_end_date'],
                 paymentMethod=full_expense['payment_method'],
                 paymentMethodId=full_expense['payment_method_id'],
+                paymentType=full_expense['payment_type'] or 'contado',
+                paidAt=full_expense['paid_at'],
                 expenseType=full_expense['expense_type'],
                 category=category
             )
 
-            # Post GL entry — graceful degrade: never fail the expense save
             try:
                 await _post_expense_gl_entry(
                     conn, tenant_id, expense_id,
@@ -1047,12 +1239,22 @@ async def create_expense_json(
                     full_expense['description'],
                     full_expense['category_code'],
                     full_expense['payment_method'],
+                    payment_type=full_expense['payment_type'] or 'contado',
+                    payment_method_id=UUID(full_expense['payment_method_id']) if full_expense['payment_method_id'] else None,
                 )
+            except MissingAccountRoleError:
+                raise
+            except HTTPException:
+                raise
             except Exception as _gl_err:
+                if payment_type == "credito":
+                    raise
                 logger.warning(f"[GL] GL post failed for expense {expense_id}: {_gl_err}")
 
             return ExpenseResponse(data=expense)
 
+    except MissingAccountRoleError:
+        raise
     except AuthenticationError:
         raise
     except APIError:
@@ -1064,6 +1266,184 @@ async def create_expense_json(
     except Exception as e:
         logger.error(f"Error creating expense: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Error interno del servidor")
+
+async def get_expense_credit_payables(
+    request: Request,
+    response: Response,
+    limit: int = 250,
+) -> ExpensesListResponse:
+    """List unpaid credit expenses for Pagos hub (#2113)."""
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    async with get_db_connection(use_transaction=False) as conn:
+        rows = await conn.fetch(
+            """
+            SELECT
+                e.id,
+                e.tenant_id,
+                e.expense_category_id,
+                e.month_year,
+                e.amount,
+                e.description,
+                e.source_system,
+                e.expense_number,
+                e.created_at,
+                e.transaction_date,
+                e.is_recurring,
+                e.frequency,
+                e.recurring_end_date,
+                e.payment_method,
+                e.payment_method_id::text as payment_method_id,
+                e.expense_type,
+                e.payment_type,
+                e.paid_at,
+                c.id as cat_id,
+                c.category_code,
+                c.category_name,
+                c.description as cat_description,
+                c.is_active as cat_active
+            FROM tenant_expenses e
+            JOIN expense_categories c ON e.expense_category_id = c.id
+            WHERE e.tenant_id = $1
+              AND lower(COALESCE(e.payment_type, '')) = 'credito'
+              AND e.paid_at IS NULL
+            ORDER BY e.transaction_date ASC, e.created_at ASC
+            LIMIT $2
+            """,
+            tenant_id,
+            limit,
+        )
+
+        expenses = []
+        for row in rows:
+            category = ExpenseCategory(
+                id=row["cat_id"],
+                categoryCode=row["category_code"],
+                categoryName=row["category_name"],
+                description=row["cat_description"],
+                isActive=row["cat_active"],
+            )
+            expenses.append(
+                Expense(
+                    id=row["id"],
+                    tenantId=row["tenant_id"],
+                    expenseCategoryId=row["expense_category_id"],
+                    monthYear=row["month_year"],
+                    amount=float(row["amount"]),
+                    description=row["description"],
+                    sourceSystem=row["source_system"],
+                    expenseNumber=row["expense_number"],
+                    createdAt=row["created_at"],
+                    transactionDate=row["transaction_date"],
+                    isRecurring=row["is_recurring"],
+                    frequency=row["frequency"],
+                    recurringEndDate=row["recurring_end_date"],
+                    paymentMethod=row["payment_method"],
+                    paymentMethodId=row["payment_method_id"],
+                    paymentType=row["payment_type"] or "credito",
+                    paidAt=row["paid_at"],
+                    expenseType=row["expense_type"],
+                    category=category,
+                )
+            )
+
+        total = len(expenses)
+        return ExpensesListResponse(
+            data=expenses,
+            total=total,
+            page=1,
+            limit=limit,
+            stats=ExpensesStats(totalAmount=sum(e.amount for e in expenses), count=total, byCategory={}),
+        )
+
+
+async def pay_expense(
+    request: Request,
+    response: Response,
+    expense_id: UUID,
+    payment_method: str,
+    payment_method_id: Optional[UUID] = None,
+    payment_reference: Optional[str] = None,
+    payment_amount: Optional[float] = None,
+    payment_date: Optional[str] = None,
+    notes: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Settle an unpaid credit expense: set paid_at + AP settlement GL (#2113)."""
+    session_context = require_valid_session(request)
+    tenant_id = session_context.tenant_id
+    if not tenant_id:
+        raise AuthenticationError("Tenant ID is required")
+
+    if not payment_method and not payment_method_id:
+        raise HTTPException(status_code=400, detail="Payment method is required to settle a credit expense")
+
+    async with get_db_connection() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT id, amount, description, expense_number, payment_type, paid_at
+            FROM tenant_expenses
+            WHERE id = $1 AND tenant_id = $2
+            """,
+            expense_id,
+            tenant_id,
+        )
+        if not row:
+            raise HTTPException(status_code=404, detail="Expense not found")
+        if (row["payment_type"] or "").lower() != "credito":
+            raise HTTPException(status_code=400, detail="Only credit expenses can be settled via Pagos")
+        if row["paid_at"] is not None:
+            raise HTTPException(status_code=400, detail="Expense is already paid")
+
+        await check_plan_quota_period(conn, tenant_id, "expense_payments_per_period")
+
+        method_slug, method_id = await _resolve_payment_method(
+            conn,
+            tenant_id,
+            payment_method,
+            str(payment_method_id) if payment_method_id else None,
+        )
+        amount = float(payment_amount) if payment_amount is not None else float(row["amount"])
+        if payment_date:
+            try:
+                payment_dt = datetime.fromisoformat(payment_date.replace("Z", "+00:00"))
+            except ValueError:
+                payment_dt = datetime.utcnow()
+        else:
+            payment_dt = datetime.utcnow()
+
+        await conn.execute(
+            """
+            UPDATE tenant_expenses
+            SET paid_at = $3,
+                payment_method = $4,
+                payment_method_id = $5::uuid
+            WHERE id = $1 AND tenant_id = $2 AND paid_at IS NULL
+            """,
+            expense_id,
+            tenant_id,
+            payment_dt,
+            method_slug,
+            method_id,
+        )
+
+        try:
+            await _post_expense_payment_gl_entry(
+                conn=conn,
+                tenant_id=tenant_id,
+                expense_id=expense_id,
+                amount=amount,
+                payment_date=payment_dt,
+                description=f"Pago gasto {row['expense_number'] or expense_id}",
+                payment_method=method_slug,
+                payment_method_id=UUID(method_id) if method_id else None,
+            )
+        except MissingAccountRoleError:
+            raise
+
+        return {"success": True, "message": "Expense payment registered successfully"}
 
 async def _track_change(
     conn,

--- a/migrations/121_expense_credit_payables.sql
+++ b/migrations/121_expense_credit_payables.sql
@@ -1,0 +1,18 @@
+-- Migration 121: gastos a crédito payables (#2113 / epic #2109)
+-- ADD-only: payment_type + paid_at for credit expenses in Pagos hub.
+
+ALTER TABLE tenant_expenses
+    ADD COLUMN IF NOT EXISTS payment_type VARCHAR(20) NOT NULL DEFAULT 'contado';
+
+ALTER TABLE tenant_expenses
+    ADD COLUMN IF NOT EXISTS paid_at TIMESTAMPTZ NULL;
+
+-- Existing expenses were paid at create (contado with method).
+UPDATE tenant_expenses
+SET paid_at = COALESCE(paid_at, created_at)
+WHERE paid_at IS NULL
+  AND lower(COALESCE(payment_type, 'contado')) = 'contado';
+
+CREATE INDEX IF NOT EXISTS idx_tenant_expenses_credit_payables
+    ON tenant_expenses (tenant_id, payment_type, paid_at)
+    WHERE lower(payment_type) = 'credito' AND paid_at IS NULL;

--- a/tests/test_expense_credit_payables.py
+++ b/tests/test_expense_credit_payables.py
@@ -1,0 +1,178 @@
+"""Gastos a crédito + Pagos settlement (#2113 / epic #2109)."""
+
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.account_role_service import AccountRole, MissingAccountRoleError
+from app.services.expenses_service import (
+    CONTADO_REQUIRES_PAYMENT_METHOD,
+    _normalize_payment_type,
+    _post_expense_gl_entry,
+    _post_expense_payment_gl_entry,
+    assert_contado_requires_payment_method,
+)
+
+
+def test_normalize_payment_type_defaults_and_rejects_unknown():
+    assert _normalize_payment_type(None) == "contado"
+    assert _normalize_payment_type("CREDITO") == "credito"
+    with pytest.raises(HTTPException) as exc:
+        _normalize_payment_type("partial")
+    assert exc.value.status_code == 400
+
+
+def test_contado_requires_payment_method():
+    assert_contado_requires_payment_method("credito", None)
+    with pytest.raises(HTTPException) as exc:
+        assert_contado_requires_payment_method("contado", None)
+    assert CONTADO_REQUIRES_PAYMENT_METHOD in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_credit_create_gl_credits_accounts_payable_role():
+    tenant_id = uuid4()
+    expense_id = uuid4()
+    debit_id = uuid4()
+    ap_id = uuid4()
+    entry_id = uuid4()
+
+    conn = MagicMock()
+    tx = MagicMock()
+    tx.__aenter__ = AsyncMock(return_value=None)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=tx)
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {
+                "debit_account_code": "5105",
+                "credit_cash_account_code": "1105",
+                "credit_default_account_code": "1110",
+            },
+            {"id": debit_id, "code": "5105"},
+            {"id": entry_id},
+        ]
+    )
+    conn.fetchval = AsyncMock(return_value=None)
+    line_args: list[tuple] = []
+
+    async def _execute(sql, *args):
+        if "INSERT INTO tenant_journal_lines" in sql:
+            line_args.append(args)
+        return "INSERT 0 1"
+
+    conn.execute = AsyncMock(side_effect=_execute)
+    resolve_account = AsyncMock(return_value=SimpleNamespace(id=ap_id, code="2205"))
+
+    with patch("app.services.expenses_service.resolve_account", resolve_account):
+        await _post_expense_gl_entry(
+            conn,
+            tenant_id,
+            expense_id,
+            amount=80.0,
+            transaction_date=date(2026, 8, 4),
+            description="Arriendo agosto",
+            category_code="RENT",
+            payment_method=None,
+            payment_type="credito",
+        )
+
+    resolve_account.assert_awaited_once()
+    assert resolve_account.await_args.args[2] == AccountRole.ACCOUNTS_PAYABLE
+    assert line_args[0][1] == debit_id
+    assert line_args[1][1] == ap_id
+
+
+@pytest.mark.asyncio
+async def test_contado_create_gl_soft_skips_without_mapping():
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+
+    await _post_expense_gl_entry(
+        conn,
+        uuid4(),
+        uuid4(),
+        amount=10.0,
+        transaction_date=date(2026, 8, 4),
+        description="Contado",
+        category_code="MISC",
+        payment_method="cash",
+        payment_type="contado",
+    )
+    conn.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_expense_payment_gl_debits_ap():
+    tenant_id = uuid4()
+    expense_id = uuid4()
+    ap_id = uuid4()
+    cash_id = uuid4()
+    entry_id = uuid4()
+
+    conn = MagicMock()
+    tx = MagicMock()
+    tx.__aenter__ = AsyncMock(return_value=None)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=tx)
+    conn.fetchval = AsyncMock(side_effect=[None, None])  # no existing; period open
+    conn.fetchrow = AsyncMock(return_value={"id": entry_id})
+    line_args: list[tuple] = []
+
+    async def _execute(sql, *args):
+        if "INSERT INTO tenant_journal_lines" in sql:
+            line_args.append(args)
+        return "INSERT 0 1"
+
+    conn.execute = AsyncMock(side_effect=_execute)
+
+    with patch(
+        "app.services.expenses_service.resolve_tenant_timezone",
+        AsyncMock(return_value="America/Bogota"),
+    ), patch(
+        "app.services.expenses_service.resolve_account",
+        AsyncMock(return_value=SimpleNamespace(id=ap_id, code="2000")),
+    ) as resolve_account, patch(
+        "app.services.expenses_service.resolve_payment_account",
+        AsyncMock(return_value=SimpleNamespace(id=cash_id, code="1000")),
+    ):
+        await _post_expense_payment_gl_entry(
+            conn=conn,
+            tenant_id=tenant_id,
+            expense_id=expense_id,
+            amount=80.0,
+            payment_date=datetime(2026, 8, 4, tzinfo=timezone.utc),
+            description="Pago gasto WR-G-1",
+            payment_method="cash",
+            payment_method_id=None,
+        )
+
+    assert resolve_account.await_args.args[2] == AccountRole.ACCOUNTS_PAYABLE
+    assert line_args[0][1] == ap_id
+    assert line_args[1][1] == cash_id
+
+
+def test_missing_ap_role_is_explicit_conflict():
+    err = MissingAccountRoleError(uuid4(), AccountRole.ACCOUNTS_PAYABLE, source="expense_credit")
+    assert err.status_code == 409
+    assert err.details["code"] == "ACCOUNT_ROLE_MISSING"
+
+
+def test_migration_121_is_add_only():
+    sql = open("migrations/121_expense_credit_payables.sql").read()
+    assert "ADD COLUMN IF NOT EXISTS payment_type" in sql
+    assert "ADD COLUMN IF NOT EXISTS paid_at" in sql
+    assert "DROP COLUMN" not in sql
+    assert "DROP TABLE" not in sql
+
+
+def test_expense_payments_quota_registered():
+    from app.services import billing_service
+
+    assert "expense_payments_per_period" in billing_service.PERIOD_QUOTA_RESOURCES
+    assert "expense_payments_per_period" in billing_service.QUOTA_KEYS
+    assert billing_service.STARTER_OPERATIONAL_QUOTAS["expense_payments_per_period"] == 30

--- a/tests/test_expense_credit_payables.py
+++ b/tests/test_expense_credit_payables.py
@@ -176,3 +176,47 @@ def test_expense_payments_quota_registered():
     assert "expense_payments_per_period" in billing_service.PERIOD_QUOTA_RESOURCES
     assert "expense_payments_per_period" in billing_service.QUOTA_KEYS
     assert billing_service.STARTER_OPERATIONAL_QUOTAS["expense_payments_per_period"] == 30
+
+
+@pytest.mark.asyncio
+async def test_update_expense_json_blocks_paid_credit():
+    from contextlib import asynccontextmanager
+    from app.models.expense import ExpenseUpdate
+    from app.services.expenses_service import update_expense_json
+
+    tenant_id = uuid4()
+    user_id = uuid4()
+    expense_id = uuid4()
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value={
+            "id": expense_id,
+            "tenant_id": tenant_id,
+            "payment_type": "credito",
+            "paid_at": datetime.now(timezone.utc),
+        }
+    )
+    conn.execute = MagicMock()
+
+    @asynccontextmanager
+    async def _db_ctx():
+        yield conn
+
+    with patch(
+        "app.services.expenses_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id, user_id=user_id),
+    ), patch(
+        "app.services.expenses_service.get_db_connection",
+        side_effect=_db_ctx,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await update_expense_json(
+                MagicMock(),
+                MagicMock(),
+                expense_id,
+                ExpenseUpdate(description="nope"),
+            )
+
+    assert exc.value.status_code == 409
+    assert "ya pagado" in exc.value.detail
+    conn.execute.assert_not_called()


### PR DESCRIPTION
## Summary
- ADD `payment_type` / `paid_at` on `tenant_expenses` (migration 121)
- Credit create: method optional; GL expense Dr / AP Cr (re-raise missing role)
- Contado unchanged (method required; mapping GL soft-skip)
- `GET /expenses/payables` + `POST /expenses/{id}/pay` with `expense_payments_per_period` quota

Refs uno0uno/warocol.com#2113  
Refs uno0uno/warocol.com#2109

## Test plan
- [ ] Create credit expense without method → unpaid payable
- [ ] Contado still requires method
- [ ] Pay via `/pay` → paid_at + AP settlement
- [ ] Quota key separate from supplier payments

## Validation evidence
```
venv/bin/pytest tests/test_expense_credit_payables.py tests/test_billing_plan_quotas.py -q
17 passed in 0.05s
```

Front Pagos/gastos UX ships in companion warocol.com PR (Closes #2113).