### PR TITLE
fix(billing): hide FE plan outside Colombia (#2201)

### DIFF
--- a/.wr/2201.yaml
+++ b/.wr/2201.yaml
@@ -1,0 +1,22 @@
+issue: 2201
+title: "fix(billing): filter intl plans + declutter plan picker UX"
+repo: api_warocol.com
+repo_remote: uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: fastapi
+branch: wr-2201-intl-plans-filter
+companion_front: wr-2201-intl-plans-declutter
+closes: "uno0uno/warocol.com#2201"
+
+paths:
+  - app/routers/billing.py
+  - app/services/billing_service.py
+  - tests/test_billing_plans_price_offer.py
+
+ac:
+  - Filter facturacion-electronica from plans list when country != CO
+  - Subscribe 422 if non-CO requests FE plan
+  - Tests cover CO vs non-CO list
+
+hints:
+  tests: "venv/bin/python -m pytest tests/test_billing_plans_price_offer.py -q"

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -67,9 +67,11 @@ async def tenant_list_plans(request: Request):
         plans = await billing_service.list_plans(conn)
         ctx = await billing_service.get_tenant_billing_context(conn, session.tenant_id)
 
-    offer = resolve_price_offer(ctx.get("country_code"))
+    country_code = ctx.get("country_code")
+    offer = resolve_price_offer(country_code)
+    active = [p for p in plans if p["is_active"]]
     return {
-        "plans": [p for p in plans if p["is_active"]],
+        "plans": billing_service.filter_plans_for_country(active, country_code),
         "price_offer": {
             "segment": offer.segment,
             "currency": offer.currency,
@@ -120,6 +122,10 @@ async def subscribe(body: SubscribeBody, request: Request):
             await billing_service.ensure_subscribe_allowed(conn, tenant_id)
 
         ctx = await billing_service.get_tenant_billing_context(conn, tenant_id)
+        billing_service.assert_plan_available_for_country(
+            plan["slug"],
+            ctx.get("country_code"),
+        )
         offer = resolve_price_offer(ctx["country_code"])
         provider_environment = resolve_provider_environment(tenant_slug=ctx.get("slug"))
 

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -1506,6 +1506,32 @@ async def list_plans(conn) -> List[Dict[str, Any]]:
     return [_serialize_plan(r) for r in rows]
 
 
+def is_colombia_country(country_code: Optional[str]) -> bool:
+    return (country_code or "").strip().upper() == "CO"
+
+
+def filter_plans_for_country(
+    plans: List[Dict[str, Any]],
+    country_code: Optional[str],
+) -> List[Dict[str, Any]]:
+    """Hide Colombia-only electronic invoicing plan outside CO (#2201)."""
+    if is_colombia_country(country_code):
+        return plans
+    return [p for p in plans if p.get("slug") != ELECTRONIC_INVOICE_PLAN_SLUG]
+
+
+def assert_plan_available_for_country(
+    plan_slug: str,
+    country_code: Optional[str],
+) -> None:
+    """Raise 422 when a country-restricted plan is requested outside CO."""
+    if plan_slug == ELECTRONIC_INVOICE_PLAN_SLUG and not is_colombia_country(country_code):
+        raise HTTPException(
+            status_code=422,
+            detail="El plan de Facturación electrónica solo está disponible para Colombia.",
+        )
+
+
 def _serialize_billing_events(rows, total: int, limit: int, offset: int) -> Dict[str, Any]:
     events = []
     for r in rows:

--- a/tests/test_billing_plans_price_offer.py
+++ b/tests/test_billing_plans_price_offer.py
@@ -1,15 +1,20 @@
-"""GET /billing/plans includes regional price_offer (#796)."""
+"""GET /billing/plans includes regional price_offer (#796) + country filter (#2201)."""
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from app.core import permissions
 from app.core.middleware import SessionContext
 from app.routers.billing import tenant_router
+from app.services.billing_service import (
+    ELECTRONIC_INVOICE_PLAN_SLUG,
+    assert_plan_available_for_country,
+    filter_plans_for_country,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -21,9 +26,36 @@ def _clear_caches():
     permissions._role_modules_cache.clear()
 
 
-def test_tenant_list_plans_includes_price_offer_for_co():
-    tenant_id = uuid4()
-    session = SessionContext({
+def _plans_catalog():
+    return [
+        {"id": str(uuid4()), "name": "Starter", "slug": "starter", "is_active": True},
+        {"id": str(uuid4()), "name": "Pro", "slug": "pro", "is_active": True},
+        {
+            "id": str(uuid4()),
+            "name": "Facturación electrónica",
+            "slug": ELECTRONIC_INVOICE_PLAN_SLUG,
+            "is_active": True,
+        },
+    ]
+
+
+def test_filter_plans_for_country_hides_fe_outside_co():
+    plans = _plans_catalog()
+    intl = filter_plans_for_country(plans, "US")
+    assert [p["slug"] for p in intl] == ["starter", "pro"]
+    co = filter_plans_for_country(plans, "CO")
+    assert [p["slug"] for p in co] == ["starter", "pro", ELECTRONIC_INVOICE_PLAN_SLUG]
+
+
+def test_assert_plan_available_for_country_blocks_fe_outside_co():
+    assert_plan_available_for_country(ELECTRONIC_INVOICE_PLAN_SLUG, "CO")
+    with pytest.raises(HTTPException) as exc:
+        assert_plan_available_for_country(ELECTRONIC_INVOICE_PLAN_SLUG, "US")
+    assert exc.value.status_code == 422
+
+
+def _session(tenant_id):
+    return SessionContext({
         "user_id": uuid4(),
         "tenant_id": tenant_id,
         "email": "test@example.com",
@@ -32,15 +64,9 @@ def test_tenant_list_plans_includes_price_offer_for_co():
         "is_active": True,
         "role": "owner",
     })
-    plan = {
-        "id": str(uuid4()),
-        "name": "Pro",
-        "slug": "pro",
-        "is_active": True,
-        "price_monthly": "0",
-        "price_annual": "95900",
-    }
 
+
+def _db_cm():
     @asynccontextmanager
     async def _db(**_kwargs):
         conn = MagicMock()
@@ -49,15 +75,23 @@ def test_tenant_list_plans_includes_price_offer_for_co():
         conn.fetch = AsyncMock(return_value=[])
         yield conn
 
+    return _db
+
+
+def test_tenant_list_plans_includes_price_offer_for_co():
+    tenant_id = uuid4()
+    session = _session(tenant_id)
+    plans = _plans_catalog()
+
     app = FastAPI()
     app.include_router(tenant_router)
 
     with patch("app.core.middleware.get_session_context", return_value=session), \
          patch("app.core.middleware.require_valid_session", return_value=session), \
          patch("app.routers.billing.require_valid_session", return_value=session), \
-         patch("app.core.permissions.get_db_connection", side_effect=_db), \
-         patch("app.routers.billing.get_db_connection", side_effect=_db), \
-         patch("app.routers.billing.billing_service.list_plans", new=AsyncMock(return_value=[plan])), \
+         patch("app.core.permissions.get_db_connection", side_effect=_db_cm()), \
+         patch("app.routers.billing.get_db_connection", side_effect=_db_cm()), \
+         patch("app.routers.billing.billing_service.list_plans", new=AsyncMock(return_value=plans)), \
          patch(
              "app.routers.billing.billing_service.get_tenant_billing_context",
              new=AsyncMock(return_value={"slug": "demo", "country_code": "CO"}),
@@ -67,9 +101,39 @@ def test_tenant_list_plans_includes_price_offer_for_co():
 
     assert res.status_code == 200
     body = res.json()
-    assert "plans" in body
-    assert body["plans"][0]["slug"] == "pro"
+    assert [p["slug"] for p in body["plans"]] == [
+        "starter",
+        "pro",
+        ELECTRONIC_INVOICE_PLAN_SLUG,
+    ]
     assert body["price_offer"]["currency"] == "USD"
     assert body["price_offer"]["segment"] == "usd_9"
     assert body["price_offer"]["annual_amount_minor"] == 9000
     assert body["price_offer"]["annual_amount"] == 90.0
+
+
+def test_tenant_list_plans_omits_fe_for_non_co():
+    tenant_id = uuid4()
+    session = _session(tenant_id)
+    plans = _plans_catalog()
+
+    app = FastAPI()
+    app.include_router(tenant_router)
+
+    with patch("app.core.middleware.get_session_context", return_value=session), \
+         patch("app.core.middleware.require_valid_session", return_value=session), \
+         patch("app.routers.billing.require_valid_session", return_value=session), \
+         patch("app.core.permissions.get_db_connection", side_effect=_db_cm()), \
+         patch("app.routers.billing.get_db_connection", side_effect=_db_cm()), \
+         patch("app.routers.billing.billing_service.list_plans", new=AsyncMock(return_value=plans)), \
+         patch(
+             "app.routers.billing.billing_service.get_tenant_billing_context",
+             new=AsyncMock(return_value={"slug": "test-23-07-2026", "country_code": "US"}),
+         ):
+        client = TestClient(app)
+        res = client.get("/billing/plans")
+
+    assert res.status_code == 200
+    body = res.json()
+    assert [p["slug"] for p in body["plans"]] == ["starter", "pro"]
+    assert body["price_offer"]["segment"] == "usd_30"


### PR DESCRIPTION
## Summary
- Filter `facturacion-electronica` from tenant plan list when country ≠ CO
- Reject subscribe to that plan outside Colombia (422)
- Tests for CO vs intl catalog

Companion front PR closes [warocol.com#2201](https://github.com/uno0uno/warocol.com/issues/2201).

## Test plan
- [ ] Non-CO tenant: plans API returns starter + pro only
- [ ] CO tenant: FE plan still listed
- [ ] Non-CO subscribe to FE plan id → 422

## Validation evidence
```
venv/bin/python -m pytest tests/test_billing_plans_price_offer.py -q
============================== 4 passed in 0.05s ==============================
```

## wr-context
See `.wr/2201.yaml` on this branch.

Made with [Cursor](https://cursor.com)