### PR TITLE
fix(runtime): restore API boot (PEP604 vs Python 3.9)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/app/services/purchases_service.py
+++ b/app/services/purchases_service.py
@@ -48,10 +48,10 @@ def direct_entry_list_clause(include_direct_payables: bool) -> str:
 
 def row_matches_purchases_list_scope(
     *,
-    is_direct_entry: bool | None,
+    is_direct_entry: Optional[bool],
     paid_at,
-    status: str | None,
-    payment_type: str | None,
+    status: Optional[str],
+    payment_type: Optional[str],
     include_direct_payables: bool,
 ) -> bool:
     """Python mirror of `direct_entry_list_clause` for unit tests (keep in sync with SQL)."""

--- a/tests/test_billing_subscription_access.py
+++ b/tests/test_billing_subscription_access.py
@@ -1,5 +1,6 @@
 """Grace-period access levels via get_subscription_access (#62, #363)."""
 from datetime import datetime, timedelta, timezone
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -9,7 +10,7 @@ from app.core.exceptions import APIError
 from app.services import billing_service
 
 
-def _conn_with_subscription(status: str, period_end: datetime | None):
+def _conn_with_subscription(status: str, period_end: Optional[datetime]):
     conn = MagicMock()
     conn.fetchrow = AsyncMock(
         return_value={

--- a/tests/test_session_token.py
+++ b/tests/test_session_token.py
@@ -1,4 +1,5 @@
 """Session cookie parsing and duplicate-token resolution (#387)."""
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
@@ -8,7 +9,7 @@ from fastapi import HTTPException, Request
 from app.core.security import collect_session_tokens, get_session_token, _normalize_session_token
 
 
-def _make_request(cookie_header: str = "", cookies: dict | None = None) -> Request:
+def _make_request(cookie_header: str = "", cookies: Optional[dict] = None) -> Request:
     scope = {
         "type": "http",
         "headers": [(b"cookie", cookie_header.encode())] if cookie_header else [],


### PR DESCRIPTION
## Summary
- Hostinger API was crash-looping: `bool | None` in `purchases_service.py` is invalid on Python 3.9 → uvicorn never starts → 502 on auth/magic-link and all routes
- Convert remaining eval-time PEP604 unions to `Optional[...]`
- Bump Dockerfile to `python:3.11-slim` to prevent recurrence

## Test plan
- [ ] Import `app.main` / container starts without TypeError
- [ ] `POST /api/auth/sign-in-magic-link` no longer 502
- [ ] Health endpoint responds

## Validation evidence
- AST scan: no remaining eval-time PEP604 unions in `app/` without `__future__`
- Server logs showed: `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` at `purchases_service.py:51`


Made with [Cursor](https://cursor.com)