### PR TITLE
feat(purchases): from_cash_drawer on purchase /pay (#2141)

### DIFF
--- a/.wr/2141.yaml
+++ b/.wr/2141.yaml
@@ -1,0 +1,43 @@
+# Compact plan for wr-fast #2141. Keep <=80 lines.
+issue: 2141
+title: "feat(finanzas): from_cash_drawer en pago efectivo de compras"
+repo: both
+repo_remote: uno0uno/api-warolabs + uno0uno/warocol.com
+cwd_api: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+cwd_front: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-2141-purchase-pay-cash-drawer
+
+paths:
+  - app/routers/purchases.py
+  - app/services/purchase_tracking_service.py
+  - tests/test_direct_payables_list.py
+  - components/payments/PaymentForm.vue
+  - .wr/2141.yaml
+
+ac:
+  - PaymentForm shows de caja / fuera de caja for purchase cash pay
+  - POST /purchases/{id}/pay persists from_cash_drawer
+  - Arqueo already filters tp.from_cash_drawer=false
+  - Non-cash forces drawer true / no toggle
+  - GL mapping unchanged
+
+out_of_scope:
+  - POS checkout
+  - PUC redesign
+  - Plan quotas
+
+hints:
+  entry: "purchase_tracking_service.transition_to_paid + PaymentForm.appendDrawerFlag"
+  pattern: "expenses pay_expense + direct_purchase _resolve_from_cash_drawer"
+  tests: "cd api_warocol.com && python -m pytest tests/test_direct_payables_list.py -q"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "ready-for-review; wr-review both PRs"

--- a/app/routers/purchases.py
+++ b/app/routers/purchases.py
@@ -561,12 +561,14 @@ async def pay_purchase_endpoint(
     payment_amount: float = Form(...),
     payment_date: str = Form(...),
     notes: Optional[str] = Form(None),
+    from_cash_drawer: Optional[bool] = Form(None),
     files: List[UploadFile] = File(None)
 ):
     """
     Transition purchase to PAID state
     Records payment method and reference
     Accepts file attachments (payment proofs, receipts, etc.)
+    Cash payments may set from_cash_drawer=false so arqueo ignores the outflow.
     """
     return await transition_to_paid(
         request=request,
@@ -578,7 +580,8 @@ async def pay_purchase_endpoint(
         payment_amount=payment_amount,
         payment_date=payment_date,
         notes=notes,
-        files=files
+        files=files,
+        from_cash_drawer=from_cash_drawer,
     )
 
 @router.post("/{purchase_id}/cancel", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])

--- a/app/services/purchase_tracking_service.py
+++ b/app/services/purchase_tracking_service.py
@@ -22,7 +22,6 @@ from app.services.account_role_service import (
 from app.services.billing_service import check_plan_quota_period
 import logging
 
-logger = logging.getLogger(__name__)
 from app.models.purchase import (
     PurchaseStatusHistory,
     PurchaseStatusHistoryCreate,
@@ -39,6 +38,20 @@ from app.models.purchase import (
     AttachmentsResponse,
 )
 from app.services.discord_service import discord_purchase_actions_service
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_from_cash_drawer(
+    payment_method_slug: Optional[str],
+    from_cash_drawer: Optional[bool],
+) -> bool:
+    """Non-cash always true; cash may opt out of arqueo drawer outflows (#2141)."""
+    if (payment_method_slug or "").strip().lower() != "cash":
+        return True
+    if from_cash_drawer is None:
+        return True
+    return bool(from_cash_drawer)
 
 # =============================================================================
 # STATE TRANSITION RULES
@@ -1383,7 +1396,8 @@ async def transition_to_paid(
     payment_amount: float,
     payment_date: str,
     notes: Optional[str] = None,
-    files: List[UploadFile] = []
+    files: List[UploadFile] = [],
+    from_cash_drawer: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """Transition purchase to paid state with optional file attachments"""
     try:
@@ -1425,6 +1439,7 @@ async def transition_to_paid(
                     payment_method,
                     payment_method_id,
                 )
+                drawer_flag = _resolve_from_cash_drawer(payment_method, from_cash_drawer)
 
                 await check_plan_quota_period(
                     conn, tenant_id, "supplier_payments_per_period"
@@ -1440,10 +1455,11 @@ async def transition_to_paid(
                         payment_reference = $3,
                         payment_amount = $4,
                         payment_date = $5,
+                        from_cash_drawer = $6,
                         paid_at = NOW(),
                         updated_at = NOW()
-                    WHERE id = $6
-                """, payment_method, payment_method_id, payment_reference, payment_amount, payment_dt, purchase_id)
+                    WHERE id = $7
+                """, payment_method, payment_method_id, payment_reference, payment_amount, payment_dt, drawer_flag, purchase_id)
 
                 # Create history entry
                 await create_status_history_entry(
@@ -1453,7 +1469,8 @@ async def transition_to_paid(
                         "payment_method": payment_method,
                         "payment_method_id": str(payment_method_id) if payment_method_id else None,
                         "payment_amount": str(payment_amount),
-                        "payment_date": payment_dt.isoformat()
+                        "payment_date": payment_dt.isoformat(),
+                        "from_cash_drawer": drawer_flag,
                     },
                     notes
                 )

--- a/tests/test_direct_payables_list.py
+++ b/tests/test_direct_payables_list.py
@@ -190,11 +190,95 @@ async def test_transition_to_paid_direct_received_sets_paid_at_and_checks_quota(
     update_sql = next(s for s in execute_sql if "UPDATE tenant_purchases" in s)
     assert "paid_at = NOW()" in update_sql
     assert "status = 'paid'" in update_sql
+    assert "from_cash_drawer = $6" in update_sql
+    update_call = next(
+        c for c in conn.execute.await_args_list if "UPDATE tenant_purchases" in c.args[0]
+    )
+    assert update_call.args[6] is True  # default cash drawer when omitted
     quota.assert_awaited_once()
     assert quota.await_args.args[1:] == (tenant_id, "supplier_payments_per_period")
     gl.assert_awaited_once()
     assert gl.await_args.kwargs["purchase_id"] == purchase_id
     assert gl.await_args.kwargs["amount"] == 150.0
+
+
+@pytest.mark.asyncio
+async def test_transition_to_paid_cash_outside_drawer_persists_false():
+    """Cash pay with from_cash_drawer=false must persist so arqueo excludes the outflow."""
+    tenant_id = uuid4()
+    user_id = uuid4()
+    purchase_id = uuid4()
+    request = MagicMock(spec=Request)
+    response = MagicMock()
+    session = _session(tenant_id, user_id)
+
+    conn = MagicMock()
+    tx = MagicMock()
+    tx.__aenter__ = AsyncMock(return_value=None)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=tx)
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {"id": purchase_id, "status": "received"},
+            {
+                "purchase_number": "WR-CD-2026-0100",
+                "supplier_name": "Proveedor MX",
+                "supplier_email": None,
+                "supplier_token": None,
+                "tenant_site": None,
+            },
+        ]
+    )
+    conn.execute = AsyncMock(return_value="UPDATE 1")
+
+    @asynccontextmanager
+    async def _db_ctx(*_a, **_k):
+        yield conn
+
+    with patch(
+        "app.services.purchase_tracking_service.require_valid_session",
+        return_value=session,
+    ), patch(
+        "app.services.purchase_tracking_service.get_db_connection",
+        side_effect=_db_ctx,
+    ), patch(
+        "app.services.purchase_tracking_service._resolve_purchase_payment_account",
+        AsyncMock(return_value=("cash", SimpleNamespace(id=uuid4()))),
+    ), patch(
+        "app.services.purchase_tracking_service.check_plan_quota_period",
+        AsyncMock(),
+    ), patch(
+        "app.services.purchase_tracking_service.create_status_history_entry",
+        AsyncMock(),
+    ), patch(
+        "app.services.purchase_tracking_service.upload_purchase_attachments",
+        AsyncMock(),
+    ), patch(
+        "app.services.purchase_tracking_service._post_supplier_payment_gl_entry",
+        AsyncMock(),
+    ), patch(
+        "app.services.purchase_tracking_service.discord_purchase_actions_service",
+        None,
+    ):
+        result = await transition_to_paid(
+            request,
+            response,
+            purchase_id,
+            payment_method="cash",
+            payment_method_id=None,
+            payment_reference="REF-OUT",
+            payment_amount=80.0,
+            payment_date="2026-08-03T12:00:00Z",
+            notes=None,
+            files=[],
+            from_cash_drawer=False,
+        )
+
+    assert result["success"] is True
+    update_call = next(
+        c for c in conn.execute.await_args_list if "UPDATE tenant_purchases" in c.args[0]
+    )
+    assert update_call.args[6] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Accept `from_cash_drawer` on `POST /{purchase_id}/pay`
- Persist on `tenant_purchases` via `transition_to_paid` (non-cash forced true)
- Tests cover default true and cash `false`

Companion front: warocol.com PR (PaymentForm). Refs https://github.com/uno0uno/warocol.com/issues/2141

## Test plan
- [ ] Pay purchase cash with fuera de caja → row `from_cash_drawer=false`
- [ ] Arqueo esperado ignores that purchase cash outflow

## Validation evidence
```text
$ ./venv/bin/pytest tests/test_direct_payables_list.py -q
..........
10 passed in 0.07s
```

## wr-context
See `.wr/2141.yaml` on this branch.

Made with [Cursor](https://cursor.com)