### PR TITLE
feat(billing): Paddle pricing matrix + env policy (#794)

### DIFF
--- a/app/core/billing_pricing.py
+++ b/app/core/billing_pricing.py
@@ -32,7 +32,6 @@ PADDLE_SANDBOX_TENANT_SLUGS = frozenset(
     {
         "waro-colombia",
         "warocolombia",
-        "waro",
     }
 )
 
@@ -82,6 +81,7 @@ SEGMENT_OFFERS: dict[PriceSegment, PriceOffer] = {
 
 
 def normalize_country_code(country_code: Optional[str]) -> str:
+    """Blank/missing country defaults to CO (usd_9) — documented in paddle-pricing-policy.md."""
     if not country_code or not str(country_code).strip():
         return "CO"
     return str(country_code).strip().upper()
@@ -119,6 +119,13 @@ def resolve_provider_environment(
     return "prod"
 
 
-def grandfather_active_annual(*, current_period_end_in_future: bool) -> bool:
-    """True when mid-period annual must not be rebilled / repriced (#797 enforces)."""
+def should_skip_mid_period_rebill(*, current_period_end_in_future: bool) -> bool:
+    """True when period end is still ahead — skip mid-cycle rebill/reprice.
+
+    Callers in #797 must also require status=active and billing_cycle=annual.
+    """
     return bool(current_period_end_in_future)
+
+
+# Back-compat alias for early docs/tests.
+grandfather_active_annual = should_skip_mid_period_rebill

--- a/app/core/billing_pricing.py
+++ b/app/core/billing_pricing.py
@@ -1,0 +1,124 @@
+"""Paddle regional pricing policy (epic #793 / batch #794).
+
+List prices are monthly; WARO subscribe is annual today — charge annual = 10× monthly.
+Do not use subscription_plans.price_* for Paddle charge amounts.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+from app.core.tenant_prefs import COUNTRY_CURRENCY_PAIRS
+
+ProviderEnvironment = Literal["prod", "test"]
+PriceSegment = Literal["usd_9", "usd_30", "eur_30"]
+
+# Eurozone countries in COUNTRY_CURRENCY_PAIRS that charge in EUR.
+EUROZONE_COUNTRIES = frozenset(
+    code for code, currencies in COUNTRY_CURRENCY_PAIRS.items() if "EUR" in currencies
+)
+
+# Countries that charge in USD (dollarized).
+USD_CHARGE_COUNTRIES = frozenset(
+    code for code, currencies in COUNTRY_CURRENCY_PAIRS.items() if currencies == ("USD",)
+) | frozenset({"PA"})  # PA supports USD/PAB; treat as dollarized list
+
+# Strong-currency / intl allowlist → USD 30 (not USD 9).
+INTL_USD_30_ALLOWLIST = frozenset({"GB", "CA", "AU", "NZ", "SG", "AE"})
+
+# Tenants that always use Paddle sandbox (WARO Colombia internal / QA).
+# Extend via settings later in #795 if needed.
+PADDLE_SANDBOX_TENANT_SLUGS = frozenset(
+    {
+        "waro-colombia",
+        "warocolombia",
+        "waro",
+    }
+)
+
+ANNUAL_MULTIPLIER = 10
+
+
+@dataclass(frozen=True)
+class PriceOffer:
+    segment: PriceSegment
+    currency: Literal["USD", "EUR"]
+    monthly_amount_minor: int  # cents / euro cents
+    annual_amount_minor: int
+    paddle_price_id_test: str
+    paddle_price_id_live: str
+
+    def paddle_price_id(self, environment: ProviderEnvironment) -> str:
+        return self.paddle_price_id_test if environment == "test" else self.paddle_price_id_live
+
+
+# Placeholders until Paddle catalog is created in #795.
+SEGMENT_OFFERS: dict[PriceSegment, PriceOffer] = {
+    "usd_9": PriceOffer(
+        segment="usd_9",
+        currency="USD",
+        monthly_amount_minor=900,
+        annual_amount_minor=900 * ANNUAL_MULTIPLIER,
+        paddle_price_id_test="TODO_PADDLE_PRICE_USD_9_ANNUAL_TEST",
+        paddle_price_id_live="TODO_PADDLE_PRICE_USD_9_ANNUAL_LIVE",
+    ),
+    "usd_30": PriceOffer(
+        segment="usd_30",
+        currency="USD",
+        monthly_amount_minor=3000,
+        annual_amount_minor=3000 * ANNUAL_MULTIPLIER,
+        paddle_price_id_test="TODO_PADDLE_PRICE_USD_30_ANNUAL_TEST",
+        paddle_price_id_live="TODO_PADDLE_PRICE_USD_30_ANNUAL_LIVE",
+    ),
+    "eur_30": PriceOffer(
+        segment="eur_30",
+        currency="EUR",
+        monthly_amount_minor=3000,
+        annual_amount_minor=3000 * ANNUAL_MULTIPLIER,
+        paddle_price_id_test="TODO_PADDLE_PRICE_EUR_30_ANNUAL_TEST",
+        paddle_price_id_live="TODO_PADDLE_PRICE_EUR_30_ANNUAL_LIVE",
+    ),
+}
+
+
+def normalize_country_code(country_code: Optional[str]) -> str:
+    if not country_code or not str(country_code).strip():
+        return "CO"
+    return str(country_code).strip().upper()
+
+
+def resolve_price_segment(country_code: Optional[str]) -> PriceSegment:
+    """Map tenant country to list segment (epic #793 + delta #794)."""
+    code = normalize_country_code(country_code)
+    if code in EUROZONE_COUNTRIES:
+        return "eur_30"
+    if code in USD_CHARGE_COUNTRIES or code in INTL_USD_30_ALLOWLIST:
+        return "usd_30"
+    return "usd_9"
+
+
+def resolve_price_offer(country_code: Optional[str]) -> PriceOffer:
+    return SEGMENT_OFFERS[resolve_price_segment(country_code)]
+
+
+def resolve_provider_environment(
+    *,
+    tenant_slug: Optional[str] = None,
+    billing_test: bool = False,
+) -> ProviderEnvironment:
+    """Paddle sandbox vs live.
+
+    test: explicit billing_test OR WARO Colombia sandbox tenant slug.
+    prod: everyone else (including Bubablue and other CO customers).
+    """
+    if billing_test:
+        return "test"
+    slug = (tenant_slug or "").strip().lower()
+    if slug in PADDLE_SANDBOX_TENANT_SLUGS:
+        return "test"
+    return "prod"
+
+
+def grandfather_active_annual(*, current_period_end_in_future: bool) -> bool:
+    """True when mid-period annual must not be rebilled / repriced (#797 enforces)."""
+    return bool(current_period_end_in_future)

--- a/docs/payments/paddle-pricing-policy.md
+++ b/docs/payments/paddle-pricing-policy.md
@@ -1,0 +1,44 @@
+# Paddle pricing policy (epic #793 / batch #794)
+
+**Status:** Config + policy. Checkout/webhooks land in [#795](https://github.com/uno0uno/api-warolabs/issues/795).  
+**Code:** `app/core/billing_pricing.py`
+
+## List prices (monthly)
+
+| Segment | Monthly | Annual (10×) | Who |
+|---------|---------|--------------|-----|
+| `usd_9` | USD 9 | **USD 90** | Non-dollarized (CO, MX, PE, …) except allowlist |
+| `usd_30` | USD 30 | **USD 300** | US, PA; allowlist GB, CA, AU, NZ, SG, AE |
+| `eur_30` | EUR 30 | **EUR 300** | Eurozone ES, DE, FR, NL |
+
+Annual multiplier **10×** matches “~2 months free” psychology (subscribe API is annual-only today).
+
+**Do not** charge from `subscription_plans.price_monthly` / `price_annual` (legacy COP display). Paddle uses segment → `paddle_price_id_*` (placeholders `TODO_PADDLE_PRICE_*` until catalog exists).
+
+## Country → segment
+
+1. Country has EUR in `COUNTRY_CURRENCY_PAIRS` → `eur_30`
+2. US / PA (dollarized) or intl allowlist → `usd_30`
+3. Else → `usd_9`
+
+## Sandbox vs live (`provider_environment`)
+
+| Value | When |
+|-------|------|
+| `test` | `billing_test=True` **or** tenant slug in `PADDLE_SANDBOX_TENANT_SLUGS` (e.g. `warocolombia`) |
+| `prod` | All other tenants (including Colombian customers like Bubablue) |
+
+Mirrors the intent of Wompi sandbox-for-WARO-CO / live-elsewhere without putting every `CO` tenant in sandbox.
+
+## Grandfather (active annuals)
+
+If `tenant_subscriptions.status = active` and `billing_cycle = annual` and `current_period_end` is still in the future:
+
+- **Do not** rebill or force the new Paddle list mid-period.
+- At period end / renew → Paddle + regional list ([#797](https://github.com/uno0uno/api-warolabs/issues/797)).
+
+Helper: `grandfather_active_annual(current_period_end_in_future=...)`.
+
+## Out of scope here
+
+Paddle SDK, webhooks, front CTA, Wompi removal.

--- a/docs/payments/paddle-pricing-policy.md
+++ b/docs/payments/paddle-pricing-policy.md
@@ -37,7 +37,12 @@ If `tenant_subscriptions.status = active` and `billing_cycle = annual` and `curr
 - **Do not** rebill or force the new Paddle list mid-period.
 - At period end / renew → Paddle + regional list ([#797](https://github.com/uno0uno/api-warolabs/issues/797)).
 
-Helper: `grandfather_active_annual(current_period_end_in_future=...)`.
+Helper: `should_skip_mid_period_rebill(current_period_end_in_future=...)`  
+(Callers must also require `status=active` and `billing_cycle=annual` — [#797](https://github.com/uno0uno/api-warolabs/issues/797).)
+
+## Missing country
+
+Blank/missing `country_code` defaults to **CO** → `usd_9` (WARO Colombia product default).
 
 ## Out of scope here
 

--- a/tests/test_billing_pricing.py
+++ b/tests/test_billing_pricing.py
@@ -1,0 +1,67 @@
+"""Tests for Paddle pricing matrix (#794)."""
+from app.core.billing_pricing import (
+    ANNUAL_MULTIPLIER,
+    EUROZONE_COUNTRIES,
+    INTL_USD_30_ALLOWLIST,
+    grandfather_active_annual,
+    resolve_price_offer,
+    resolve_price_segment,
+    resolve_provider_environment,
+)
+
+
+def test_eurozone_maps_to_eur_30():
+    for code in ("ES", "DE", "FR", "NL"):
+        assert code in EUROZONE_COUNTRIES
+        assert resolve_price_segment(code) == "eur_30"
+        offer = resolve_price_offer(code)
+        assert offer.currency == "EUR"
+        assert offer.monthly_amount_minor == 3000
+        assert offer.annual_amount_minor == 3000 * ANNUAL_MULTIPLIER
+
+
+def test_dollarized_maps_to_usd_30():
+    for code in ("US", "PA"):
+        assert resolve_price_segment(code) == "usd_30"
+        offer = resolve_price_offer(code)
+        assert offer.currency == "USD"
+        assert offer.monthly_amount_minor == 3000
+        assert offer.annual_amount_minor == 30000
+
+
+def test_latam_maps_to_usd_9():
+    for code in ("CO", "MX", "PE", "CL", "AR", "BR", "CR", "UY", "DO"):
+        assert resolve_price_segment(code) == "usd_9"
+        offer = resolve_price_offer(code)
+        assert offer.currency == "USD"
+        assert offer.monthly_amount_minor == 900
+        assert offer.annual_amount_minor == 9000
+
+
+def test_intl_allowlist_maps_to_usd_30():
+    for code in INTL_USD_30_ALLOWLIST:
+        assert resolve_price_segment(code) == "usd_30"
+
+
+def test_in_cn_stay_usd_9():
+    assert resolve_price_segment("IN") == "usd_9"
+    assert resolve_price_segment("CN") == "usd_9"
+
+
+def test_paddle_price_id_by_environment():
+    offer = resolve_price_offer("CO")
+    assert "TEST" in offer.paddle_price_id("test")
+    assert "LIVE" in offer.paddle_price_id("prod")
+
+
+def test_provider_environment_sandbox_slugs_and_flag():
+    assert resolve_provider_environment(tenant_slug="warocolombia") == "test"
+    assert resolve_provider_environment(tenant_slug="waro-colombia") == "test"
+    assert resolve_provider_environment(billing_test=True) == "test"
+    assert resolve_provider_environment(tenant_slug="bubablue") == "prod"
+    assert resolve_provider_environment(tenant_slug="bubablue", billing_test=False) == "prod"
+
+
+def test_grandfather_active_annual():
+    assert grandfather_active_annual(current_period_end_in_future=True) is True
+    assert grandfather_active_annual(current_period_end_in_future=False) is False

--- a/tests/test_billing_pricing.py
+++ b/tests/test_billing_pricing.py
@@ -3,10 +3,12 @@ from app.core.billing_pricing import (
     ANNUAL_MULTIPLIER,
     EUROZONE_COUNTRIES,
     INTL_USD_30_ALLOWLIST,
+    PADDLE_SANDBOX_TENANT_SLUGS,
     grandfather_active_annual,
     resolve_price_offer,
     resolve_price_segment,
     resolve_provider_environment,
+    should_skip_mid_period_rebill,
 )
 
 
@@ -55,13 +57,23 @@ def test_paddle_price_id_by_environment():
 
 
 def test_provider_environment_sandbox_slugs_and_flag():
+    assert PADDLE_SANDBOX_TENANT_SLUGS == frozenset({"waro-colombia", "warocolombia"})
     assert resolve_provider_environment(tenant_slug="warocolombia") == "test"
     assert resolve_provider_environment(tenant_slug="waro-colombia") == "test"
+    assert resolve_provider_environment(tenant_slug="waro") == "prod"
     assert resolve_provider_environment(billing_test=True) == "test"
     assert resolve_provider_environment(tenant_slug="bubablue") == "prod"
     assert resolve_provider_environment(tenant_slug="bubablue", billing_test=False) == "prod"
 
 
+def test_blank_country_defaults_to_co_usd_9():
+    assert resolve_price_segment(None) == "usd_9"
+    assert resolve_price_segment("") == "usd_9"
+    assert resolve_price_offer(None).annual_amount_minor == 9000
+
+
 def test_grandfather_active_annual():
+    assert should_skip_mid_period_rebill(current_period_end_in_future=True) is True
+    assert should_skip_mid_period_rebill(current_period_end_in_future=False) is False
     assert grandfather_active_annual(current_period_end_in_future=True) is True
     assert grandfather_active_annual(current_period_end_in_future=False) is False


### PR DESCRIPTION
## Summary
- Add `app/core/billing_pricing.py`: country → usd_9 / usd_30 / eur_30, annual = 10× monthly
- Sandbox env for WARO Colombia slugs / `billing_test`; prod for other tenants (incl. CO customers)
- Document grandfather + policy in `docs/payments/paddle-pricing-policy.md`
- Unit tests for segments, allowlist, env, grandfather helper

Closes #794  
Epic #793

## Test plan
- [ ] CO/MX → USD 9 annual 90; US/PA → USD 30 annual 300; ES → EUR 30 annual 300
- [ ] GB/CA/AU/NZ/SG/AE → USD 30
- [ ] `warocolombia` slug → provider_environment test; bubablue → prod
- [ ] Placeholders TODO_PADDLE_PRICE_* until #795 catalog

## Validation evidence
```text
$ ./venv/bin/pytest tests/test_billing_pricing.py -q
........
8 passed in 0.04s
```

## wr-context
See `.wr/794.yaml` locally (gitignored).

Made with [Cursor](https://cursor.com)