### PR TITLE
feat(abastecimiento): delete compra directa allows negative stock (#791)

### DIFF
--- a/app/services/direct_purchase_service.py
+++ b/app/services/direct_purchase_service.py
@@ -313,7 +313,10 @@ async def _void_direct_purchase_gl_entry(
     reason: str = "Compra directa eliminada",
 ) -> bool:
     """
-    Void all posted inventario GL entries for a direct purchase.
+    Void posted GL for a direct purchase:
+      - inventario entries (Dr inventory / Cr cash|AP)
+      - supplier-payment entries (system + "Pago proveedor%", same source_id)
+
     Raises HTTP 400 if any entry sits in a closed monthly period.
     Returns True if at least one entry was voided.
     """
@@ -323,14 +326,20 @@ async def _void_direct_purchase_gl_entry(
            FROM tenant_journal_entries
            WHERE tenant_id = $1
              AND source_id = $2
-             AND source_module = 'inventario'
              AND status = 'posted'
+             AND (
+                   source_module = 'inventario'
+                   OR (
+                     source_module = 'system'
+                     AND description LIKE 'Pago proveedor%'
+                   )
+             )
            ORDER BY created_at ASC""",
         tenant_id,
         purchase_id,
     )
     if not entries:
-        logger.info(f"[GL] No posted inventario GL for purchase {purchase_id} — skip void")
+        logger.info(f"[GL] No posted purchase/payment GL for purchase {purchase_id} — skip void")
         return False
 
     for entry in entries:
@@ -394,7 +403,7 @@ async def _void_direct_purchase_gl_entry(
             )
 
         logger.info(
-            f"[GL] ✅ Voided inventario entry {entry['id']} → reversing {rev_id} "
+            f"[GL] ✅ Voided {entry['source_module']} entry {entry['id']} → reversing {rev_id} "
             f"for purchase {purchase_id}"
         )
 
@@ -1770,8 +1779,9 @@ async def delete_direct_purchase(
     purchase_id: UUID,
 ) -> Dict[str, Any]:
     """
-    Delete a direct purchase: reverse inventory with movement trail, void GL,
-    then hard-delete the purchase and child rows.
+    Delete a direct purchase: reverse inventory with movement trail (stock may
+    go negative), void inventario + supplier-payment GL, then hard-delete the
+    purchase and child rows.
     """
     try:
         session_context = require_valid_session(request)
@@ -1851,16 +1861,9 @@ async def delete_direct_purchase(
                             ),
                         )
 
+                    # Allow negative stock: sales may already have consumed part of
+                    # this purchase; tenant owns physical reconciliation (#791).
                     current_stock = _direct_purchase_decimal(inventory_row["current_stock"])
-                    if current_stock < qty:
-                        raise HTTPException(
-                            status_code=400,
-                            detail=(
-                                "No se puede eliminar: el stock actual es insuficiente para "
-                                "revertir la compra (parte del inventario ya fue consumido)"
-                            ),
-                        )
-
                     new_stock = current_stock - qty
                     await conn.execute(
                         """UPDATE tenant_inventory
@@ -1902,6 +1905,11 @@ async def delete_direct_purchase(
                     reason="Compra directa eliminada",
                 )
 
+                await conn.execute(
+                    "DELETE FROM purchase_payments WHERE purchase_id = $1 AND tenant_id = $2",
+                    purchase_id,
+                    tenant_id,
+                )
                 await conn.execute(
                     "DELETE FROM purchase_attachments WHERE purchase_id = $1 AND tenant_id = $2",
                     purchase_id,

--- a/tests/test_direct_purchase_delete.py
+++ b/tests/test_direct_purchase_delete.py
@@ -1,4 +1,4 @@
-"""Delete direct purchase: GL void + inventory reverse (#2186)."""
+"""Delete direct purchase: GL void + inventory reverse (#2186, #791)."""
 from datetime import date, datetime
 from decimal import Decimal
 from types import SimpleNamespace
@@ -76,6 +76,63 @@ async def test_void_inventario_gl_creates_reversing_entry():
     assert "voided" in void_sql
     insert_entry = conn.fetchrow.await_args.args[0]
     assert "'system'" in insert_entry or "system" in insert_entry
+    entries_sql = conn.fetch.await_args_list[0].args[0]
+    assert "inventario" in entries_sql
+    assert "Pago proveedor%" in entries_sql
+
+
+@pytest.mark.asyncio
+async def test_void_supplier_payment_gl_creates_reversing_entry():
+    tenant_id = uuid4()
+    purchase_id = uuid4()
+    entry_id = uuid4()
+    rev_id = uuid4()
+    account_a = uuid4()
+    account_b = uuid4()
+
+    conn = MagicMock()
+    conn.fetch = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "id": entry_id,
+                    "entry_date": date(2026, 3, 11),
+                    "period_year": 2026,
+                    "period_month": 3,
+                    "description": "Pago proveedor WR-CD-0003",
+                    "total_debit": Decimal("80"),
+                    "total_credit": Decimal("80"),
+                    "source_module": "system",
+                }
+            ],
+            [
+                {
+                    "account_id": account_a,
+                    "debit": Decimal("80"),
+                    "credit": Decimal("0"),
+                    "description": "AP",
+                    "line_order": 0,
+                },
+                {
+                    "account_id": account_b,
+                    "debit": Decimal("0"),
+                    "credit": Decimal("80"),
+                    "description": "Cash",
+                    "line_order": 1,
+                },
+            ],
+        ]
+    )
+    conn.fetchval = AsyncMock(return_value=None)
+    conn.execute = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"id": rev_id})
+
+    voided = await _void_direct_purchase_gl_entry(
+        conn, tenant_id, purchase_id, "Compra directa eliminada"
+    )
+
+    assert voided is True
+    assert any("voided" in c.args[0] for c in conn.execute.await_args_list if c.args)
 
 
 @pytest.mark.asyncio
@@ -145,11 +202,13 @@ async def test_delete_blocks_closed_purchase_period():
 
 
 @pytest.mark.asyncio
-async def test_delete_blocks_insufficient_stock():
+async def test_delete_allows_insufficient_stock_going_negative():
+    """#791: stock below purchase qty must still reverse (may go negative)."""
     tenant_id = uuid4()
     user_id = uuid4()
     purchase_id = uuid4()
     ingredient_id = uuid4()
+    entry_id = uuid4()
     request = MagicMock()
     response = MagicMock()
 
@@ -162,20 +221,51 @@ async def test_delete_blocks_insufficient_stock():
                 "purchase_date": datetime(2026, 3, 1),
                 "status": "paid",
             },
-            {"id": uuid4(), "current_stock": Decimal("2")},  # stock < qty 5
+            {"id": uuid4(), "current_stock": Decimal("2")},  # stock < qty 5 → -3
+            {"id": uuid4()},  # reversing JE
         ]
     )
-    conn.fetchval = AsyncMock(return_value=None)  # period open
+    conn.fetchval = AsyncMock(return_value=None)
     conn.fetch = AsyncMock(
-        return_value=[
-            {
-                "ingredient_id": ingredient_id,
-                "quantity": Decimal("5"),
-                "unit": "gr",
-            }
+        side_effect=[
+            [
+                {
+                    "ingredient_id": ingredient_id,
+                    "quantity": Decimal("5"),
+                    "unit": "gr",
+                }
+            ],
+            [
+                {
+                    "id": entry_id,
+                    "entry_date": date(2026, 3, 1),
+                    "period_year": 2026,
+                    "period_month": 3,
+                    "description": "WR-CD-0100",
+                    "total_debit": Decimal("50"),
+                    "total_credit": Decimal("50"),
+                    "source_module": "inventario",
+                }
+            ],
+            [
+                {
+                    "account_id": uuid4(),
+                    "debit": Decimal("50"),
+                    "credit": Decimal("0"),
+                    "description": "line",
+                    "line_order": 0,
+                },
+                {
+                    "account_id": uuid4(),
+                    "debit": Decimal("0"),
+                    "credit": Decimal("50"),
+                    "description": "line",
+                    "line_order": 1,
+                },
+            ],
         ]
     )
-    conn.execute = AsyncMock()
+    conn.execute = AsyncMock(return_value="DELETE 1")
 
     db_cm = MagicMock()
     db_cm.__aenter__ = AsyncMock(return_value=conn)
@@ -188,11 +278,15 @@ async def test_delete_blocks_insufficient_stock():
         "app.services.direct_purchase_service.get_db_connection",
         return_value=db_cm,
     ):
-        with pytest.raises(HTTPException) as exc:
-            await delete_direct_purchase(request, response, purchase_id)
+        result = await delete_direct_purchase(request, response, purchase_id)
 
-    assert exc.value.status_code == 400
-    assert "insuficiente" in exc.value.detail.lower()
+    assert result["success"] is True
+    update_stock = [
+        c.args for c in conn.execute.await_args_list
+        if c.args and "UPDATE tenant_inventory" in c.args[0]
+    ]
+    assert update_stock
+    assert update_stock[0][1] == Decimal("-3")  # 2 - 5
 
 
 @pytest.mark.asyncio
@@ -280,4 +374,5 @@ async def test_delete_happy_path_reverses_stock_voids_gl_and_deletes_row():
     sqls = [c.args[0] for c in conn.execute.await_args_list if c.args]
     assert any("tenant_ingredient_movements" in s for s in sqls)
     assert any("voided" in s for s in sqls)
+    assert any("DELETE FROM purchase_payments" in s for s in sqls)
     assert any("DELETE FROM tenant_purchases" in s for s in sqls)


### PR DESCRIPTION
## Summary
- Allow delete when stock &lt; purchased qty (stock may go negative); keep closed-period guards
- Void inventario **and** supplier-payment (`system` / `Pago proveedor%`) journal entries
- Delete `purchase_payments` rows before hard-deleting the purchase
- Front confirm copy left as optional companion on `warocol.com`

Closes #791

## Test plan
- [ ] Delete paid contado compra with partial sales (stock &lt; qty) → succeeds; stock negative; GL voided+reversed
- [ ] Delete credito unpaid → Inventario/CxP voided
- [ ] Delete credito with later supplier payment JE → both inventario and pago voided
- [ ] Closed period still blocked
- [ ] Bubablue WR-CD-2026-0054 style case no longer 400 insufficient stock

## Validation evidence
```text
$ ./venv/bin/pytest tests/test_direct_purchase_delete.py -q
...... 
6 passed in 0.06s
```

## wr-context
See `.wr/791.yaml` locally (gitignored LLM contract).

Made with [Cursor](https://cursor.com)