### PR TITLE
feat(billing): plans price_offer for Paddle UI (#796)

### DIFF
--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -57,13 +57,28 @@ class SubscribeBody(BaseModel):
     dependencies=[Depends(require_module(Module.MI_PLAN))],
 )
 async def tenant_list_plans(request: Request):
-    """List active subscription plans (tenant-facing, read-only)."""
+    """List active subscription plans plus regional Paddle price_offer (#796)."""
     session = require_valid_session(request)
+    from app.core.billing_pricing import resolve_price_offer
+
     async with get_db_connection(use_transaction=False) as conn:
         if session.lifecycle_status == "pending":
             await onboarding_service.ensure_onboarding_payment_ready(conn, session)
         plans = await billing_service.list_plans(conn)
-        return [p for p in plans if p["is_active"]]
+        ctx = await billing_service.get_tenant_billing_context(conn, session.tenant_id)
+
+    offer = resolve_price_offer(ctx.get("country_code"))
+    return {
+        "plans": [p for p in plans if p["is_active"]],
+        "price_offer": {
+            "segment": offer.segment,
+            "currency": offer.currency,
+            "monthly_amount_minor": offer.monthly_amount_minor,
+            "annual_amount_minor": offer.annual_amount_minor,
+            "monthly_amount": offer.monthly_amount_minor / 100.0,
+            "annual_amount": offer.annual_amount_minor / 100.0,
+        },
+    }
 
 
 @tenant_router.post(

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -2044,6 +2044,23 @@ async def activate_subscription_by_gateway_ref(
     )
 
 
+async def get_tenant_billing_context(conn, tenant_id: UUID) -> Dict[str, Any]:
+    """Country + slug for Paddle pricing/env resolution (#794/#796)."""
+    row = await conn.fetchrow(
+        """
+        SELECT t.slug,
+               COALESCE(tfp.country_code, 'CO') AS country_code
+        FROM tenants t
+        LEFT JOIN tenant_financial_profiles tfp ON tfp.tenant_id = t.id
+        WHERE t.id = $1
+        """,
+        tenant_id,
+    )
+    if not row:
+        return {"slug": None, "country_code": "CO"}
+    return {"slug": row["slug"], "country_code": row["country_code"] or "CO"}
+
+
 async def get_tenant_subscription(conn, tenant_id: UUID) -> Dict[str, Any]:
     """
     Return the tenant's current subscription with plan details and current

--- a/tests/test_billing_plans_price_offer.py
+++ b/tests/test_billing_plans_price_offer.py
@@ -1,0 +1,75 @@
+"""GET /billing/plans includes regional price_offer (#796)."""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core import permissions
+from app.core.middleware import SessionContext
+from app.routers.billing import tenant_router
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+    yield
+    permissions._enforcement_mode_cache.clear()
+    permissions._role_modules_cache.clear()
+
+
+def test_tenant_list_plans_includes_price_offer_for_co():
+    tenant_id = uuid4()
+    session = SessionContext({
+        "user_id": uuid4(),
+        "tenant_id": tenant_id,
+        "email": "test@example.com",
+        "name": "Test",
+        "expires_at": None,
+        "is_active": True,
+        "role": "owner",
+    })
+    plan = {
+        "id": str(uuid4()),
+        "name": "Pro",
+        "slug": "pro",
+        "is_active": True,
+        "price_monthly": "0",
+        "price_annual": "95900",
+    }
+
+    @asynccontextmanager
+    async def _db(**_kwargs):
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value="disabled")
+        conn.fetchrow = AsyncMock(return_value=None)
+        conn.fetch = AsyncMock(return_value=[])
+        yield conn
+
+    app = FastAPI()
+    app.include_router(tenant_router)
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.routers.billing.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_db), \
+         patch("app.routers.billing.get_db_connection", side_effect=_db), \
+         patch("app.routers.billing.billing_service.list_plans", new=AsyncMock(return_value=[plan])), \
+         patch(
+             "app.routers.billing.billing_service.get_tenant_billing_context",
+             new=AsyncMock(return_value={"slug": "demo", "country_code": "CO"}),
+         ):
+        client = TestClient(app)
+        res = client.get("/billing/plans")
+
+    assert res.status_code == 200
+    body = res.json()
+    assert "plans" in body
+    assert body["plans"][0]["slug"] == "pro"
+    assert body["price_offer"]["currency"] == "USD"
+    assert body["price_offer"]["segment"] == "usd_9"
+    assert body["price_offer"]["annual_amount_minor"] == 9000
+    assert body["price_offer"]["annual_amount"] == 90.0


### PR DESCRIPTION
## Summary
- `GET /billing/plans` now returns `{ plans, price_offer }` from `resolve_price_offer(country)`
- Adds `get_tenant_billing_context` for country/slug lookup
- Companion for front Paddle checkout CTA batch

Refs #796 (closes via warocol.com PR)

## Validation evidence
```
./venv/bin/pytest tests/test_billing_plans_price_offer.py tests/test_billing_pricing.py -q
10 passed
```

## Test plan
- [ ] CO tenant → price_offer USD 90 annual
- [ ] US tenant → USD 300; ES → EUR 300
- [ ] Merge after or with #800 (Paddle subscribe)


Made with [Cursor](https://cursor.com)