### PR TITLE
feat(cierre): from_cash_drawer for expenses and direct purchases

### DIFF
--- a/.wr/786.yaml
+++ b/.wr/786.yaml
@@ -1,0 +1,50 @@
+# Machine contract for wr-exec — keep ≤80 lines. Refs epic #785.
+issue: 786
+title: "feat(cierre): from_cash_drawer on expenses and direct purchases for arqueo"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-786-from-cash-drawer
+parent_epic: 785
+
+paths:
+  - sql/20260805_from_cash_drawer.sql
+  - app/models/expense.py
+  - app/models/purchase.py
+  - app/routers/expenses.py
+  - app/services/expenses_service.py
+  - app/services/direct_purchase_service.py
+  - app/services/cierre_service.py
+  - tests/test_cierre_preview_cash.py
+
+ac:
+  - ADD ONLY from_cash_drawer boolean NOT NULL DEFAULT true on tenant_expenses + tenant_purchases
+  - Models/API accept/return fromCashDrawer; non-cash → default/force true
+  - create/update/pay expense + create/update direct purchase persist the flag
+  - pay_expense Form accepts fromCashDrawer when settling credit in cash
+  - cierre gastos_efectivo + cash_purchases AND COALESCE(from_cash_drawer,true)=true
+  - _compute_method_outflow_rows applies the same predicate (preview net matches cashExpected)
+  - Existing rows (default true) keep current arqueo math; false excluded from cashExpected
+  - pytest evidence in PR; no DROP/destructive ALTER; GL posting unchanged
+
+out_of_scope:
+  - Front UI (warocol.com#2135)
+  - Formal OC / supplier purchase orders
+  - New payment_method slug/group
+  - Backfill of historical cierre snapshots
+
+hints:
+  entry: "cierre_service._compute_preview gastos/cash_purchases ~L1632; _compute_method_outflow_rows ~L1289"
+  pattern: "sql/* ADD COLUMN IF NOT EXISTS … NOT NULL DEFAULT; ExpenseBase paymentMethod aliases"
+  tests: "cd api_warocol.com && ./venv/bin/pytest tests/test_cierre_preview_cash.py -q"
+
+risk:
+  sensitive: true
+  areas: [payments, cash-drawer]
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "apply sql on prod (ADD only); then /wr-research warocol.com#2135 --delta"

--- a/app/models/expense.py
+++ b/app/models/expense.py
@@ -69,6 +69,8 @@ class ExpenseBase(BaseModel):
     payment_method_id: Optional[str] = Field(None, alias='paymentMethodId')
     payment_type: Optional[str] = Field('contado', alias='paymentType')  # contado | credito
     expense_type: Optional[ExpenseType] = Field(None, alias='expenseType')
+    # Drawer control only (#786): false = cash did not leave the till (exclude from arqueo).
+    from_cash_drawer: bool = Field(True, alias='fromCashDrawer')
 
     class Config:
         populate_by_name = True
@@ -89,6 +91,7 @@ class ExpenseUpdate(BaseModel):
     payment_method_id: Optional[str] = Field(None, alias='paymentMethodId')
     payment_type: Optional[str] = Field(None, alias='paymentType')
     expense_type: Optional[ExpenseType] = Field(None, alias='expenseType')
+    from_cash_drawer: Optional[bool] = Field(None, alias='fromCashDrawer')
 
     class Config:
         populate_by_name = True

--- a/app/models/purchase.py
+++ b/app/models/purchase.py
@@ -478,6 +478,8 @@ class DirectPurchaseCreate(BaseModel):
     payment_reference: Optional[str] = None
     payment_amount: Optional[Decimal] = None
     payment_date: Optional[str] = None
+    # Drawer control only (#786): false = cash did not leave the till (exclude from arqueo).
+    from_cash_drawer: bool = Field(True, alias='fromCashDrawer')
 
     class Config:
         populate_by_name = True
@@ -494,6 +496,7 @@ class DirectPurchaseUpdate(BaseModel):
     payment_reference: Optional[str] = None
     payment_amount: Optional[Decimal] = None
     payment_date: Optional[str] = None
+    from_cash_drawer: Optional[bool] = Field(None, alias='fromCashDrawer')
 
     class Config:
         populate_by_name = True

--- a/app/routers/expenses.py
+++ b/app/routers/expenses.py
@@ -86,6 +86,7 @@ async def pay_expense_endpoint(
     payment_amount: Optional[float] = Form(None),
     payment_date: Optional[str] = Form(None),
     notes: Optional[str] = Form(None),
+    from_cash_drawer: Optional[bool] = Form(None),
 ):
     """Settle unpaid credit expense (Pagos)."""
     return await pay_expense(
@@ -98,6 +99,7 @@ async def pay_expense_endpoint(
         payment_amount=payment_amount,
         payment_date=payment_date,
         notes=notes,
+        from_cash_drawer=from_cash_drawer,
     )
 
 @router.post("/{expense_id}/attachments", dependencies=[Depends(require_module(Module.FINANZAS))])

--- a/app/routers/purchases.py
+++ b/app/routers/purchases.py
@@ -200,7 +200,8 @@ async def create_direct_purchase_endpoint(
         payment_reference=purchase_data.payment_reference,
         payment_amount=purchase_data.payment_amount,
         payment_date=purchase_data.payment_date,
-        purchase_date=purchase_data.purchase_date
+        purchase_date=purchase_data.purchase_date,
+        from_cash_drawer=purchase_data.from_cash_drawer,
     )
 
     # Schedule anomaly check after the purchase transaction has committed
@@ -303,7 +304,8 @@ async def update_direct_purchase_endpoint(
         payment_method_id=purchase_data.payment_method_id,
         payment_reference=purchase_data.payment_reference,
         payment_amount=purchase_data.payment_amount,
-        payment_date=purchase_data.payment_date
+        payment_date=purchase_data.payment_date,
+        from_cash_drawer=purchase_data.from_cash_drawer,
     )
 
     try:

--- a/app/services/cierre_service.py
+++ b/app/services/cierre_service.py
@@ -1313,6 +1313,7 @@ async def _compute_method_outflow_rows(
         LEFT JOIN payment_method_groups pmg ON pmg.id = pm.group_id
         WHERE e.tenant_id = $1
           AND COALESCE(pmg.slug, e.payment_method) IS NOT NULL
+          AND COALESCE(e.from_cash_drawer, true) = true
           {expense_filter}
         GROUP BY COALESCE(pmg.slug, e.payment_method), COALESCE(pm.name, e.payment_method)
         """,
@@ -1332,6 +1333,7 @@ async def _compute_method_outflow_rows(
           AND tp.status = 'paid'
           AND COALESCE(tp.payment_amount, 0) > 0
           AND COALESCE(pmg.slug, tp.payment_method) IS NOT NULL
+          AND COALESCE(tp.from_cash_drawer, true) = true
           {purchase_filter}
         GROUP BY COALESCE(pmg.slug, tp.payment_method), COALESCE(pm.name, tp.payment_method)
         """,
@@ -1635,6 +1637,7 @@ async def _compute_preview(
         FROM tenant_expenses
         WHERE tenant_id = $1
           AND payment_method = 'cash'
+          AND COALESCE(from_cash_drawer, true) = true
           {expense_filter}
         """,
         tenant_id, *expense_params,
@@ -1653,6 +1656,7 @@ async def _compute_preview(
           AND tp.status = 'paid'
           AND COALESCE(tp.payment_amount, 0) > 0
           AND COALESCE(pmg.slug, tp.payment_method) = 'cash'
+          AND COALESCE(tp.from_cash_drawer, true) = true
           {purchase_filter}
         """,
         tenant_id, *purchase_params,

--- a/app/services/direct_purchase_service.py
+++ b/app/services/direct_purchase_service.py
@@ -161,6 +161,18 @@ def assert_contado_requires_payment_method(
     raise HTTPException(status_code=400, detail=CONTADO_REQUIRES_PAYMENT_METHOD_DETAIL)
 
 
+def _resolve_from_cash_drawer(
+    payment_method_slug: Optional[str],
+    from_cash_drawer: Optional[bool],
+) -> bool:
+    """Non-cash always true; cash may opt out of arqueo drawer outflows (#786)."""
+    if (payment_method_slug or "").strip().lower() != "cash":
+        return True
+    if from_cash_drawer is None:
+        return True
+    return bool(from_cash_drawer)
+
+
 async def _normalize_direct_purchase_payment(
     conn,
     payment_method: Optional[str],
@@ -401,7 +413,8 @@ async def create_direct_purchase(
     payment_reference: Optional[str] = None,
     payment_amount: Optional[float] = None,
     payment_date: Optional[str] = None,
-    purchase_date: Optional[str] = None
+    purchase_date: Optional[str] = None,
+    from_cash_drawer: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """
     Create a direct purchase that immediately updates inventory.
@@ -447,6 +460,7 @@ async def create_direct_purchase(
                     payment_method_id,
                 )
                 assert_contado_requires_payment_method(payment_type, payment_method)
+                drawer_flag = _resolve_from_cash_drawer(payment_method, from_cash_drawer)
 
                 # 2. Calculate totals from items
                 total_amount = _calculate_direct_purchase_total(items)
@@ -483,11 +497,13 @@ async def create_direct_purchase(
                         is_direct_entry,
                         received_at,
                         received_by,
-                        paid_at
+                        paid_at,
+                        from_cash_drawer
                     ) VALUES (
                         $1, $2, $3, COALESCE($20, NOW()), $4, 0, $5, $6, $7, $8, $9, $10,
                         $11, $12, $13, $14::uuid, $15, $16, $17, TRUE, NOW(), $18,
-                        CASE WHEN $19 THEN NOW() ELSE NULL END
+                        CASE WHEN $19 THEN NOW() ELSE NULL END,
+                        $21
                     )
                     RETURNING id, purchase_date
                 """,
@@ -510,7 +526,8 @@ async def create_direct_purchase(
                     _parse_date(payment_date),
                     user_id,
                     bool(payment_method and payment_amount),
-                    _parse_date(purchase_date)
+                    _parse_date(purchase_date),
+                    drawer_flag,
                 )
 
                 purchase_id = purchase_row['id']
@@ -1122,7 +1139,8 @@ async def update_direct_purchase(
     payment_method_id: Optional[str] = None,
     payment_reference: Optional[str] = None,
     payment_amount: Optional[float] = None,
-    payment_date: Optional[str] = None
+    payment_date: Optional[str] = None,
+    from_cash_drawer: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """
     Update a direct purchase.
@@ -1482,6 +1500,7 @@ async def update_direct_purchase(
                     payment_method_id,
                 )
                 assert_contado_requires_payment_method(effective_payment_type, payment_method)
+                drawer_flag = _resolve_from_cash_drawer(payment_method, from_cash_drawer)
 
                 # 9. Update purchase record
                 await conn.execute("""
@@ -1499,7 +1518,8 @@ async def update_direct_purchase(
                         status = $9,
                         updated_at = NOW(),
                         paid_at = CASE WHEN $10 THEN NOW() ELSE paid_at END,
-                        purchase_date = COALESCE($12, purchase_date)
+                        purchase_date = COALESCE($12, purchase_date),
+                        from_cash_drawer = $14
                     WHERE id = $11
                 """,
                     total_amount,
@@ -1515,6 +1535,7 @@ async def update_direct_purchase(
                     purchase_id,
                     _parse_date(purchase_date),
                     payment_type,
+                    drawer_flag,
                 )
 
                 # 10. Create status history if status changed

--- a/app/services/direct_purchase_service.py
+++ b/app/services/direct_purchase_service.py
@@ -764,7 +764,8 @@ async def create_direct_purchase(
                         "status": final_status,
                         "total_amount": total_amount,
                         "items_count": len(items),
-                        "inventory_updated": True
+                        "inventory_updated": True,
+                        "fromCashDrawer": bool(drawer_flag),
                     }
                 }
 
@@ -1500,10 +1501,9 @@ async def update_direct_purchase(
                     payment_method_id,
                 )
                 assert_contado_requires_payment_method(effective_payment_type, payment_method)
-                drawer_flag = _resolve_from_cash_drawer(payment_method, from_cash_drawer)
 
                 # 9. Update purchase record
-                await conn.execute("""
+                update_sql = """
                     UPDATE tenant_purchases
                     SET
                         total_amount = $1,
@@ -1518,10 +1518,9 @@ async def update_direct_purchase(
                         status = $9,
                         updated_at = NOW(),
                         paid_at = CASE WHEN $10 THEN NOW() ELSE paid_at END,
-                        purchase_date = COALESCE($12, purchase_date),
-                        from_cash_drawer = $14
-                    WHERE id = $11
-                """,
+                        purchase_date = COALESCE($12, purchase_date)
+                """
+                update_params: list = [
                     total_amount,
                     notes,
                     invoice_number,
@@ -1535,8 +1534,25 @@ async def update_direct_purchase(
                     purchase_id,
                     _parse_date(purchase_date),
                     payment_type,
-                    drawer_flag,
-                )
+                ]
+                drawer_flag = None
+                if from_cash_drawer is not None:
+                    drawer_flag = _resolve_from_cash_drawer(payment_method, from_cash_drawer)
+                    update_sql += ",\n                        from_cash_drawer = $14"
+                    update_params.append(drawer_flag)
+                elif payment_method and (payment_method or "").strip().lower() != "cash":
+                    # Non-cash payment forces drawer flag true (ignore stale false).
+                    drawer_flag = True
+                    update_sql += ",\n                        from_cash_drawer = $14"
+                    update_params.append(drawer_flag)
+                update_sql += "\n                    WHERE id = $11"
+                await conn.execute(update_sql, *update_params)
+
+                if drawer_flag is None:
+                    drawer_flag = await conn.fetchval(
+                        "SELECT COALESCE(from_cash_drawer, true) FROM tenant_purchases WHERE id = $1",
+                        purchase_id,
+                    )
 
                 # 10. Create status history if status changed
                 if new_status != current_status:
@@ -1559,7 +1575,8 @@ async def update_direct_purchase(
                         "status": new_status,
                         "total_amount": total_amount,
                         "items_count": len(items),
-                        "inventory_updated": True
+                        "inventory_updated": True,
+                        "fromCashDrawer": bool(drawer_flag),
                     }
                 }
 

--- a/app/services/expenses_service.py
+++ b/app/services/expenses_service.py
@@ -72,7 +72,27 @@ def _expense_payable_fields(row) -> Dict[str, Any]:
         "paymentMethodId": row["payment_method_id"] if _row_has(row, "payment_method_id") else None,
         "paymentType": (row["payment_type"] if _row_has(row, "payment_type") else None) or "contado",
         "paidAt": row["paid_at"] if _row_has(row, "paid_at") else None,
+        "fromCashDrawer": _from_cash_drawer_from_row(row),
     }
+
+
+def _resolve_from_cash_drawer(
+    payment_method_slug: Optional[str],
+    from_cash_drawer: Optional[bool],
+) -> bool:
+    """Non-cash always counts as drawer-neutral true; cash may opt out of arqueo (#786)."""
+    if (payment_method_slug or "").strip().lower() != "cash":
+        return True
+    if from_cash_drawer is None:
+        return True
+    return bool(from_cash_drawer)
+
+
+def _from_cash_drawer_from_row(row) -> bool:
+    if not _row_has(row, "from_cash_drawer"):
+        return True
+    val = row["from_cash_drawer"]
+    return True if val is None else bool(val)
 
 
 def _looks_like_uuid(value: Optional[str]) -> bool:
@@ -562,6 +582,7 @@ async def get_expenses_list(
                     e.recurring_end_date,
                     e.payment_method,
                     e.payment_method_id::text as payment_method_id,
+                    e.from_cash_drawer,
                     e.expense_type,
                     c.id as cat_id,
                     c.category_code,
@@ -689,6 +710,7 @@ async def get_expenses_list(
                     paymentMethod=row['payment_method'],
                     paymentMethodId=row['payment_method_id'],
                     paymentType=(row['payment_type'] if 'payment_type' in row.keys() else None) or 'contado',
+                    fromCashDrawer=_from_cash_drawer_from_row(row),
                     paidAt=row['paid_at'] if 'paid_at' in row.keys() else None,
                     expenseType=row['expense_type'],
                     category=category
@@ -746,6 +768,7 @@ async def get_expense_by_id(
                     e.recurring_end_date,
                     e.payment_method,
                     e.payment_method_id::text as payment_method_id,
+                    e.from_cash_drawer,
                     e.expense_type,
                     e.payment_type,
                     e.paid_at,
@@ -825,6 +848,7 @@ async def get_expense_by_id(
                 paymentMethod=full_expense['payment_method'],
                 paymentMethodId=full_expense['payment_method_id'],
                 paymentType=(full_expense['payment_type'] if 'payment_type' in full_expense.keys() else None) or 'contado',
+                fromCashDrawer=_from_cash_drawer_from_row(full_expense),
                 paidAt=full_expense['paid_at'] if 'paid_at' in full_expense.keys() else None,
                 expenseType=full_expense['expense_type'],
                 category=category,
@@ -1158,8 +1182,9 @@ async def create_expense_json(
                     payment_method_id,
                     expense_type,
                     payment_type,
-                    paid_at
-                ) VALUES ($1, $2, $3, $4, $5, $6, 'manual', $7, $8, $9, $10, $11, $12::uuid, $13, $14, $15)
+                    paid_at,
+                    from_cash_drawer
+                ) VALUES ($1, $2, $3, $4, $5, $6, 'manual', $7, $8, $9, $10, $11, $12::uuid, $13, $14, $15, $16)
                 RETURNING id, created_at
             """,
                 tenant_id,
@@ -1177,6 +1202,10 @@ async def create_expense_json(
                 expense_data.expense_type,
                 payment_type,
                 paid_at_value,
+                _resolve_from_cash_drawer(
+                    payment_method_raw,
+                    getattr(expense_data, "from_cash_drawer", None),
+                ),
             )
 
             expense_id = row['id']
@@ -1199,6 +1228,7 @@ async def create_expense_json(
                     e.recurring_end_date,
                     e.payment_method,
                     e.payment_method_id::text as payment_method_id,
+                    e.from_cash_drawer,
                     e.expense_type,
                     e.payment_type,
                     e.paid_at,
@@ -1237,6 +1267,7 @@ async def create_expense_json(
                 paymentMethod=full_expense['payment_method'],
                 paymentMethodId=full_expense['payment_method_id'],
                 paymentType=full_expense['payment_type'] or 'contado',
+                fromCashDrawer=_from_cash_drawer_from_row(full_expense),
                 paidAt=full_expense['paid_at'],
                 expenseType=full_expense['expense_type'],
                 category=category
@@ -1355,6 +1386,7 @@ async def get_expense_credit_payables(
                     paymentMethod=row["payment_method"],
                     paymentMethodId=row["payment_method_id"],
                     paymentType=row["payment_type"] or "credito",
+                    fromCashDrawer=_from_cash_drawer_from_row(row),
                     paidAt=row["paid_at"],
                     expenseType=row["expense_type"],
                     category=category,
@@ -1381,6 +1413,7 @@ async def pay_expense(
     payment_amount: Optional[float] = None,
     payment_date: Optional[str] = None,
     notes: Optional[str] = None,
+    from_cash_drawer: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """Settle an unpaid credit expense: set paid_at + AP settlement GL (#2113)."""
     session_context = require_valid_session(request)
@@ -1416,6 +1449,7 @@ async def pay_expense(
             payment_method,
             str(payment_method_id) if payment_method_id else None,
         )
+        drawer_flag = _resolve_from_cash_drawer(method_slug, from_cash_drawer)
         amount = float(row["amount"])
         if payment_amount is not None and abs(float(payment_amount) - amount) > 0.01:
             raise HTTPException(status_code=400, detail="Partial expense payments are not supported")
@@ -1448,7 +1482,8 @@ async def pay_expense(
             UPDATE tenant_expenses
             SET paid_at = $3,
                 payment_method = $4,
-                payment_method_id = $5::uuid
+                payment_method_id = $5::uuid,
+                from_cash_drawer = $6
             WHERE id = $1 AND tenant_id = $2 AND paid_at IS NULL
             """,
             expense_id,
@@ -1456,6 +1491,7 @@ async def pay_expense(
             payment_dt,
             method_slug,
             method_id,
+            drawer_flag,
         )
 
         return {"success": True, "message": "Expense payment registered successfully"}
@@ -1746,6 +1782,7 @@ async def update_expense(
                     e.payment_method_id,
                     e.payment_type,
                     e.paid_at,
+                    e.from_cash_drawer,
                     c.id as cat_id,
                     c.category_code,
                     c.category_name,
@@ -1780,6 +1817,7 @@ async def update_expense(
                 paymentMethod=full_expense['payment_method'],
                 paymentMethodId=full_expense['payment_method_id'] if 'payment_method_id' in full_expense.keys() else None,
                 paymentType=(full_expense['payment_type'] if 'payment_type' in full_expense.keys() else None) or 'contado',
+                fromCashDrawer=_from_cash_drawer_from_row(full_expense),
                 paidAt=full_expense['paid_at'] if 'paid_at' in full_expense.keys() else None,
                 category=category
             )
@@ -1912,6 +1950,26 @@ async def update_expense_json(
                 update_fields.append(f"payment_method_id = ${param_count}::uuid")
                 update_values.append(upd_payment_method_id)
                 param_count += 1
+                update_fields.append(f"from_cash_drawer = ${param_count}")
+                update_values.append(
+                    _resolve_from_cash_drawer(
+                        upd_payment_method,
+                        expense_data.from_cash_drawer,
+                    )
+                )
+                param_count += 1
+            elif expense_data.from_cash_drawer is not None:
+                # Method unchanged — resolve against existing payment_method.
+                existing_pm = await conn.fetchval(
+                    "SELECT payment_method FROM tenant_expenses WHERE id = $1 AND tenant_id = $2",
+                    expense_id,
+                    tenant_id,
+                )
+                update_fields.append(f"from_cash_drawer = ${param_count}")
+                update_values.append(
+                    _resolve_from_cash_drawer(existing_pm, expense_data.from_cash_drawer)
+                )
+                param_count += 1
 
             if expense_data.expense_type is not None:
                 update_fields.append(f"expense_type = ${param_count}")
@@ -1933,7 +1991,7 @@ async def update_expense_json(
                     e.amount, e.description, e.source_system, e.created_at,
                     e.transaction_date, e.is_recurring, e.frequency, e.recurring_end_date,
                     e.payment_method, e.payment_method_id::text as payment_method_id, e.expense_type,
-                    e.payment_type, e.paid_at,
+                    e.payment_type, e.paid_at, e.from_cash_drawer,
                     c.id as cat_id, c.category_code, c.category_name,
                     c.description as cat_description, c.is_active as cat_active
                 FROM tenant_expenses e
@@ -1965,6 +2023,7 @@ async def update_expense_json(
                 paymentMethod=full_expense['payment_method'],
                 paymentMethodId=full_expense['payment_method_id'],
                 paymentType=(full_expense['payment_type'] if 'payment_type' in full_expense.keys() else None) or 'contado',
+                fromCashDrawer=_from_cash_drawer_from_row(full_expense),
                 paidAt=full_expense['paid_at'] if 'paid_at' in full_expense.keys() else None,
                 category=category
             )

--- a/sql/20260805_from_cash_drawer.sql
+++ b/sql/20260805_from_cash_drawer.sql
@@ -1,0 +1,14 @@
+-- api-warolabs#786 / epic #785: till cash vs other cash for arqueo
+-- ADD ONLY — do not DROP or rewrite existing columns.
+
+ALTER TABLE tenant_expenses
+    ADD COLUMN IF NOT EXISTS from_cash_drawer boolean NOT NULL DEFAULT true;
+
+COMMENT ON COLUMN tenant_expenses.from_cash_drawer IS
+    'When payment is cash: true = left the till (counts in arqueo); false = other cash source (excluded from drawer expected). Default true preserves legacy behavior.';
+
+ALTER TABLE tenant_purchases
+    ADD COLUMN IF NOT EXISTS from_cash_drawer boolean NOT NULL DEFAULT true;
+
+COMMENT ON COLUMN tenant_purchases.from_cash_drawer IS
+    'When payment is cash: true = left the till (counts in arqueo); false = other cash source (excluded from drawer expected). Default true preserves legacy behavior.';

--- a/tests/test_cierre_preview_cash.py
+++ b/tests/test_cierre_preview_cash.py
@@ -71,6 +71,13 @@ def test_resolve_from_cash_drawer_non_cash_forces_true():
     assert resolve_expense_drawer(None, False) is True
 
 
+def test_resolve_from_cash_drawer_omitted_on_update_means_preserve_semantics():
+    """Update path must not treat omitted fromCashDrawer as True for cash."""
+    assert resolve_purchase_drawer("cash", None) is True  # create default
+    # Preservation is SQL-side (skip SET); helper only applies when client sends a value.
+    assert resolve_purchase_drawer("cash", False) is False
+
+
 def test_table_advance_partial_close_moves_amount_to_advance_tender():
     adjusted = _apply_table_session_advances_to_methods(
         {"cash": 100_000.0},

--- a/tests/test_cierre_preview_cash.py
+++ b/tests/test_cierre_preview_cash.py
@@ -1,9 +1,11 @@
-"""Unit tests for cierre preview cashExpected (warocol.com#948)."""
+"""Unit tests for cierre preview cashExpected (warocol.com#948 / api-warolabs#786)."""
 from app.services.cierre_service import (
     _advance_audit_totals,
     _apply_table_session_advances_to_methods,
     _compute_cash_expected,
 )
+from app.services.expenses_service import _resolve_from_cash_drawer as resolve_expense_drawer
+from app.services.direct_purchase_service import _resolve_from_cash_drawer as resolve_purchase_drawer
 
 
 def test_cash_expected_all_cash_tips_embedded_in_total_cash():
@@ -43,6 +45,30 @@ def test_cash_expected_subtracts_expenses_and_cash_purchases_once():
         cash_purchases=20_000.0,
     )
     assert result == 270_000.0
+
+
+def test_cash_expected_excludes_non_drawer_cash_outflows_when_sums_already_filtered():
+    """When SQL filters from_cash_drawer=false, those amounts are omitted from the sums."""
+    result = _compute_cash_expected(
+        opening_cash=100_000.0,
+        total_cash=200_000.0,
+        gastos_efectivo=0.0,  # outside-till cash expense excluded upstream
+        cash_purchases=0.0,   # outside-till cash purchase excluded upstream
+    )
+    assert result == 300_000.0
+
+
+def test_resolve_from_cash_drawer_cash_defaults_true():
+    assert resolve_expense_drawer("cash", None) is True
+    assert resolve_expense_drawer("cash", True) is True
+    assert resolve_expense_drawer("cash", False) is False
+    assert resolve_purchase_drawer("cash", False) is False
+
+
+def test_resolve_from_cash_drawer_non_cash_forces_true():
+    assert resolve_expense_drawer("card", False) is True
+    assert resolve_purchase_drawer("digital", False) is True
+    assert resolve_expense_drawer(None, False) is True
 
 
 def test_table_advance_partial_close_moves_amount_to_advance_tender():


### PR DESCRIPTION
## Summary
- ADD `from_cash_drawer` (default true) on `tenant_expenses` / `tenant_purchases`
- Persist via expense create/update/pay + direct purchase create/update (`fromCashDrawer`)
- Arqueo preview sums and method outflows only count drawer cash
- GL/payment method catalog unchanged

Closes #786
Refs #785

## Test plan
- [ ] Apply `sql/20260805_from_cash_drawer.sql` on prod (ADD only)
- [ ] Cash expense/direct with `fromCashDrawer=false` does not reduce arqueo `cashExpected`
- [ ] Default/omitted flag keeps legacy behavior

## Validation evidence
```
$ ./venv/bin/pytest tests/test_cierre_preview_cash.py -q
============================= test session starts ==============================
platform darwin -- Python 3.12.1, pytest-8.3.4, pluggy-1.6.0
rootdir: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
configfile: pytest.ini
plugins: anyio-4.12.1, asyncio-0.24.0, cov-6.0.0
asyncio: mode=Mode.AUTO, default_loop_scope=function
collected 10 items

tests/test_cierre_preview_cash.py ..........                             [100%]

============================== 10 passed in 0.04s ==============================
```

## wr-context
See `.wr/786.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)