### PR TITLE
feat(billing): deprecate Wompi from billing paths (#798)

### DIFF
--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -211,7 +211,6 @@ async def get_my_remaining_usage(request: Request):
 )
 async def verify_payment(
     request: Request,
-    background_tasks: BackgroundTasks,
     transaction_id: str = Query(...),
 ):
     """

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -27,7 +27,6 @@ from app.database import get_db_connection
 from app.services import (
     billing_service,
     billing_email_service,
-    billing_webhook_service,
     legal_service,
     onboarding_service,
     paddle_service,
@@ -216,11 +215,10 @@ async def verify_payment(
     transaction_id: str = Query(...),
 ):
     """
-    Consulta el estado de una transacción al regresar del checkout de Wompi
-    y reconcilia una aprobación si el webhook todavía no fue procesado.
+    Read-only status for a legacy Wompi transaction (#798).
 
-    La activación usa exclusivamente el resultado consultado por el servidor
-    en Wompi y exige que la referencia pertenezca al tenant autenticado.
+    Does not activate or renew subscriptions — new billing is Paddle-only.
+    Still requires the payment link to belong to the authenticated tenant.
     """
     session = require_valid_session(request)
     tenant_id = session.tenant_id
@@ -244,49 +242,17 @@ async def verify_payment(
         from fastapi import HTTPException
         raise HTTPException(status_code=404, detail="Payment transaction not found")
 
-    if wompi_status == "APPROVED":
-        amount_in_cents = billing_service._webhook_amount_in_cents(
-            transaction.get("amount_in_cents")
-        )
-        currency = str(transaction.get("currency") or "").strip().upper()
-        period_anchor = billing_service.parse_wompi_period_anchor(transaction)
-        async with get_db_connection() as conn:
-            tenant_info = await billing_service.activate_tenant_subscription(
-                conn,
-                gateway_reference=payment_link_id,
-                payment_id=transaction_id,
-                amount=amount_in_cents / 100,
-                currency=currency,
-                period_anchor=period_anchor,
-                expected_tenant_id=tenant_id,
-                amount_in_cents=amount_in_cents,
-            )
-        if tenant_info:
-            background_tasks.add_task(
-                billing_email_service.send_payment_renewed_email,
-                tenant_name=tenant_info["tenant_name"],
-                tenant_email=tenant_info["tenant_email"],
-                next_period_end=tenant_info["next_period_end"],
-            )
-            background_tasks.add_task(
-                billing_webhook_service.send_payment_approved_webhook,
-                tenant_id=tenant_info["tenant_id"],
-                subscription_id=tenant_info["subscription_id"],
-                tenant_name=tenant_info["tenant_name"],
-                tenant_email=tenant_info["tenant_email"],
-                plan_name=tenant_info["plan_name"],
-                amount=amount_in_cents / 100,
-                currency=currency,
-                next_period_end=tenant_info["next_period_end"],
-                gateway_reference=payment_link_id,
-                transaction_id=transaction_id,
-            )
-
+    logger.info(
+        "verify-payment read-only (#798): no Wompi activate tx=%s status=%s",
+        transaction_id,
+        wompi_status,
+    )
     return {
         "status": internal_status,
         "wompi_status": wompi_status,
         "transaction_id": transaction_id,
         "payment_link_id": payment_link_id,
+        "activation": "deprecated",
     }
 
 
@@ -326,7 +292,7 @@ async def get_my_billing_events(
 async def cancel_my_subscription(request: Request):
     """
     Cancela la suscripción activa del tenant en la DB.
-    Wompi Payment Links no requieren cancelación en la API.
+    Provider cancel (Paddle) is handled separately when wired; DB status is source of access.
     """
     session = require_valid_session(request)
 
@@ -339,25 +305,21 @@ async def cancel_my_subscription(request: Request):
 
 
 # NOTE: Authenticated by Wompi signature verification, not session.
-# Do NOT add require_module() here — it would break payment confirmations.
+# Do NOT add require_module() here — legacy URL still receives retries.
 @tenant_router.post("/webhook", status_code=200)
 async def wompi_webhook(
     request: Request,
     background_tasks: BackgroundTasks,
 ):
     """
-    Wompi webhook endpoint — llamado por Wompi al completar una transacción.
+    Legacy Wompi webhook — signature verified, Colombia billing no-op (#798).
 
-    Evento: transaction.updated
-    - status APPROVED → activa la suscripción
-    - status DECLINED/VOIDED/ERROR → marca como cancelled + email
-
-    Verifica la firma incluida en el body del evento.
+    Prefer POST /payments/webhooks/wompi for central routing (Tickets forward).
     """
     body = await request.json()
     event = body.get("event", "")
 
-    logger.info("Wompi webhook received: event=%s", event)
+    logger.info("Wompi webhook received (deprecated billing): event=%s", event)
 
     if not wompi_service.verify_event_signature(body):
         logger.warning("Wompi webhook: firma inválida — rechazando")
@@ -370,7 +332,7 @@ async def wompi_webhook(
     await wompi_colombia_webhook_service.handle_transaction_updated(
         body, background_tasks
     )
-    return {"received": True}
+    return {"received": True, "deprecated": True}
 
 
 # ── Grace period & access control — issue #62 ────────────────────────────────

--- a/app/routers/payments_webhook.py
+++ b/app/routers/payments_webhook.py
@@ -45,7 +45,7 @@ async def wompi_sandbox_webhook(
 
 
 @router.post("/paddle", status_code=200)
-async def paddle_live_webhook(request: Request):
+async def paddle_live_webhook(request: Request, background_tasks: BackgroundTasks):
     """Paddle Billing live webhook — signature verified with live secret (#795)."""
     raw = await request.body()
     paddle_service.verify_paddle_signature(
@@ -54,11 +54,13 @@ async def paddle_live_webhook(request: Request):
         environment="prod",
     )
     payload = json.loads(raw.decode("utf-8"))
-    return await paddle_service.handle_verified_webhook(payload, environment="prod")
+    return await paddle_service.handle_verified_webhook(
+        payload, environment="prod", background_tasks=background_tasks
+    )
 
 
 @router.post("/paddle/sandbox", status_code=200)
-async def paddle_sandbox_webhook(request: Request):
+async def paddle_sandbox_webhook(request: Request, background_tasks: BackgroundTasks):
     """Paddle Billing sandbox webhook — signature verified with sandbox secret (#795)."""
     raw = await request.body()
     paddle_service.verify_paddle_signature(
@@ -67,4 +69,6 @@ async def paddle_sandbox_webhook(request: Request):
         environment="test",
     )
     payload = json.loads(raw.decode("utf-8"))
-    return await paddle_service.handle_verified_webhook(payload, environment="test")
+    return await paddle_service.handle_verified_webhook(
+        payload, environment="test", background_tasks=background_tasks
+    )

--- a/app/routers/payments_webhook.py
+++ b/app/routers/payments_webhook.py
@@ -2,10 +2,10 @@
 Payment provider webhook ingress.
 
 Public URLs:
-  POST /payments/webhooks/wompi[+sandbox]
+  POST /payments/webhooks/wompi[+sandbox]   — Tickets forward; Colombia billing no-op (#798)
   POST /payments/webhooks/paddle[+sandbox]
 
-Legacy Colombia Wompi URL remains: POST /billing/webhook
+Legacy Colombia Wompi URL remains: POST /billing/webhook (also no-op for billing activate)
 """
 import json
 

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -3529,6 +3529,65 @@ async def mark_subscription_past_due(
         )
         return None
 
+    return await _apply_past_due_from_row(
+        conn,
+        row,
+        event_type=event_type,
+        metadata={"gateway_reference": gateway_reference},
+    )
+
+
+async def mark_subscription_past_due_by_tenant(
+    conn,
+    tenant_id: UUID,
+    event_type: str,
+    *,
+    paddle_transaction_id: Optional[str] = None,
+    paddle_subscription_id: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """
+    Paddle failure path (#798): resolve subscription by tenant_id.
+
+    Failed Paddle txns use a new transaction id that is not yet stored as
+    gateway_reference, so lookup-by-txn would always miss.
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT ts.id AS subscription_id, ts.tenant_id, ts.status,
+               ts.current_period_end
+        FROM tenant_subscriptions ts
+        WHERE ts.tenant_id = $1
+        """,
+        tenant_id,
+    )
+    if row is None:
+        logger.warning(
+            "mark_subscription_past_due_by_tenant: no subscription tenant=%s",
+            tenant_id,
+        )
+        return None
+
+    metadata: Dict[str, Any] = {"provider": "paddle", "tenant_id": str(tenant_id)}
+    if paddle_transaction_id:
+        metadata["paddle_transaction_id"] = paddle_transaction_id
+    if paddle_subscription_id:
+        metadata["paddle_subscription_id"] = paddle_subscription_id
+
+    return await _apply_past_due_from_row(
+        conn,
+        row,
+        event_type=event_type,
+        metadata=metadata,
+    )
+
+
+async def _apply_past_due_from_row(
+    conn,
+    row,
+    *,
+    event_type: str,
+    metadata: Dict[str, Any],
+) -> Dict[str, Any]:
     sub_id = row["subscription_id"]
     tenant_id = row["tenant_id"]
     status = row["status"]
@@ -3547,13 +3606,12 @@ async def mark_subscription_past_due(
         """, sub_id)
     else:
         logger.info(
-            "mark_subscription_past_due: skipped past_due status=%s period_end=%s ref=%s",
+            "mark_subscription_past_due: skipped past_due status=%s period_end=%s tenant=%s",
             status,
             period_end,
-            gateway_reference,
+            tenant_id,
         )
 
-    # Fetch tenant info for email
     tenant = await conn.fetchrow(
         "SELECT name, email FROM tenants WHERE id = $1", tenant_id
     )
@@ -3561,12 +3619,9 @@ async def mark_subscription_past_due(
     await conn.execute("""
         INSERT INTO billing_events (tenant_id, subscription_id, event_type, metadata)
         VALUES ($1, $2, $3, $4)
-    """, tenant_id, sub_id, event_type, {"gateway_reference": gateway_reference})
+    """, tenant_id, sub_id, event_type, metadata)
 
-    logger.info(
-        "%s: tenant=%s preapproval=%s",
-        event_type, tenant_id, gateway_reference,
-    )
+    logger.info("%s: tenant=%s metadata=%s", event_type, tenant_id, metadata)
 
     return {
         "tenant_id": str(tenant_id),

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -2186,6 +2186,38 @@ async def activate_subscription_by_gateway_ref(
     return True
 
 
+async def get_tenant_notify_info_after_activate(
+    conn,
+    *,
+    tenant_id: UUID,
+) -> Optional[Dict[str, Any]]:
+    """Tenant + plan fields for renewal email / outbound webhook after Paddle activate."""
+    row = await conn.fetchrow(
+        """
+        SELECT ts.id AS subscription_id,
+               ts.current_period_end,
+               t.name AS tenant_name,
+               t.email AS tenant_email,
+               sp.name AS plan_name
+        FROM tenant_subscriptions ts
+        JOIN tenants t ON t.id = ts.tenant_id
+        JOIN subscription_plans sp ON sp.id = ts.plan_id
+        WHERE ts.tenant_id = $1
+        """,
+        tenant_id,
+    )
+    if row is None:
+        return None
+    period_end = row["current_period_end"]
+    return {
+        "tenant_id": str(tenant_id),
+        "subscription_id": str(row["subscription_id"]),
+        "tenant_name": row["tenant_name"] or "",
+        "tenant_email": row["tenant_email"],
+        "plan_name": row["plan_name"] or "",
+        "next_period_end": period_end.isoformat() if period_end else "",
+    }
+
 
 async def get_tenant_billing_context(conn, tenant_id: UUID) -> Dict[str, Any]:
     """Country + slug for Paddle pricing/env resolution."""

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -1720,14 +1720,19 @@ async def create_onboarding_payment_attempt(
     amount_in_cents: int,
     provider_environment: str = "prod",
     currency: str = "COP",
-    provider: str = "wompi",
+    provider: str = "paddle",
 ) -> UUID:
     """Create immutable attempt evidence before requesting a checkout link."""
     if provider_environment not in ("prod", "test"):
         raise HTTPException(status_code=422, detail="Invalid payment provider environment")
     currency_norm = str(currency or "COP").strip().upper()
-    provider_norm = str(provider or "wompi").strip().lower()
-    if provider_norm not in ("wompi", "paddle"):
+    provider_norm = str(provider or "paddle").strip().lower()
+    if provider_norm == "wompi":
+        raise HTTPException(
+            status_code=422,
+            detail="Wompi is deprecated for new billing payments; use Paddle",
+        )
+    if provider_norm not in ("paddle",):
         raise HTTPException(status_code=422, detail="Invalid payment provider")
     if currency_norm not in ("COP", "USD", "EUR"):
         raise HTTPException(status_code=422, detail="Invalid payment currency")
@@ -2059,7 +2064,7 @@ async def activate_subscription_by_gateway_ref(
     currency: str = "COP",
     paddle_transaction_id: Optional[str] = None,
     paddle_subscription_id: Optional[str] = None,
-    provider: str = "wompi",
+    provider: str = "paddle",
     provider_environment: Optional[str] = None,
 ) -> bool:
     """

--- a/app/services/paddle_service.py
+++ b/app/services/paddle_service.py
@@ -248,6 +248,31 @@ def extract_transaction_event(payload: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+async def _notify_payment_approved(tenant_info: Dict[str, Any], *, amount: float, currency: str, gateway_reference: str, transaction_id: str) -> None:
+    """Fire renewal email + outbound approved webhook after a successful activate."""
+    from app.services import billing_email_service, billing_webhook_service
+
+    if not tenant_info:
+        return
+    await billing_email_service.send_payment_renewed_email(
+        tenant_name=tenant_info.get("tenant_name") or "",
+        tenant_email=tenant_info.get("tenant_email"),
+        next_period_end=tenant_info.get("next_period_end") or "",
+    )
+    await billing_webhook_service.send_payment_approved_webhook(
+        tenant_id=tenant_info["tenant_id"],
+        subscription_id=tenant_info["subscription_id"],
+        tenant_name=tenant_info.get("tenant_name") or "",
+        tenant_email=tenant_info.get("tenant_email"),
+        plan_name=tenant_info.get("plan_name") or "",
+        amount=amount,
+        currency=currency,
+        next_period_end=tenant_info.get("next_period_end"),
+        gateway_reference=gateway_reference,
+        transaction_id=transaction_id,
+    )
+
+
 async def handle_verified_webhook(
     payload: Dict[str, Any],
     *,
@@ -256,8 +281,9 @@ async def handle_verified_webhook(
     """Process a signature-verified Paddle event. Returns summary dict."""
     from uuid import UUID as _UUID
 
+    from app.config import settings
     from app.database import get_db_connection
-    from app.services import billing_service
+    from app.services import billing_email_service, billing_service
 
     parsed = extract_transaction_event(payload)
     event_type = parsed["event_type"]
@@ -277,6 +303,17 @@ async def handle_verified_webhook(
 
     if event_type in failed_events or status in {"failed", "canceled", "cancelled"}:
         logger.info("Paddle payment not successful event=%s status=%s txn=%s", event_type, status, txn_id)
+        if txn_id:
+            async with get_db_connection() as conn:
+                tenant_info = await billing_service.mark_subscription_past_due(
+                    conn, str(txn_id), "payment_rejected"
+                )
+            if tenant_info and tenant_info.get("tenant_email"):
+                await billing_email_service.send_payment_rejected_email(
+                    tenant_name=tenant_info.get("tenant_name") or "",
+                    tenant_email=tenant_info.get("tenant_email"),
+                    billing_url=f"{settings.frontend_url}/gestion/billing",
+                )
         return {"ok": True, "activated": False, "reason": "failed_or_cancelled"}
 
     if event_type not in success_events:
@@ -292,6 +329,12 @@ async def handle_verified_webhook(
         return {"ok": True, "activated": False, "reason": "missing_ids"}
 
     amount = (parsed["amount_minor"] or 0) / 100.0
+    currency = str(parsed.get("currency") or "USD").upper()
+    activated = False
+    tenant_info = None
+    onboarding = False
+    reason = None
+
     async with get_db_connection() as conn:
         if parsed.get("attempt_id"):
             try:
@@ -310,41 +353,57 @@ async def handle_verified_webhook(
                     str(parsed["subscription_id"]) if parsed.get("subscription_id") else None
                 ),
             )
-            return {
-                "ok": True,
-                "activated": bool(result.get("activated")),
-                "transaction_id": txn_id,
-                "reason": result.get("reason"),
-                "onboarding": True,
-            }
+            activated = bool(result.get("activated"))
+            tenant_info = result.get("tenant_info")
+            onboarding = True
+            reason = result.get("reason")
+        else:
+            if not parsed["tenant_id"]:
+                logger.warning("Paddle webhook missing tenant: %s", parsed)
+                return {"ok": True, "activated": False, "reason": "missing_ids"}
 
-        if not parsed["tenant_id"]:
-            logger.warning("Paddle webhook missing tenant: %s", parsed)
-            return {"ok": True, "activated": False, "reason": "missing_ids"}
+            try:
+                tenant_id = _UUID(str(parsed["tenant_id"]))
+            except ValueError:
+                return {"ok": True, "activated": False, "reason": "bad_tenant_id"}
 
-        try:
-            tenant_id = _UUID(str(parsed["tenant_id"]))
-        except ValueError:
-            return {"ok": True, "activated": False, "reason": "bad_tenant_id"}
+            activated = await billing_service.activate_subscription_by_gateway_ref(
+                conn,
+                tenant_id=tenant_id,
+                gateway_reference=str(txn_id),
+                wompi_transaction_id="",
+                amount=amount,
+                period_anchor=parsed["period_anchor"],
+                currency=parsed["currency"],
+                paddle_transaction_id=str(txn_id),
+                paddle_subscription_id=(
+                    str(parsed["subscription_id"]) if parsed.get("subscription_id") else None
+                ),
+                provider="paddle",
+                provider_environment=environment,
+            )
+            if activated:
+                tenant_info = await billing_service.get_tenant_notify_info_after_activate(
+                    conn, tenant_id=tenant_id
+                )
+            reason = None if activated else "not_activated"
 
-        activated = await billing_service.activate_subscription_by_gateway_ref(
-            conn,
-            tenant_id=tenant_id,
-            gateway_reference=str(txn_id),
-            wompi_transaction_id="",
+    if activated and tenant_info:
+        await _notify_payment_approved(
+            tenant_info,
             amount=amount,
-            period_anchor=parsed["period_anchor"],
-            currency=parsed["currency"],
-            paddle_transaction_id=str(txn_id),
-            paddle_subscription_id=(
-                str(parsed["subscription_id"]) if parsed.get("subscription_id") else None
-            ),
-            provider="paddle",
-            provider_environment=environment,
+            currency=currency,
+            gateway_reference=str(txn_id),
+            transaction_id=str(txn_id),
         )
-    return {
+
+    out: Dict[str, Any] = {
         "ok": True,
         "activated": bool(activated),
         "transaction_id": txn_id,
-        "reason": None if activated else "not_activated",
+        "reason": reason,
     }
+    if onboarding:
+        out["onboarding"] = True
+    return out
+

--- a/app/services/paddle_service.py
+++ b/app/services/paddle_service.py
@@ -273,17 +273,38 @@ async def _notify_payment_approved(tenant_info: Dict[str, Any], *, amount: float
     )
 
 
+async def _notify_payment_rejected(tenant_info: Dict[str, Any]) -> None:
+    from app.config import settings
+    from app.services import billing_email_service
+
+    if not tenant_info or not tenant_info.get("tenant_email"):
+        return
+    await billing_email_service.send_payment_rejected_email(
+        tenant_name=tenant_info.get("tenant_name") or "",
+        tenant_email=tenant_info.get("tenant_email"),
+        billing_url=f"{settings.frontend_url}/gestion/billing",
+    )
+
+
+def _schedule_background(background_tasks, coro_fn, *args, **kwargs) -> None:
+    """Queue notify work after the webhook HTTP response (Paddle retry-safe)."""
+    if background_tasks is None:
+        logger.warning("Paddle notify skipped: BackgroundTasks missing for %s", coro_fn.__name__)
+        return
+    background_tasks.add_task(coro_fn, *args, **kwargs)
+
+
 async def handle_verified_webhook(
     payload: Dict[str, Any],
     *,
     environment: ProviderEnvironment,
+    background_tasks=None,
 ) -> Dict[str, Any]:
     """Process a signature-verified Paddle event. Returns summary dict."""
     from uuid import UUID as _UUID
 
-    from app.config import settings
     from app.database import get_db_connection
-    from app.services import billing_email_service, billing_service
+    from app.services import billing_service
 
     parsed = extract_transaction_event(payload)
     event_type = parsed["event_type"]
@@ -303,17 +324,31 @@ async def handle_verified_webhook(
 
     if event_type in failed_events or status in {"failed", "canceled", "cancelled"}:
         logger.info("Paddle payment not successful event=%s status=%s txn=%s", event_type, status, txn_id)
-        if txn_id:
-            async with get_db_connection() as conn:
-                tenant_info = await billing_service.mark_subscription_past_due(
-                    conn, str(txn_id), "payment_rejected"
-                )
-            if tenant_info and tenant_info.get("tenant_email"):
-                await billing_email_service.send_payment_rejected_email(
-                    tenant_name=tenant_info.get("tenant_name") or "",
-                    tenant_email=tenant_info.get("tenant_email"),
-                    billing_url=f"{settings.frontend_url}/gestion/billing",
-                )
+        tenant_raw = parsed.get("tenant_id")
+        if not tenant_raw:
+            logger.warning(
+                "Paddle failure missing tenant_id txn=%s sub=%s — cannot mark past_due",
+                txn_id,
+                parsed.get("subscription_id"),
+            )
+            return {"ok": True, "activated": False, "reason": "failed_or_cancelled"}
+        try:
+            tenant_id = _UUID(str(tenant_raw))
+        except ValueError:
+            return {"ok": True, "activated": False, "reason": "failed_or_cancelled"}
+
+        async with get_db_connection() as conn:
+            tenant_info = await billing_service.mark_subscription_past_due_by_tenant(
+                conn,
+                tenant_id,
+                "payment_rejected",
+                paddle_transaction_id=str(txn_id) if txn_id else None,
+                paddle_subscription_id=(
+                    str(parsed["subscription_id"]) if parsed.get("subscription_id") else None
+                ),
+            )
+        if tenant_info:
+            _schedule_background(background_tasks, _notify_payment_rejected, tenant_info)
         return {"ok": True, "activated": False, "reason": "failed_or_cancelled"}
 
     if event_type not in success_events:
@@ -388,8 +423,11 @@ async def handle_verified_webhook(
                 )
             reason = None if activated else "not_activated"
 
-    if activated and tenant_info:
-        await _notify_payment_approved(
+    # Renewals only — onboarding first payment should not get "renovada" copy.
+    if activated and tenant_info and not onboarding:
+        _schedule_background(
+            background_tasks,
+            _notify_payment_approved,
             tenant_info,
             amount=amount,
             currency=currency,

--- a/app/services/tenant_financial_profile_service.py
+++ b/app/services/tenant_financial_profile_service.py
@@ -91,7 +91,8 @@ def _capabilities(country_code: str) -> FinancialCapabilities:
         colombia_payroll=colombia,
         matias_dian=colombia,
         cop_wallet=colombia,
-        wompi=colombia,
+        # Wompi pay capability retired; Paddle-only checkout (#798)
+        wompi=False,
         fixed_cop_discounts=colombia,
     )
 

--- a/app/services/wompi_colombia_webhook_service.py
+++ b/app/services/wompi_colombia_webhook_service.py
@@ -1,17 +1,14 @@
 """
 Colombia billing — Wompi transaction.updated handler (api-warolabs #353).
 
-Extracted from billing.wompi_webhook so the central router and legacy
-POST /billing/webhook share the same activation logic.
+Deprecated for new billing activations (#798). Signature-verified callers
+should no-op with 200 so Wompi does not retry; Tickets routing is unchanged
+in wompi_webhook_router_service.
 """
 import logging
 from typing import Any, Dict
 
 from fastapi import BackgroundTasks
-
-from app.config import settings
-from app.database import get_db_connection
-from app.services import billing_email_service, billing_service, billing_webhook_service
 
 logger = logging.getLogger(__name__)
 
@@ -22,104 +19,17 @@ async def handle_transaction_updated(
     provider_environment: str = "prod",
 ) -> None:
     """
-    Process a verified Wompi transaction.updated event for Colombia billing.
+    No-op for Colombia billing after Paddle-only (#798).
 
-    Caller must verify the signature and filter non-transaction events first.
+    Caller must still verify the webhook signature before invoking this.
+    Historical payment_event / metadata rows are left untouched.
     """
-    transaction = body.get("data", {}).get("transaction", {})
-    wompi_status = transaction.get("status", "").upper()
-    payment_link_id = transaction.get("payment_link_id", "")
-    transaction_id = str(transaction.get("id", ""))
-    amount_cents = transaction.get("amount_in_cents", 0)
-
+    transaction = body.get("data", {}).get("transaction", {}) or {}
     logger.info(
-        "Wompi Colombia transaction: link=%s status=%s tx=%s",
-        payment_link_id,
-        wompi_status,
-        transaction_id,
+        "Wompi Colombia billing deprecated (#798): no-op env=%s status=%s tx=%s link=%s",
+        provider_environment,
+        str(transaction.get("status", "")).upper(),
+        transaction.get("id"),
+        transaction.get("payment_link_id"),
     )
-
-    if not payment_link_id:
-        return
-
-    async with get_db_connection() as conn:
-        onboarding_result = await billing_service.process_onboarding_payment_transaction(
-            conn,
-            transaction,
-            provider_environment=provider_environment,
-        )
-    if onboarding_result["handled"]:
-        tenant_info = onboarding_result["tenant_info"]
-        if tenant_info:
-            background_tasks.add_task(
-                billing_email_service.send_payment_renewed_email,
-                tenant_name=tenant_info["tenant_name"],
-                tenant_email=tenant_info["tenant_email"],
-                next_period_end=tenant_info["next_period_end"],
-            )
-            background_tasks.add_task(
-                billing_webhook_service.send_payment_approved_webhook,
-                tenant_id=tenant_info["tenant_id"],
-                subscription_id=tenant_info["subscription_id"],
-                tenant_name=tenant_info["tenant_name"],
-                tenant_email=tenant_info["tenant_email"],
-                plan_name=tenant_info["plan_name"],
-                amount=amount_cents / 100,
-                currency="COP",
-                next_period_end=tenant_info["next_period_end"],
-                gateway_reference=payment_link_id,
-                transaction_id=transaction_id,
-            )
-        return
-
-    if provider_environment != "prod":
-        logger.warning(
-            "Wompi sandbox event has no matching onboarding attempt; "
-            "legacy subscription handling skipped"
-        )
-        return
-
-    if wompi_status == "APPROVED":
-        period_anchor = billing_service.parse_wompi_period_anchor(transaction)
-        async with get_db_connection() as conn:
-            tenant_info = await billing_service.activate_tenant_subscription(
-                conn,
-                gateway_reference=payment_link_id,
-                payment_id=transaction_id,
-                amount=amount_cents / 100,
-                currency="COP",
-                period_anchor=period_anchor,
-            )
-        if tenant_info:
-            background_tasks.add_task(
-                billing_email_service.send_payment_renewed_email,
-                tenant_name=tenant_info["tenant_name"],
-                tenant_email=tenant_info["tenant_email"],
-                next_period_end=tenant_info["next_period_end"],
-            )
-            background_tasks.add_task(
-                billing_webhook_service.send_payment_approved_webhook,
-                tenant_id=tenant_info["tenant_id"],
-                subscription_id=tenant_info["subscription_id"],
-                tenant_name=tenant_info["tenant_name"],
-                tenant_email=tenant_info["tenant_email"],
-                plan_name=tenant_info["plan_name"],
-                amount=amount_cents / 100,
-                currency="COP",
-                next_period_end=tenant_info["next_period_end"],
-                gateway_reference=payment_link_id,
-                transaction_id=transaction_id,
-            )
-
-    elif wompi_status in ("DECLINED", "VOIDED", "ERROR"):
-        async with get_db_connection() as conn:
-            tenant_info = await billing_service.mark_subscription_past_due(
-                conn, payment_link_id, "payment_rejected"
-            )
-        if tenant_info:
-            background_tasks.add_task(
-                billing_email_service.send_payment_rejected_email,
-                tenant_name=tenant_info["tenant_name"],
-                tenant_email=tenant_info["tenant_email"],
-                billing_url=f"{settings.frontend_url}/gestion/billing",
-            )
+    return

--- a/app/services/wompi_colombia_webhook_service.py
+++ b/app/services/wompi_colombia_webhook_service.py
@@ -25,10 +25,13 @@ async def handle_transaction_updated(
     Historical payment_event / metadata rows are left untouched.
     """
     transaction = body.get("data", {}).get("transaction", {}) or {}
-    logger.info(
+    status = str(transaction.get("status", "")).upper()
+    level = logging.WARNING if status == "APPROVED" else logging.INFO
+    logger.log(
+        level,
         "Wompi Colombia billing deprecated (#798): no-op env=%s status=%s tx=%s link=%s",
         provider_environment,
-        str(transaction.get("status", "")).upper(),
+        status,
         transaction.get("id"),
         transaction.get("payment_link_id"),
     )

--- a/app/services/wompi_webhook_router_service.py
+++ b/app/services/wompi_webhook_router_service.py
@@ -179,12 +179,13 @@ async def dispatch_verified_event(
             return {"status": "received"}
 
         if route == WompiRoute.COLOMBIA:
+            # Billing activate/renew via Wompi removed (#798); keep Tickets path.
             await wompi_colombia_webhook_service.handle_transaction_updated(
                 body,
                 background_tasks,
                 provider_environment=expected_environment,
             )
-            return {"received": True}
+            return {"received": True, "deprecated": True}
 
         logger.warning(
             "Wompi ingress: unknown classification — tx=%s ref=%s link=%s redirect=%s sku=%s amount=%s",

--- a/tests/test_onboarding_billing.py
+++ b/tests/test_onboarding_billing.py
@@ -435,7 +435,6 @@ async def test_colombia_wompi_handler_is_noop(caplog):
 async def test_browser_verify_payment_is_read_only_for_approved_transaction():
     tenant_id = uuid4()
     session = SimpleNamespace(tenant_id=tenant_id)
-    background_tasks = BackgroundTasks()
     transaction = {
         "id": "tx-approved",
         "status": "APPROVED",
@@ -462,14 +461,12 @@ async def test_browser_verify_payment_is_read_only_for_approved_transaction():
     ) as activate:
         result = await billing.verify_payment(
             object(),
-            background_tasks,
             transaction_id="tx-approved",
         )
 
     assert result["status"] == "active"
     assert result["activation"] == "deprecated"
     activate.assert_not_awaited()
-    assert len(background_tasks.tasks) == 0
 
 
 @pytest.mark.asyncio
@@ -501,7 +498,6 @@ async def test_browser_verify_payment_does_not_activate_pending_transaction():
     ) as activate:
         result = await billing.verify_payment(
             object(),
-            BackgroundTasks(),
             transaction_id="tx-pending",
         )
 

--- a/tests/test_onboarding_billing.py
+++ b/tests/test_onboarding_billing.py
@@ -407,22 +407,28 @@ async def test_paid_identity_activation_accepts_promoted_admin_and_updates_once(
 
 
 @pytest.mark.asyncio
-async def test_colombia_wompi_handler_is_noop():
+async def test_colombia_wompi_handler_is_noop(caplog):
     """#798 — verified Colombia events must not activate/renew."""
+    import logging
+
     from app.services import wompi_colombia_webhook_service
 
-    await wompi_colombia_webhook_service.handle_transaction_updated(
-        {
-            "data": {
-                "transaction": {
-                    "id": "tx-approved",
-                    "status": "APPROVED",
-                    "payment_link_id": "link-onboarding",
+    with caplog.at_level(logging.WARNING):
+        await wompi_colombia_webhook_service.handle_transaction_updated(
+            {
+                "data": {
+                    "transaction": {
+                        "id": "tx-approved",
+                        "status": "APPROVED",
+                        "payment_link_id": "link-onboarding",
+                    }
                 }
-            }
-        },
-        MagicMock(),
-    )
+            },
+            MagicMock(),
+        )
+
+    assert any("deprecated (#798)" in r.message for r in caplog.records)
+    assert any(r.levelno == logging.WARNING for r in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/test_onboarding_billing.py
+++ b/tests/test_onboarding_billing.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
-from fastapi import BackgroundTasks, HTTPException
+from fastapi import HTTPException
 
 from app.routers import billing
 from app.services import billing_service, wompi_service

--- a/tests/test_onboarding_billing.py
+++ b/tests/test_onboarding_billing.py
@@ -124,9 +124,24 @@ async def test_each_retry_inserts_a_new_payment_attempt():
     for call in conn.fetchrow.await_args_list:
         assert "INSERT INTO billing_payment_attempts" in call.args[0]
         assert "ON CONFLICT" not in call.args[0]
-        assert call.args[3] == "wompi"
+        assert call.args[3] == "paddle"
         assert call.args[5] == "COP"
         assert call.args[6] == "prod"
+
+
+@pytest.mark.asyncio
+async def test_create_onboarding_payment_attempt_rejects_wompi():
+    conn = AsyncMock()
+    with pytest.raises(HTTPException) as exc:
+        await billing_service.create_onboarding_payment_attempt(
+            conn,
+            tenant_id=uuid4(),
+            plan_id=uuid4(),
+            amount_in_cents=9000,
+            provider="wompi",
+        )
+    assert exc.value.status_code == 422
+    conn.fetchrow.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -392,85 +407,26 @@ async def test_paid_identity_activation_accepts_promoted_admin_and_updates_once(
 
 
 @pytest.mark.asyncio
-async def test_declined_onboarding_attempt_never_calls_legacy_past_due():
-    transaction = {
-        "id": "tx-declined",
-        "status": "DECLINED",
-        "payment_link_id": "link-onboarding",
-    }
-    background_tasks = MagicMock()
-    handled = {"handled": True, "tenant_info": None}
-
-    @asynccontextmanager
-    async def db_context():
-        yield AsyncMock()
-
+async def test_colombia_wompi_handler_is_noop():
+    """#798 — verified Colombia events must not activate/renew."""
     from app.services import wompi_colombia_webhook_service
 
-    with patch.object(
-        wompi_colombia_webhook_service,
-        "get_db_connection",
-        side_effect=db_context,
-    ), patch.object(
-        wompi_colombia_webhook_service.billing_service,
-        "process_onboarding_payment_transaction",
-        new=AsyncMock(return_value=handled),
-    ), patch.object(
-        wompi_colombia_webhook_service.billing_service,
-        "mark_subscription_past_due",
-        new=AsyncMock(),
-    ) as legacy_past_due:
-        await wompi_colombia_webhook_service.handle_transaction_updated(
-            {"data": {"transaction": transaction}}, background_tasks
-        )
-
-    legacy_past_due.assert_not_awaited()
+    await wompi_colombia_webhook_service.handle_transaction_updated(
+        {
+            "data": {
+                "transaction": {
+                    "id": "tx-approved",
+                    "status": "APPROVED",
+                    "payment_link_id": "link-onboarding",
+                }
+            }
+        },
+        MagicMock(),
+    )
 
 
 @pytest.mark.asyncio
-async def test_unmatched_sandbox_event_never_calls_legacy_subscription_handlers():
-    transaction = {
-        "id": "tx-sandbox",
-        "status": "APPROVED",
-        "payment_link_id": "sandbox-link",
-    }
-    background_tasks = MagicMock()
-
-    @asynccontextmanager
-    async def db_context():
-        yield AsyncMock()
-
-    from app.services import wompi_colombia_webhook_service
-
-    with patch.object(
-        wompi_colombia_webhook_service,
-        "get_db_connection",
-        side_effect=db_context,
-    ), patch.object(
-        wompi_colombia_webhook_service.billing_service,
-        "process_onboarding_payment_transaction",
-        new=AsyncMock(return_value={"handled": False, "tenant_info": None}),
-    ), patch.object(
-        wompi_colombia_webhook_service.billing_service,
-        "activate_tenant_subscription",
-        new=AsyncMock(),
-    ) as legacy_activate, patch.object(
-        wompi_colombia_webhook_service.billing_service,
-        "mark_subscription_past_due",
-        new=AsyncMock(),
-    ) as legacy_past_due:
-        await wompi_colombia_webhook_service.handle_transaction_updated(
-            {"data": {"transaction": transaction}},
-            background_tasks,
-            provider_environment="test",
-        )
-
-    legacy_activate.assert_not_awaited()
-    legacy_past_due.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_browser_verify_payment_reconciles_owned_approved_subscription():
+async def test_browser_verify_payment_is_read_only_for_approved_transaction():
     tenant_id = uuid4()
     session = SimpleNamespace(tenant_id=tenant_id)
     background_tasks = BackgroundTasks()
@@ -481,14 +437,6 @@ async def test_browser_verify_payment_reconciles_owned_approved_subscription():
         "amount_in_cents": 9590000,
         "currency": "COP",
         "finalized_at": "2026-07-16T18:32:25.077Z",
-    }
-    tenant_info = {
-        "tenant_id": str(tenant_id),
-        "subscription_id": str(uuid4()),
-        "tenant_name": "Test tenant",
-        "tenant_email": "test@example.com",
-        "plan_name": "Pro",
-        "next_period_end": "2027-07-16T18:32:25.077+00:00",
     }
 
     @asynccontextmanager
@@ -504,7 +452,7 @@ async def test_browser_verify_payment_reconciles_owned_approved_subscription():
     ), patch.object(
         billing.billing_service,
         "activate_tenant_subscription",
-        new=AsyncMock(return_value=tenant_info),
+        new=AsyncMock(),
     ) as activate:
         result = await billing.verify_payment(
             object(),
@@ -513,14 +461,9 @@ async def test_browser_verify_payment_reconciles_owned_approved_subscription():
         )
 
     assert result["status"] == "active"
-    activate.assert_awaited_once()
-    kwargs = activate.await_args.kwargs
-    assert kwargs["gateway_reference"] == "link-onboarding"
-    assert kwargs["payment_id"] == "tx-approved"
-    assert kwargs["expected_tenant_id"] == tenant_id
-    assert kwargs["amount_in_cents"] == 9590000
-    assert kwargs["currency"] == "COP"
-    assert len(background_tasks.tasks) == 2
+    assert result["activation"] == "deprecated"
+    activate.assert_not_awaited()
+    assert len(background_tasks.tasks) == 0
 
 
 @pytest.mark.asyncio
@@ -557,4 +500,5 @@ async def test_browser_verify_payment_does_not_activate_pending_transaction():
         )
 
     assert result["status"] == "pending"
+    assert result["activation"] == "deprecated"
     activate.assert_not_awaited()

--- a/tests/test_paddle_billing.py
+++ b/tests/test_paddle_billing.py
@@ -119,6 +119,17 @@ async def test_handle_webhook_activates_on_completed():
     tenant_id = uuid4()
     payload = _completed_payload(tenant_id=tenant_id)
     activate = AsyncMock(return_value=True)
+    notify_info = AsyncMock(
+        return_value={
+            "tenant_id": str(tenant_id),
+            "subscription_id": str(uuid4()),
+            "tenant_name": "T",
+            "tenant_email": "t@example.com",
+            "plan_name": "Pro",
+            "next_period_end": "2027-01-01T00:00:00+00:00",
+        }
+    )
+    notify = AsyncMock()
 
     @asynccontextmanager
     async def _db():
@@ -127,11 +138,15 @@ async def test_handle_webhook_activates_on_completed():
     with patch("app.database.get_db_connection", side_effect=_db), patch(
         "app.services.billing_service.activate_subscription_by_gateway_ref",
         activate,
-    ):
+    ), patch(
+        "app.services.billing_service.get_tenant_notify_info_after_activate",
+        notify_info,
+    ), patch.object(paddle_service, "_notify_payment_approved", notify):
         out = await paddle_service.handle_verified_webhook(payload, environment="test")
 
     assert out["activated"] is True
     activate.assert_awaited_once()
+    notify.assert_awaited_once()
     kwargs = activate.await_args.kwargs
     assert kwargs["provider"] == "paddle"
     assert kwargs["paddle_transaction_id"] == "txn_paddle_1"

--- a/tests/test_paddle_billing.py
+++ b/tests/test_paddle_billing.py
@@ -10,7 +10,7 @@ from typing import Optional
 from uuid import uuid4
 
 import pytest
-from fastapi import FastAPI, HTTPException
+from fastapi import BackgroundTasks, FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from app.core.billing_pricing import resolve_price_offer
@@ -129,7 +129,7 @@ async def test_handle_webhook_activates_on_completed():
             "next_period_end": "2027-01-01T00:00:00+00:00",
         }
     )
-    notify = AsyncMock()
+    background = BackgroundTasks()
 
     @asynccontextmanager
     async def _db():
@@ -141,12 +141,15 @@ async def test_handle_webhook_activates_on_completed():
     ), patch(
         "app.services.billing_service.get_tenant_notify_info_after_activate",
         notify_info,
-    ), patch.object(paddle_service, "_notify_payment_approved", notify):
-        out = await paddle_service.handle_verified_webhook(payload, environment="test")
+    ):
+        out = await paddle_service.handle_verified_webhook(
+            payload, environment="test", background_tasks=background
+        )
 
     assert out["activated"] is True
     activate.assert_awaited_once()
-    notify.assert_awaited_once()
+    assert len(background.tasks) == 1
+    assert background.tasks[0].func is paddle_service._notify_payment_approved
     kwargs = activate.await_args.kwargs
     assert kwargs["provider"] == "paddle"
     assert kwargs["paddle_transaction_id"] == "txn_paddle_1"
@@ -180,7 +183,21 @@ async def test_handle_webhook_routes_onboarding_attempt():
     tenant_id = uuid4()
     attempt_id = uuid4()
     payload = _completed_payload(tenant_id=tenant_id, attempt_id=attempt_id)
-    onboard = AsyncMock(return_value={"handled": True, "activated": True})
+    onboard = AsyncMock(
+        return_value={
+            "handled": True,
+            "activated": True,
+            "tenant_info": {
+                "tenant_id": str(tenant_id),
+                "subscription_id": str(uuid4()),
+                "tenant_name": "T",
+                "tenant_email": "t@example.com",
+                "plan_name": "Pro",
+                "next_period_end": "2027-01-01T00:00:00+00:00",
+            },
+        }
+    )
+    background = BackgroundTasks()
 
     @asynccontextmanager
     async def _db():
@@ -193,13 +210,17 @@ async def test_handle_webhook_routes_onboarding_attempt():
         "app.services.billing_service.activate_subscription_by_gateway_ref",
         new=AsyncMock(),
     ) as activate:
-        out = await paddle_service.handle_verified_webhook(payload, environment="test")
+        out = await paddle_service.handle_verified_webhook(
+            payload, environment="test", background_tasks=background
+        )
 
     assert out["activated"] is True
     assert out["onboarding"] is True
     onboard.assert_awaited_once()
     assert onboard.await_args.kwargs["attempt_id"] == attempt_id
     activate.assert_not_awaited()
+    # First onboarding payment must not queue "renovada" email
+    assert len(background.tasks) == 0
 
 
 @pytest.mark.asyncio
@@ -222,23 +243,53 @@ async def test_subscription_activated_event_ignored():
 
 
 @pytest.mark.asyncio
-async def test_handle_webhook_failed_does_not_activate():
+async def test_handle_webhook_failed_marks_past_due_by_tenant():
     tenant_id = uuid4()
     payload = {
         "event_type": "transaction.payment_failed",
         "data": {
             "id": "txn_fail",
             "status": "failed",
+            "subscription_id": "sub_paddle_fail",
             "custom_data": {"tenant_id": str(tenant_id)},
         },
     }
+    past_due = AsyncMock(
+        return_value={
+            "tenant_id": str(tenant_id),
+            "subscription_id": str(uuid4()),
+            "tenant_name": "T",
+            "tenant_email": "t@example.com",
+        }
+    )
     activate = AsyncMock()
-    with patch("app.services.billing_service.activate_subscription_by_gateway_ref", activate):
-        out = await paddle_service.handle_verified_webhook(payload, environment="test")
+    background = BackgroundTasks()
+
+    @asynccontextmanager
+    async def _db():
+        yield MagicMock()
+
+    with patch("app.database.get_db_connection", side_effect=_db), patch(
+        "app.services.billing_service.mark_subscription_past_due_by_tenant",
+        past_due,
+    ), patch(
+        "app.services.billing_service.activate_subscription_by_gateway_ref",
+        activate,
+    ):
+        out = await paddle_service.handle_verified_webhook(
+            payload, environment="test", background_tasks=background
+        )
 
     assert out["activated"] is False
     assert out["reason"] == "failed_or_cancelled"
     activate.assert_not_awaited()
+    past_due.assert_awaited_once()
+    kwargs = past_due.await_args.kwargs
+    assert past_due.await_args.args[1] == tenant_id
+    assert kwargs["paddle_transaction_id"] == "txn_fail"
+    assert kwargs["paddle_subscription_id"] == "sub_paddle_fail"
+    assert len(background.tasks) == 1
+    assert background.tasks[0].func is paddle_service._notify_payment_rejected
 
 
 @pytest.mark.asyncio

--- a/tests/test_wompi_webhook_router.py
+++ b/tests/test_wompi_webhook_router.py
@@ -130,7 +130,7 @@ async def test_dispatch_gateway_reference_calls_colombia_not_tickets(background_
     ):
         result = await dispatch_verified_event(body, background_tasks)
 
-    assert result == {"received": True}
+    assert result == {"received": True, "deprecated": True}
     colombia.assert_awaited_once_with(
         body, background_tasks, provider_environment="prod"
     )
@@ -159,7 +159,7 @@ async def test_dispatch_billing_redirect_calls_colombia_not_tickets(background_t
     ):
         result = await dispatch_verified_event(body, background_tasks)
 
-    assert result == {"received": True}
+    assert result == {"received": True, "deprecated": True}
     colombia.assert_awaited_once_with(
         body, background_tasks, provider_environment="prod"
     )


### PR DESCRIPTION
## Summary
- Colombia Wompi webhooks verify then no-op (no activate/renew); Tickets forward unchanged
- `GET /billing/verify-payment` is read-only; `capabilities.wompi` always false; new attempts reject `provider=wompi`
- Paddle failure → past_due by tenant_id; notifies via BackgroundTasks
- Keep legacy history metadata

Supersedes closed stacked PR #803 (base branch deleted after #802 merge). Rebased onto main.

Closes #798

## Test plan
- [ ] Tickets `WT-` Wompi events still forward
- [ ] Colombia billing Wompi event returns 200 and does not activate
- [ ] Paddle checkout + webhooks still activate; failed renew marks past_due by tenant

## Validation evidence
```
configfile: pytest.ini
plugins: asyncio-0.24.0, cov-6.0.0, repeat-0.9.4, xdist-3.8.0, anyio-4.10.0, langsmith-0.9.0, deepeval-3.8.4, rerunfailures-16.1
asyncio: mode=Mode.AUTO, default_loop_scope=function
collected 63 items

tests/test_paddle_billing.py ............                                [ 19%]
tests/test_wompi_webhook_router.py ............                          [ 38%]
tests/test_billing_activation.py ............                            [ 57%]
tests/test_onboarding_billing.py ...........................             [100%]Running teardown with pytest sessionfinish...


============================== 63 passed in 0.24s ==============================
```

Made with [Cursor](https://cursor.com)