### PR TITLE
feat(billing): monthly subscribe + renew webhooks (#807)

### DIFF
--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -45,7 +45,7 @@ tenant_router = APIRouter(prefix="/billing", tags=["Billing"])
 class SubscribeBody(BaseModel):
     """Body for POST /billing/subscribe"""
     plan_id: UUID
-    billing_cycle: str = "annual"  # new subscriptions: annual only (#877)
+    billing_cycle: str = "monthly"  # new subscriptions: monthly only (#807)
     payer_email: Optional[str] = None
 
 
@@ -88,16 +88,16 @@ async def tenant_list_plans(request: Request):
 )
 async def subscribe(body: SubscribeBody, request: Request):
     """
-    Subscribe the authenticated tenant to a plan via Paddle checkout (#795).
+    Subscribe the authenticated tenant to a plan via Paddle checkout (#807).
 
-    billing_cycle must be 'annual' for new subscriptions (#877).
+    billing_cycle must be 'monthly' for new subscriptions.
     Active annuals with a future period end are blocked mid-period (#797).
     """
-    if body.billing_cycle != "annual":
+    if body.billing_cycle != "monthly":
         from fastapi import HTTPException
         raise HTTPException(
             status_code=422,
-            detail="Las suscripciones nuevas solo están disponibles con ciclo anual (billing_cycle='annual').",
+            detail="Las suscripciones nuevas solo estan disponibles con ciclo mensual (billing_cycle='monthly').",
         )
 
     session = require_valid_session(request)
@@ -128,7 +128,7 @@ async def subscribe(body: SubscribeBody, request: Request):
                 conn,
                 tenant_id=tenant_id,
                 plan_id=body.plan_id,
-                amount_in_cents=offer.annual_amount_minor,
+                amount_in_cents=offer.monthly_amount_minor,
                 provider_environment=provider_environment,
                 currency=offer.currency,
                 provider="paddle",
@@ -175,9 +175,9 @@ async def subscribe(body: SubscribeBody, request: Request):
         "plan_id": str(body.plan_id),
         "checkout_url": paddle_result["checkout_url"],
         "gateway_reference": paddle_result["gateway_reference"],
-        "amount_in_cents": offer.annual_amount_minor,
+        "amount_in_cents": offer.monthly_amount_minor,
         "currency": offer.currency,
-        "billing_cycle": "annual",
+        "billing_cycle": "monthly",
         "status": "pending",
         "provider": "paddle",
     }

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -1741,7 +1741,7 @@ async def create_onboarding_payment_attempt(
             tenant_id, plan_id, provider, expected_amount_in_cents,
             currency, billing_cycle, status, provider_environment
         )
-        VALUES ($1, $2, $3, $4, $5, 'annual', 'created', $6)
+        VALUES ($1, $2, $3, $4, $5, 'monthly', 'created', $6)
         RETURNING id
     """, tenant_id, plan_id, provider_norm, amount_in_cents, currency_norm, provider_environment)
     return row["id"]
@@ -2167,7 +2167,7 @@ async def activate_subscription_by_gateway_ref(
         conn,
         subscription_id=row["id"],
         tenant_id=tenant_id,
-        billing_cycle=row["billing_cycle"] or "annual",
+        billing_cycle=row["billing_cycle"] or "monthly",
         amount=amount,
         currency=currency,
         metadata=metadata,
@@ -3149,10 +3149,10 @@ async def process_paddle_onboarding_payment(
             tenant_id, plan_id, billing_cycle, status, gateway_reference,
             current_period_start, current_period_end
         )
-        VALUES ($1, $2, 'annual', 'active', $3, $4, $4 + interval '1 year')
+        VALUES ($1, $2, 'monthly', 'active', $3, $4, $4 + interval '1 month')
         ON CONFLICT (tenant_id) DO UPDATE SET
             plan_id = EXCLUDED.plan_id,
-            billing_cycle = 'annual',
+            billing_cycle = 'monthly',
             status = 'active',
             gateway_reference = EXCLUDED.gateway_reference,
             current_period_start = EXCLUDED.current_period_start,

--- a/app/services/paddle_service.py
+++ b/app/services/paddle_service.py
@@ -136,7 +136,7 @@ async def create_checkout(
     attempt_id: Optional[UUID] = None,
 ) -> Dict[str, Any]:
     """
-    Create a Paddle Billing transaction checkout for the annual price.
+    Create a Paddle Billing transaction checkout for the monthly price (#807).
 
     Returns: checkout_url, paddle_transaction_id, gateway_reference, currency, amount_minor
     """
@@ -163,7 +163,7 @@ async def create_checkout(
             "paddle_transaction_id": fake_id,
             "gateway_reference": fake_id,
             "currency": offer.currency,
-            "amount_minor": offer.annual_amount_minor,
+            "amount_minor": offer.monthly_amount_minor,
             "price_id": price_id,
             "mock": True,
         }
@@ -206,7 +206,7 @@ async def create_checkout(
         "paddle_transaction_id": txn_id,
         "gateway_reference": txn_id,
         "currency": offer.currency,
-        "amount_minor": offer.annual_amount_minor,
+        "amount_minor": offer.monthly_amount_minor,
         "price_id": price_id,
         "mock": False,
     }
@@ -250,7 +250,7 @@ def extract_transaction_event(payload: Dict[str, Any]) -> Dict[str, Any]:
         "status": str(data.get("status") or "").lower(),
         "tenant_id": custom.get("tenant_id"),
         "plan_id": custom.get("plan_id"),
-        "billing_cycle": custom.get("billing_cycle") or "annual",
+        "billing_cycle": custom.get("billing_cycle") or "monthly",
         "attempt_id": custom.get("attempt_id"),
         "provider_environment": custom.get("provider_environment") or "prod",
         "amount_minor": amount_minor_int,

--- a/tests/test_billing_activation.py
+++ b/tests/test_billing_activation.py
@@ -237,6 +237,60 @@ async def test_activate_tenant_subscription_rejects_return_amount_mismatch():
     conn.execute.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_activate_by_gateway_ref_monthly_past_due_extends_period():
+    tenant_id = uuid4()
+    sub_id = uuid4()
+    sub_row = {"id": sub_id, "status": "past_due", "billing_cycle": "monthly"}
+    conn, _ = _conn_with_activation(sub_row=sub_row)
+
+    await billing_service.activate_subscription_by_gateway_ref(
+        conn,
+        tenant_id=tenant_id,
+        gateway_reference="txn_monthly_1",
+        amount=9.0,
+        currency="USD",
+        paddle_transaction_id="txn_monthly_1",
+        provider="paddle",
+    )
+
+    update_call = None
+    for call in conn.fetchrow.await_args_list:
+        sql = " ".join(str(call.args[0]).split())
+        if "UPDATE tenant_subscriptions" in sql:
+            update_call = call
+            break
+    assert update_call is not None
+    assert update_call.args[2] == "monthly"
+    metadata = json.loads(conn.execute.call_args[0][5])
+    assert metadata["paddle_transaction_id"] == "txn_monthly_1"
+
+
+@pytest.mark.asyncio
+async def test_activate_by_gateway_ref_monthly_pending_activates():
+    tenant_id = uuid4()
+    sub_row = {"id": uuid4(), "status": "pending", "billing_cycle": "monthly"}
+    conn, _ = _conn_with_activation(sub_row=sub_row)
+
+    activated = await billing_service.activate_subscription_by_gateway_ref(
+        conn,
+        tenant_id=tenant_id,
+        gateway_reference="txn_monthly_pending",
+        amount=9.0,
+        currency="USD",
+        paddle_transaction_id="txn_monthly_pending",
+        provider="paddle",
+    )
+
+    assert activated is True
+    update_args = [
+        c.args for c in conn.fetchrow.await_args_list
+        if "UPDATE tenant_subscriptions" in " ".join(str(c.args[0]).split())
+    ]
+    assert update_args
+    assert update_args[0][2] == "monthly"
+
+
 def test_parse_wompi_period_anchor_prefers_finalized_at():
     anchor = billing_service.parse_wompi_period_anchor({
         "finalized_at": "2025-05-31T18:00:00.000Z",

--- a/tests/test_billing_subscribe_cycle.py
+++ b/tests/test_billing_subscribe_cycle.py
@@ -1,4 +1,4 @@
-"""POST /billing/subscribe — annual-only for new subscriptions (#877)."""
+"""POST /billing/subscribe — monthly-only for new subscriptions (#807)."""
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -39,7 +39,7 @@ def _build_app():
     return app, session
 
 
-def test_subscribe_rejects_monthly_billing_cycle():
+def test_subscribe_rejects_annual_billing_cycle():
     app, session = _build_app()
     plan_id = uuid4()
 
@@ -58,11 +58,11 @@ def test_subscribe_rejects_monthly_billing_cycle():
         client = TestClient(app)
         res = client.post(
             "/billing/subscribe",
-            json={"plan_id": str(plan_id), "billing_cycle": "monthly"},
+            json={"plan_id": str(plan_id), "billing_cycle": "annual"},
         )
 
     assert res.status_code == 422
-    assert "anual" in res.json()["detail"].lower()
+    assert "mensual" in res.json()["detail"].lower()
 
 
 def test_subscribe_requires_current_terms_before_paddle_checkout():
@@ -107,7 +107,7 @@ def test_subscribe_requires_current_terms_before_paddle_checkout():
         client = TestClient(app)
         res = client.post(
             "/billing/subscribe",
-            json={"plan_id": str(plan_id), "billing_cycle": "annual"},
+            json={"plan_id": str(plan_id), "billing_cycle": "monthly"},
         )
 
     assert res.status_code == 409
@@ -171,7 +171,7 @@ async def test_active_promoted_tenant_uses_normal_subscription_flow():
         billing.paddle_service,
         "create_checkout",
         new=AsyncMock(return_value=checkout),
-    ), patch.object(
+    ) as paddle, patch.object(
         billing.billing_service,
         "subscribe_tenant",
         new=AsyncMock(return_value=subscribed),
@@ -181,11 +181,13 @@ async def test_active_promoted_tenant_uses_normal_subscription_flow():
         new=AsyncMock(),
     ) as onboarding_attempt:
         result = await billing.subscribe(
-            billing.SubscribeBody(plan_id=plan_id, billing_cycle="annual"),
+            billing.SubscribeBody(plan_id=plan_id, billing_cycle="monthly"),
             MagicMock(),
         )
 
     assert result == subscribed
     terms.assert_awaited_once_with(conn, tenant_id)
     subscribe.assert_awaited_once()
+    assert subscribe.await_args.kwargs["billing_cycle"] == "monthly"
+    assert paddle.await_args.kwargs["billing_cycle"] == "monthly"
     onboarding_attempt.assert_not_awaited()

--- a/tests/test_paddle_billing.py
+++ b/tests/test_paddle_billing.py
@@ -39,7 +39,7 @@ def _completed_payload(
     custom = {
         "tenant_id": str(tenant_id),
         "plan_id": str(uuid4()),
-        "billing_cycle": "annual",
+        "billing_cycle": "monthly",
         "provider_environment": "test",
     }
     if attempt_id is not None:
@@ -52,7 +52,7 @@ def _completed_payload(
             "currency_code": "USD",
             "billed_at": "2026-08-01T12:00:00Z",
             "custom_data": custom,
-            "details": {"totals": {"grand_total": "9000", "currency_code": "USD"}},
+            "details": {"totals": {"grand_total": "900", "currency_code": "USD"}},
             "subscription_id": "sub_paddle_1",
         },
     }
@@ -104,12 +104,12 @@ async def test_create_checkout_uses_offer_not_plan_cop(monkeypatch):
         environment="test",
         tenant_id=uuid4(),
         plan_id=uuid4(),
-        billing_cycle="annual",
+        billing_cycle="monthly",
         redirect_url="https://example.test/billing/confirmacion",
     )
 
     assert result["currency"] == "USD"
-    assert result["amount_minor"] == 9000  # $90 annual, not COP plan price
+    assert result["amount_minor"] == 900  # $9 monthly, not COP plan price
     assert result["mock"] is True
     assert "paddle_txn=" in result["checkout_url"]
 
@@ -155,7 +155,7 @@ async def test_handle_webhook_activates_on_completed():
     assert kwargs["paddle_transaction_id"] == "txn_paddle_1"
     assert kwargs["paddle_subscription_id"] == "sub_paddle_1"
     assert kwargs["currency"] == "USD"
-    assert kwargs["amount"] == 90.0
+    assert kwargs["amount"] == 9.0
 
 
 @pytest.mark.asyncio
@@ -295,7 +295,7 @@ async def test_handle_webhook_failed_marks_past_due_by_tenant():
 @pytest.mark.asyncio
 async def test_activate_paddle_duplicate_skips():
     tenant_id = uuid4()
-    sub_row = {"id": uuid4(), "status": "pending", "billing_cycle": "annual"}
+    sub_row = {"id": uuid4(), "status": "pending", "billing_cycle": "monthly"}
     conn = MagicMock()
     conn.fetchrow = AsyncMock(return_value=sub_row)
     conn.fetchval = AsyncMock(return_value=1)  # duplicate paddle txn
@@ -305,7 +305,7 @@ async def test_activate_paddle_duplicate_skips():
         conn,
         tenant_id=tenant_id,
         gateway_reference="txn_paddle_1",
-        amount=90.0,
+        amount=9.0,
         currency="USD",
         paddle_transaction_id="txn_paddle_1",
         provider="paddle",
@@ -327,7 +327,7 @@ async def test_process_paddle_onboarding_payment_activates():
         "tenant_id": tenant_id,
         "plan_id": plan_id,
         "provider_reference": "txn_onboard_1",
-        "expected_amount_in_cents": 9000,
+        "expected_amount_in_cents": 900,
         "currency": "USD",
         "status": "pending",
         "provider_transaction_id": None,
@@ -354,7 +354,7 @@ async def test_process_paddle_onboarding_payment_activates():
             conn,
             attempt_id=attempt_id,
             transaction_id="txn_onboard_1",
-            amount_minor=9000,
+            amount_minor=900,
             currency="USD",
             provider_environment="test",
             paddle_subscription_id="sub_1",


### PR DESCRIPTION
## Summary
- `POST /billing/subscribe` defaults to `monthly`; rejects `annual` with 422
- Checkout/onboarding amounts use `monthly_amount_minor`; Paddle onboarding activates with +1 month
- Webhook `billing_cycle` fallback defaults to monthly; past_due-by-tenant path unchanged

Closes #807

## Test plan
- [x] pytest subscribe_cycle + paddle_billing + billing_activation
- [ ] Sandbox E2E checkout once webhook secret is set

## Validation evidence
```
collected 29 items
tests/test_billing_subscribe_cycle.py ...                                [ 10%]
tests/test_paddle_billing.py ............                                [ 51%]
tests/test_billing_activation.py ..............                          [100%]
============================== 29 passed in 0.51s ==============================
```

Made with [Cursor](https://cursor.com)