### PR TITLE
feat(abastecimiento): DELETE compra directa with GL void + inventory reverse

### DIFF
--- a/app/routers/purchases.py
+++ b/app/routers/purchases.py
@@ -26,6 +26,7 @@ from app.services.purchase_tracking_service import (
 )
 from app.services.direct_purchase_service import (
     create_direct_purchase,
+    delete_direct_purchase,
     get_direct_purchases_list,
     get_direct_purchase_by_id,
     get_supplier_catalog_prices,
@@ -319,6 +320,23 @@ async def update_direct_purchase_endpoint(
         pass
 
     return result
+
+
+@router.delete("/direct/{purchase_id}", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])
+async def delete_direct_purchase_endpoint(
+    purchase_id: UUID,
+    request: Request,
+    response: Response,
+):
+    """
+    Delete a direct purchase: reverse inventory (with movement trail), void GL,
+    then remove the purchase row.
+    """
+    return await delete_direct_purchase(
+        request=request,
+        response=response,
+        purchase_id=purchase_id,
+    )
 
 
 @router.post("/direct/{purchase_id}/attachments", dependencies=[Depends(require_module(Module.ABASTECIMIENTO))])

--- a/app/services/direct_purchase_service.py
+++ b/app/services/direct_purchase_service.py
@@ -311,10 +311,11 @@ async def _void_direct_purchase_gl_entry(
     tenant_id: UUID,
     purchase_id: UUID,
     reason: str = "Compra directa eliminada",
-) -> None:
+) -> bool:
     """
     Void all posted inventario GL entries for a direct purchase.
     Raises HTTP 400 if any entry sits in a closed monthly period.
+    Returns True if at least one entry was voided.
     """
     entries = await conn.fetch(
         """SELECT id, entry_date, period_year, period_month, description,
@@ -330,7 +331,7 @@ async def _void_direct_purchase_gl_entry(
     )
     if not entries:
         logger.info(f"[GL] No posted inventario GL for purchase {purchase_id} — skip void")
-        return
+        return False
 
     for entry in entries:
         closed = await conn.fetchval(
@@ -396,6 +397,8 @@ async def _void_direct_purchase_gl_entry(
             f"[GL] ✅ Voided inventario entry {entry['id']} → reversing {rev_id} "
             f"for purchase {purchase_id}"
         )
+
+    return True
 
 
 def calculate_changes_summary(before: List[Dict], after: List[Dict]) -> Dict:
@@ -1892,7 +1895,7 @@ async def delete_direct_purchase(
                         user_id,
                     )
 
-                await _void_direct_purchase_gl_entry(
+                gl_voided = await _void_direct_purchase_gl_entry(
                     conn,
                     tenant_id,
                     purchase_id,
@@ -1929,7 +1932,7 @@ async def delete_direct_purchase(
                         "id": str(purchase_id),
                         "purchase_number": purchase_number,
                         "inventory_reversed": True,
-                        "gl_voided": True,
+                        "gl_voided": gl_voided,
                     },
                 }
 
@@ -1942,5 +1945,5 @@ async def delete_direct_purchase(
         logger.exception(e)
         raise HTTPException(
             status_code=500,
-            detail=f"Error eliminando compra directa: {str(e)}",
+            detail="Error interno del servidor",
         )

--- a/app/services/direct_purchase_service.py
+++ b/app/services/direct_purchase_service.py
@@ -306,6 +306,98 @@ async def _post_purchase_gl_entry(
     )
 
 
+async def _void_direct_purchase_gl_entry(
+    conn,
+    tenant_id: UUID,
+    purchase_id: UUID,
+    reason: str = "Compra directa eliminada",
+) -> None:
+    """
+    Void all posted inventario GL entries for a direct purchase.
+    Raises HTTP 400 if any entry sits in a closed monthly period.
+    """
+    entries = await conn.fetch(
+        """SELECT id, entry_date, period_year, period_month, description,
+                  total_debit, total_credit, source_module
+           FROM tenant_journal_entries
+           WHERE tenant_id = $1
+             AND source_id = $2
+             AND source_module = 'inventario'
+             AND status = 'posted'
+           ORDER BY created_at ASC""",
+        tenant_id,
+        purchase_id,
+    )
+    if not entries:
+        logger.info(f"[GL] No posted inventario GL for purchase {purchase_id} — skip void")
+        return
+
+    for entry in entries:
+        closed = await conn.fetchval(
+            """SELECT 1 FROM tenant_monthly_periods
+               WHERE tenant_id = $1 AND year = $2 AND month = $3 AND status = 'closed'""",
+            tenant_id,
+            entry["period_year"],
+            entry["period_month"],
+        )
+        if closed:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"No se puede eliminar una compra directa de un período cerrado "
+                    f"({entry['period_year']}-{entry['period_month']:02d})"
+                ),
+            )
+
+        original_lines = await conn.fetch(
+            """SELECT account_id, debit, credit, description, line_order
+               FROM tenant_journal_lines
+               WHERE journal_entry_id = $1 ORDER BY line_order""",
+            entry["id"],
+        )
+
+        await conn.execute(
+            "UPDATE tenant_journal_entries SET status = 'voided', voided_at = NOW() WHERE id = $1",
+            entry["id"],
+        )
+
+        rev_row = await conn.fetchrow(
+            """INSERT INTO tenant_journal_entries
+                   (tenant_id, entry_date, period_year, period_month,
+                    description, source_module, source_id, status,
+                    total_debit, total_credit, posted_at)
+               VALUES ($1, $2, $3, $4, $5, 'system', $6, 'posted', $7, $8, NOW())
+               RETURNING id""",
+            tenant_id,
+            entry["entry_date"],
+            entry["period_year"],
+            entry["period_month"],
+            f"Reversión: {entry['description']} — {reason}",
+            entry["id"],
+            float(entry["total_debit"]),
+            float(entry["total_credit"]),
+        )
+        rev_id = rev_row["id"]
+
+        for line in original_lines:
+            await conn.execute(
+                """INSERT INTO tenant_journal_lines
+                       (journal_entry_id, account_id, debit, credit, description, line_order)
+                   VALUES ($1, $2, $3, $4, $5, $6)""",
+                rev_id,
+                line["account_id"],
+                float(line["credit"] or 0),
+                float(line["debit"] or 0),
+                line["description"],
+                line["line_order"],
+            )
+
+        logger.info(
+            f"[GL] ✅ Voided inventario entry {entry['id']} → reversing {rev_id} "
+            f"for purchase {purchase_id}"
+        )
+
+
 def calculate_changes_summary(before: List[Dict], after: List[Dict]) -> Dict:
     """
     Genera resumen legible de cambios entre items antes y después de una edición.
@@ -1667,3 +1759,188 @@ async def upload_direct_purchase_attachments(
         logger.error(f"Error in upload_direct_purchase_attachments: {str(e)}")
         logger.exception(e)
         raise HTTPException(status_code=500, detail="Error subiendo archivos")
+
+
+async def delete_direct_purchase(
+    request: Request,
+    response: Response,
+    purchase_id: UUID,
+) -> Dict[str, Any]:
+    """
+    Delete a direct purchase: reverse inventory with movement trail, void GL,
+    then hard-delete the purchase and child rows.
+    """
+    try:
+        session_context = require_valid_session(request)
+        tenant_id = session_context.tenant_id
+        user_id = session_context.user_id
+
+        if not tenant_id:
+            raise AuthenticationError("Tenant ID is required")
+
+        async with get_db_connection() as conn:
+            async with conn.transaction():
+                purchase = await conn.fetchrow(
+                    """SELECT id, purchase_number, purchase_date, status
+                       FROM tenant_purchases
+                       WHERE id = $1 AND tenant_id = $2 AND is_direct_entry = TRUE
+                       FOR UPDATE""",
+                    purchase_id,
+                    tenant_id,
+                )
+                if not purchase:
+                    raise HTTPException(status_code=404, detail="Compra directa no encontrada")
+
+                purchase_date = purchase["purchase_date"]
+                if hasattr(purchase_date, "year"):
+                    period_year = purchase_date.year
+                    period_month = purchase_date.month
+                else:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="La compra directa no tiene fecha válida para validar el período",
+                    )
+
+                closed = await conn.fetchval(
+                    """SELECT 1 FROM tenant_monthly_periods
+                       WHERE tenant_id = $1 AND year = $2 AND month = $3 AND status = 'closed'""",
+                    tenant_id,
+                    period_year,
+                    period_month,
+                )
+                if closed:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=(
+                            f"No se puede eliminar una compra directa de un período cerrado "
+                            f"({period_year}-{period_month:02d})"
+                        ),
+                    )
+
+                items = await conn.fetch(
+                    """SELECT ingredient_id, quantity, unit
+                       FROM tenant_purchase_items
+                       WHERE purchase_id = $1""",
+                    purchase_id,
+                )
+
+                purchase_number = purchase["purchase_number"]
+                for item in items:
+                    ingredient_id = item["ingredient_id"]
+                    qty = _direct_purchase_decimal(item["quantity"])
+                    if qty <= 0:
+                        continue
+
+                    inventory_row = await conn.fetchrow(
+                        """SELECT id, current_stock
+                           FROM tenant_inventory
+                           WHERE tenant_id = $1 AND ingredient_id = $2
+                           FOR UPDATE""",
+                        tenant_id,
+                        ingredient_id,
+                    )
+                    if not inventory_row:
+                        raise HTTPException(
+                            status_code=400,
+                            detail=(
+                                "No se puede eliminar: no hay inventario registrado para "
+                                "revertir uno o más artículos de la compra"
+                            ),
+                        )
+
+                    current_stock = _direct_purchase_decimal(inventory_row["current_stock"])
+                    if current_stock < qty:
+                        raise HTTPException(
+                            status_code=400,
+                            detail=(
+                                "No se puede eliminar: el stock actual es insuficiente para "
+                                "revertir la compra (parte del inventario ya fue consumido)"
+                            ),
+                        )
+
+                    new_stock = current_stock - qty
+                    await conn.execute(
+                        """UPDATE tenant_inventory
+                           SET current_stock = $1, last_updated = NOW()
+                           WHERE tenant_id = $2 AND ingredient_id = $3""",
+                        new_stock,
+                        tenant_id,
+                        ingredient_id,
+                    )
+                    await conn.execute(
+                        """INSERT INTO tenant_ingredient_movements (
+                               tenant_id,
+                               ingredient_id,
+                               movement_type,
+                               quantity_change,
+                               unit,
+                               previous_stock,
+                               new_stock,
+                               reference_table,
+                               reference_id,
+                               notes,
+                               created_by
+                           ) VALUES ($1, $2, 'adjustment', $3, $4, $5, $6, 'tenant_purchases', $7, $8, $9)""",
+                        tenant_id,
+                        ingredient_id,
+                        -qty,
+                        item["unit"],
+                        current_stock,
+                        new_stock,
+                        purchase_id,
+                        f"Eliminación compra directa - {purchase_number}",
+                        user_id,
+                    )
+
+                await _void_direct_purchase_gl_entry(
+                    conn,
+                    tenant_id,
+                    purchase_id,
+                    reason="Compra directa eliminada",
+                )
+
+                await conn.execute(
+                    "DELETE FROM purchase_attachments WHERE purchase_id = $1 AND tenant_id = $2",
+                    purchase_id,
+                    tenant_id,
+                )
+                await conn.execute(
+                    "DELETE FROM purchase_status_history WHERE purchase_id = $1 AND tenant_id = $2",
+                    purchase_id,
+                    tenant_id,
+                )
+                await conn.execute(
+                    "DELETE FROM tenant_purchase_items WHERE purchase_id = $1",
+                    purchase_id,
+                )
+                result = await conn.execute(
+                    """DELETE FROM tenant_purchases
+                       WHERE id = $1 AND tenant_id = $2 AND is_direct_entry = TRUE""",
+                    purchase_id,
+                    tenant_id,
+                )
+                if result == "DELETE 0":
+                    raise HTTPException(status_code=404, detail="Compra directa no encontrada")
+
+                return {
+                    "success": True,
+                    "message": "Compra directa eliminada exitosamente",
+                    "data": {
+                        "id": str(purchase_id),
+                        "purchase_number": purchase_number,
+                        "inventory_reversed": True,
+                        "gl_voided": True,
+                    },
+                }
+
+    except AuthenticationError:
+        raise
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error in delete_direct_purchase: {str(e)}")
+        logger.exception(e)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Error eliminando compra directa: {str(e)}",
+        )

--- a/tests/test_direct_purchase_delete.py
+++ b/tests/test_direct_purchase_delete.py
@@ -1,0 +1,283 @@
+"""Delete direct purchase: GL void + inventory reverse (#2186)."""
+from datetime import date, datetime
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.direct_purchase_service import (
+    _void_direct_purchase_gl_entry,
+    delete_direct_purchase,
+)
+
+
+def _conn_with_tx():
+    conn = MagicMock()
+    tx = MagicMock()
+    tx.__aenter__ = AsyncMock(return_value=None)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction.return_value = tx
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_void_inventario_gl_creates_reversing_entry():
+    tenant_id = uuid4()
+    purchase_id = uuid4()
+    entry_id = uuid4()
+    rev_id = uuid4()
+    account_a = uuid4()
+    account_b = uuid4()
+
+    conn = MagicMock()
+    conn.fetch = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "id": entry_id,
+                    "entry_date": date(2026, 3, 10),
+                    "period_year": 2026,
+                    "period_month": 3,
+                    "description": "WR-CD-0001",
+                    "total_debit": Decimal("100"),
+                    "total_credit": Decimal("100"),
+                    "source_module": "inventario",
+                }
+            ],
+            [
+                {
+                    "account_id": account_a,
+                    "debit": Decimal("100"),
+                    "credit": Decimal("0"),
+                    "description": "WR-CD-0001",
+                    "line_order": 0,
+                },
+                {
+                    "account_id": account_b,
+                    "debit": Decimal("0"),
+                    "credit": Decimal("100"),
+                    "description": "WR-CD-0001",
+                    "line_order": 1,
+                },
+            ],
+        ]
+    )
+    conn.fetchval = AsyncMock(return_value=None)  # period open
+    conn.execute = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"id": rev_id})
+
+    await _void_direct_purchase_gl_entry(conn, tenant_id, purchase_id, "Compra directa eliminada")
+
+    assert conn.execute.await_count >= 3  # void + 2 reverse lines
+    void_sql = conn.execute.await_args_list[0].args[0]
+    assert "voided" in void_sql
+    insert_entry = conn.fetchrow.await_args.args[0]
+    assert "'system'" in insert_entry or "system" in insert_entry
+
+
+@pytest.mark.asyncio
+async def test_void_inventario_gl_blocks_closed_period():
+    tenant_id = uuid4()
+    purchase_id = uuid4()
+    entry_id = uuid4()
+
+    conn = MagicMock()
+    conn.fetch = AsyncMock(
+        return_value=[
+            {
+                "id": entry_id,
+                "entry_date": date(2026, 1, 5),
+                "period_year": 2026,
+                "period_month": 1,
+                "description": "WR-CD-0002",
+                "total_debit": Decimal("50"),
+                "total_credit": Decimal("50"),
+                "source_module": "inventario",
+            }
+        ]
+    )
+    conn.fetchval = AsyncMock(return_value=1)  # closed
+
+    with pytest.raises(HTTPException) as exc:
+        await _void_direct_purchase_gl_entry(conn, tenant_id, purchase_id)
+
+    assert exc.value.status_code == 400
+    assert "período cerrado" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_delete_blocks_closed_purchase_period():
+    tenant_id = uuid4()
+    purchase_id = uuid4()
+    request = MagicMock()
+    response = MagicMock()
+
+    conn = _conn_with_tx()
+    conn.fetchrow = AsyncMock(
+        return_value={
+            "id": purchase_id,
+            "purchase_number": "WR-CD-0099",
+            "purchase_date": datetime(2026, 2, 15),
+            "status": "paid",
+        }
+    )
+    conn.fetchval = AsyncMock(return_value=1)  # closed period
+
+    db_cm = MagicMock()
+    db_cm.__aenter__ = AsyncMock(return_value=conn)
+    db_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "app.services.direct_purchase_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id, user_id=uuid4()),
+    ), patch(
+        "app.services.direct_purchase_service.get_db_connection",
+        return_value=db_cm,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await delete_direct_purchase(request, response, purchase_id)
+
+    assert exc.value.status_code == 400
+    assert "período cerrado" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_delete_blocks_insufficient_stock():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    purchase_id = uuid4()
+    ingredient_id = uuid4()
+    request = MagicMock()
+    response = MagicMock()
+
+    conn = _conn_with_tx()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {
+                "id": purchase_id,
+                "purchase_number": "WR-CD-0100",
+                "purchase_date": datetime(2026, 3, 1),
+                "status": "paid",
+            },
+            {"id": uuid4(), "current_stock": Decimal("2")},  # stock < qty 5
+        ]
+    )
+    conn.fetchval = AsyncMock(return_value=None)  # period open
+    conn.fetch = AsyncMock(
+        return_value=[
+            {
+                "ingredient_id": ingredient_id,
+                "quantity": Decimal("5"),
+                "unit": "gr",
+            }
+        ]
+    )
+    conn.execute = AsyncMock()
+
+    db_cm = MagicMock()
+    db_cm.__aenter__ = AsyncMock(return_value=conn)
+    db_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "app.services.direct_purchase_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id, user_id=user_id),
+    ), patch(
+        "app.services.direct_purchase_service.get_db_connection",
+        return_value=db_cm,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await delete_direct_purchase(request, response, purchase_id)
+
+    assert exc.value.status_code == 400
+    assert "insuficiente" in exc.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_delete_happy_path_reverses_stock_voids_gl_and_deletes_row():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    purchase_id = uuid4()
+    ingredient_id = uuid4()
+    entry_id = uuid4()
+    request = MagicMock()
+    response = MagicMock()
+
+    conn = _conn_with_tx()
+    # fetchrow: purchase, inventory, reversing JE id
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            {
+                "id": purchase_id,
+                "purchase_number": "WR-CD-0101",
+                "purchase_date": datetime(2026, 3, 2),
+                "status": "paid",
+            },
+            {"id": uuid4(), "current_stock": Decimal("10")},
+            {"id": uuid4()},  # reversing JE
+        ]
+    )
+    # fetchval: purchase period open, then JE period open
+    conn.fetchval = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "ingredient_id": ingredient_id,
+                    "quantity": Decimal("4"),
+                    "unit": "gr",
+                }
+            ],
+            [
+                {
+                    "id": entry_id,
+                    "entry_date": date(2026, 3, 2),
+                    "period_year": 2026,
+                    "period_month": 3,
+                    "description": "WR-CD-0101",
+                    "total_debit": Decimal("40"),
+                    "total_credit": Decimal("40"),
+                    "source_module": "inventario",
+                }
+            ],
+            [
+                {
+                    "account_id": uuid4(),
+                    "debit": Decimal("40"),
+                    "credit": Decimal("0"),
+                    "description": "line",
+                    "line_order": 0,
+                },
+                {
+                    "account_id": uuid4(),
+                    "debit": Decimal("0"),
+                    "credit": Decimal("40"),
+                    "description": "line",
+                    "line_order": 1,
+                },
+            ],
+        ]
+    )
+    conn.execute = AsyncMock(return_value="DELETE 1")
+
+    db_cm = MagicMock()
+    db_cm.__aenter__ = AsyncMock(return_value=conn)
+    db_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "app.services.direct_purchase_service.require_valid_session",
+        return_value=SimpleNamespace(tenant_id=tenant_id, user_id=user_id),
+    ), patch(
+        "app.services.direct_purchase_service.get_db_connection",
+        return_value=db_cm,
+    ):
+        result = await delete_direct_purchase(request, response, purchase_id)
+
+    assert result["success"] is True
+    assert result["data"]["inventory_reversed"] is True
+    sqls = [c.args[0] for c in conn.execute.await_args_list if c.args]
+    assert any("tenant_ingredient_movements" in s for s in sqls)
+    assert any("voided" in s for s in sqls)
+    assert any("DELETE FROM tenant_purchases" in s for s in sqls)


### PR DESCRIPTION
## Summary
- Adds `DELETE /purchases/direct/{id}` to reverse inventory with `tenant_ingredient_movements`, void `inventario` journal entries (reversing `system` entry), then hard-delete the purchase and children
- Blocks closed monthly periods and insufficient stock (no silent clamp)
- Mirrors expense delete GL pattern; inventory reverse is stricter than edit

Closes uno0uno/warocol.com#2186  
Refs uno0uno/warocol.com#2185

## Test plan
- [x] `pytest tests/test_direct_purchase_delete.py -q`
- [ ] Manual: create compra directa → delete → stock + movements + GL trail

## Validation evidence

```text
$ ./venv/bin/pytest tests/test_direct_purchase_delete.py -q
collected 5 items
tests/test_direct_purchase_delete.py .....                               [100%]
============================== 5 passed in 0.04s ===============================
```

## wr-context
See `api_warocol.com/.wr/2186.yaml` (gitignored).

Made with [Cursor](https://cursor.com)