### PR TITLE
feat(billing): monthly Paddle catalog + policy (#806)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -108,6 +108,26 @@ class Settings(BaseSettings):
     paddle_webhook_secret_sandbox: Optional[str] = Field(
         default=None, alias='PADDLE_WEBHOOK_SECRET_SANDBOX'
     )
+    # Monthly Paddle price IDs — default charge cycle for new checkouts (#806 / epic #805)
+    paddle_price_usd_9_monthly_live: Optional[str] = Field(
+        default=None, alias='PADDLE_PRICE_USD_9_MONTHLY_LIVE'
+    )
+    paddle_price_usd_9_monthly_test: Optional[str] = Field(
+        default=None, alias='PADDLE_PRICE_USD_9_MONTHLY_TEST'
+    )
+    paddle_price_usd_30_monthly_live: Optional[str] = Field(
+        default=None, alias='PADDLE_PRICE_USD_30_MONTHLY_LIVE'
+    )
+    paddle_price_usd_30_monthly_test: Optional[str] = Field(
+        default=None, alias='PADDLE_PRICE_USD_30_MONTHLY_TEST'
+    )
+    paddle_price_eur_30_monthly_live: Optional[str] = Field(
+        default=None, alias='PADDLE_PRICE_EUR_30_MONTHLY_LIVE'
+    )
+    paddle_price_eur_30_monthly_test: Optional[str] = Field(
+        default=None, alias='PADDLE_PRICE_EUR_30_MONTHLY_TEST'
+    )
+    # Annual price IDs — optional legacy only (not required for new checkout)
     paddle_price_usd_9_annual_live: Optional[str] = Field(
         default=None, alias='PADDLE_PRICE_USD_9_ANNUAL_LIVE'
     )

--- a/app/core/billing_pricing.py
+++ b/app/core/billing_pricing.py
@@ -1,6 +1,7 @@
-"""Paddle regional pricing policy (epic #793 / batch #794).
+"""Paddle regional pricing policy (epic #805 / batch #806).
 
-List prices are monthly; WARO subscribe is annual today — charge annual = 10× monthly.
+List prices and default Paddle charge for new checkouts are monthly
+(USD 9 / USD 30 / EUR 30). Annual 10× from #793 is legacy/display only.
 Do not use subscription_plans.price_* for Paddle charge amounts.
 """
 from __future__ import annotations
@@ -52,31 +53,31 @@ class PriceOffer:
         return self.paddle_price_id_test if environment == "test" else self.paddle_price_id_live
 
 
-# Placeholders until Paddle catalog is created in #795.
+# Placeholders until env PADDLE_PRICE_*_MONTHLY_* is set (prefer env via paddle_service).
 SEGMENT_OFFERS: dict[PriceSegment, PriceOffer] = {
     "usd_9": PriceOffer(
         segment="usd_9",
         currency="USD",
         monthly_amount_minor=900,
         annual_amount_minor=900 * ANNUAL_MULTIPLIER,
-        paddle_price_id_test="TODO_PADDLE_PRICE_USD_9_ANNUAL_TEST",
-        paddle_price_id_live="TODO_PADDLE_PRICE_USD_9_ANNUAL_LIVE",
+        paddle_price_id_test="TODO_PADDLE_PRICE_USD_9_MONTHLY_TEST",
+        paddle_price_id_live="TODO_PADDLE_PRICE_USD_9_MONTHLY_LIVE",
     ),
     "usd_30": PriceOffer(
         segment="usd_30",
         currency="USD",
         monthly_amount_minor=3000,
         annual_amount_minor=3000 * ANNUAL_MULTIPLIER,
-        paddle_price_id_test="TODO_PADDLE_PRICE_USD_30_ANNUAL_TEST",
-        paddle_price_id_live="TODO_PADDLE_PRICE_USD_30_ANNUAL_LIVE",
+        paddle_price_id_test="TODO_PADDLE_PRICE_USD_30_MONTHLY_TEST",
+        paddle_price_id_live="TODO_PADDLE_PRICE_USD_30_MONTHLY_LIVE",
     ),
     "eur_30": PriceOffer(
         segment="eur_30",
         currency="EUR",
         monthly_amount_minor=3000,
         annual_amount_minor=3000 * ANNUAL_MULTIPLIER,
-        paddle_price_id_test="TODO_PADDLE_PRICE_EUR_30_ANNUAL_TEST",
-        paddle_price_id_live="TODO_PADDLE_PRICE_EUR_30_ANNUAL_LIVE",
+        paddle_price_id_test="TODO_PADDLE_PRICE_EUR_30_MONTHLY_TEST",
+        paddle_price_id_live="TODO_PADDLE_PRICE_EUR_30_MONTHLY_LIVE",
     ),
 }
 

--- a/app/services/paddle_service.py
+++ b/app/services/paddle_service.py
@@ -1,8 +1,8 @@
 """
-Paddle Billing — WARO SaaS checkout + webhooks (epic #793 / batch #795).
+Paddle Billing — WARO SaaS checkout + webhooks (epic #793 / #805).
 
-Creates annual checkouts from billing_pricing segments. Verifies Paddle-Signature
-webhooks and activates subscriptions via billing_service.
+Resolves monthly Paddle price IDs from billing_pricing segments (#806).
+Verifies Paddle-Signature webhooks and activates subscriptions via billing_service.
 """
 from __future__ import annotations
 
@@ -46,8 +46,16 @@ def _webhook_secret(environment: ProviderEnvironment) -> Optional[str]:
 
 
 def configured_price_id(offer: PriceOffer, environment: ProviderEnvironment) -> str:
-    """Prefer env-configured Paddle price IDs; fall back to segment placeholders."""
-    mapping = {
+    """Prefer monthly env price IDs; annual env only if monthly unset; else placeholders."""
+    monthly_mapping = {
+        ("usd_9", "test"): settings.paddle_price_usd_9_monthly_test,
+        ("usd_9", "prod"): settings.paddle_price_usd_9_monthly_live,
+        ("usd_30", "test"): settings.paddle_price_usd_30_monthly_test,
+        ("usd_30", "prod"): settings.paddle_price_usd_30_monthly_live,
+        ("eur_30", "test"): settings.paddle_price_eur_30_monthly_test,
+        ("eur_30", "prod"): settings.paddle_price_eur_30_monthly_live,
+    }
+    annual_mapping = {
         ("usd_9", "test"): settings.paddle_price_usd_9_annual_test,
         ("usd_9", "prod"): settings.paddle_price_usd_9_annual_live,
         ("usd_30", "test"): settings.paddle_price_usd_30_annual_test,
@@ -55,9 +63,13 @@ def configured_price_id(offer: PriceOffer, environment: ProviderEnvironment) -> 
         ("eur_30", "test"): settings.paddle_price_eur_30_annual_test,
         ("eur_30", "prod"): settings.paddle_price_eur_30_annual_live,
     }
-    configured = mapping.get((offer.segment, environment))
-    if configured and str(configured).strip():
-        return str(configured).strip()
+    key = (offer.segment, environment)
+    monthly = monthly_mapping.get(key)
+    if monthly and str(monthly).strip():
+        return str(monthly).strip()
+    annual = annual_mapping.get(key)
+    if annual and str(annual).strip():
+        return str(annual).strip()
     return offer.paddle_price_id(environment)
 
 

--- a/docs/payments/paddle-pricing-policy.md
+++ b/docs/payments/paddle-pricing-policy.md
@@ -1,19 +1,30 @@
-# Paddle pricing policy (epic #793 / batch #794)
+# Paddle pricing policy (epic #805 / batch #806)
 
-**Status:** Config + policy. Checkout/webhooks land in [#795](https://github.com/uno0uno/api-warolabs/issues/795).  
-**Code:** `app/core/billing_pricing.py`
+**Status:** Monthly is the **default charge cycle** for new checkouts.  
+**Code:** `app/core/billing_pricing.py`, `app/services/paddle_service.py` (`configured_price_id`)  
+**Related:** Epic [#805](https://github.com/uno0uno/api-warolabs/issues/805); annual 10× from [#793](https://github.com/uno0uno/api-warolabs/issues/793) is **legacy** only.
 
-## List prices (monthly)
+## List prices (monthly = charge basis)
 
-| Segment | Monthly | Annual (10×) | Who |
-|---------|---------|--------------|-----|
-| `usd_9` | USD 9 | **USD 90** | Non-dollarized (CO, MX, PE, …) except allowlist |
-| `usd_30` | USD 30 | **USD 300** | US, PA; allowlist GB, CA, AU, NZ, SG, AE |
-| `eur_30` | EUR 30 | **EUR 300** | Eurozone ES, DE, FR, NL |
+| Segment | Monthly (charge) | Annual 10× (legacy display) | Who |
+|---------|------------------|-----------------------------|-----|
+| `usd_9` | **USD 9** | USD 90 | Non-dollarized (CO, MX, PE, …) except allowlist |
+| `usd_30` | **USD 30** | USD 300 | US, PA; allowlist GB, CA, AU, NZ, SG, AE |
+| `eur_30` | **EUR 30** | EUR 300 | Eurozone ES, DE, FR, NL |
 
-Annual multiplier **10×** matches “~2 months free” psychology (subscribe API is annual-only today).
+Charge amounts use `monthly_amount_minor` (900 / 3000 / 3000). Do **not** charge from `subscription_plans.price_*` (legacy COP display).
 
-**Do not** charge from `subscription_plans.price_monthly` / `price_annual` (legacy COP display). Paddle uses segment → `paddle_price_id_*` (placeholders `TODO_PADDLE_PRICE_*` until catalog exists).
+## Env price IDs
+
+Prefer monthly (required for new checkout once #807 unlocks the cycle):
+
+- `PADDLE_PRICE_USD_9_MONTHLY_{TEST,LIVE}`
+- `PADDLE_PRICE_USD_30_MONTHLY_{TEST,LIVE}`
+- `PADDLE_PRICE_EUR_30_MONTHLY_{TEST,LIVE}`
+
+Annual `PADDLE_PRICE_*_ANNUAL_*` is optional fallback only if monthly is unset. Segment placeholders are `TODO_PADDLE_PRICE_*_MONTHLY_*`.
+
+**Deploy note:** Do not set monthly env in **prod** until subscribe defaults to monthly (#807); otherwise checkout may bill a monthly Paddle price while the API still labels the cycle annual.
 
 ## Country → segment
 
@@ -28,27 +39,18 @@ Annual multiplier **10×** matches “~2 months free” psychology (subscribe AP
 | `test` | `billing_test=True` **or** tenant slug in `PADDLE_SANDBOX_TENANT_SLUGS` (e.g. `warocolombia`) |
 | `prod` | All other tenants (including Colombian customers like Bubablue) |
 
-Mirrors the intent of Wompi sandbox-for-WARO-CO / live-elsewhere without putting every `CO` tenant in sandbox.
-
 ## Grandfather (active annuals)
 
 If `tenant_subscriptions.status = active` and `billing_cycle = annual` and `current_period_end` is still in the future:
 
-- **Do not** rebill or force the new Paddle list mid-period.
-- At period end / renew → Paddle + regional list ([#797](https://github.com/uno0uno/api-warolabs/issues/797)).
+- **Do not** rebill or force monthly mid-period.
+- At period end / renew → monthly Paddle list ([#809](https://github.com/uno0uno/api-warolabs/issues/809)).
 
-Helpers (wired in #797):
+Helpers:
 
 - `is_grandfathered_annual(status=..., billing_cycle=..., current_period_end=...)`
 - `should_skip_mid_period_rebill(current_period_end_in_future=...)` (period flag only)
 
-Call sites: `ensure_subscribe_allowed` / `subscribe_tenant` (409 `grandfather_active_period`);
-`activate_subscription_by_gateway_ref` skips mid-period and renews via tenant lookup when Paddle `gateway_reference` rotates.
-
 ## Missing country
 
 Blank/missing `country_code` defaults to **CO** → `usd_9` (WARO Colombia product default).
-
-## Out of scope here
-
-Paddle SDK, webhooks, front CTA, Wompi removal.

--- a/tests/test_billing_pricing.py
+++ b/tests/test_billing_pricing.py
@@ -1,4 +1,6 @@
-"""Tests for Paddle pricing matrix (#794)."""
+"""Tests for Paddle pricing matrix (#794 / #806)."""
+from unittest.mock import patch
+
 from app.core.billing_pricing import (
     ANNUAL_MULTIPLIER,
     EUROZONE_COUNTRIES,
@@ -10,6 +12,7 @@ from app.core.billing_pricing import (
     resolve_provider_environment,
     should_skip_mid_period_rebill,
 )
+from app.services.paddle_service import configured_price_id
 
 
 def test_eurozone_maps_to_eur_30():
@@ -52,8 +55,32 @@ def test_in_cn_stay_usd_9():
 
 def test_paddle_price_id_by_environment():
     offer = resolve_price_offer("CO")
-    assert "TEST" in offer.paddle_price_id("test")
-    assert "LIVE" in offer.paddle_price_id("prod")
+    assert "MONTHLY_TEST" in offer.paddle_price_id("test")
+    assert "MONTHLY_LIVE" in offer.paddle_price_id("prod")
+
+
+def test_charge_basis_is_monthly_minors():
+    assert resolve_price_offer("CO").monthly_amount_minor == 900
+    assert resolve_price_offer("US").monthly_amount_minor == 3000
+    assert resolve_price_offer("ES").monthly_amount_minor == 3000
+
+
+def test_configured_price_id_prefers_monthly_over_annual():
+    offer = resolve_price_offer("CO")
+    with patch("app.services.paddle_service.settings") as mock_settings:
+        mock_settings.paddle_price_usd_9_monthly_test = "pri_monthly_test"
+        mock_settings.paddle_price_usd_9_annual_test = "pri_annual_test"
+        assert configured_price_id(offer, "test") == "pri_monthly_test"
+
+
+def test_configured_price_id_falls_back_to_annual_then_placeholder():
+    offer = resolve_price_offer("CO")
+    with patch("app.services.paddle_service.settings") as mock_settings:
+        mock_settings.paddle_price_usd_9_monthly_test = None
+        mock_settings.paddle_price_usd_9_annual_test = "pri_annual_only"
+        assert configured_price_id(offer, "test") == "pri_annual_only"
+        mock_settings.paddle_price_usd_9_annual_test = None
+        assert configured_price_id(offer, "test").startswith("TODO_PADDLE_PRICE_USD_9_MONTHLY")
 
 
 def test_provider_environment_sandbox_slugs_and_flag():


### PR DESCRIPTION
## Summary
- Add `PADDLE_PRICE_*_MONTHLY_{TEST,LIVE}` config slots; annual IDs remain optional legacy
- `configured_price_id` prefers monthly env → annual fallback → monthly placeholders
- Policy doc: monthly is default charge for new checkouts (epic #805)
- Charge basis stays `monthly_amount_minor` (900 / 3000 / 3000)

Closes #806

## Test plan
- [x] `python -m pytest tests/test_billing_pricing.py -q`
- [ ] Do not set monthly env in prod until #807 unlocks monthly subscribe

## Validation evidence
```
collected 12 items
tests/test_billing_pricing.py ............                               [100%]
============================== 12 passed in 0.11s ==============================
```

Made with [Cursor](https://cursor.com)