### PR TITLE
feat(billing): Paddle provider + webhooks (#795)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -81,7 +81,7 @@ class Settings(BaseSettings):
     discord_purchase_actions_webhook_url: Optional[str] = Field(default=None, alias='DISCORD_PURCHASE_ACTIONS_WEBHOOK_URL')
     discord_leads_webhook_url: Optional[str] = Field(default=None, alias='DISCORD_LEADS_WEBHOOK_URL')
 
-    # Wompi — pasarela de pagos Colombia (issue #60)
+    # Wompi — pasarela de pagos Colombia (issue #60); legacy until #798
     wompi_public_key: Optional[str] = Field(default=None, alias='WOMPI_PUBLIC_KEY')
     wompi_private_key: Optional[str] = Field(default=None, alias='WOMPI_PRIVATE_KEY')
     wompi_events_secret: Optional[str] = Field(default=None, alias='WOMPI_EVENTS_SECRET')
@@ -97,6 +97,34 @@ class Settings(BaseSettings):
     )
     wompi_webhook_forward_secret: Optional[str] = Field(
         default=None, alias='WOMPI_WEBHOOK_FORWARD_SECRET'
+    )
+
+    # Paddle Billing — regional SaaS checkout (epic #793 / batch #795)
+    paddle_api_key_live: Optional[str] = Field(default=None, alias='PADDLE_API_KEY_LIVE')
+    paddle_api_key_sandbox: Optional[str] = Field(default=None, alias='PADDLE_API_KEY_SANDBOX')
+    paddle_webhook_secret_live: Optional[str] = Field(
+        default=None, alias='PADDLE_WEBHOOK_SECRET_LIVE'
+    )
+    paddle_webhook_secret_sandbox: Optional[str] = Field(
+        default=None, alias='PADDLE_WEBHOOK_SECRET_SANDBOX'
+    )
+    paddle_price_usd_9_annual_live: Optional[str] = Field(
+        default=None, alias='PADDLE_PRICE_USD_9_ANNUAL_LIVE'
+    )
+    paddle_price_usd_9_annual_test: Optional[str] = Field(
+        default=None, alias='PADDLE_PRICE_USD_9_ANNUAL_TEST'
+    )
+    paddle_price_usd_30_annual_live: Optional[str] = Field(
+        default=None, alias='PADDLE_PRICE_USD_30_ANNUAL_LIVE'
+    )
+    paddle_price_usd_30_annual_test: Optional[str] = Field(
+        default=None, alias='PADDLE_PRICE_USD_30_ANNUAL_TEST'
+    )
+    paddle_price_eur_30_annual_live: Optional[str] = Field(
+        default=None, alias='PADDLE_PRICE_EUR_30_ANNUAL_LIVE'
+    )
+    paddle_price_eur_30_annual_test: Optional[str] = Field(
+        default=None, alias='PADDLE_PRICE_EUR_30_ANNUAL_TEST'
     )
 
     # Cron secret — grace period reminders (issue #62)

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -114,6 +114,8 @@ async def subscribe(body: SubscribeBody, request: Request):
                 plan_id=body.plan_id,
                 amount_in_cents=offer.annual_amount_minor,
                 provider_environment=provider_environment,
+                currency=offer.currency,
+                provider="paddle",
             )
         else:
             paddle_result = await paddle_service.create_checkout(

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -30,6 +30,7 @@ from app.services import (
     billing_webhook_service,
     legal_service,
     onboarding_service,
+    paddle_service,
     wompi_service,
     wompi_colombia_webhook_service,
 )
@@ -73,14 +74,9 @@ async def tenant_list_plans(request: Request):
 )
 async def subscribe(body: SubscribeBody, request: Request):
     """
-    Subscribe the authenticated tenant to a plan via Wompi Payment Link.
+    Subscribe the authenticated tenant to a plan via Paddle checkout (#795).
 
-    1. Valida que el plan exista y esté activo
-    2. Crea un Payment Link en Wompi
-    3. Guarda wompi_link_id y status='pending' en DB
-    4. Retorna checkout_url para redirigir al checkout de Wompi
-
-    billing_cycle debe ser 'annual' para nuevas suscripciones (#877).
+    billing_cycle must be 'annual' for new subscriptions (#877).
     """
     if body.billing_cycle != "annual":
         from fastapi import HTTPException
@@ -93,6 +89,13 @@ async def subscribe(body: SubscribeBody, request: Request):
     tenant_id = session.tenant_id
     is_pending_onboarding = session.lifecycle_status == "pending"
 
+    from urllib.parse import urlparse
+    from app.core.billing_pricing import resolve_price_offer, resolve_provider_environment
+
+    parsed = urlparse(settings.frontend_url)
+    frontend_host = f"{parsed.scheme}://{parsed.netloc}"
+    redirect_url = f"{frontend_host}/billing/confirmacion"
+
     async with get_db_connection() as conn:
         if is_pending_onboarding:
             await onboarding_service.ensure_onboarding_payment_ready(conn, session)
@@ -100,66 +103,65 @@ async def subscribe(body: SubscribeBody, request: Request):
         if not is_pending_onboarding:
             await legal_service.ensure_current_terms_accepted(conn, tenant_id)
 
-        amount_in_cents = plan.get("amount_in_cents")
-        if amount_in_cents is None:
-            amount_in_cents = billing_service.annual_price_in_cents(plan["price_annual"])
-
-        # Strip any base path from frontend_url to get the root host
-        # e.g. "http://localhost:8080/waro-colombia" → "http://localhost:8080"
-        from urllib.parse import urlparse
-        parsed = urlparse(settings.frontend_url)
-        frontend_host = f"{parsed.scheme}://{parsed.netloc}"
-        redirect_url = f"{frontend_host}/billing/confirmacion"
+        ctx = await billing_service.get_tenant_billing_context(conn, tenant_id)
+        offer = resolve_price_offer(ctx["country_code"])
+        provider_environment = resolve_provider_environment(tenant_slug=ctx.get("slug"))
 
         if is_pending_onboarding:
             attempt_id = await billing_service.create_onboarding_payment_attempt(
                 conn,
                 tenant_id=tenant_id,
                 plan_id=body.plan_id,
-                amount_in_cents=amount_in_cents,
-                provider_environment=wompi_service.configured_event_environment(),
+                amount_in_cents=offer.annual_amount_minor,
+                provider_environment=provider_environment,
             )
         else:
-            wompi_result = await wompi_service.create_payment_link(
-                plan_name=plan["name"],
-                amount_in_cents=amount_in_cents,
+            paddle_result = await paddle_service.create_checkout(
+                offer=offer,
+                environment=provider_environment,
+                tenant_id=tenant_id,
+                plan_id=body.plan_id,
                 billing_cycle=body.billing_cycle,
-                sku=tenant_id,
                 redirect_url=redirect_url,
+                customer_email=body.payer_email,
             )
             return await billing_service.subscribe_tenant(
                 conn,
                 tenant_id=tenant_id,
                 plan_id=body.plan_id,
                 billing_cycle=body.billing_cycle,
-                checkout_url=wompi_result["checkout_url"],
-                gateway_reference=wompi_result["wompi_link_id"],
+                checkout_url=paddle_result["checkout_url"],
+                gateway_reference=paddle_result["gateway_reference"],
             )
 
-    wompi_result = await wompi_service.create_payment_link(
-        plan_name=plan["name"],
-        amount_in_cents=amount_in_cents,
+    paddle_result = await paddle_service.create_checkout(
+        offer=offer,
+        environment=provider_environment,
+        tenant_id=tenant_id,
+        plan_id=body.plan_id,
         billing_cycle=body.billing_cycle,
-        sku=attempt_id,
         redirect_url=redirect_url,
+        customer_email=body.payer_email,
+        attempt_id=attempt_id,
     )
     async with get_db_connection() as conn:
         await billing_service.attach_onboarding_payment_link(
             conn,
             attempt_id=attempt_id,
             tenant_id=tenant_id,
-            provider_reference=wompi_result["wompi_link_id"],
-            checkout_url=wompi_result["checkout_url"],
+            provider_reference=paddle_result["gateway_reference"],
+            checkout_url=paddle_result["checkout_url"],
         )
     return {
         "attempt_id": str(attempt_id),
         "plan_id": str(body.plan_id),
-        "checkout_url": wompi_result["checkout_url"],
-        "gateway_reference": wompi_result["wompi_link_id"],
-        "amount_in_cents": amount_in_cents,
-        "currency": "COP",
+        "checkout_url": paddle_result["checkout_url"],
+        "gateway_reference": paddle_result["gateway_reference"],
+        "amount_in_cents": offer.annual_amount_minor,
+        "currency": offer.currency,
         "billing_cycle": "annual",
         "status": "pending",
+        "provider": "paddle",
     }
 
 

--- a/app/routers/payments_webhook.py
+++ b/app/routers/payments_webhook.py
@@ -1,12 +1,17 @@
 """
-Central Wompi webhook ingress (api-warolabs #353).
+Payment provider webhook ingress.
 
-Public URL: POST /payments/webhooks/wompi
-Legacy Colombia URL remains: POST /billing/webhook
+Public URLs:
+  POST /payments/webhooks/wompi[+sandbox]
+  POST /payments/webhooks/paddle[+sandbox]
+
+Legacy Colombia Wompi URL remains: POST /billing/webhook
 """
+import json
+
 from fastapi import APIRouter, BackgroundTasks, Request
 
-from app.services import wompi_webhook_router_service
+from app.services import paddle_service, wompi_webhook_router_service
 
 router = APIRouter(prefix="/payments/webhooks", tags=["Payments Webhooks"])
 
@@ -37,3 +42,29 @@ async def wompi_sandbox_webhook(
     return await wompi_webhook_router_service.dispatch_verified_event(
         body, background_tasks, expected_environment="test"
     )
+
+
+@router.post("/paddle", status_code=200)
+async def paddle_live_webhook(request: Request):
+    """Paddle Billing live webhook — signature verified with live secret (#795)."""
+    raw = await request.body()
+    paddle_service.verify_paddle_signature(
+        raw_body=raw,
+        signature_header=request.headers.get("Paddle-Signature"),
+        environment="prod",
+    )
+    payload = json.loads(raw.decode("utf-8"))
+    return await paddle_service.handle_verified_webhook(payload, environment="prod")
+
+
+@router.post("/paddle/sandbox", status_code=200)
+async def paddle_sandbox_webhook(request: Request):
+    """Paddle Billing sandbox webhook — signature verified with sandbox secret (#795)."""
+    raw = await request.body()
+    paddle_service.verify_paddle_signature(
+        raw_body=raw,
+        signature_header=request.headers.get("Paddle-Signature"),
+        environment="test",
+    )
+    payload = json.loads(raw.decode("utf-8"))
+    return await paddle_service.handle_verified_webhook(payload, environment="test")

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -1919,9 +1919,24 @@ def parse_wompi_period_anchor(transaction: Dict[str, Any]) -> datetime:
 async def payment_approved_exists(
     conn,
     subscription_id: UUID,
-    wompi_transaction_id: str,
+    wompi_transaction_id: str = "",
+    *,
+    paddle_transaction_id: Optional[str] = None,
 ) -> bool:
-    """True if this Wompi transaction already recorded as payment_approved."""
+    """True if this provider transaction already recorded as payment_approved."""
+    if paddle_transaction_id:
+        row = await conn.fetchval(
+            """
+            SELECT 1 FROM billing_events
+            WHERE subscription_id = $1
+              AND event_type = 'payment_approved'
+              AND metadata->>'paddle_transaction_id' = $2
+            LIMIT 1
+            """,
+            subscription_id,
+            paddle_transaction_id,
+        )
+        return row is not None
     if not wompi_transaction_id:
         return False
     row = await conn.fetchval(
@@ -1983,13 +1998,19 @@ async def activate_subscription_by_gateway_ref(
     conn,
     tenant_id: UUID,
     gateway_reference: str,
-    wompi_transaction_id: str,
-    amount: float,
+    wompi_transaction_id: str = "",
+    amount: float = 0.0,
     period_anchor: Optional[datetime] = None,
+    *,
+    currency: str = "COP",
+    paddle_transaction_id: Optional[str] = None,
+    paddle_subscription_id: Optional[str] = None,
+    provider: str = "wompi",
+    provider_environment: Optional[str] = None,
 ) -> None:
     """
-    Activa la suscripción del tenant cuando Wompi confirma el pago (verify-payment).
-    Extiende el período según billing_cycle para filas pending o past_due.
+    Activate tenant subscription when payment provider confirms payment.
+    Extends the period for pending or past_due rows (Wompi or Paddle).
     """
     row = await conn.fetchrow(
         """SELECT id, status, billing_cycle
@@ -2015,13 +2036,30 @@ async def activate_subscription_by_gateway_ref(
         )
         return
 
-    if await payment_approved_exists(conn, row["id"], wompi_transaction_id):
+    if await payment_approved_exists(
+        conn,
+        row["id"],
+        wompi_transaction_id,
+        paddle_transaction_id=paddle_transaction_id,
+    ):
         logger.info(
-            "activate_subscription: duplicate wompi_transaction_id=%s tenant=%s — skipped",
-            wompi_transaction_id,
+            "activate_subscription: duplicate provider txn tenant=%s — skipped",
             tenant_id,
         )
         return
+
+    metadata: Dict[str, Any] = {
+        "gateway_reference": gateway_reference,
+        "provider": provider,
+    }
+    if wompi_transaction_id:
+        metadata["wompi_transaction_id"] = wompi_transaction_id
+    if paddle_transaction_id:
+        metadata["paddle_transaction_id"] = paddle_transaction_id
+    if paddle_subscription_id:
+        metadata["paddle_subscription_id"] = paddle_subscription_id
+    if provider_environment:
+        metadata["provider_environment"] = provider_environment
 
     period_end = await _activate_subscription_with_period(
         conn,
@@ -2029,19 +2067,37 @@ async def activate_subscription_by_gateway_ref(
         tenant_id=tenant_id,
         billing_cycle=row["billing_cycle"],
         amount=amount,
-        currency="COP",
-        metadata={
-            "wompi_transaction_id": wompi_transaction_id,
-            "gateway_reference": gateway_reference,
-        },
+        currency=currency,
+        metadata=metadata,
         period_anchor=period_anchor,
     )
     await onboarding_service.activate_paid_onboarding_identity(conn, tenant_id)
 
     logger.info(
-        "Subscription activated: tenant=%s transaction=%s amount=%s period_end=%s",
-        tenant_id, wompi_transaction_id, amount, period_end,
+        "Subscription activated: tenant=%s provider=%s txn=%s amount=%s period_end=%s",
+        tenant_id,
+        provider,
+        paddle_transaction_id or wompi_transaction_id,
+        amount,
+        period_end,
     )
+
+
+async def get_tenant_billing_context(conn, tenant_id: UUID) -> Dict[str, Any]:
+    """Country + slug for Paddle pricing/env resolution."""
+    row = await conn.fetchrow(
+        """
+        SELECT t.slug,
+               COALESCE(tfp.country_code, 'CO') AS country_code
+        FROM tenants t
+        LEFT JOIN tenant_financial_profiles tfp ON tfp.tenant_id = t.id
+        WHERE t.id = $1
+        """,
+        tenant_id,
+    )
+    if not row:
+        return {"slug": None, "country_code": "CO"}
+    return {"slug": row["slug"], "country_code": row["country_code"] or "CO"}
 
 
 async def get_tenant_subscription(conn, tenant_id: UUID) -> Dict[str, Any]:

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -1719,18 +1719,26 @@ async def create_onboarding_payment_attempt(
     plan_id: UUID,
     amount_in_cents: int,
     provider_environment: str = "prod",
+    currency: str = "COP",
+    provider: str = "wompi",
 ) -> UUID:
-    """Create immutable attempt evidence before requesting a Wompi link."""
+    """Create immutable attempt evidence before requesting a checkout link."""
     if provider_environment not in ("prod", "test"):
-        raise HTTPException(status_code=422, detail="Invalid Wompi environment")
+        raise HTTPException(status_code=422, detail="Invalid payment provider environment")
+    currency_norm = str(currency or "COP").strip().upper()
+    provider_norm = str(provider or "wompi").strip().lower()
+    if provider_norm not in ("wompi", "paddle"):
+        raise HTTPException(status_code=422, detail="Invalid payment provider")
+    if currency_norm not in ("COP", "USD", "EUR"):
+        raise HTTPException(status_code=422, detail="Invalid payment currency")
     row = await conn.fetchrow("""
         INSERT INTO billing_payment_attempts (
-            tenant_id, plan_id, expected_amount_in_cents,
+            tenant_id, plan_id, provider, expected_amount_in_cents,
             currency, billing_cycle, status, provider_environment
         )
-        VALUES ($1, $2, $3, 'COP', 'annual', 'created', $4)
+        VALUES ($1, $2, $3, $4, $5, 'annual', 'created', $6)
         RETURNING id
-    """, tenant_id, plan_id, amount_in_cents, provider_environment)
+    """, tenant_id, plan_id, provider_norm, amount_in_cents, currency_norm, provider_environment)
     return row["id"]
 
 
@@ -2007,10 +2015,11 @@ async def activate_subscription_by_gateway_ref(
     paddle_subscription_id: Optional[str] = None,
     provider: str = "wompi",
     provider_environment: Optional[str] = None,
-) -> None:
+) -> bool:
     """
     Activate tenant subscription when payment provider confirms payment.
     Extends the period for pending or past_due rows (Wompi or Paddle).
+    Returns True only when a payment_approved event was written.
     """
     row = await conn.fetchrow(
         """SELECT id, status, billing_cycle
@@ -2023,18 +2032,18 @@ async def activate_subscription_by_gateway_ref(
             "activate_subscription: no subscription found for tenant=%s gateway_ref=%s",
             tenant_id, gateway_reference,
         )
-        return
+        return False
 
     if row["status"] == "active":
         logger.info("activate_subscription: already active tenant=%s", tenant_id)
-        return
+        return False
 
     if row["status"] not in _ACTIVATABLE_STATUSES:
         logger.warning(
             "activate_subscription: status=%s not activatable tenant=%s gateway_ref=%s",
             row["status"], tenant_id, gateway_reference,
         )
-        return
+        return False
 
     if await payment_approved_exists(
         conn,
@@ -2046,7 +2055,7 @@ async def activate_subscription_by_gateway_ref(
             "activate_subscription: duplicate provider txn tenant=%s — skipped",
             tenant_id,
         )
-        return
+        return False
 
     metadata: Dict[str, Any] = {
         "gateway_reference": gateway_reference,
@@ -2081,6 +2090,7 @@ async def activate_subscription_by_gateway_ref(
         amount,
         period_end,
     )
+    return True
 
 
 async def get_tenant_billing_context(conn, tenant_id: UUID) -> Dict[str, Any]:
@@ -2869,6 +2879,192 @@ async def process_onboarding_payment_transaction(
 
     return {
         "handled": True,
+        "tenant_info": {
+            "tenant_id": str(attempt["tenant_id"]),
+            "subscription_id": str(subscription["id"]),
+            "tenant_name": identity["tenant_name"],
+            "tenant_email": identity["tenant_email"],
+            "plan_name": attempt["plan_name"],
+            "next_period_end": subscription["current_period_end"].isoformat(),
+        },
+    }
+
+
+async def process_paddle_onboarding_payment(
+    conn,
+    *,
+    attempt_id: UUID,
+    transaction_id: str,
+    amount_minor: int,
+    currency: str,
+    period_anchor: Optional[datetime] = None,
+    provider_environment: str = "prod",
+    paddle_subscription_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Activate paid onboarding from a verified Paddle transaction (#795).
+
+    Looks up billing_payment_attempts by attempt_id + provider=paddle.
+    """
+    txn_id = str(transaction_id or "").strip()
+    if not txn_id:
+        return {"handled": False, "activated": False, "reason": "missing_txn"}
+
+    attempt = await conn.fetchrow(
+        """
+        SELECT a.id, a.tenant_id, a.plan_id, a.provider_reference,
+               a.expected_amount_in_cents, a.currency, a.status,
+               a.provider_transaction_id, a.provider_environment,
+               p.name AS plan_name, p.is_active AS plan_is_active
+        FROM billing_payment_attempts a
+        JOIN subscription_plans p ON p.id = a.plan_id
+        WHERE a.id = $1
+          AND a.provider = 'paddle'
+        FOR UPDATE OF a
+        """,
+        attempt_id,
+    )
+    if attempt is None:
+        return {"handled": False, "activated": False, "reason": "attempt_not_found"}
+    if attempt["provider_environment"] != provider_environment:
+        raise HTTPException(status_code=409, detail="Paddle environment mismatch")
+
+    await conn.execute("SELECT pg_advisory_xact_lock(hashtext($1))", txn_id)
+    duplicate_attempt_id = await conn.fetchval(
+        """
+        SELECT id
+        FROM billing_payment_attempts
+        WHERE provider_transaction_id = $1
+          AND provider_environment = $2
+          AND id <> $3
+        LIMIT 1
+        """,
+        txn_id,
+        provider_environment,
+        attempt["id"],
+    )
+    if duplicate_attempt_id is not None:
+        raise HTTPException(status_code=409, detail="Paddle transaction ID mismatch")
+
+    if attempt["status"] == "approved":
+        if attempt["provider_transaction_id"] != txn_id:
+            raise HTTPException(status_code=409, detail="Paddle transaction ID mismatch")
+        return {"handled": True, "activated": False, "reason": "already_approved"}
+
+    expected_currency = str(attempt["currency"]).strip().upper()
+    currency_norm = str(currency or "").strip().upper()
+    expected_amount = int(attempt["expected_amount_in_cents"])
+    if (
+        currency_norm != expected_currency
+        or int(amount_minor) != expected_amount
+        or not attempt["plan_is_active"]
+    ):
+        raise HTTPException(status_code=409, detail="Paddle payment evidence mismatch")
+
+    existing_subscription = await conn.fetchrow(
+        """
+        SELECT id, status
+        FROM tenant_subscriptions
+        WHERE tenant_id = $1
+        FOR UPDATE
+        """,
+        attempt["tenant_id"],
+    )
+    identity = await onboarding_service.activate_paid_onboarding_identity(
+        conn, attempt["tenant_id"]
+    )
+    if identity is None:
+        await conn.execute(
+            """
+            UPDATE billing_payment_attempts
+            SET status = 'approved', provider_transaction_id = $2,
+                resolved_at = now(), updated_at = now()
+            WHERE id = $1
+            """,
+            attempt["id"],
+            txn_id,
+        )
+        logger.error(
+            "Paddle onboarding payment requires reconciliation: tenant=%s attempt=%s txn=%s",
+            attempt["tenant_id"],
+            attempt["id"],
+            txn_id,
+        )
+        return {"handled": True, "activated": False, "reason": "reconciliation_required"}
+
+    if existing_subscription is not None and existing_subscription["status"] != "pending":
+        raise HTTPException(status_code=409, detail="Tenant subscription activation conflict")
+
+    anchor = period_anchor or datetime.now(timezone.utc)
+    if anchor.tzinfo is None:
+        anchor = anchor.replace(tzinfo=timezone.utc)
+    gateway_reference = str(attempt["provider_reference"] or txn_id)
+
+    subscription = await conn.fetchrow(
+        """
+        INSERT INTO tenant_subscriptions (
+            tenant_id, plan_id, billing_cycle, status, gateway_reference,
+            current_period_start, current_period_end
+        )
+        VALUES ($1, $2, 'annual', 'active', $3, $4, $4 + interval '1 year')
+        ON CONFLICT (tenant_id) DO UPDATE SET
+            plan_id = EXCLUDED.plan_id,
+            billing_cycle = 'annual',
+            status = 'active',
+            gateway_reference = EXCLUDED.gateway_reference,
+            current_period_start = EXCLUDED.current_period_start,
+            current_period_end = EXCLUDED.current_period_end,
+            cancelled_at = NULL,
+            updated_at = now()
+        WHERE tenant_subscriptions.status = 'pending'
+        RETURNING id, current_period_end
+        """,
+        attempt["tenant_id"],
+        attempt["plan_id"],
+        gateway_reference,
+        anchor,
+    )
+    if subscription is None:
+        raise HTTPException(status_code=409, detail="Tenant subscription activation conflict")
+
+    metadata = {
+        "payment_attempt_id": str(attempt["id"]),
+        "paddle_transaction_id": txn_id,
+        "gateway_reference": gateway_reference,
+        "plan_id": str(attempt["plan_id"]),
+        "provider": "paddle",
+        "provider_environment": provider_environment,
+    }
+    if paddle_subscription_id:
+        metadata["paddle_subscription_id"] = paddle_subscription_id
+
+    await conn.execute(
+        """
+        INSERT INTO billing_events (
+            tenant_id, subscription_id, event_type, amount, currency, metadata
+        )
+        VALUES ($1, $2, 'payment_approved', $3, $4, $5)
+        """,
+        attempt["tenant_id"],
+        subscription["id"],
+        Decimal(amount_minor) / Decimal("100"),
+        expected_currency,
+        json.dumps(metadata),
+    )
+    await conn.execute(
+        """
+        UPDATE billing_payment_attempts
+        SET status = 'approved', provider_transaction_id = $2,
+            resolved_at = now(), updated_at = now()
+        WHERE id = $1
+        """,
+        attempt["id"],
+        txn_id,
+    )
+
+    return {
+        "handled": True,
+        "activated": True,
         "tenant_info": {
             "tenant_id": str(attempt["tenant_id"]),
             "subscription_id": str(subscription["id"]),

--- a/app/services/paddle_service.py
+++ b/app/services/paddle_service.py
@@ -77,6 +77,7 @@ def verify_paddle_signature(
     raw_body: bytes,
     signature_header: Optional[str],
     environment: ProviderEnvironment,
+    max_skew_seconds: int = 300,
 ) -> None:
     """Verify Paddle-Signature (ts + h1 HMAC-SHA256). Raises 401 on failure."""
     secret = _webhook_secret(environment)
@@ -95,6 +96,15 @@ def verify_paddle_signature(
     h1 = parts.get("h1")
     if not ts or not h1:
         raise HTTPException(status_code=401, detail="Invalid Paddle-Signature format")
+
+    try:
+        ts_int = int(ts)
+    except ValueError as exc:
+        raise HTTPException(status_code=401, detail="Invalid Paddle-Signature timestamp") from exc
+
+    now = int(datetime.now(timezone.utc).timestamp())
+    if abs(now - ts_int) > max_skew_seconds:
+        raise HTTPException(status_code=401, detail="Paddle-Signature timestamp skew too large")
 
     payload = f"{ts}:".encode("utf-8") + raw_body
     expected = hmac.new(secret.encode("utf-8"), payload, hashlib.sha256).hexdigest()
@@ -254,10 +264,10 @@ async def handle_verified_webhook(
     status = parsed["status"]
     txn_id = parsed["transaction_id"]
 
+    # Rely on transaction.completed/paid — subscription.activated uses sub_* ids.
     success_events = {
         "transaction.completed",
         "transaction.paid",
-        "subscription.activated",
     }
     failed_events = {
         "transaction.payment_failed",
@@ -273,22 +283,51 @@ async def handle_verified_webhook(
         logger.info("Paddle event ignored event=%s status=%s", event_type, status)
         return {"ok": True, "activated": False, "reason": "ignored_event"}
 
-    if not txn_id or not parsed["tenant_id"]:
-        logger.warning("Paddle webhook missing txn/tenant: %s", parsed)
+    if not txn_id:
+        logger.warning("Paddle webhook missing txn: %s", parsed)
         return {"ok": True, "activated": False, "reason": "missing_ids"}
-
-    try:
-        tenant_id = _UUID(str(parsed["tenant_id"]))
-    except ValueError:
-        return {"ok": True, "activated": False, "reason": "bad_tenant_id"}
 
     amount = (parsed["amount_minor"] or 0) / 100.0
     async with get_db_connection() as conn:
-        await billing_service.activate_subscription_by_gateway_ref(
+        if parsed.get("attempt_id"):
+            try:
+                attempt_id = _UUID(str(parsed["attempt_id"]))
+            except ValueError:
+                return {"ok": True, "activated": False, "reason": "bad_attempt_id"}
+            result = await billing_service.process_paddle_onboarding_payment(
+                conn,
+                attempt_id=attempt_id,
+                transaction_id=str(txn_id),
+                amount_minor=int(parsed["amount_minor"] or 0),
+                currency=parsed["currency"],
+                period_anchor=parsed["period_anchor"],
+                provider_environment=environment,
+                paddle_subscription_id=(
+                    str(parsed["subscription_id"]) if parsed.get("subscription_id") else None
+                ),
+            )
+            return {
+                "ok": True,
+                "activated": bool(result.get("activated")),
+                "transaction_id": txn_id,
+                "reason": result.get("reason"),
+                "onboarding": True,
+            }
+
+        if not parsed["tenant_id"]:
+            logger.warning("Paddle webhook missing tenant: %s", parsed)
+            return {"ok": True, "activated": False, "reason": "missing_ids"}
+
+        try:
+            tenant_id = _UUID(str(parsed["tenant_id"]))
+        except ValueError:
+            return {"ok": True, "activated": False, "reason": "bad_tenant_id"}
+
+        activated = await billing_service.activate_subscription_by_gateway_ref(
             conn,
             tenant_id=tenant_id,
             gateway_reference=str(txn_id),
-            wompi_transaction_id="",  # unused when paddle id set
+            wompi_transaction_id="",
             amount=amount,
             period_anchor=parsed["period_anchor"],
             currency=parsed["currency"],
@@ -299,4 +338,9 @@ async def handle_verified_webhook(
             provider="paddle",
             provider_environment=environment,
         )
-    return {"ok": True, "activated": True, "transaction_id": txn_id}
+    return {
+        "ok": True,
+        "activated": bool(activated),
+        "transaction_id": txn_id,
+        "reason": None if activated else "not_activated",
+    }

--- a/app/services/paddle_service.py
+++ b/app/services/paddle_service.py
@@ -279,8 +279,12 @@ async def handle_verified_webhook(
         logger.info("Paddle payment not successful event=%s status=%s txn=%s", event_type, status, txn_id)
         return {"ok": True, "activated": False, "reason": "failed_or_cancelled"}
 
-    if event_type not in success_events and status not in {"completed", "paid", "billed"}:
+    if event_type not in success_events:
         logger.info("Paddle event ignored event=%s status=%s", event_type, status)
+        return {"ok": True, "activated": False, "reason": "ignored_event"}
+
+    if status and status not in {"completed", "paid", "billed"}:
+        logger.info("Paddle txn status not success event=%s status=%s", event_type, status)
         return {"ok": True, "activated": False, "reason": "ignored_event"}
 
     if not txn_id:

--- a/app/services/paddle_service.py
+++ b/app/services/paddle_service.py
@@ -1,0 +1,302 @@
+"""
+Paddle Billing — WARO SaaS checkout + webhooks (epic #793 / batch #795).
+
+Creates annual checkouts from billing_pricing segments. Verifies Paddle-Signature
+webhooks and activates subscriptions via billing_service.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import secrets
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+import httpx
+from fastapi import HTTPException
+
+from app.config import settings
+from app.core.billing_pricing import (
+    PriceOffer,
+    ProviderEnvironment,
+)
+
+logger = logging.getLogger(__name__)
+
+PADDLE_LIVE_API = "https://api.paddle.com"
+PADDLE_SANDBOX_API = "https://sandbox-api.paddle.com"
+
+
+def _api_base(environment: ProviderEnvironment) -> str:
+    return PADDLE_SANDBOX_API if environment == "test" else PADDLE_LIVE_API
+
+
+def _api_key(environment: ProviderEnvironment) -> Optional[str]:
+    if environment == "test":
+        return settings.paddle_api_key_sandbox
+    return settings.paddle_api_key_live
+
+
+def _webhook_secret(environment: ProviderEnvironment) -> Optional[str]:
+    if environment == "test":
+        return settings.paddle_webhook_secret_sandbox
+    return settings.paddle_webhook_secret_live
+
+
+def configured_price_id(offer: PriceOffer, environment: ProviderEnvironment) -> str:
+    """Prefer env-configured Paddle price IDs; fall back to segment placeholders."""
+    mapping = {
+        ("usd_9", "test"): settings.paddle_price_usd_9_annual_test,
+        ("usd_9", "prod"): settings.paddle_price_usd_9_annual_live,
+        ("usd_30", "test"): settings.paddle_price_usd_30_annual_test,
+        ("usd_30", "prod"): settings.paddle_price_usd_30_annual_live,
+        ("eur_30", "test"): settings.paddle_price_eur_30_annual_test,
+        ("eur_30", "prod"): settings.paddle_price_eur_30_annual_live,
+    }
+    configured = mapping.get((offer.segment, environment))
+    if configured and str(configured).strip():
+        return str(configured).strip()
+    return offer.paddle_price_id(environment)
+
+
+def require_usable_price_id(price_id: str, environment: ProviderEnvironment) -> str:
+    if price_id.startswith("TODO_"):
+        if environment == "prod":
+            raise HTTPException(
+                status_code=422,
+                detail="Paddle price ID no configurado para este segmento (prod)",
+            )
+        logger.warning("Using placeholder Paddle price_id=%s in test env", price_id)
+    return price_id
+
+
+def verify_paddle_signature(
+    *,
+    raw_body: bytes,
+    signature_header: Optional[str],
+    environment: ProviderEnvironment,
+) -> None:
+    """Verify Paddle-Signature (ts + h1 HMAC-SHA256). Raises 401 on failure."""
+    secret = _webhook_secret(environment)
+    if not secret:
+        raise HTTPException(status_code=503, detail="Paddle webhook secret not configured")
+    if not signature_header:
+        raise HTTPException(status_code=401, detail="Missing Paddle-Signature")
+
+    parts: Dict[str, str] = {}
+    for item in signature_header.split(";"):
+        item = item.strip()
+        if "=" in item:
+            k, v = item.split("=", 1)
+            parts[k.strip()] = v.strip()
+    ts = parts.get("ts")
+    h1 = parts.get("h1")
+    if not ts or not h1:
+        raise HTTPException(status_code=401, detail="Invalid Paddle-Signature format")
+
+    payload = f"{ts}:".encode("utf-8") + raw_body
+    expected = hmac.new(secret.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, h1):
+        raise HTTPException(status_code=401, detail="Invalid Paddle webhook signature")
+
+
+async def create_checkout(
+    *,
+    offer: PriceOffer,
+    environment: ProviderEnvironment,
+    tenant_id: UUID,
+    plan_id: UUID,
+    billing_cycle: str,
+    redirect_url: str,
+    customer_email: Optional[str] = None,
+    attempt_id: Optional[UUID] = None,
+) -> Dict[str, Any]:
+    """
+    Create a Paddle Billing transaction checkout for the annual price.
+
+    Returns: checkout_url, paddle_transaction_id, gateway_reference, currency, amount_minor
+    """
+    price_id = require_usable_price_id(
+        configured_price_id(offer, environment),
+        environment,
+    )
+    custom_data: Dict[str, str] = {
+        "tenant_id": str(tenant_id),
+        "plan_id": str(plan_id),
+        "billing_cycle": billing_cycle,
+        "provider_environment": environment,
+    }
+    if attempt_id:
+        custom_data["attempt_id"] = str(attempt_id)
+
+    api_key = _api_key(environment)
+    if not api_key or price_id.startswith("TODO_"):
+        # Dev/sandbox without catalog: synthetic checkout (webhook tests mock activation).
+        fake_id = f"txn_mock_{secrets.token_hex(8)}"
+        sep = "&" if "?" in redirect_url else "?"
+        return {
+            "checkout_url": f"{redirect_url}{sep}paddle_txn={fake_id}",
+            "paddle_transaction_id": fake_id,
+            "gateway_reference": fake_id,
+            "currency": offer.currency,
+            "amount_minor": offer.annual_amount_minor,
+            "price_id": price_id,
+            "mock": True,
+        }
+
+    body: Dict[str, Any] = {
+        "items": [{"price_id": price_id, "quantity": 1}],
+        "custom_data": custom_data,
+        "checkout": {"url": redirect_url},
+    }
+    if customer_email:
+        body["customer"] = {"email": customer_email}
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                f"{_api_base(environment)}/transactions",
+                json=body,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+            )
+    except httpx.HTTPError as exc:
+        logger.exception("Paddle create transaction failed: %s", exc)
+        raise HTTPException(status_code=502, detail="Error contactando Paddle") from exc
+
+    if response.status_code >= 400:
+        logger.error("Paddle checkout error %s: %s", response.status_code, response.text[:500])
+        raise HTTPException(status_code=502, detail="Paddle rechazó la creación del checkout")
+
+    data = response.json().get("data") or {}
+    txn_id = data.get("id")
+    checkout = data.get("checkout") or {}
+    checkout_url = checkout.get("url")
+    if not txn_id or not checkout_url:
+        raise HTTPException(status_code=502, detail="Respuesta incompleta de Paddle")
+
+    return {
+        "checkout_url": checkout_url,
+        "paddle_transaction_id": txn_id,
+        "gateway_reference": txn_id,
+        "currency": offer.currency,
+        "amount_minor": offer.annual_amount_minor,
+        "price_id": price_id,
+        "mock": False,
+    }
+
+
+def parse_period_anchor(event_data: Dict[str, Any]) -> datetime:
+    for key in ("billed_at", "created_at", "updated_at"):
+        raw = event_data.get(key)
+        if not raw:
+            continue
+        text = str(raw).replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError:
+            continue
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    return datetime.now(timezone.utc)
+
+
+def extract_transaction_event(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize Paddle webhook payload into activation fields."""
+    event_type = str(payload.get("event_type") or payload.get("eventType") or "")
+    data = payload.get("data") or {}
+    custom = data.get("custom_data") or {}
+    totals = data.get("details", {}).get("totals") or data.get("totals") or {}
+    amount_minor = totals.get("grand_total") or totals.get("total") or 0
+    try:
+        amount_minor_int = int(amount_minor)
+    except (TypeError, ValueError):
+        amount_minor_int = 0
+    currency = str(
+        totals.get("currency_code")
+        or data.get("currency_code")
+        or "USD"
+    ).upper()
+    return {
+        "event_type": event_type,
+        "transaction_id": data.get("id"),
+        "status": str(data.get("status") or "").lower(),
+        "tenant_id": custom.get("tenant_id"),
+        "plan_id": custom.get("plan_id"),
+        "billing_cycle": custom.get("billing_cycle") or "annual",
+        "attempt_id": custom.get("attempt_id"),
+        "provider_environment": custom.get("provider_environment") or "prod",
+        "amount_minor": amount_minor_int,
+        "currency": currency,
+        "period_anchor": parse_period_anchor(data),
+        "subscription_id": (data.get("subscription_id") or None),
+    }
+
+
+async def handle_verified_webhook(
+    payload: Dict[str, Any],
+    *,
+    environment: ProviderEnvironment,
+) -> Dict[str, Any]:
+    """Process a signature-verified Paddle event. Returns summary dict."""
+    from uuid import UUID as _UUID
+
+    from app.database import get_db_connection
+    from app.services import billing_service
+
+    parsed = extract_transaction_event(payload)
+    event_type = parsed["event_type"]
+    status = parsed["status"]
+    txn_id = parsed["transaction_id"]
+
+    success_events = {
+        "transaction.completed",
+        "transaction.paid",
+        "subscription.activated",
+    }
+    failed_events = {
+        "transaction.payment_failed",
+        "transaction.canceled",
+        "transaction.cancelled",
+    }
+
+    if event_type in failed_events or status in {"failed", "canceled", "cancelled"}:
+        logger.info("Paddle payment not successful event=%s status=%s txn=%s", event_type, status, txn_id)
+        return {"ok": True, "activated": False, "reason": "failed_or_cancelled"}
+
+    if event_type not in success_events and status not in {"completed", "paid", "billed"}:
+        logger.info("Paddle event ignored event=%s status=%s", event_type, status)
+        return {"ok": True, "activated": False, "reason": "ignored_event"}
+
+    if not txn_id or not parsed["tenant_id"]:
+        logger.warning("Paddle webhook missing txn/tenant: %s", parsed)
+        return {"ok": True, "activated": False, "reason": "missing_ids"}
+
+    try:
+        tenant_id = _UUID(str(parsed["tenant_id"]))
+    except ValueError:
+        return {"ok": True, "activated": False, "reason": "bad_tenant_id"}
+
+    amount = (parsed["amount_minor"] or 0) / 100.0
+    async with get_db_connection() as conn:
+        await billing_service.activate_subscription_by_gateway_ref(
+            conn,
+            tenant_id=tenant_id,
+            gateway_reference=str(txn_id),
+            wompi_transaction_id="",  # unused when paddle id set
+            amount=amount,
+            period_anchor=parsed["period_anchor"],
+            currency=parsed["currency"],
+            paddle_transaction_id=str(txn_id),
+            paddle_subscription_id=(
+                str(parsed["subscription_id"]) if parsed.get("subscription_id") else None
+            ),
+            provider="paddle",
+            provider_environment=environment,
+        )
+    return {"ok": True, "activated": True, "transaction_id": txn_id}

--- a/migrations/122_paddle_payment_attempt_provider.sql
+++ b/migrations/122_paddle_payment_attempt_provider.sql
@@ -1,0 +1,22 @@
+-- Issue #795: allow Paddle onboarding payment attempts (USD/EUR + provider=paddle).
+-- Additive only: widen CHECKs; existing Wompi/COP rows remain valid.
+
+ALTER TABLE billing_payment_attempts
+    DROP CONSTRAINT IF EXISTS billing_payment_attempts_provider_check;
+
+ALTER TABLE billing_payment_attempts
+    ADD CONSTRAINT billing_payment_attempts_provider_check
+    CHECK (provider IN ('wompi', 'paddle'));
+
+ALTER TABLE billing_payment_attempts
+    DROP CONSTRAINT IF EXISTS billing_payment_attempts_currency_check;
+
+ALTER TABLE billing_payment_attempts
+    ADD CONSTRAINT billing_payment_attempts_currency_check
+    CHECK (currency IN ('COP', 'USD', 'EUR'));
+
+COMMENT ON TABLE billing_payment_attempts IS
+    'Append-only checkout evidence (Wompi or Paddle) used to activate paid onboarding from verified webhooks.';
+
+COMMENT ON COLUMN billing_payment_attempts.expected_amount_in_cents IS
+    'Server-calculated annual price in provider minor units (COP centavos or USD/EUR cents).';

--- a/tests/test_billing_subscribe_cycle.py
+++ b/tests/test_billing_subscribe_cycle.py
@@ -65,7 +65,7 @@ def test_subscribe_rejects_monthly_billing_cycle():
     assert "anual" in res.json()["detail"].lower()
 
 
-def test_subscribe_requires_current_terms_before_wompi_link():
+def test_subscribe_requires_current_terms_before_paddle_checkout():
     app, session = _build_app()
     plan_id = uuid4()
 
@@ -103,7 +103,7 @@ def test_subscribe_requires_current_terms_before_wompi_link():
              "price_annual": 1200000.0,
          })), \
          patch("app.routers.billing.legal_service.ensure_current_terms_accepted", new=AsyncMock(side_effect=terms_error)), \
-         patch("app.routers.billing.wompi_service.create_payment_link", new=AsyncMock()) as wompi_mock:
+         patch("app.routers.billing.paddle_service.create_checkout", new=AsyncMock()) as paddle_mock:
         client = TestClient(app)
         res = client.post(
             "/billing/subscribe",
@@ -112,7 +112,7 @@ def test_subscribe_requires_current_terms_before_wompi_link():
 
     assert res.status_code == 409
     assert res.json()["detail"]["code"] == "terms_acceptance_required"
-    wompi_mock.assert_not_awaited()
+    paddle_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -145,7 +145,7 @@ async def test_active_promoted_tenant_uses_normal_subscription_flow():
     }
     checkout = {
         "checkout_url": "https://checkout.example.test",
-        "wompi_link_id": "link-normal",
+        "gateway_reference": "txn_paddle_normal",
     }
     subscribed = {"status": "pending", "checkout_url": checkout["checkout_url"]}
 
@@ -160,8 +160,12 @@ async def test_active_promoted_tenant_uses_normal_subscription_flow():
         "ensure_current_terms_accepted",
         new=AsyncMock(),
     ) as terms, patch.object(
-        billing.wompi_service,
-        "create_payment_link",
+        billing.billing_service,
+        "get_tenant_billing_context",
+        new=AsyncMock(return_value={"slug": "demo", "country_code": "CO"}),
+    ), patch.object(
+        billing.paddle_service,
+        "create_checkout",
         new=AsyncMock(return_value=checkout),
     ), patch.object(
         billing.billing_service,

--- a/tests/test_onboarding_billing.py
+++ b/tests/test_onboarding_billing.py
@@ -124,7 +124,9 @@ async def test_each_retry_inserts_a_new_payment_attempt():
     for call in conn.fetchrow.await_args_list:
         assert "INSERT INTO billing_payment_attempts" in call.args[0]
         assert "ON CONFLICT" not in call.args[0]
-        assert call.args[4] == "prod"
+        assert call.args[3] == "wompi"
+        assert call.args[5] == "COP"
+        assert call.args[6] == "prod"
 
 
 @pytest.mark.asyncio

--- a/tests/test_onboarding_country_terms.py
+++ b/tests/test_onboarding_country_terms.py
@@ -297,10 +297,10 @@ async def test_pending_subscribe_checks_onboarding_before_wompi():
         "ensure_onboarding_payment_ready",
         new=AsyncMock(side_effect=not_ready),
     ), patch.object(
-        billing.wompi_service,
-        "create_payment_link",
+        billing.paddle_service,
+        "create_checkout",
         new=AsyncMock(),
-    ) as wompi:
+    ) as paddle:
         with pytest.raises(HTTPException) as exc:
             await billing.subscribe(
                 billing.SubscribeBody(plan_id=uuid4(), billing_cycle="annual"),
@@ -309,7 +309,7 @@ async def test_pending_subscribe_checks_onboarding_before_wompi():
 
     assert exc.value.detail["code"] == "ONBOARDING_PAYMENT_NOT_READY"
     get_plan.assert_not_awaited()
-    wompi.assert_not_awaited()
+    paddle.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_paddle_billing.py
+++ b/tests/test_paddle_billing.py
@@ -2,8 +2,11 @@
 import hashlib
 import hmac
 import json
+import time
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Optional
 from uuid import uuid4
 
 import pytest
@@ -15,7 +18,9 @@ from app.routers.payments_webhook import router as payments_webhook_router
 from app.services import billing_service, paddle_service
 
 
-def _sign(raw: bytes, secret: str, ts: str = "1717200000") -> str:
+def _sign(raw: bytes, secret: str, ts: Optional[str] = None) -> str:
+    if ts is None:
+        ts = str(int(time.time()))
     digest = hmac.new(
         secret.encode("utf-8"),
         f"{ts}:".encode("utf-8") + raw,
@@ -24,7 +29,21 @@ def _sign(raw: bytes, secret: str, ts: str = "1717200000") -> str:
     return f"ts={ts};h1={digest}"
 
 
-def _completed_payload(*, tenant_id, txn_id="txn_paddle_1", status="completed"):
+def _completed_payload(
+    *,
+    tenant_id,
+    txn_id="txn_paddle_1",
+    status="completed",
+    attempt_id=None,
+):
+    custom = {
+        "tenant_id": str(tenant_id),
+        "plan_id": str(uuid4()),
+        "billing_cycle": "annual",
+        "provider_environment": "test",
+    }
+    if attempt_id is not None:
+        custom["attempt_id"] = str(attempt_id)
     return {
         "event_type": "transaction.completed",
         "data": {
@@ -32,12 +51,7 @@ def _completed_payload(*, tenant_id, txn_id="txn_paddle_1", status="completed"):
             "status": status,
             "currency_code": "USD",
             "billed_at": "2026-08-01T12:00:00Z",
-            "custom_data": {
-                "tenant_id": str(tenant_id),
-                "plan_id": str(uuid4()),
-                "billing_cycle": "annual",
-                "provider_environment": "test",
-            },
+            "custom_data": custom,
             "details": {"totals": {"grand_total": "9000", "currency_code": "USD"}},
             "subscription_id": "sub_paddle_1",
         },
@@ -55,12 +69,26 @@ def test_verify_paddle_signature_ok():
         )
 
 
+def test_verify_paddle_signature_rejects_stale_ts():
+    secret = "whsec_test"
+    raw = b"{}"
+    with patch.object(paddle_service.settings, "paddle_webhook_secret_sandbox", secret):
+        with pytest.raises(HTTPException) as exc:
+            paddle_service.verify_paddle_signature(
+                raw_body=raw,
+                signature_header=_sign(raw, secret, ts="1"),
+                environment="test",
+            )
+    assert exc.value.status_code == 401
+    assert "skew" in exc.value.detail.lower()
+
+
 def test_verify_paddle_signature_rejects_bad_h1():
     with patch.object(paddle_service.settings, "paddle_webhook_secret_sandbox", "whsec_test"):
         with pytest.raises(HTTPException) as exc:
             paddle_service.verify_paddle_signature(
                 raw_body=b"{}",
-                signature_header="ts=1;h1=deadbeef",
+                signature_header=f"ts={int(time.time())};h1=deadbeef",
                 environment="test",
             )
     assert exc.value.status_code == 401
@@ -90,7 +118,7 @@ async def test_create_checkout_uses_offer_not_plan_cop(monkeypatch):
 async def test_handle_webhook_activates_on_completed():
     tenant_id = uuid4()
     payload = _completed_payload(tenant_id=tenant_id)
-    activate = AsyncMock()
+    activate = AsyncMock(return_value=True)
 
     @asynccontextmanager
     async def _db():
@@ -110,6 +138,72 @@ async def test_handle_webhook_activates_on_completed():
     assert kwargs["paddle_subscription_id"] == "sub_paddle_1"
     assert kwargs["currency"] == "USD"
     assert kwargs["amount"] == 90.0
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_noop_reports_not_activated():
+    tenant_id = uuid4()
+    payload = _completed_payload(tenant_id=tenant_id)
+    activate = AsyncMock(return_value=False)
+
+    @asynccontextmanager
+    async def _db():
+        yield MagicMock()
+
+    with patch("app.database.get_db_connection", side_effect=_db), patch(
+        "app.services.billing_service.activate_subscription_by_gateway_ref",
+        activate,
+    ):
+        out = await paddle_service.handle_verified_webhook(payload, environment="test")
+
+    assert out["activated"] is False
+    assert out["reason"] == "not_activated"
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_routes_onboarding_attempt():
+    tenant_id = uuid4()
+    attempt_id = uuid4()
+    payload = _completed_payload(tenant_id=tenant_id, attempt_id=attempt_id)
+    onboard = AsyncMock(return_value={"handled": True, "activated": True})
+
+    @asynccontextmanager
+    async def _db():
+        yield MagicMock()
+
+    with patch("app.database.get_db_connection", side_effect=_db), patch(
+        "app.services.billing_service.process_paddle_onboarding_payment",
+        onboard,
+    ), patch(
+        "app.services.billing_service.activate_subscription_by_gateway_ref",
+        new=AsyncMock(),
+    ) as activate:
+        out = await paddle_service.handle_verified_webhook(payload, environment="test")
+
+    assert out["activated"] is True
+    assert out["onboarding"] is True
+    onboard.assert_awaited_once()
+    assert onboard.await_args.kwargs["attempt_id"] == attempt_id
+    activate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_subscription_activated_event_ignored():
+    payload = {
+        "event_type": "subscription.activated",
+        "data": {
+            "id": "sub_only",
+            "status": "active",
+            "custom_data": {"tenant_id": str(uuid4())},
+        },
+    }
+    activate = AsyncMock()
+    with patch("app.services.billing_service.activate_subscription_by_gateway_ref", activate):
+        out = await paddle_service.handle_verified_webhook(payload, environment="test")
+
+    assert out["activated"] is False
+    assert out["reason"] == "ignored_event"
+    activate.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -141,7 +235,7 @@ async def test_activate_paddle_duplicate_skips():
     conn.fetchval = AsyncMock(return_value=1)  # duplicate paddle txn
     conn.execute = AsyncMock()
 
-    await billing_service.activate_subscription_by_gateway_ref(
+    activated = await billing_service.activate_subscription_by_gateway_ref(
         conn,
         tenant_id=tenant_id,
         gateway_reference="txn_paddle_1",
@@ -152,8 +246,57 @@ async def test_activate_paddle_duplicate_skips():
         provider_environment="test",
     )
 
+    assert activated is False
     conn.execute.assert_not_called()
     conn.fetchval.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_process_paddle_onboarding_payment_activates():
+    attempt_id = uuid4()
+    tenant_id = uuid4()
+    plan_id = uuid4()
+    attempt = {
+        "id": attempt_id,
+        "tenant_id": tenant_id,
+        "plan_id": plan_id,
+        "provider_reference": "txn_onboard_1",
+        "expected_amount_in_cents": 9000,
+        "currency": "USD",
+        "status": "pending",
+        "provider_transaction_id": None,
+        "provider_environment": "test",
+        "plan_name": "Pro",
+        "plan_is_active": True,
+    }
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        side_effect=[
+            attempt,
+            {"id": uuid4(), "status": "pending"},
+            {"id": uuid4(), "current_period_end": datetime(2027, 8, 1, tzinfo=timezone.utc)},
+        ]
+    )
+    conn.fetchval = AsyncMock(return_value=None)
+    conn.execute = AsyncMock()
+
+    with patch(
+        "app.services.billing_service.onboarding_service.activate_paid_onboarding_identity",
+        new=AsyncMock(return_value={"tenant_name": "Cafe", "tenant_email": "a@b.com"}),
+    ):
+        result = await billing_service.process_paddle_onboarding_payment(
+            conn,
+            attempt_id=attempt_id,
+            transaction_id="txn_onboard_1",
+            amount_minor=9000,
+            currency="USD",
+            provider_environment="test",
+            paddle_subscription_id="sub_1",
+        )
+
+    assert result["handled"] is True
+    assert result["activated"] is True
+    assert result["tenant_info"]["tenant_name"] == "Cafe"
 
 
 def test_paddle_webhook_route_verifies_and_handles():

--- a/tests/test_paddle_billing.py
+++ b/tests/test_paddle_billing.py
@@ -1,0 +1,184 @@
+"""Paddle checkout + webhook activation (#795)."""
+import hashlib
+import hmac
+import json
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from app.core.billing_pricing import resolve_price_offer
+from app.routers.payments_webhook import router as payments_webhook_router
+from app.services import billing_service, paddle_service
+
+
+def _sign(raw: bytes, secret: str, ts: str = "1717200000") -> str:
+    digest = hmac.new(
+        secret.encode("utf-8"),
+        f"{ts}:".encode("utf-8") + raw,
+        hashlib.sha256,
+    ).hexdigest()
+    return f"ts={ts};h1={digest}"
+
+
+def _completed_payload(*, tenant_id, txn_id="txn_paddle_1", status="completed"):
+    return {
+        "event_type": "transaction.completed",
+        "data": {
+            "id": txn_id,
+            "status": status,
+            "currency_code": "USD",
+            "billed_at": "2026-08-01T12:00:00Z",
+            "custom_data": {
+                "tenant_id": str(tenant_id),
+                "plan_id": str(uuid4()),
+                "billing_cycle": "annual",
+                "provider_environment": "test",
+            },
+            "details": {"totals": {"grand_total": "9000", "currency_code": "USD"}},
+            "subscription_id": "sub_paddle_1",
+        },
+    }
+
+
+def test_verify_paddle_signature_ok():
+    secret = "whsec_test"
+    raw = b'{"event_type":"transaction.completed"}'
+    with patch.object(paddle_service.settings, "paddle_webhook_secret_sandbox", secret):
+        paddle_service.verify_paddle_signature(
+            raw_body=raw,
+            signature_header=_sign(raw, secret),
+            environment="test",
+        )
+
+
+def test_verify_paddle_signature_rejects_bad_h1():
+    with patch.object(paddle_service.settings, "paddle_webhook_secret_sandbox", "whsec_test"):
+        with pytest.raises(HTTPException) as exc:
+            paddle_service.verify_paddle_signature(
+                raw_body=b"{}",
+                signature_header="ts=1;h1=deadbeef",
+                environment="test",
+            )
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_create_checkout_uses_offer_not_plan_cop(monkeypatch):
+    offer = resolve_price_offer("CO")
+    monkeypatch.setattr(paddle_service.settings, "paddle_api_key_sandbox", None)
+
+    result = await paddle_service.create_checkout(
+        offer=offer,
+        environment="test",
+        tenant_id=uuid4(),
+        plan_id=uuid4(),
+        billing_cycle="annual",
+        redirect_url="https://example.test/billing/confirmacion",
+    )
+
+    assert result["currency"] == "USD"
+    assert result["amount_minor"] == 9000  # $90 annual, not COP plan price
+    assert result["mock"] is True
+    assert "paddle_txn=" in result["checkout_url"]
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_activates_on_completed():
+    tenant_id = uuid4()
+    payload = _completed_payload(tenant_id=tenant_id)
+    activate = AsyncMock()
+
+    @asynccontextmanager
+    async def _db():
+        yield MagicMock()
+
+    with patch("app.database.get_db_connection", side_effect=_db), patch(
+        "app.services.billing_service.activate_subscription_by_gateway_ref",
+        activate,
+    ):
+        out = await paddle_service.handle_verified_webhook(payload, environment="test")
+
+    assert out["activated"] is True
+    activate.assert_awaited_once()
+    kwargs = activate.await_args.kwargs
+    assert kwargs["provider"] == "paddle"
+    assert kwargs["paddle_transaction_id"] == "txn_paddle_1"
+    assert kwargs["paddle_subscription_id"] == "sub_paddle_1"
+    assert kwargs["currency"] == "USD"
+    assert kwargs["amount"] == 90.0
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_failed_does_not_activate():
+    tenant_id = uuid4()
+    payload = {
+        "event_type": "transaction.payment_failed",
+        "data": {
+            "id": "txn_fail",
+            "status": "failed",
+            "custom_data": {"tenant_id": str(tenant_id)},
+        },
+    }
+    activate = AsyncMock()
+    with patch("app.services.billing_service.activate_subscription_by_gateway_ref", activate):
+        out = await paddle_service.handle_verified_webhook(payload, environment="test")
+
+    assert out["activated"] is False
+    assert out["reason"] == "failed_or_cancelled"
+    activate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_activate_paddle_duplicate_skips():
+    tenant_id = uuid4()
+    sub_row = {"id": uuid4(), "status": "pending", "billing_cycle": "annual"}
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=sub_row)
+    conn.fetchval = AsyncMock(return_value=1)  # duplicate paddle txn
+    conn.execute = AsyncMock()
+
+    await billing_service.activate_subscription_by_gateway_ref(
+        conn,
+        tenant_id=tenant_id,
+        gateway_reference="txn_paddle_1",
+        amount=90.0,
+        currency="USD",
+        paddle_transaction_id="txn_paddle_1",
+        provider="paddle",
+        provider_environment="test",
+    )
+
+    conn.execute.assert_not_called()
+    conn.fetchval.assert_awaited_once()
+
+
+def test_paddle_webhook_route_verifies_and_handles():
+    secret = "whsec_live"
+    tenant_id = uuid4()
+    payload = _completed_payload(tenant_id=tenant_id)
+    raw = json.dumps(payload).encode("utf-8")
+
+    app = FastAPI()
+    app.include_router(payments_webhook_router)
+
+    with patch.object(paddle_service.settings, "paddle_webhook_secret_live", secret), patch(
+        "app.services.paddle_service.handle_verified_webhook",
+        new=AsyncMock(return_value={"ok": True, "activated": True}),
+    ) as handler:
+        client = TestClient(app)
+        res = client.post(
+            "/payments/webhooks/paddle",
+            content=raw,
+            headers={
+                "Content-Type": "application/json",
+                "Paddle-Signature": _sign(raw, secret),
+            },
+        )
+
+    assert res.status_code == 200
+    assert res.json()["activated"] is True
+    handler.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Add `paddle_service` for annual checkout (PriceOffer segments) and Paddle-Signature webhooks
- Route `POST /billing/subscribe` through Paddle (mock checkout when keys/price IDs are unset); keep Wompi until #798
- Activate/renew via `paddle_transaction_id` metadata with idempotent duplicate skips
- Ingress: `POST /payments/webhooks/paddle` and `/paddle/sandbox`

Closes #795

## Validation evidence
```
./venv/bin/pytest tests/test_paddle_billing.py tests/test_billing_activation.py tests/test_billing_subscribe_cycle.py -q
============================== 22 passed in 0.25s ==============================
```

## Test plan
- [ ] Sandbox webhook with test secret activates pending subscription for allowlisted CO slug
- [ ] Duplicate `transaction.completed` does not double-extend period
- [ ] `transaction.payment_failed` leaves subscription pending
- [ ] Subscribe for CO tenant returns USD 90 annual amount (not COP plan price)
- [ ] Prod path fails closed when price ID still `TODO_*`


Made with [Cursor](https://cursor.com)