### PR TITLE
fix(billing): Paddle checkout URL contract + localhost omit (#2208)

### DIFF
--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -109,6 +109,8 @@ async def subscribe(body: SubscribeBody, request: Request):
     from urllib.parse import urlparse
     from app.core.billing_pricing import resolve_price_offer, resolve_provider_environment
 
+    # Return page after Paddle pay (#2208): transaction payment links use this as
+    # checkout.url when not localhost; activation still comes from webhooks.
     parsed = urlparse(settings.frontend_url)
     frontend_host = f"{parsed.scheme}://{parsed.netloc}"
     redirect_url = f"{frontend_host}/billing/confirmacion"

--- a/app/services/paddle_service.py
+++ b/app/services/paddle_service.py
@@ -12,6 +12,7 @@ import logging
 import secrets
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 from uuid import UUID
 
 import httpx
@@ -136,7 +137,17 @@ async def create_checkout(
     attempt_id: Optional[UUID] = None,
 ) -> Dict[str, Any]:
     """
-    Create a Paddle Billing transaction checkout for the monthly price (#807).
+    Create a Paddle Billing transaction checkout for the monthly price (#807 / #2208).
+
+    Contract (Hosted Checkout pay.paddle.io is not available via Transactions API):
+    - ``checkout_url`` is a **transaction payment link**: merchant default payment
+      link (or approved ``checkout.url`` override) + ``?_ptxn=txn_…``.
+    - Activation remains Paddle webhooks, not the return page.
+    - Return/success page for WARO is ``{FRONTEND_URL}/billing/confirmacion``
+      (passed as ``redirect_url`` / ``checkout.url`` when the host is not local).
+
+    Localhost / 127.0.0.1: omit ``checkout.url`` so Paddle uses the dashboard
+    default payment link (passing localhost is rejected as domain_not_approved).
 
     Returns: checkout_url, paddle_transaction_id, gateway_reference, currency, amount_minor
     """
@@ -171,8 +182,13 @@ async def create_checkout(
     body: Dict[str, Any] = {
         "items": [{"price_id": price_id, "quantity": 1}],
         "custom_data": custom_data,
-        "checkout": {"url": redirect_url},
     }
+    # Sandbox default payment link can be localhost; passing checkout.url with
+    # localhost is rejected (domain_is_not_approved) even in Test mode. Omit
+    # override so Paddle uses the dashboard default payment link.
+    redirect_host = (urlparse(redirect_url).hostname or "").lower()
+    if redirect_host not in {"localhost", "127.0.0.1"}:
+        body["checkout"] = {"url": redirect_url}
     if customer_email:
         body["customer"] = {"email": customer_email}
 

--- a/tests/test_paddle_billing.py
+++ b/tests/test_paddle_billing.py
@@ -115,6 +115,136 @@ async def test_create_checkout_uses_offer_not_plan_cop(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_create_checkout_omits_checkout_url_for_localhost(monkeypatch):
+    """#2208 — localhost checkout.url is rejected by Paddle; omit override."""
+    offer = resolve_price_offer("CO")
+    monkeypatch.setattr(
+        paddle_service.settings,
+        "paddle_api_key_sandbox",
+        "pdl_sdbx_test_key",
+    )
+    monkeypatch.setattr(
+        paddle_service,
+        "configured_price_id",
+        lambda _offer, _env: "pri_test_usd_9",
+    )
+    monkeypatch.setattr(
+        paddle_service,
+        "require_usable_price_id",
+        lambda price_id, _env: price_id,
+    )
+
+    captured: dict = {}
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {
+                "data": {
+                    "id": "txn_local_1",
+                    "checkout": {
+                        "url": "http://localhost:8080/billing/confirmacion?_ptxn=txn_local_1",
+                    },
+                }
+            }
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, url, json=None, headers=None):
+            captured["url"] = url
+            captured["json"] = json
+            return _Resp()
+
+    with patch("app.services.paddle_service.httpx.AsyncClient", _Client):
+        result = await paddle_service.create_checkout(
+            offer=offer,
+            environment="test",
+            tenant_id=uuid4(),
+            plan_id=uuid4(),
+            billing_cycle="monthly",
+            redirect_url="http://localhost:8080/billing/confirmacion",
+        )
+
+    assert "checkout" not in captured["json"]
+    assert result["paddle_transaction_id"] == "txn_local_1"
+    assert "_ptxn=txn_local_1" in result["checkout_url"]
+
+
+@pytest.mark.asyncio
+async def test_create_checkout_passes_checkout_url_for_production_host(monkeypatch):
+    """#2208 — non-local redirect still sets checkout.url override."""
+    offer = resolve_price_offer("US")
+    monkeypatch.setattr(
+        paddle_service.settings,
+        "paddle_api_key_sandbox",
+        "pdl_sdbx_test_key",
+    )
+    monkeypatch.setattr(
+        paddle_service,
+        "configured_price_id",
+        lambda _offer, _env: "pri_test_usd_9",
+    )
+    monkeypatch.setattr(
+        paddle_service,
+        "require_usable_price_id",
+        lambda price_id, _env: price_id,
+    )
+
+    captured: dict = {}
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {
+                "data": {
+                    "id": "txn_prod_1",
+                    "checkout": {
+                        "url": "https://warocol.com/billing/confirmacion?_ptxn=txn_prod_1",
+                    },
+                }
+            }
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, url, json=None, headers=None):
+            captured["json"] = json
+            return _Resp()
+
+    with patch("app.services.paddle_service.httpx.AsyncClient", _Client):
+        result = await paddle_service.create_checkout(
+            offer=offer,
+            environment="test",
+            tenant_id=uuid4(),
+            plan_id=uuid4(),
+            billing_cycle="monthly",
+            redirect_url="https://warocol.com/billing/confirmacion",
+        )
+
+    assert captured["json"]["checkout"] == {
+        "url": "https://warocol.com/billing/confirmacion",
+    }
+    assert result["paddle_transaction_id"] == "txn_prod_1"
+
+
+@pytest.mark.asyncio
 async def test_handle_webhook_activates_on_completed():
     tenant_id = uuid4()
     payload = _completed_payload(tenant_id=tenant_id)


### PR DESCRIPTION
## Summary
- Document that subscribe `checkout_url` is a **transaction payment link** (`_ptxn`), not Paddle Hosted Checkout (`pay.paddle.io`) — epic #2207 outcome C.
- Omit `checkout.url` when redirect host is localhost/127.0.0.1 so sandbox uses the dashboard default payment link.
- Clarify return page is `{FRONTEND_URL}/billing/confirmacion` (webhook still activates).

Closes uno0uno/warocol.com#2208  
Epic: uno0uno/warocol.com#2207

## Test plan
- [x] `./venv/bin/pytest tests/test_paddle_billing.py -q`
- [ ] Smoke: sandbox subscribe with local FRONTEND_URL still creates txn

## Validation evidence
```
============================= test session starts ==============================
platform darwin -- Python 3.12.1, pytest-8.3.4, pluggy-1.6.0
rootdir: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
configfile: pytest.ini
plugins: anyio-4.12.1, asyncio-0.24.0, cov-6.0.0
asyncio: mode=Mode.AUTO, default_loop_scope=function
collected 14 items

tests/test_paddle_billing.py ..............                              [100%]

============================== 14 passed in 0.10s ==============================
```

Made with [Cursor](https://cursor.com)