### PR TITLE
fix(payments): resolve group GL parents by accounting localization

### DIFF
--- a/app/services/account_role_service.py
+++ b/app/services/account_role_service.py
@@ -206,6 +206,40 @@ def payment_role(payment_slug: Optional[str]) -> str:
     return PAYMENT_ROLE_BY_SLUG.get(payment_slug or "", AccountRole.CASH)
 
 
+async def resolve_group_parent_account(
+    conn,
+    tenant_id: UUID,
+    *,
+    slug: Optional[str],
+    gl_account_id: Optional[UUID] = None,
+    gl_account_code: Optional[str] = None,
+    group_tenant_id: Optional[UUID] = None,
+) -> Optional[AccountRef]:
+    """
+    Parent GL for a payment method group in the current tenant's chart.
+
+    Global groups (tenant_id IS NULL) ignore hardcoded CO PUC codes and resolve
+    via payment_role(slug) + localization defaults (CO → 1110 BANK, GLOBAL → 1010).
+    Tenant-owned groups still honor explicit id/code when present in the chart.
+    """
+    explicit = await resolve_account_by_id(conn, tenant_id, gl_account_id)
+    if explicit:
+        return explicit
+
+    if group_tenant_id is not None:
+        legacy = await resolve_legacy_account(conn, tenant_id, gl_account_code)
+        if legacy:
+            return legacy
+
+    return await resolve_account(
+        conn,
+        tenant_id,
+        payment_role(slug),
+        required=False,
+        source="payment_group_list",
+    )
+
+
 async def resolve_payment_account(
     conn,
     tenant_id: UUID,

--- a/app/services/payment_method_service.py
+++ b/app/services/payment_method_service.py
@@ -16,6 +16,7 @@ from app.models.payment_method import (
     PatchMethodRequest,
 )
 from app.services.billing_service import check_plan_quota_growth
+from app.services.account_role_service import resolve_group_parent_account
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +29,10 @@ async def list_groups(request: Request) -> dict:
       - global defaults (tenant_id IS NULL)
       - tenant's own custom groups
     Includes method_count: number of active methods the tenant has per group.
+
+    glAccountCode / glAccountId are resolved for the current tenant's chart of
+    accounts (localization roles), so global CO PUC defaults do not leak to
+    non-CO tenants (api-warolabs#782).
     """
     session = require_valid_session(request)
     tenant_id = session.tenant_id
@@ -57,21 +62,43 @@ async def list_groups(request: Request) -> dict:
             tenant_id,
         )
 
-    data = [
-        {
-            "id": str(row["id"]),
-            "tenantId": str(row["tenant_id"]) if row["tenant_id"] else None,
-            "name": row["name"],
-            "slug": row["slug"],
-            "triggersCartera": row["triggers_cartera"],
-            "isActive": row["is_active"],
-            "sortOrder": row["sort_order"],
-            "glAccountCode": row["gl_account_code"],
-            "glAccountId": str(row["gl_account_id"]) if row["gl_account_id"] else None,
-            "methodCount": row["method_count"],
-        }
-        for row in rows
-    ]
+        data = []
+        for row in rows:
+            resolved = await resolve_group_parent_account(
+                conn,
+                tenant_id,
+                slug=row["slug"],
+                gl_account_id=row["gl_account_id"],
+                gl_account_code=row["gl_account_code"],
+                group_tenant_id=row["tenant_id"],
+            )
+            if resolved:
+                gl_code = resolved.code
+                gl_id = str(resolved.id)
+            elif row["tenant_id"] is not None:
+                # Keep tenant-customized bindings visible even if not in chart yet.
+                gl_code = row["gl_account_code"]
+                gl_id = str(row["gl_account_id"]) if row["gl_account_id"] else None
+            else:
+                # Never expose global CO-only codes when they are not in this chart.
+                gl_code = None
+                gl_id = None
+
+            data.append(
+                {
+                    "id": str(row["id"]),
+                    "tenantId": str(row["tenant_id"]) if row["tenant_id"] else None,
+                    "name": row["name"],
+                    "slug": row["slug"],
+                    "triggersCartera": row["triggers_cartera"],
+                    "isActive": row["is_active"],
+                    "sortOrder": row["sort_order"],
+                    "glAccountCode": gl_code,
+                    "glAccountId": gl_id,
+                    "methodCount": row["method_count"],
+                }
+            )
+
     return {"success": True, "data": data}
 
 

--- a/tests/test_payment_group_gl_resolve.py
+++ b/tests/test_payment_group_gl_resolve.py
@@ -1,0 +1,202 @@
+"""api-warolabs#782 — payment group GL parents resolve by localization role."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services.account_role_service import (
+    AccountRef,
+    AccountRole,
+    resolve_group_parent_account,
+)
+from app.services import payment_method_service
+
+
+class _AsyncContext:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_global_group_parent_ignores_co_code_and_uses_bank_role():
+    """GLOBAL / MX chart: stored 1110 must not win; BANK role → 1010."""
+    tenant_id = uuid4()
+    bank = AccountRef(uuid4(), "1010", "Bank", AccountRole.BANK, "localization_default")
+    conn = MagicMock()
+
+    with patch(
+        "app.services.account_role_service.resolve_account_by_id",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "app.services.account_role_service.resolve_legacy_account",
+        new=AsyncMock(),
+    ) as legacy, patch(
+        "app.services.account_role_service.resolve_account",
+        new=AsyncMock(return_value=bank),
+    ) as resolve:
+        resolved = await resolve_group_parent_account(
+            conn,
+            tenant_id,
+            slug="digital",
+            gl_account_id=None,
+            gl_account_code="1110",
+            group_tenant_id=None,
+        )
+
+    assert resolved == bank
+    legacy.assert_not_awaited()
+    resolve.assert_awaited_once_with(
+        conn,
+        tenant_id,
+        AccountRole.BANK,
+        required=False,
+        source="payment_group_list",
+    )
+
+
+@pytest.mark.asyncio
+async def test_global_group_parent_co_bank_role_returns_puc_1110():
+    tenant_id = uuid4()
+    bank = AccountRef(uuid4(), "1110", "Bancos", AccountRole.BANK, "localization_default")
+    conn = MagicMock()
+
+    with patch(
+        "app.services.account_role_service.resolve_account_by_id",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "app.services.account_role_service.resolve_account",
+        new=AsyncMock(return_value=bank),
+    ):
+        resolved = await resolve_group_parent_account(
+            conn,
+            tenant_id,
+            slug="digital",
+            gl_account_code="1110",
+            group_tenant_id=None,
+        )
+
+    assert resolved is not None
+    assert resolved.code == "1110"
+
+
+@pytest.mark.asyncio
+async def test_tenant_group_honors_legacy_code_in_chart():
+    tenant_id = uuid4()
+    group_tenant_id = tenant_id
+    legacy_acct = AccountRef(uuid4(), "9999", "Custom", None, "legacy_binding")
+    conn = MagicMock()
+
+    with patch(
+        "app.services.account_role_service.resolve_account_by_id",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "app.services.account_role_service.resolve_legacy_account",
+        new=AsyncMock(return_value=legacy_acct),
+    ) as legacy, patch(
+        "app.services.account_role_service.resolve_account",
+        new=AsyncMock(),
+    ) as resolve:
+        resolved = await resolve_group_parent_account(
+            conn,
+            tenant_id,
+            slug="digital",
+            gl_account_code="9999",
+            group_tenant_id=group_tenant_id,
+        )
+
+    assert resolved == legacy_acct
+    legacy.assert_awaited_once()
+    resolve.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_list_groups_exposes_resolved_codes_for_global_digital():
+    tenant_id = uuid4()
+    digital_id = uuid4()
+    bank_id = uuid4()
+    conn = MagicMock()
+    conn.fetch = AsyncMock(
+        return_value=[
+            {
+                "id": digital_id,
+                "tenant_id": None,
+                "name": "Digital",
+                "slug": "digital",
+                "triggers_cartera": False,
+                "is_active": True,
+                "sort_order": 2,
+                "gl_account_code": "1110",
+                "gl_account_id": None,
+                "method_count": 0,
+            }
+        ]
+    )
+    resolved = AccountRef(bank_id, "1010", "Bank", AccountRole.BANK, "localization_default")
+    request = MagicMock()
+
+    with patch(
+        "app.services.payment_method_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id),
+    ), patch(
+        "app.services.payment_method_service.get_db_connection",
+        return_value=_AsyncContext(conn),
+    ), patch(
+        "app.services.payment_method_service.resolve_group_parent_account",
+        new=AsyncMock(return_value=resolved),
+    ) as resolve_parent:
+        payload = await payment_method_service.list_groups(request)
+
+    assert payload["success"] is True
+    assert payload["data"][0]["glAccountCode"] == "1010"
+    assert payload["data"][0]["glAccountId"] == str(bank_id)
+    resolve_parent.assert_awaited_once()
+    kwargs = resolve_parent.await_args.kwargs
+    assert kwargs["slug"] == "digital"
+    assert kwargs["gl_account_code"] == "1110"
+    assert kwargs["group_tenant_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_groups_hides_global_co_code_when_role_unresolved():
+    tenant_id = uuid4()
+    conn = MagicMock()
+    conn.fetch = AsyncMock(
+        return_value=[
+            {
+                "id": uuid4(),
+                "tenant_id": None,
+                "name": "Digital",
+                "slug": "digital",
+                "triggers_cartera": False,
+                "is_active": True,
+                "sort_order": 2,
+                "gl_account_code": "1110",
+                "gl_account_id": None,
+                "method_count": 0,
+            }
+        ]
+    )
+    request = MagicMock()
+
+    with patch(
+        "app.services.payment_method_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id),
+    ), patch(
+        "app.services.payment_method_service.get_db_connection",
+        return_value=_AsyncContext(conn),
+    ), patch(
+        "app.services.payment_method_service.resolve_group_parent_account",
+        new=AsyncMock(return_value=None),
+    ):
+        payload = await payment_method_service.list_groups(request)
+
+    assert payload["data"][0]["glAccountCode"] is None
+    assert payload["data"][0]["glAccountId"] is None


### PR DESCRIPTION
## Summary
- Global payment method groups no longer expose hardcoded CO PUC codes (`1110`/`1105`/`1305`) as the tenant parent.
- `list_groups` resolves `glAccountCode` / `glAccountId` via `payment_role(slug)` + localization defaults (CO → PUC, GLOBAL → `1000`/`1010`/`1100`).
- Tenant-owned groups still honor explicit id/code when present in the chart.

## Front AC (waived — no code change)
The create panel already uses `group.glAccountCode` from `list_groups` (`defaultPaymentMethodParentCode` / `groupParentInChart`). Once this API ships, MX Digital receives `1010` and the false “not in chart” path goes away without a warocol.com PR. Optional UX polish on branch `wr-2125-metodos-pago-puc-panel-ux` is out of scope for #782.

## Test plan
- [x] `./venv/bin/pytest tests/test_payment_group_gl_resolve.py -q`
- [ ] MX tenant (e.g. TEST-23-07-2026): Digital shows `1010` (Bank), add method assumes that parent
- [ ] CO tenant: Digital still resolves to `1110`

## Validation evidence

```text
$ ./venv/bin/pytest tests/test_payment_group_gl_resolve.py -q
collected 5 items
tests/test_payment_group_gl_resolve.py .....                             [100%]
============================== 5 passed in 0.04s ===============================
```

Closes #782