### PR TITLE
fix(billing): grandfather annuals renew as monthly (#809)

### DIFF
--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -2023,15 +2023,16 @@ async def _activate_subscription_with_period(
     metadata: Dict[str, Any],
     period_anchor: Optional[datetime] = None,
 ) -> Optional[datetime]:
-    """Set subscription active, extend billing period, record payment_approved."""
+    """Set subscription active, persist billing_cycle, extend period, record payment_approved."""
     # Interval literals stay in SQL — asyncpg cannot bind '1 year' strings as interval.
-    cycle = billing_cycle if billing_cycle in ("monthly", "annual") else "annual"
+    cycle = billing_cycle if billing_cycle in ("monthly", "annual") else "monthly"
     anchor = period_anchor or datetime.now(timezone.utc)
     if anchor.tzinfo is None:
         anchor = anchor.replace(tzinfo=timezone.utc)
     updated = await conn.fetchrow("""
         UPDATE tenant_subscriptions
         SET status               = 'active',
+            billing_cycle        = $2::text,
             current_period_start = $3::timestamptz,
             current_period_end   = $3::timestamptz + CASE
                 WHEN $2::text = 'monthly' THEN interval '1 month'
@@ -2163,11 +2164,19 @@ async def activate_subscription_by_gateway_ref(
                 gateway_reference,
             )
 
+    # Post-grandfather renew (#809): non-grandfathered annual → monthly period + catalog.
+    cycle = str(row["billing_cycle"] or "monthly").lower()
+    if cycle == "annual":
+        cycle = "monthly"
+        metadata["converted_from_annual"] = True
+    elif cycle not in ("monthly", "annual"):
+        cycle = "monthly"
+
     period_end = await _activate_subscription_with_period(
         conn,
         subscription_id=row["id"],
         tenant_id=tenant_id,
-        billing_cycle=row["billing_cycle"] or "monthly",
+        billing_cycle=cycle,
         amount=amount,
         currency=currency,
         metadata=metadata,

--- a/docs/payments/paddle-pricing-policy.md
+++ b/docs/payments/paddle-pricing-policy.md
@@ -44,7 +44,7 @@ Annual `PADDLE_PRICE_*_ANNUAL_*` is optional fallback only if monthly is unset. 
 If `tenant_subscriptions.status = active` and `billing_cycle = annual` and `current_period_end` is still in the future:
 
 - **Do not** rebill or force monthly mid-period.
-- At period end / renew → monthly Paddle list ([#809](https://github.com/uno0uno/api-warolabs/issues/809)).
+- At period end / renew → monthly Paddle list and **`billing_cycle` flips to `monthly`** (+1 month) ([#809](https://github.com/uno0uno/api-warolabs/issues/809)).
 
 Helpers:
 

--- a/tests/test_billing_grandfather.py
+++ b/tests/test_billing_grandfather.py
@@ -1,8 +1,7 @@
-"""Grandfather mid-period gate + Paddle renew (#797)."""
+"""Grandfather mid-period gate + post-end monthly renew (#797 / #809)."""
 import json
-from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
@@ -79,7 +78,7 @@ async def test_subscribe_tenant_refuses_grandfathered_overwrite():
             conn,
             tenant_id=tenant_id,
             plan_id=uuid4(),
-            billing_cycle="annual",
+            billing_cycle="monthly",
             checkout_url="https://checkout.test",
             gateway_reference="txn_new",
         )
@@ -89,11 +88,11 @@ async def test_subscribe_tenant_refuses_grandfathered_overwrite():
 
 
 @pytest.mark.asyncio
-async def test_paddle_renew_by_tenant_extends_when_period_ended():
+async def test_paddle_renew_by_tenant_converts_ended_annual_to_monthly():
     tenant_id = uuid4()
     sub_id = uuid4()
     past = datetime.now(timezone.utc) - timedelta(days=3)
-    new_end = datetime.now(timezone.utc) + timedelta(days=365)
+    new_end = datetime.now(timezone.utc) + timedelta(days=30)
     conn = MagicMock()
     tenant_row = {
         "id": sub_id,
@@ -108,6 +107,8 @@ async def test_paddle_renew_by_tenant_extends_when_period_ended():
         if "AND gateway_reference" in sql:
             return None
         if "UPDATE tenant_subscriptions" in sql and "current_period_end" in sql:
+            assert "billing_cycle" in sql
+            assert args[1] == "monthly"
             return {"current_period_end": new_end}
         if "FROM tenant_subscriptions" in sql:
             return tenant_row
@@ -121,7 +122,7 @@ async def test_paddle_renew_by_tenant_extends_when_period_ended():
         conn,
         tenant_id=tenant_id,
         gateway_reference="txn_new_paddle",
-        amount=90.0,
+        amount=9.0,
         currency="USD",
         paddle_transaction_id="txn_new_paddle",
         provider="paddle",
@@ -140,6 +141,50 @@ async def test_paddle_renew_by_tenant_extends_when_period_ended():
     assert metadata["paddle_transaction_id"] == "txn_new_paddle"
     assert metadata["renewal"] is True
     assert metadata["previous_gateway_reference"] == "txn_old"
+    assert metadata["converted_from_annual"] is True
+
+
+@pytest.mark.asyncio
+async def test_paddle_renew_past_due_annual_converts_to_monthly():
+    tenant_id = uuid4()
+    sub_id = uuid4()
+    past = datetime.now(timezone.utc) - timedelta(days=10)
+    new_end = datetime.now(timezone.utc) + timedelta(days=30)
+    conn = MagicMock()
+    sub_row = {
+        "id": sub_id,
+        "status": "past_due",
+        "billing_cycle": "annual",
+        "current_period_end": past,
+        "gateway_reference": "txn_past_due",
+    }
+
+    async def fetchrow_side_effect(query, *args):
+        sql = " ".join(query.split())
+        if "FROM tenant_subscriptions" in sql and "gateway_reference" in sql:
+            return sub_row
+        if "UPDATE tenant_subscriptions" in sql and "current_period_end" in sql:
+            assert args[1] == "monthly"
+            return {"current_period_end": new_end}
+        return None
+
+    conn.fetchrow = AsyncMock(side_effect=fetchrow_side_effect)
+    conn.fetchval = AsyncMock(return_value=None)
+    conn.execute = AsyncMock()
+
+    activated = await billing_service.activate_subscription_by_gateway_ref(
+        conn,
+        tenant_id=tenant_id,
+        gateway_reference="txn_past_due",
+        amount=9.0,
+        currency="USD",
+        paddle_transaction_id="txn_past_due_pay",
+        provider="paddle",
+    )
+
+    assert activated is True
+    metadata = json.loads(conn.execute.call_args[0][5])
+    assert metadata["converted_from_annual"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Mid-period active annuals still skipped (grandfather unchanged)
- Post-end / past_due annual renewals coerce to `monthly`, persist cycle, extend +1 month
- Avoids re-locking converted tenants onto annual periods after #805 cutover

Closes #809

## Test plan
- [x] `pytest tests/test_billing_grandfather.py` (+ activation regression)

## Validation evidence
```
collected 21 items
tests/test_billing_grandfather.py .......                                [ 33%]
tests/test_billing_activation.py ..............                          [100%]
============================== 21 passed in 0.17s ==============================
```

Made with [Cursor](https://cursor.com)