### PR TITLE
chore(billing): drive Paddle sandbox/live from env (#813)

### DIFF
--- a/.wr/813.yaml
+++ b/.wr/813.yaml
@@ -9,6 +9,7 @@ branch: wr-813-paddle-env-sandbox
 paths:
   - app/config.py
   - app/core/billing_pricing.py
+  - app/routers/billing.py
   - docs/payments/paddle-pricing-policy.md
   - tests/test_billing_pricing.py
 

--- a/.wr/813.yaml
+++ b/.wr/813.yaml
@@ -1,0 +1,36 @@
+issue: 813
+title: "chore(billing): drive Paddle sandbox/live from env (no hardcoded QA slugs)"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-813-paddle-env-sandbox
+
+paths:
+  - app/config.py
+  - app/core/billing_pricing.py
+  - docs/payments/paddle-pricing-policy.md
+  - tests/test_billing_pricing.py
+
+ac:
+  - PADDLE_ENVIRONMENT=sandbox|production in config (default sandbox for local ergonomics like WOMPI_ENVIRONMENT)
+  - PADDLE_SANDBOX_TENANT_SLUGS CSV optional; empty → fallback warocolombia,waro-colombia
+  - resolve_provider_environment: billing_test OR paddle_environment sandbox OR slug/id in allowlist → test; else prod
+  - Docs describe local vs prod
+  - Tests: sandbox env forces test for arbitrary slug; prod+allowlist; prod without match → live
+
+out_of_scope:
+  - country segments, front, live catalog, paddle_service URLs
+
+hints:
+  pattern: "WOMPI_ENVIRONMENT + MATIAS_SANDBOX_TENANT_IDS CSV split"
+  entry: "resolve_provider_environment in billing_pricing.py"
+  tests: "venv/bin/python -m pytest tests/test_billing_pricing.py -q"
+
+risk:
+  sensitive: true
+  areas: [payments]
+  note: "Default PADDLE_ENVIRONMENT=sandbox matches WOMPI; prod deploys must set production"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/config.py
+++ b/app/config.py
@@ -100,6 +100,10 @@ class Settings(BaseSettings):
     )
 
     # Paddle Billing — regional SaaS checkout (epic #793 / batch #795)
+    # sandbox|production — default sandbox (local/dev); prod must set production (#813)
+    paddle_environment: str = Field(default='sandbox', alias='PADDLE_ENVIRONMENT')
+    # CSV of tenant slugs and/or ids routed to Paddle Test when paddle_environment=production
+    paddle_sandbox_tenant_slugs: str = Field(default='', alias='PADDLE_SANDBOX_TENANT_SLUGS')
     paddle_api_key_live: Optional[str] = Field(default=None, alias='PADDLE_API_KEY_LIVE')
     paddle_api_key_sandbox: Optional[str] = Field(default=None, alias='PADDLE_API_KEY_SANDBOX')
     paddle_webhook_secret_live: Optional[str] = Field(

--- a/app/core/billing_pricing.py
+++ b/app/core/billing_pricing.py
@@ -28,14 +28,15 @@ USD_CHARGE_COUNTRIES = frozenset(
 # Strong-currency / intl allowlist → USD 30 (not USD 9).
 INTL_USD_30_ALLOWLIST = frozenset({"GB", "CA", "AU", "NZ", "SG", "AE"})
 
-# Tenants that always use Paddle sandbox (WARO Colombia internal / QA).
-# Extend via settings later in #795 if needed.
-PADDLE_SANDBOX_TENANT_SLUGS = frozenset(
+# Fallback QA allowlist when PADDLE_SANDBOX_TENANT_SLUGS env is unset (#813).
+DEFAULT_PADDLE_SANDBOX_TENANT_SLUGS = frozenset(
     {
         "waro-colombia",
         "warocolombia",
     }
 )
+# Back-compat alias (prefer resolve_paddle_sandbox_tenant_keys() / env).
+PADDLE_SANDBOX_TENANT_SLUGS = DEFAULT_PADDLE_SANDBOX_TENANT_SLUGS
 
 ANNUAL_MULTIPLIER = 10
 
@@ -103,20 +104,47 @@ def resolve_price_offer(country_code: Optional[str]) -> PriceOffer:
     return SEGMENT_OFFERS[resolve_price_segment(country_code)]
 
 
+def resolve_paddle_sandbox_tenant_keys() -> frozenset[str]:
+    """CSV from PADDLE_SANDBOX_TENANT_SLUGS, or DEFAULT_PADDLE_SANDBOX_TENANT_SLUGS."""
+    from app.config import settings
+
+    raw = (settings.paddle_sandbox_tenant_slugs or "").strip()
+    if not raw:
+        return DEFAULT_PADDLE_SANDBOX_TENANT_SLUGS
+    return frozenset(part.strip().lower() for part in raw.split(",") if part.strip())
+
+
 def resolve_provider_environment(
     *,
     tenant_slug: Optional[str] = None,
+    tenant_id: Optional[str] = None,
     billing_test: bool = False,
 ) -> ProviderEnvironment:
-    """Paddle sandbox vs live.
+    """Paddle sandbox vs live (#813).
 
-    test: explicit billing_test OR WARO Colombia sandbox tenant slug.
-    prod: everyone else (including Bubablue and other CO customers).
+    test when:
+    - billing_test=True, or
+    - PADDLE_ENVIRONMENT is sandbox|test (default sandbox for local/dev), or
+    - production mode and tenant slug/id is in PADDLE_SANDBOX_TENANT_SLUGS
+      (empty env → DEFAULT_PADDLE_SANDBOX_TENANT_SLUGS).
+
+    prod: PADDLE_ENVIRONMENT=production and tenant not on allowlist.
     """
     if billing_test:
         return "test"
+
+    from app.config import settings
+
+    mode = (settings.paddle_environment or "sandbox").strip().lower()
+    if mode in ("sandbox", "test"):
+        return "test"
+
+    keys = resolve_paddle_sandbox_tenant_keys()
     slug = (tenant_slug or "").strip().lower()
-    if slug in PADDLE_SANDBOX_TENANT_SLUGS:
+    if slug and slug in keys:
+        return "test"
+    tid = str(tenant_id).strip().lower() if tenant_id else ""
+    if tid and tid in keys:
         return "test"
     return "prod"
 

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -121,7 +121,10 @@ async def subscribe(body: SubscribeBody, request: Request):
 
         ctx = await billing_service.get_tenant_billing_context(conn, tenant_id)
         offer = resolve_price_offer(ctx["country_code"])
-        provider_environment = resolve_provider_environment(tenant_slug=ctx.get("slug"))
+        provider_environment = resolve_provider_environment(
+            tenant_slug=ctx.get("slug"),
+            tenant_id=str(tenant_id) if tenant_id else None,
+        )
 
         if is_pending_onboarding:
             attempt_id = await billing_service.create_onboarding_payment_attempt(

--- a/docs/payments/paddle-pricing-policy.md
+++ b/docs/payments/paddle-pricing-policy.md
@@ -34,10 +34,17 @@ Annual `PADDLE_PRICE_*_ANNUAL_*` is optional fallback only if monthly is unset. 
 
 ## Sandbox vs live (`provider_environment`)
 
-| Value | When |
-|-------|------|
-| `test` | `billing_test=True` **or** tenant slug in `PADDLE_SANDBOX_TENANT_SLUGS` (e.g. `warocolombia`) |
-| `prod` | All other tenants (including Colombian customers like Bubablue) |
+Driven by env (Wompi / Matías pattern) — not hardcoded QA slugs alone ([#813](https://github.com/uno0uno/api-warolabs/issues/813)):
+
+| Env | Role |
+|-----|------|
+| `PADDLE_ENVIRONMENT` | `sandbox` (default) or `production`. Local/dev → leave default or set `sandbox` so **any** tenant uses Paddle Test. **Production deploys must set `production`.** |
+| `PADDLE_SANDBOX_TENANT_SLUGS` | Optional CSV of tenant slugs and/or ids that stay on Test when `PADDLE_ENVIRONMENT=production`. Empty → fallback `warocolombia,waro-colombia`. |
+
+| `provider_environment` | When |
+|------------------------|------|
+| `test` | `billing_test=True`, **or** `PADDLE_ENVIRONMENT` is `sandbox`/`test`, **or** (production mode and tenant on allowlist) |
+| `prod` | `PADDLE_ENVIRONMENT=production` and tenant **not** on allowlist (e.g. Bubablue) |
 
 ## Grandfather (active annuals)
 

--- a/tests/test_billing_pricing.py
+++ b/tests/test_billing_pricing.py
@@ -83,14 +83,34 @@ def test_configured_price_id_falls_back_to_annual_then_placeholder():
         assert configured_price_id(offer, "test").startswith("TODO_PADDLE_PRICE_USD_9_MONTHLY")
 
 
-def test_provider_environment_sandbox_slugs_and_flag():
+def test_provider_environment_sandbox_env_forces_test_for_any_slug():
+    """PADDLE_ENVIRONMENT=sandbox → test for arbitrary tenants (#813)."""
+    with patch("app.config.settings") as mock_settings:
+        mock_settings.paddle_environment = "sandbox"
+        mock_settings.paddle_sandbox_tenant_slugs = ""
+        assert resolve_provider_environment(tenant_slug="bubablue") == "test"
+        assert resolve_provider_environment(tenant_slug="any-tenant") == "test"
+
+
+def test_provider_environment_production_allowlist_and_live():
+    """Production mode: allowlist → test; others → prod (#813)."""
     assert PADDLE_SANDBOX_TENANT_SLUGS == frozenset({"waro-colombia", "warocolombia"})
-    assert resolve_provider_environment(tenant_slug="warocolombia") == "test"
-    assert resolve_provider_environment(tenant_slug="waro-colombia") == "test"
-    assert resolve_provider_environment(tenant_slug="waro") == "prod"
-    assert resolve_provider_environment(billing_test=True) == "test"
-    assert resolve_provider_environment(tenant_slug="bubablue") == "prod"
-    assert resolve_provider_environment(tenant_slug="bubablue", billing_test=False) == "prod"
+    with patch("app.config.settings") as mock_settings:
+        mock_settings.paddle_environment = "production"
+        mock_settings.paddle_sandbox_tenant_slugs = ""
+        assert resolve_provider_environment(tenant_slug="warocolombia") == "test"
+        assert resolve_provider_environment(tenant_slug="waro-colombia") == "test"
+        assert resolve_provider_environment(tenant_slug="waro") == "prod"
+        assert resolve_provider_environment(tenant_slug="bubablue") == "prod"
+        assert resolve_provider_environment(billing_test=True) == "test"
+
+        mock_settings.paddle_sandbox_tenant_slugs = "qa-slug,11111111-1111-1111-1111-111111111111"
+        assert resolve_provider_environment(tenant_slug="qa-slug") == "test"
+        assert (
+            resolve_provider_environment(tenant_id="11111111-1111-1111-1111-111111111111")
+            == "test"
+        )
+        assert resolve_provider_environment(tenant_slug="bubablue") == "prod"
 
 
 def test_blank_country_defaults_to_co_usd_9():


### PR DESCRIPTION
## Summary
- Add `PADDLE_ENVIRONMENT` (default `sandbox`) and optional `PADDLE_SANDBOX_TENANT_SLUGS` CSV
- `resolve_provider_environment` uses env mode + allowlist (fallback QA slugs when CSV empty)
- Docs + tests for sandbox-any-tenant / prod allowlist / prod live

Closes #813

## Test plan
- [ ] Local with default/`sandbox`: any tenant checkout hits Paddle Test
- [ ] Prod deploy has `PADDLE_ENVIRONMENT=production`
- [ ] QA slug still Test under production + empty/default allowlist
- [ ] Non-allowlist tenant under production → Live

## Validation evidence
```
venv/bin/python -m pytest tests/test_billing_pricing.py -q
============================= 13 passed in 0.10s ==============================
```

## wr-context
See `.wr/813.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)